### PR TITLE
LibWeb: Drive CSS filter animations from the compositor

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1046,6 +1046,7 @@ void KeyframeEffect::invalidate_effect()
 {
     m_compositor_opacity_keyframe_value_cache.clear();
     m_compositor_background_color_keyframe_value_cache.clear();
+    m_compositor_filter_keyframe_value_cache.clear();
     m_compositor_transform_keyframe_value_cache.clear();
     m_is_compositor_driven = false;
     m_is_compositor_replaced = false;

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -213,6 +213,8 @@ public:
             return m_compositor_opacity_keyframe_value_cache;
         case Compositor::VisualAnimation::TargetKind::BackgroundColor:
             return m_compositor_background_color_keyframe_value_cache;
+        case Compositor::VisualAnimation::TargetKind::Filter:
+            return m_compositor_filter_keyframe_value_cache;
         case Compositor::VisualAnimation::TargetKind::Transform:
             return m_compositor_transform_keyframe_value_cache;
         }
@@ -251,6 +253,7 @@ private:
     u64 m_animation_preparation_generation { 0 };
     Optional<CompositorKeyframeValueCache> m_compositor_opacity_keyframe_value_cache;
     Optional<CompositorKeyframeValueCache> m_compositor_background_color_keyframe_value_cache;
+    Optional<CompositorKeyframeValueCache> m_compositor_filter_keyframe_value_cache;
     Optional<CompositorKeyframeValueCache> m_compositor_transform_keyframe_value_cache;
     Vector<Compositor::VisualAnimation> m_retained_compositor_animations;
     bool m_is_compositor_driven { false };

--- a/Libraries/LibWeb/Compositor/VisualAnimation.cpp
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.cpp
@@ -213,6 +213,98 @@ bool VisualAnimationTransformOperation::is_valid() const
     return all_of(values, [](float value) { return isfinite(value); });
 }
 
+static Gfx::Color interpolate_legacy_srgb_color(Gfx::Color from, Gfx::Color to, double progress)
+{
+    auto from_alpha = static_cast<double>(from.alpha()) / 255.0;
+    auto to_alpha = static_cast<double>(to.alpha()) / 255.0;
+    auto alpha = clamp(from_alpha + (to_alpha - from_alpha) * progress, 0.0, 1.0);
+    if (alpha == 0)
+        return Gfx::Color::Transparent;
+    auto interpolate_channel = [&](u8 from_channel, u8 to_channel) {
+        auto from_premultiplied = static_cast<double>(from_channel) * from_alpha;
+        auto to_premultiplied = static_cast<double>(to_channel) * to_alpha;
+        auto channel = (from_premultiplied + (to_premultiplied - from_premultiplied) * progress) / alpha;
+        return round_to<u8>(clamp(channel, 0.0, 255.0));
+    };
+    return Gfx::Color {
+        interpolate_channel(from.red(), to.red()),
+        interpolate_channel(from.green(), to.green()),
+        interpolate_channel(from.blue(), to.blue()),
+        round_to<u8>(alpha * 255.0),
+    };
+}
+
+bool VisualAnimationFilterOperation::matches(VisualAnimationFilterOperation const& other) const
+{
+    return kind == other.kind
+        && (kind != VisualAnimationFilterOperationKind::Color || color_operation == other.color_operation);
+}
+
+VisualAnimationFilterOperation VisualAnimationFilterOperation::initial_value() const
+{
+    auto initial = *this;
+    initial.amount = 0;
+    initial.offset_x = 0;
+    initial.offset_y = 0;
+    initial.color = Gfx::Color::Transparent;
+    if (kind == VisualAnimationFilterOperationKind::Color
+        && !first_is_one_of(color_operation, Gfx::ColorFilterType::Grayscale, Gfx::ColorFilterType::Invert, Gfx::ColorFilterType::Sepia))
+        initial.amount = 1;
+    return initial;
+}
+
+VisualAnimationFilterOperation VisualAnimationFilterOperation::interpolated_with(VisualAnimationFilterOperation const& other, double progress) const
+{
+    VERIFY(matches(other));
+    auto interpolate = [&](float from, float to) {
+        return static_cast<float>(from + (to - from) * progress);
+    };
+    auto result = *this;
+    result.amount = interpolate(amount, other.amount);
+    result.offset_x = interpolate(offset_x, other.offset_x);
+    result.offset_y = interpolate(offset_y, other.offset_y);
+    if (kind == VisualAnimationFilterOperationKind::DropShadow)
+        result.color = interpolate_legacy_srgb_color(color, other.color, progress);
+
+    if (first_is_one_of(kind, VisualAnimationFilterOperationKind::Blur, VisualAnimationFilterOperationKind::DropShadow))
+        result.amount = max(result.amount, 0.0f);
+    if (kind == VisualAnimationFilterOperationKind::Color) {
+        result.amount = max(result.amount, 0.0f);
+        if (first_is_one_of(color_operation, Gfx::ColorFilterType::Grayscale, Gfx::ColorFilterType::Invert, Gfx::ColorFilterType::Opacity, Gfx::ColorFilterType::Sepia))
+            result.amount = min(result.amount, 1.0f);
+    }
+    return result;
+}
+
+bool VisualAnimationFilterOperation::is_valid() const
+{
+    if (!first_is_one_of(kind,
+            VisualAnimationFilterOperationKind::Blur,
+            VisualAnimationFilterOperationKind::DropShadow,
+            VisualAnimationFilterOperationKind::Color,
+            VisualAnimationFilterOperationKind::HueRotate))
+        return false;
+    if (!isfinite(amount) || !isfinite(offset_x) || !isfinite(offset_y))
+        return false;
+    if (first_is_one_of(kind, VisualAnimationFilterOperationKind::Blur, VisualAnimationFilterOperationKind::DropShadow) && amount < 0)
+        return false;
+    if (kind != VisualAnimationFilterOperationKind::Color)
+        return true;
+    if (!first_is_one_of(color_operation,
+            Gfx::ColorFilterType::Brightness,
+            Gfx::ColorFilterType::Contrast,
+            Gfx::ColorFilterType::Grayscale,
+            Gfx::ColorFilterType::Invert,
+            Gfx::ColorFilterType::Opacity,
+            Gfx::ColorFilterType::Saturate,
+            Gfx::ColorFilterType::Sepia))
+        return false;
+    if (amount < 0)
+        return false;
+    return !first_is_one_of(color_operation, Gfx::ColorFilterType::Grayscale, Gfx::ColorFilterType::Invert, Gfx::ColorFilterType::Opacity, Gfx::ColorFilterType::Sepia)
+        || amount <= 1;
+}
+
 bool VisualAnimation::has_same_parameters_except_anchor(VisualAnimation const& other) const
 {
     return target_kind == other.target_kind
@@ -236,26 +328,6 @@ bool VisualAnimation::has_same_animation_parameters(VisualAnimation const& other
 
 static VisualAnimationValue interpolate_value(VisualAnimationValue const& from, VisualAnimationValue const& to, double progress)
 {
-    auto interpolate_legacy_srgb_color = [](Gfx::Color from, Gfx::Color to, double progress) -> Gfx::Color {
-        auto from_alpha = static_cast<double>(from.alpha()) / 255.0;
-        auto to_alpha = static_cast<double>(to.alpha()) / 255.0;
-        auto alpha = clamp(from_alpha + (to_alpha - from_alpha) * progress, 0.0, 1.0);
-        if (alpha == 0)
-            return Gfx::Color::Transparent;
-        auto interpolate_channel = [&](u8 from_channel, u8 to_channel) {
-            auto from_premultiplied = static_cast<double>(from_channel) * from_alpha;
-            auto to_premultiplied = static_cast<double>(to_channel) * to_alpha;
-            auto channel = (from_premultiplied + (to_premultiplied - from_premultiplied) * progress) / alpha;
-            return round_to<u8>(clamp(channel, 0.0, 255.0));
-        };
-        return Gfx::Color {
-            interpolate_channel(from.red(), to.red()),
-            interpolate_channel(from.green(), to.green()),
-            interpolate_channel(from.blue(), to.blue()),
-            round_to<u8>(alpha * 255.0),
-        };
-    };
-
     VERIFY(from.index() == to.index());
     return from.visit(
         [&](float from_opacity) -> VisualAnimationValue {
@@ -264,6 +336,23 @@ static VisualAnimationValue interpolate_value(VisualAnimationValue const& from, 
         },
         [&](Gfx::Color from_color) -> VisualAnimationValue {
             return interpolate_legacy_srgb_color(from_color, to.get<Gfx::Color>(), progress);
+        },
+        [&](VisualAnimationFilterList const& from_filters) -> VisualAnimationValue {
+            auto padded_from_filters = from_filters;
+            auto padded_to_filters = to.get<VisualAnimationFilterList>();
+            while (padded_from_filters.size() < padded_to_filters.size())
+                padded_from_filters.append(padded_to_filters[padded_from_filters.size()].initial_value());
+            while (padded_to_filters.size() < padded_from_filters.size())
+                padded_to_filters.append(padded_from_filters[padded_to_filters.size()].initial_value());
+            for (size_t index = 0; index < padded_from_filters.size(); ++index) {
+                if (!padded_from_filters[index].matches(padded_to_filters[index]))
+                    return progress < 0.5 ? from_filters : to.get<VisualAnimationFilterList>();
+            }
+            VisualAnimationFilterList filters;
+            filters.ensure_capacity(padded_from_filters.size());
+            for (size_t index = 0; index < padded_from_filters.size(); ++index)
+                filters.unchecked_append(padded_from_filters[index].interpolated_with(padded_to_filters[index], progress));
+            return filters;
         },
         [&](VisualAnimationTransformList const& from_transforms) -> VisualAnimationValue {
             auto const& to_transforms = to.get<VisualAnimationTransformList>();
@@ -357,11 +446,39 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
     if (!isfinite(eased_interval_progress))
         return {};
     auto value = interpolate_value(from_keyframe->value, to_keyframe->value, eased_interval_progress);
+    if (value.has<VisualAnimationFilterList>()
+        && any_of(value.get<VisualAnimationFilterList>(), [](auto const& operation) { return !operation.is_valid(); }))
+        return {};
 
     Sample sample;
     value.visit(
         [&](float opacity) { sample.opacity = opacity; },
         [&](Gfx::Color background_color) { sample.background_color = background_color; },
+        [&](VisualAnimationFilterList const& filters) {
+            sample.samples_filter = true;
+            Optional<Gfx::Filter> composed_filter;
+            for (auto const& operation : filters) {
+                Gfx::Filter filter = [&, operation] {
+                    switch (operation.kind) {
+                    case VisualAnimationFilterOperationKind::Blur:
+                        return Gfx::Filter::blur(operation.amount, operation.amount);
+                    case VisualAnimationFilterOperationKind::DropShadow:
+                        return Gfx::Filter::drop_shadow(operation.offset_x, operation.offset_y, operation.amount, operation.color);
+                    case VisualAnimationFilterOperationKind::Color:
+                        return Gfx::Filter::color(operation.color_operation, operation.amount);
+                    case VisualAnimationFilterOperationKind::HueRotate:
+                        return Gfx::Filter::hue_rotate(operation.amount);
+                    }
+                    VERIFY_NOT_REACHED();
+                }();
+                composed_filter = composed_filter.has_value() ? Gfx::Filter::compose(filter, *composed_filter) : move(filter);
+            }
+            if (composed_filter.has_value()) {
+                sample.filter_bytes = Gfx::serialize_filter(*composed_filter, [](Gfx::DecodedImageFrame const&) -> u64 {
+                    VERIFY_NOT_REACHED();
+                });
+            }
+        },
         [&](VisualAnimationTransformList const& transforms) {
             for (auto const& transform : transforms)
                 sample.transform = sample.transform * transform.to_matrix();
@@ -377,6 +494,11 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
             return {};
         return sample;
     }
+    if (target_kind == TargetKind::Filter) {
+        if (!sample.samples_filter)
+            return {};
+        return sample;
+    }
     for (size_t row = 0; row < 4; ++row) {
         for (size_t column = 0; column < 4; ++column) {
             if (!isfinite(sample.transform[row, column]))
@@ -388,7 +510,7 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
 
 bool VisualAnimation::is_valid() const
 {
-    if (!first_is_one_of(target_kind, TargetKind::Opacity, TargetKind::BackgroundColor, TargetKind::Transform))
+    if (!first_is_one_of(target_kind, TargetKind::Opacity, TargetKind::BackgroundColor, TargetKind::Filter, TargetKind::Transform))
         return false;
     if (visual_context_node_indices.is_empty())
         return false;
@@ -425,6 +547,14 @@ bool VisualAnimation::is_valid() const
 
         if (target_kind == TargetKind::BackgroundColor) {
             if (!keyframe.value.has<Gfx::Color>())
+                return false;
+            continue;
+        }
+
+        if (target_kind == TargetKind::Filter) {
+            if (!keyframe.value.has<VisualAnimationFilterList>())
+                return false;
+            if (any_of(keyframe.value.get<VisualAnimationFilterList>(), [](auto const& operation) { return !operation.is_valid(); }))
                 return false;
             continue;
         }
@@ -516,6 +646,31 @@ ErrorOr<Web::Compositor::VisualAnimationTransformOperation> decode(Decoder& deco
     return Web::Compositor::VisualAnimationTransformOperation {
         .kind = TRY(decoder.decode<Web::Compositor::VisualAnimationTransformOperationKind>()),
         .values = TRY(decoder.decode<Vector<float>>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::VisualAnimationFilterOperation const& operation)
+{
+    TRY(encoder.encode(operation.kind));
+    TRY(encoder.encode(operation.amount));
+    TRY(encoder.encode(operation.offset_x));
+    TRY(encoder.encode(operation.offset_y));
+    TRY(encoder.encode(operation.color));
+    TRY(encoder.encode(operation.color_operation));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::VisualAnimationFilterOperation> decode(Decoder& decoder)
+{
+    return Web::Compositor::VisualAnimationFilterOperation {
+        .kind = TRY(decoder.decode<Web::Compositor::VisualAnimationFilterOperationKind>()),
+        .amount = TRY(decoder.decode<float>()),
+        .offset_x = TRY(decoder.decode<float>()),
+        .offset_y = TRY(decoder.decode<float>()),
+        .color = TRY(decoder.decode<Gfx::Color>()),
+        .color_operation = TRY(decoder.decode<Gfx::ColorFilterType>()),
     };
 }
 

--- a/Libraries/LibWeb/Compositor/VisualAnimation.h
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.h
@@ -6,10 +6,12 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/Time.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/Filter.h>
 #include <LibGfx/Matrix4x4.h>
 #include <LibIPC/Forward.h>
 #include <LibWeb/Export.h>
@@ -85,6 +87,29 @@ enum class VisualAnimationTransformOperationKind : u8 {
     SkewY,
 };
 
+enum class VisualAnimationFilterOperationKind : u8 {
+    Blur,
+    DropShadow,
+    Color,
+    HueRotate,
+};
+
+struct VisualAnimationFilterOperation {
+    WEB_API bool matches(VisualAnimationFilterOperation const&) const;
+    WEB_API VisualAnimationFilterOperation initial_value() const;
+    WEB_API VisualAnimationFilterOperation interpolated_with(VisualAnimationFilterOperation const&, double progress) const;
+    WEB_API bool is_valid() const;
+
+    VisualAnimationFilterOperationKind kind { VisualAnimationFilterOperationKind::Blur };
+    float amount { 0 };
+    float offset_x { 0 };
+    float offset_y { 0 };
+    Gfx::Color color { Gfx::Color::Transparent };
+    Gfx::ColorFilterType color_operation { Gfx::ColorFilterType::Brightness };
+
+    bool operator==(VisualAnimationFilterOperation const&) const = default;
+};
+
 struct VisualAnimationTransformOperation {
     WEB_API Gfx::FloatMatrix4x4 to_matrix() const;
     WEB_API bool is_valid() const;
@@ -97,7 +122,8 @@ struct VisualAnimationTransformOperation {
 };
 
 using VisualAnimationTransformList = Vector<VisualAnimationTransformOperation>;
-using VisualAnimationValue = Variant<float, Gfx::Color, VisualAnimationTransformList>;
+using VisualAnimationFilterList = Vector<VisualAnimationFilterOperation>;
+using VisualAnimationValue = Variant<float, Gfx::Color, VisualAnimationFilterList, VisualAnimationTransformList>;
 
 struct VisualAnimationKeyframe {
     double offset { 0 };
@@ -111,12 +137,15 @@ struct VisualAnimation {
     struct Sample {
         float opacity { 1 };
         Optional<Gfx::Color> background_color;
+        bool samples_filter { false };
+        ByteBuffer filter_bytes;
         Gfx::FloatMatrix4x4 transform { Gfx::FloatMatrix4x4::identity() };
     };
 
     enum class TargetKind : u8 {
         Opacity,
         BackgroundColor,
+        Filter,
         Transform,
     };
 
@@ -160,6 +189,11 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::VisualAnimationTransformOperation const&);
 template<>
 WEB_API ErrorOr<Web::Compositor::VisualAnimationTransformOperation> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::VisualAnimationFilterOperation const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::VisualAnimationFilterOperation> decode(Decoder&);
 
 template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::VisualAnimationKeyframe const&);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -80,10 +80,12 @@
 #include <LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ComputationContext.h>
+#include <LibWeb/CSS/StyleValues/FilterStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OpacityValueStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RandomValueSharingStyleValue.h>
+#include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/CSS/StyleValues/TransformationStyleValue.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/TransitionEvent.h>
@@ -7644,7 +7646,7 @@ static Optional<float> compositor_opacity_animation_value(CSS::StyleValue const&
 
 static Optional<Gfx::Color> compositor_background_color_animation_value(CSS::StyleValue const& style_value, DOM::AbstractElement target)
 {
-    // Legacy sRGB colors interpolate in gamma-encoded sRGB, which Gfx::Color::mixed_with() matches. Keep modern
+    // Legacy sRGB colors interpolate in gamma-encoded sRGB, which the compositor sampler matches. Keep modern
     // color syntaxes on the main thread until compositor values can retain their interpolation color space.
     if (style_value.to_keyword() == CSS::Keyword::Currentcolor)
         return {};
@@ -7654,6 +7656,73 @@ static Optional<Gfx::Color> compositor_background_color_animation_value(CSS::Sty
     if (!color.has_value())
         return {};
     return color.release_value();
+}
+
+static Optional<Compositor::VisualAnimationFilterList> compositor_filter_animation_value(CSS::StyleValue const& style_value, DOM::AbstractElement target, float device_pixels_per_css_pixel)
+{
+    if (style_value.to_keyword() == CSS::Keyword::None)
+        return Compositor::VisualAnimationFilterList {};
+    if (!style_value.is_value_list())
+        return {};
+
+    Compositor::VisualAnimationFilterList operations;
+    operations.ensure_capacity(style_value.as_value_list().size());
+    for (auto const& value : style_value.as_value_list().values()) {
+        if (!value->is_filter())
+            return {};
+        auto const& filter = value->as_filter();
+        switch (filter.kind()) {
+        case CSS::FilterStyleValue::Kind::Blur: {
+            auto const& blur = static_cast<CSS::BlurFilterStyleValue const&>(filter);
+            operations.append({
+                .kind = Compositor::VisualAnimationFilterOperationKind::Blur,
+                .amount = CSSPixels::nearest_value_for(blur.resolved_radius()).to_float() * device_pixels_per_css_pixel,
+            });
+            break;
+        }
+        case CSS::FilterStyleValue::Kind::DropShadow: {
+            auto const& drop_shadow = static_cast<CSS::DropShadowFilterStyleValue const&>(filter);
+            auto color_value = drop_shadow.color();
+            // Gfx filters hold 8-bit sRGB colors. Keep modern color interpolation and currentcolor on the main thread
+            // until compositor filter values can retain the interpolation color space and source color syntax.
+            if (!color_value || !color_value->is_color() || color_value->as_color().color_syntax() != CSS::ColorSyntax::Legacy)
+                return {};
+            auto color = color_value->to_color(CSS::ColorResolutionContext::for_element(target));
+            if (!color.has_value())
+                return {};
+            auto resolve_length = [&](CSS::StyleValue const& length) {
+                auto css_pixels = CSSPixels::nearest_value_for(CSS::Length::from_style_value(length, {}).absolute_length_to_px_without_rounding());
+                return css_pixels.to_float() * device_pixels_per_css_pixel;
+            };
+            operations.append({
+                .kind = Compositor::VisualAnimationFilterOperationKind::DropShadow,
+                .amount = drop_shadow.radius() ? resolve_length(*drop_shadow.radius()) : 0,
+                .offset_x = resolve_length(*drop_shadow.offset_x()),
+                .offset_y = resolve_length(*drop_shadow.offset_y()),
+                .color = color.release_value(),
+            });
+            break;
+        }
+        case CSS::FilterStyleValue::Kind::Color: {
+            auto const& color = static_cast<CSS::ColorFilterStyleValue const&>(filter);
+            operations.append({
+                .kind = Compositor::VisualAnimationFilterOperationKind::Color,
+                .amount = color.resolved_amount(),
+                .color_operation = color.operation(),
+            });
+            break;
+        }
+        case CSS::FilterStyleValue::Kind::HueRotate: {
+            auto const& hue_rotate = static_cast<CSS::HueRotateFilterStyleValue const&>(filter);
+            operations.append({
+                .kind = Compositor::VisualAnimationFilterOperationKind::HueRotate,
+                .amount = hue_rotate.angle_degrees(),
+            });
+            break;
+        }
+        }
+    }
+    return operations;
 }
 
 static bool transform_keyframes_only_translate_horizontally(ReadonlySpan<Compositor::VisualAnimationKeyframe> keyframes)
@@ -7753,10 +7822,11 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
 
     bool targets_opacity = target_kind == Compositor::VisualAnimation::TargetKind::Opacity && effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity));
     bool targets_background_color = target_kind == Compositor::VisualAnimation::TargetKind::BackgroundColor && effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::BackgroundColor));
+    bool targets_filter = target_kind == Compositor::VisualAnimation::TargetKind::Filter && effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Filter));
     bool targets_transform = target_kind == Compositor::VisualAnimation::TargetKind::Transform && any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); });
-    if (!targets_opacity && !targets_background_color && !targets_transform)
+    if (!targets_opacity && !targets_background_color && !targets_filter && !targets_transform)
         return {};
-    if (any_of(effect.target_properties(), [&](auto const& property) { return !first_is_one_of(property.id(), CSS::PropertyID::Opacity, CSS::PropertyID::BackgroundColor) && !is_transform_family_property(property.id()); }))
+    if (any_of(effect.target_properties(), [&](auto const& property) { return !first_is_one_of(property.id(), CSS::PropertyID::Opacity, CSS::PropertyID::BackgroundColor, CSS::PropertyID::Filter) && !is_transform_family_property(property.id()); }))
         return {};
     auto target = effect.target_abstract_element();
     if (!target.has_value() || target->element().namespace_uri() == Namespace::SVG)
@@ -7878,6 +7948,18 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                     if (color.has_value())
                         value = Compositor::VisualAnimationValue { color.release_value() };
                 }
+            } else if (target_kind == Compositor::VisualAnimation::TargetKind::Filter) {
+                auto property = entry.properties.get(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Filter));
+                if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
+                    new_cache.values.append({});
+                    continue;
+                }
+                auto style_value = resolved_compositor_animation_style_value(CSS::PropertyID::Filter, property->get<CSS::RustStyleValueHandle>(), *target);
+                if (style_value) {
+                    auto filter = compositor_filter_animation_value(*style_value, *target, device_pixels_per_css_pixel);
+                    if (filter.has_value())
+                        value = Compositor::VisualAnimationValue { filter.release_value() };
+                }
             } else {
                 Compositor::VisualAnimationTransformList operations;
                 bool skip_keyframe = false;
@@ -7981,6 +8063,8 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                 return Layout::RustFFI::FfiVisualAnimationTargetKind::Opacity;
             case Compositor::VisualAnimation::TargetKind::BackgroundColor:
                 return Layout::RustFFI::FfiVisualAnimationTargetKind::BackgroundColor;
+            case Compositor::VisualAnimation::TargetKind::Filter:
+                return Layout::RustFFI::FfiVisualAnimationTargetKind::Filter;
             case Compositor::VisualAnimation::TargetKind::Transform:
                 return Layout::RustFFI::FfiVisualAnimationTargetKind::Transform;
             }
@@ -8110,6 +8194,7 @@ void Document::update_compositor_animations()
     struct CompetingEffects {
         CompetingPropertyEffects opacity;
         CompetingPropertyEffects background_color;
+        CompetingPropertyEffects filter;
         CompetingPropertyEffects transform;
     };
 
@@ -8359,6 +8444,8 @@ void Document::update_compositor_animations()
             add_competing_effect(effects.opacity);
         if (effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::BackgroundColor)))
             add_competing_effect(effects.background_color);
+        if (effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Filter)))
+            add_competing_effect(effects.filter);
         if (any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); })) {
             add_competing_effect(effects.transform);
             in_effect_transform_effects_by_target.ensure(&target->element()).append(effect);
@@ -8384,6 +8471,7 @@ void Document::update_compositor_animations()
         };
         validate_winner(effects.opacity);
         validate_winner(effects.background_color);
+        validate_winner(effects.filter);
         validate_winner(effects.transform);
     }
 
@@ -8476,19 +8564,22 @@ void Document::update_compositor_animations()
 
         bool targets_opacity = effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity));
         bool targets_background_color = effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::BackgroundColor));
+        bool targets_filter = effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Filter));
         bool targets_transform = any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); });
-        bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto const& property) { return !first_is_one_of(property.id(), CSS::PropertyID::Opacity, CSS::PropertyID::BackgroundColor) && !is_transform_family_property(property.id()); });
+        bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto const& property) { return !first_is_one_of(property.id(), CSS::PropertyID::Opacity, CSS::PropertyID::BackgroundColor, CSS::PropertyID::Filter) && !is_transform_family_property(property.id()); });
         if (targets_unsupported_property)
             continue;
         auto target_effects = competing_effects.get(*abstract_target);
         VERIFY(target_effects.has_value());
         bool opacity_has_replace_winner = !targets_opacity || target_effects->opacity.winner;
         bool background_color_has_replace_winner = !targets_background_color || target_effects->background_color.winner;
+        bool filter_has_replace_winner = !targets_filter || target_effects->filter.winner;
         bool transform_has_replace_winner = !targets_transform || target_effects->transform.winner;
         bool selected_for_opacity = targets_opacity && target_effects->opacity.winner.ptr() == &effect;
         bool selected_for_background_color = targets_background_color && target_effects->background_color.winner.ptr() == &effect;
+        bool selected_for_filter = targets_filter && target_effects->filter.winner.ptr() == &effect;
         bool selected_for_transform = targets_transform && target_effects->transform.winner.ptr() == &effect;
-        bool all_targeted_properties_have_replace_winners = opacity_has_replace_winner && background_color_has_replace_winner && transform_has_replace_winner;
+        bool all_targeted_properties_have_replace_winners = opacity_has_replace_winner && background_color_has_replace_winner && filter_has_replace_winner && transform_has_replace_winner;
 
         Optional<bool> only_translates_horizontally;
 
@@ -8518,7 +8609,30 @@ void Document::update_compositor_animations()
             }
         }
 
-        if (!selected_for_opacity && !selected_for_background_color && !selected_for_transform) {
+        // Filters need an effects frame whose filter payload can be replaced. Validate the descriptor before forcing
+        // that frame, which requires one repaint before the animation can move to the compositor.
+        Layout::Node* filter_layout_node = nullptr;
+        Optional<Compositor::VisualAnimation> filter_visual_animation;
+        bool filter_animation_is_valid = false;
+        if (selected_for_filter) {
+            if (auto* layout_node = abstract_target->unsafe_layout_node()) {
+                filter_layout_node = layout_node;
+                bool missing_visual_context_node = false;
+                filter_visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Filter, only_translates_horizontally, &missing_visual_context_node);
+                filter_animation_is_valid = filter_visual_animation.has_value() || missing_visual_context_node;
+                if (!filter_animation_is_valid) {
+                    filter_layout_node = nullptr;
+                } else if (missing_visual_context_node && !layout_node->needs_compositor_effects_layer()) {
+                    layout_node->set_needs_compositor_effects_layer(true);
+                    schedule_accumulated_visual_context_update(*layout_node, AccumulatedVisualContextUpdateScope::Structure);
+                    CSS::RequiredInvalidationAfterStyleChange invalidation;
+                    invalidation.ensure_at_least(CSS::InvalidationLevel::Repaint);
+                    Painting::repaint_after_style_change(*layout_node, invalidation);
+                }
+            }
+        }
+
+        if (!selected_for_opacity && !selected_for_background_color && !selected_for_filter && !selected_for_transform) {
             bool can_throttle_replaced_effect = animation.play_state() == Bindings::AnimationPlayState::Running
                 && !animation.pending()
                 && animation.playback_rate() > 0
@@ -8553,6 +8667,18 @@ void Document::update_compositor_animations()
                 m_layout_nodes_with_forced_compositor_background_color_frame.append(*background_color_layout_node);
             layout_nodes_with_stale_forced_background_color_frame.remove_first_matching([&](auto const& stale_layout_node) {
                 return stale_layout_node.ptr() == background_color_layout_node;
+            });
+        }
+        bool filter_was_handed_off = !selected_for_filter;
+        if (filter_visual_animation.has_value()) {
+            effect_visual_animations.append(filter_visual_animation.release_value());
+            filter_was_handed_off = true;
+        }
+        if (filter_layout_node && filter_animation_is_valid) {
+            if (!any_of(m_layout_nodes_with_forced_compositor_effects_layer, [&](auto const& forced_layout_node) { return forced_layout_node.ptr() == filter_layout_node; }))
+                m_layout_nodes_with_forced_compositor_effects_layer.append(*filter_layout_node);
+            layout_nodes_with_stale_forced_effects_layer.remove_first_matching([&](auto const& stale_layout_node) {
+                return stale_layout_node.ptr() == filter_layout_node;
             });
         }
         bool transform_was_handed_off = !selected_for_transform;
@@ -8610,7 +8736,7 @@ void Document::update_compositor_animations()
                 }
             }
         }
-        if (all_targeted_properties_have_replace_winners && opacity_was_handed_off && background_color_was_handed_off && transform_was_handed_off)
+        if (all_targeted_properties_have_replace_winners && opacity_was_handed_off && background_color_was_handed_off && filter_was_handed_off && transform_was_handed_off)
             effect.set_is_compositor_driven(true);
         effect.set_is_observation_relevant_compositor_animation(transform_affects_observation);
         schedule_next_phase_wakeup(effect, animation);

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -137,7 +137,10 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation
 {
     Vector<Layout::RustFFI::FfiFrameOpacitySample> opacity_samples;
     Vector<Layout::RustFFI::FfiFrameBackgroundColorSample> background_color_samples;
+    Vector<ByteBuffer> filter_sample_storage;
+    Vector<Layout::RustFFI::FfiFrameFilterSample> filter_samples;
     Vector<Layout::RustFFI::FfiSpatialTransformSample> transform_samples;
+    filter_sample_storage.ensure_capacity(visual_animations().size());
     for (auto const& animation : visual_animations()) {
         auto elapsed_nanoseconds = monotonic_time_ns > animation.monotonic_time_at_anchor_ns
             ? monotonic_time_ns - animation.monotonic_time_at_anchor_ns
@@ -145,11 +148,22 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation
         auto sample = animation.sample(AK::Duration::from_nanoseconds(elapsed_nanoseconds));
         if (!sample.has_value())
             continue;
+        Optional<ReadonlyBytes> filter_bytes;
+        if (animation.target_kind == Compositor::VisualAnimation::TargetKind::Filter && !sample->filter_bytes.is_empty()) {
+            filter_sample_storage.append(move(sample->filter_bytes));
+            filter_bytes = filter_sample_storage.last().bytes();
+        }
         for (auto node_index : animation.visual_context_node_indices) {
             if (animation.target_kind == Compositor::VisualAnimation::TargetKind::Opacity)
                 opacity_samples.append({ .frame = node_index, .opacity = sample->opacity });
             else if (animation.target_kind == Compositor::VisualAnimation::TargetKind::BackgroundColor)
                 background_color_samples.append({ .frame = node_index, .color = *sample->background_color });
+            else if (animation.target_kind == Compositor::VisualAnimation::TargetKind::Filter)
+                filter_samples.append({
+                    .frame = node_index,
+                    .filter_bytes = filter_bytes.has_value() ? filter_bytes->data() : nullptr,
+                    .filter_size = filter_bytes.has_value() ? filter_bytes->size() : 0,
+                });
             else
                 transform_samples.append({ .spatial = node_index, .matrix = sample->transform });
         }
@@ -157,6 +171,7 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation
     auto tree = adopt_rust_handle(Layout::RustFFI::visual_context_tree_with_sampled_values(m_rust_tree,
         opacity_samples.data(), opacity_samples.size(),
         background_color_samples.data(), background_color_samples.size(),
+        filter_samples.data(), filter_samples.size(),
         transform_samples.data(), transform_samples.size()));
     tree.m_visual_animations = m_visual_animations;
     return tree;
@@ -171,6 +186,8 @@ bool AccumulatedVisualContextTree::visual_animation_targets_are_valid(Compositor
             return Layout::RustFFI::FfiVisualAnimationTargetKind::Opacity;
         case Compositor::VisualAnimation::TargetKind::BackgroundColor:
             return Layout::RustFFI::FfiVisualAnimationTargetKind::BackgroundColor;
+        case Compositor::VisualAnimation::TargetKind::Filter:
+            return Layout::RustFFI::FfiVisualAnimationTargetKind::Filter;
         case Compositor::VisualAnimation::TargetKind::Transform:
             return Layout::RustFFI::FfiVisualAnimationTargetKind::Transform;
         }

--- a/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
@@ -330,6 +330,28 @@ impl TreeChainComparison<'_> {
         }
         true
     }
+
+    fn changing_filter_may_affect_output_bounds(&self, old_context: ContextRef, new_context: ContextRef) -> bool {
+        let mut old_frame = old_context.frame;
+        let mut new_frame = new_context.frame;
+        while !old_frame.is_none() {
+            let old_node = &self.old_tree.frame_nodes[old_frame.0 as usize];
+            let new_node = &self.new_tree.frame_nodes[new_frame.0 as usize];
+            if let (FrameData::Effects(old_effects), FrameData::Effects(new_effects)) = (&old_node.data, &new_node.data)
+                && old_effects.filter != new_effects.filter
+                && old_effects
+                    .filter
+                    .iter()
+                    .chain(new_effects.filter.iter())
+                    .any(|filter| crate::painting::filter_bytes::may_affect_output_bounds(filter))
+            {
+                return true;
+            }
+            old_frame = old_node.parent;
+            new_frame = new_node.parent;
+        }
+        false
+    }
 }
 
 fn intersect_like_gfx_rect(rect: FloatRect, other: FloatRect) -> FloatRect {
@@ -490,6 +512,10 @@ pub fn compute_display_list_damage(
     let add_visual_context_damage =
         |damage: &mut DamageAccumulator, old_command: &CommandReference<'_>, new_command: &CommandReference<'_>| {
             if chains.chains_are_equal(old_command.header.context, new_command.header.context) {
+                return;
+            }
+            if chains.changing_filter_may_affect_output_bounds(old_command.header.context, new_command.header.context) {
+                damage.changed_unbounded_command = true;
                 return;
             }
             if !old_command.header.has_bounding_rect || !new_command.header.has_bounding_rect {
@@ -769,6 +795,57 @@ mod tests {
         })
     }
 
+    fn effects(filter: Vec<u8>) -> FrameData {
+        FrameData::Effects(EffectsData {
+            opacity: 1.0,
+            blend_mode: CompositingAndBlendingOperator::Normal,
+            filter: Some(Rc::new(filter)),
+        })
+    }
+
+    fn blur_filter(radius: f32) -> Vec<u8> {
+        let mut bytes = vec![crate::painting::ffi::FilterOperationType::Blur as u8];
+        bytes.extend_from_slice(&radius.to_ne_bytes());
+        bytes.extend_from_slice(&radius.to_ne_bytes());
+        bytes.push(0);
+        bytes
+    }
+
+    fn color_filter(amount: f32) -> Vec<u8> {
+        let mut bytes = vec![crate::painting::ffi::FilterOperationType::ColorFilter as u8];
+        bytes.extend_from_slice(&0i32.to_ne_bytes());
+        bytes.extend_from_slice(&amount.to_ne_bytes());
+        bytes.push(0);
+        bytes
+    }
+
+    fn drop_shadow_filter(offset: f32, radius: f32) -> Vec<u8> {
+        let mut bytes = vec![crate::painting::ffi::FilterOperationType::DropShadow as u8];
+        bytes.extend_from_slice(&offset.to_ne_bytes());
+        bytes.extend_from_slice(&offset.to_ne_bytes());
+        bytes.extend_from_slice(&radius.to_ne_bytes());
+        bytes.extend_from_slice(&RED.0.to_ne_bytes());
+        bytes.push(0);
+        bytes
+    }
+
+    fn damage_for_filter_change(old_filter: Vec<u8>, new_filter: Vec<u8>) -> Option<IntRect> {
+        let mut old_tree = identity_tree();
+        let old_frame = old_tree.append_frame(effects(old_filter), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        let mut new_tree = identity_tree();
+        let new_frame = new_tree.append_frame(effects(new_filter), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        let rect = IntRect::new(10, 10, 20, 20);
+        let fill = FillRect {
+            rect,
+            color: RED,
+            compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+            background_color_animation_frame: FrameNodeIndex::NONE,
+        };
+        let old_display_list = command_bytes(&fill, Some(rect), context_in(VISUAL_VIEWPORT_NODE_INDEX, old_frame));
+        let new_display_list = command_bytes(&fill, Some(rect), context_in(VISUAL_VIEWPORT_NODE_INDEX, new_frame));
+        damage(&old_display_list, &old_tree, &new_display_list, &new_tree)
+    }
+
     fn damage(
         old_bytes: &[u8],
         old_tree: &VisualContextTree,
@@ -1021,6 +1098,23 @@ mod tests {
         assert_eq!(
             damage(&display_list, &old_tree, &display_list, &new_tree),
             Some(IntRect::new(9, 9, 32, 22))
+        );
+    }
+
+    #[test]
+    fn changed_extent_affecting_filter_has_unbounded_damage() {
+        assert_eq!(damage_for_filter_change(blur_filter(1.0), blur_filter(10.0)), None);
+        assert_eq!(
+            damage_for_filter_change(drop_shadow_filter(1.0, 1.0), drop_shadow_filter(10.0, 10.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn changed_color_filter_has_bounded_damage() {
+        assert_eq!(
+            damage_for_filter_change(color_filter(0.5), color_filter(1.0)),
+            Some(IntRect::new(9, 9, 22, 22))
         );
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1229,7 +1229,8 @@ pub unsafe extern "C" fn layout_arena_paintable_visual_animation_target_indices(
     arena.with_paintable_visual_context_node_handles(slot, |handles| {
         let owned_indices: Vec<u32> = match target_kind {
             crate::painting::host::FfiVisualAnimationTargetKind::Opacity
-            | crate::painting::host::FfiVisualAnimationTargetKind::BackgroundColor => {
+            | crate::painting::host::FfiVisualAnimationTargetKind::BackgroundColor
+            | crate::painting::host::FfiVisualAnimationTargetKind::Filter => {
                 handles.frame_handles().map(|index| index.0).collect()
             }
             crate::painting::host::FfiVisualAnimationTargetKind::Transform => {
@@ -3019,9 +3020,9 @@ pub unsafe extern "C" fn visual_context_tree_with_visual_viewport_transform(
 
 /// # Safety
 ///
-/// `tree` must be a live retained tree handle; `frame_opacities` must address `frame_opacity_count`
-/// samples and `spatial_matrices` `spatial_matrix_count` samples. Returns a retained handle to a copy
-/// of the tree carrying the sampled values; the copy keeps the structural epoch.
+/// `tree` must be a live retained tree handle; each sample array must address its stated count, and
+/// each non-empty filter sample must address its stated byte count. Returns a retained handle to a
+/// copy of the tree carrying the sampled values; the copy keeps the structural epoch.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
     tree: *const c_void,
@@ -3029,15 +3030,18 @@ pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
     frame_opacity_count: usize,
     frame_background_colors: *const crate::painting::host::FfiFrameBackgroundColorSample,
     frame_background_color_count: usize,
+    frame_filters: *const crate::painting::host::FfiFrameFilterSample,
+    frame_filter_count: usize,
     spatial_matrices: *const crate::painting::host::FfiSpatialTransformSample,
     spatial_matrix_count: usize,
 ) -> *const c_void {
     let tree = unsafe { tree_from_handle(tree) };
     // SAFETY: The caller guarantees the sample arrays address the stated counts.
-    let (frame_opacities, frame_background_colors, spatial_matrices) = unsafe {
+    let (frame_opacities, frame_background_colors, frame_filters, spatial_matrices) = unsafe {
         (
             ffi_slice(frame_opacities, frame_opacity_count),
             ffi_slice(frame_background_colors, frame_background_color_count),
+            ffi_slice(frame_filters, frame_filter_count),
             ffi_slice(spatial_matrices, spatial_matrix_count),
         )
     };
@@ -3049,12 +3053,30 @@ pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
         .iter()
         .map(|sample| (FrameNodeIndex(sample.frame), sample.color))
         .collect();
+    let frame_filters: Vec<(FrameNodeIndex, Option<Rc<Vec<u8>>>)> = frame_filters
+        .iter()
+        .map(|sample| {
+            let filter = if sample.filter_size == 0 {
+                None
+            } else {
+                // SAFETY: The caller guarantees each filter byte range addresses the stated size.
+                Some(Rc::new(
+                    unsafe { ffi_slice(sample.filter_bytes, sample.filter_size) }.to_vec(),
+                ))
+            };
+            (FrameNodeIndex(sample.frame), filter)
+        })
+        .collect();
     let spatial_matrices: Vec<(SpatialNodeIndex, libgfx_rust::FloatMatrix4x4)> = spatial_matrices
         .iter()
         .map(|sample| (SpatialNodeIndex(sample.spatial), sample.matrix))
         .collect();
-    let sampled =
-        tree.with_sampled_visual_animation_values(&frame_opacities, &frame_background_colors, &spatial_matrices);
+    let sampled = tree.with_sampled_visual_animation_values(
+        &frame_opacities,
+        &frame_background_colors,
+        &frame_filters,
+        &spatial_matrices,
+    );
     Rc::into_raw(Rc::new(sampled)).cast()
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/filter_bytes.rs
+++ b/Libraries/LibWeb/Rust/src/painting/filter_bytes.rs
@@ -22,6 +22,47 @@ pub(crate) fn contains_url(filter: &ComputedFilter) -> bool {
         .any(|operation| operation.kind == FILTER_KIND_URL)
 }
 
+pub(crate) fn may_affect_output_bounds(bytes: &[u8]) -> bool {
+    fn skip(bytes: &[u8], offset: &mut usize, count: usize) -> Option<()> {
+        *offset = offset.checked_add(count)?;
+        (*offset <= bytes.len()).then_some(())
+    }
+
+    fn parse_optional_filter(bytes: &[u8], offset: &mut usize) -> Option<bool> {
+        let has_filter = *bytes.get(*offset)? != 0;
+        *offset += 1;
+        if has_filter {
+            parse_filter(bytes, offset)
+        } else {
+            Some(false)
+        }
+    }
+
+    fn parse_filter(bytes: &[u8], offset: &mut usize) -> Option<bool> {
+        let operation = *bytes.get(*offset)?;
+        *offset += 1;
+        if operation == FilterOperationType::Compose as u8 {
+            let outer_affects_bounds = parse_filter(bytes, offset)?;
+            if outer_affects_bounds {
+                return Some(true);
+            }
+            return parse_filter(bytes, offset);
+        }
+        if operation == FilterOperationType::ColorFilter as u8 {
+            skip(bytes, offset, size_of::<i32>() + size_of::<f32>())?;
+            return parse_optional_filter(bytes, offset);
+        }
+        if operation == FilterOperationType::HueRotate as u8 {
+            skip(bytes, offset, size_of::<f32>())?;
+            return parse_optional_filter(bytes, offset);
+        }
+        Some(true)
+    }
+
+    let mut offset = 0;
+    parse_filter(bytes, &mut offset).is_none_or(|affects_bounds| affects_bounds || offset != bytes.len())
+}
+
 pub(crate) fn serialize_non_url_filter(filter: &ComputedFilter, device_pixels_per_css_pixel: f64) -> Option<Vec<u8>> {
     let operations = filter.operations.as_slice();
     if operations.is_empty() || operations.iter().any(|operation| operation.kind == FILTER_KIND_URL) {

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -156,7 +156,16 @@ pub struct FfiFrameBackgroundColorSample {
 pub enum FfiVisualAnimationTargetKind {
     Opacity,
     BackgroundColor,
+    Filter,
     Transform,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct FfiFrameFilterSample {
+    pub frame: u32,
+    pub filter_bytes: *const u8,
+    pub filter_size: usize,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
@@ -639,6 +639,7 @@ impl VisualContextTree {
         &self,
         frame_opacities: &[(FrameNodeIndex, f32)],
         frame_background_colors: &[(FrameNodeIndex, libgfx_rust::Color)],
+        frame_filters: &[(FrameNodeIndex, Option<std::rc::Rc<Vec<u8>>>)],
         spatial_matrices: &[(SpatialNodeIndex, FloatMatrix4x4)],
     ) -> VisualContextTree {
         let mut sampled = self.clone();
@@ -647,6 +648,13 @@ impl VisualContextTree {
                 sampled.frame_nodes.get_mut(frame.0 as usize).map(|node| &mut node.data)
             {
                 effects.opacity = *opacity;
+            }
+        }
+        for (frame, filter) in frame_filters {
+            if let Some(FrameData::Effects(effects)) =
+                sampled.frame_nodes.get_mut(frame.0 as usize).map(|node| &mut node.data)
+            {
+                effects.filter = filter.clone();
             }
         }
         for (spatial, matrix) in spatial_matrices {
@@ -672,7 +680,7 @@ impl VisualContextTree {
     ) -> bool {
         use crate::painting::host::FfiVisualAnimationTargetKind;
         match target_kind {
-            FfiVisualAnimationTargetKind::Opacity => matches!(
+            FfiVisualAnimationTargetKind::Opacity | FfiVisualAnimationTargetKind::Filter => matches!(
                 self.frame_nodes.get(target as usize).map(|node| &node.data),
                 Some(FrameData::Effects(_))
             ),

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -598,6 +598,68 @@ TEST_CASE(background_color_animation_replaces_the_recorded_fill_color)
     EXPECT_EQ(bitmap->get_pixel(0, 0), (Gfx::Color { 128, 0, 128 }));
 }
 
+TEST_CASE(filter_animations_replace_their_effects_frame_filters)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, false };
+    Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
+    Web::Painting::VisualContextTreeTestBuilder builder;
+    auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    Vector<Web::Painting::FrameNodeIndex> frames;
+    Vector<Web::Compositor::VisualAnimation> animations;
+    for (u32 i = 0; i < 8; ++i) {
+        auto frame = builder.append_effects_frame(Web::Painting::NO_FRAME_NODE, spatial);
+        frames.append(frame);
+        animations.append({
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Filter,
+            .visual_context_node_indices = { frame.value() },
+            .iteration_duration_ms = 1000,
+            .iteration_count = 1,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, Web::Compositor::VisualAnimationFilterList { { .kind = Web::Compositor::VisualAnimationFilterOperationKind::Color, .amount = 1, .color_operation = Gfx::ColorFilterType::Opacity } } },
+                { 1, {}, Web::Compositor::VisualAnimationFilterList { { .kind = Web::Compositor::VisualAnimationFilterOperationKind::Color, .amount = 0, .color_operation = Gfx::ColorFilterType::Opacity } } },
+            },
+        });
+    }
+    auto visual_context_tree = builder.finish();
+    auto anchor = MonotonicTime::now();
+    for (auto& animation : animations)
+        animation.monotonic_time_at_anchor_ns = anchor.nanoseconds();
+    visual_context_tree.set_visual_animations(move(animations));
+
+    ByteBuffer command_bytes;
+    for (u32 i = 0; i < frames.size(); ++i) {
+        auto command = Web::Painting::FillRect {
+            { static_cast<i32>(i), 0, 1, 1 },
+            Gfx::Color::Red,
+            Gfx::CompositingAndBlendingOperator::Normal,
+            Web::Painting::NO_FRAME_NODE,
+        };
+        append_display_list_command(command_bytes, command, command.rect, { spatial, frames[i] });
+    }
+
+    Gfx::IntRect viewport_rect { 0, 0, static_cast<i32>(frames.size()), 1 };
+    context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
+    VERIFY(context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed).has_value());
+    context.install_display_list_update(
+        decode_display_list(visual_context_tree, move(command_bytes), Gfx::Color::Transparent),
+        visual_context_tree,
+        {});
+
+    EXPECT(context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(500)));
+    context.queue_present_frame({ viewport_rect, viewport_rect });
+    EXPECT(context.present_synchronously(display_list_player, nullptr));
+
+    auto bitmap = context.latest_rendered_surface()->snapshot_bitmap();
+    for (u32 i = 0; i < frames.size(); ++i) {
+        auto pixel = bitmap->get_pixel(i, 0);
+        EXPECT_EQ(pixel.red(), 128);
+        EXPECT_EQ(pixel.alpha(), 128);
+    }
+}
+
 TEST_CASE(finite_visual_animations_stop_after_their_terminal_sample)
 {
     TestWebContentClient client;

--- a/Tests/LibWeb/TestVisualAnimation.cpp
+++ b/Tests/LibWeb/TestVisualAnimation.cpp
@@ -200,6 +200,61 @@ TEST_CASE(extrapolates_overshooting_background_color_easing)
     EXPECT_EQ(sampled->alpha(), 255);
 }
 
+TEST_CASE(interpolates_filter_operation_initial_values)
+{
+    VisualAnimationFilterOperation drop_shadow {
+        .kind = VisualAnimationFilterOperationKind::DropShadow,
+        .amount = 10,
+        .offset_x = 20,
+        .offset_y = -10,
+        .color = Gfx::Color::Blue,
+    };
+    auto interpolated_drop_shadow = drop_shadow.initial_value().interpolated_with(drop_shadow, 0.5);
+    EXPECT_EQ(interpolated_drop_shadow.amount, 5);
+    EXPECT_EQ(interpolated_drop_shadow.offset_x, 10);
+    EXPECT_EQ(interpolated_drop_shadow.offset_y, -5);
+    EXPECT_EQ(interpolated_drop_shadow.color.blue(), 255);
+    EXPECT_EQ(interpolated_drop_shadow.color.alpha(), 128);
+
+    VisualAnimationFilterOperation grayscale {
+        .kind = VisualAnimationFilterOperationKind::Color,
+        .amount = 0.75,
+        .color_operation = Gfx::ColorFilterType::Grayscale,
+    };
+    EXPECT_EQ(grayscale.initial_value().amount, 0);
+    EXPECT_EQ(grayscale.initial_value().interpolated_with(grayscale, 2).amount, 1);
+}
+
+TEST_CASE(rejects_non_finite_interpolated_filter_values)
+{
+    Vector<VisualAnimationFilterOperation> operations {
+        { .kind = VisualAnimationFilterOperationKind::Blur, .amount = NumericLimits<float>::max() },
+        { .kind = VisualAnimationFilterOperationKind::DropShadow, .amount = NumericLimits<float>::max(), .offset_x = NumericLimits<float>::max(), .offset_y = NumericLimits<float>::max() },
+        { .kind = VisualAnimationFilterOperationKind::Color, .amount = NumericLimits<float>::max(), .color_operation = Gfx::ColorFilterType::Brightness },
+        { .kind = VisualAnimationFilterOperationKind::HueRotate, .amount = NumericLimits<float>::max() },
+    };
+    for (auto const& operation : operations) {
+        auto initial = operation;
+        initial.amount = 0;
+        initial.offset_x = 0;
+        initial.offset_y = 0;
+        VisualAnimation animation {
+            .target_kind = VisualAnimation::TargetKind::Filter,
+            .visual_context_node_indices = { 0 },
+            .local_time_at_anchor_ms = 750,
+            .iteration_duration_ms = 1000,
+            .easing = linear_easing(),
+            .keyframes = {
+                { 0, { .kind = VisualAnimationEasing::Kind::Linear, .linear_points = { { 0, 0 }, { 1, 2 } } }, VisualAnimationFilterList { initial } },
+                { 1, linear_easing(), VisualAnimationFilterList { operation } },
+            },
+        };
+
+        EXPECT(animation.is_valid());
+        EXPECT(!animation.sample(AK::Duration::zero()).has_value());
+    }
+}
+
 TEST_CASE(rejects_invalid_timing)
 {
     VisualAnimation animation;

--- a/Tests/LibWeb/Text/expected/css/compositor-filter-animation.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-filter-animation.txt
@@ -1,0 +1,5 @@
+CSS filter functions use compositor: true
+URL filter stays on main thread: true
+stable CSS filters build no overlays: true
+stable CSS filters request no animation frames: true
+cancel removes CSS filter animations: true

--- a/Tests/LibWeb/Text/expected/css/compositor-transition-pending-start.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-transition-pending-start.txt
@@ -18,7 +18,7 @@ paired transitions share their provisional timing anchor: true
 pending fade-out creates an effects frame: true
 withdrawn fade-out removes its forced effects frame: true
 adding an opacity animation creates an effects frame: true
-adding a filter withdraws compositor opacity: true
-adding a filter removes the forced effects frame: true
+adding a filter keeps mixed effect on compositor: true
+adding a filter retains the forced effects frame: true
 retargeted opacity starts with paired translate on compositor: true
 retargeted paired transitions share their provisional timing anchor: true

--- a/Tests/LibWeb/Text/input/css/compositor-filter-animation.html
+++ b/Tests/LibWeb/Text/input/css/compositor-filter-animation.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes functions {
+        from { filter: none; }
+        to { filter: blur(4px) brightness(0.5) hue-rotate(90deg); }
+    }
+
+    @keyframes shadow {
+        from { filter: drop-shadow(0 0 0 rgba(0, 0, 255, 0)); }
+        to { filter: drop-shadow(8px 4px 2px blue); }
+    }
+
+    @keyframes referenced {
+        from { filter: url(#blur); }
+        to { filter: url(#blur-more); }
+    }
+
+    .target {
+        width: 20px;
+        height: 20px;
+        background: red;
+    }
+
+    #functions {
+        animation: functions 1s linear infinite;
+    }
+
+    #shadow {
+        animation: shadow 1s linear infinite;
+    }
+
+    #referenced {
+        animation: referenced 1s linear infinite;
+    }
+</style>
+<svg width="0" height="0">
+    <filter id="blur"><feGaussianBlur stdDeviation="2" /></filter>
+    <filter id="blur-more"><feGaussianBlur stdDeviation="4" /></filter>
+</svg>
+<div id="functions" class="target"></div>
+<div id="shadow" class="target"></div>
+<div id="referenced" class="target"></div>
+<script>
+    asyncTest(async done => {
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        const initialCounters = internals.getStyleInvalidationCounters();
+        const initialAnimationCount = document.getAnimations().length;
+        document.querySelector("#referenced").getAnimations()[0].cancel();
+        for (let i = 0; i < 2; ++i)
+            await new Promise(requestAnimationFrame);
+
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            internals.updateCompositorAnimations();
+        const stableCounters = internals.getStyleInvalidationCounters();
+
+        for (const animation of document.getAnimations())
+            animation.cancel();
+        internals.updateCompositorAnimations();
+        const cancellationCounters = internals.getStyleInvalidationCounters();
+
+        println(`CSS filter functions use compositor: ${initialCounters.compositorVisualAnimations >= 2}`);
+        println(`URL filter stays on main thread: ${initialAnimationCount === 3 && initialCounters.compositorVisualAnimations === 2}`);
+        println(`stable CSS filters build no overlays: ${stableCounters.animatedStyleOverlayBuilds === 0}`);
+        println(`stable CSS filters request no animation frames: ${stableCounters.animationFramePumpRequests === 0}`);
+        println(`cancel removes CSS filter animations: ${cancellationCounters.compositorVisualAnimations === 0}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-transition-pending-start.html
+++ b/Tests/LibWeb/Text/input/css/compositor-transition-pending-start.html
@@ -197,8 +197,8 @@
         const mixedEffectCounters = internals.getStyleInvalidationCounters();
         const mixedEffectNeedsEffectsFrame = internals.visualContextNodeIndices(pairedTarget).needsCompositorEffectsLayer;
         println(`adding an opacity animation creates an effects frame: ${mixedOpacityNeedsEffectsFrame}`);
-        println(`adding a filter withdraws compositor opacity: ${mixedEffectCounters.compositorVisualAnimations === 0}`);
-        println(`adding a filter removes the forced effects frame: ${!mixedEffectNeedsEffectsFrame}`);
+        println(`adding a filter keeps mixed effect on compositor: ${mixedEffectCounters.compositorVisualAnimations === 2}`);
+        println(`adding a filter retains the forced effects frame: ${mixedEffectNeedsEffectsFrame}`);
         mixedAnimation.cancel();
 
         pairedRetargetTarget.classList.add("first");


### PR DESCRIPTION
Sample interpolable non-URL filter functions into effects-frame filter payloads. Follow CSS list matching, padding, discrete fallback, and per-function range rules. Reject samples that overflow to non-finite values after easing.

Force an effects frame while a filter is handed off, then replace its serialized filter in the sampled visual context used by the compositor. Keep sample byte storage stable while Rust borrows it, and invalidate the full viewport when changing blur or drop-shadow output can escape command bounds.

Keep URL filters and color-space-sensitive drop shadows on the main thread. Add unit, compositor pixel, damage, and web regression coverage for interpolation and handoff.