### PR TITLE
LibWeb: Skip animation update entries whose style was republished

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -847,6 +847,9 @@ AnimationUpdateContext::~AnimationUpdateContext()
         // animation style into.
         if (target->style_node_id() == 0)
             continue;
+        // An earlier entry already republished this style with the current animation values.
+        if (element.style_record_identity() != it.value.style_record_before_update)
+            continue;
         // Provisionally started transitions are not associated with the element yet, so they are
         // never among the collected effects, but their values are already part of the published
         // style. Collect them first, in composite order below every associated effect, or this

--- a/Tests/LibWeb/Crash/Animations/pseudo-element-animation-republished-during-update.html
+++ b/Tests/LibWeb/Crash/Animations/pseudo-element-animation-republished-during-update.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+@keyframes fade {
+    from { color: red; }
+    to { color: blue; }
+}
+@keyframes grow {
+    from { background-color: red; }
+    to { background-color: blue; }
+}
+div {
+    animation: fade 1s infinite;
+}
+div::before {
+    content: "x";
+    animation: grow 1s infinite;
+}
+</style>
+<div>Hello world</div>


### PR DESCRIPTION
Previously, animating an inherited property on an element whose pseudo-element also ran an animation crashed. Each frame update records the style every animated element and pseudo-element had before the update, then updates them one at a time. Updating the element also recomputes its pseudo-element style, so by the time the pseudo-element is reached its recorded style no longer exists. Skip an entry whose style has already been replaced during the update, since the replacement already reflects the current animation values.

This fixes a regression introduced by 64799a44f4a.

Found with Domato.