### PR TITLE
Drop a queued same-document navigation of a gone document

### DIFF
--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -1928,6 +1928,18 @@ void CanonicalTraversable::finalize_a_same_document_navigation(HistoryOperation&
     // AD-HOC: WebContent performs this object-identity check synchronously before enqueueing. Repeating
     // it against the later canonical active entry would incorrectly discard back-to-back synchronous pushState()
     // calls; Firefox and Chromium preserve both entries.
+    //
+    // AD-HOC: The document that made the navigation can still have been replaced by the time this queue position
+    //         is reached: a cross-document navigation that committed ahead of it unloads that document, and that
+    //         document can push entries until it is destroyed (e.g. from pagehide, or from a timer that fires
+    //         during the commit). Such a stale finalization must not be applied. Its target entry belongs to a
+    //         document that is no longer active, so applying it would traverse across documents and populate the
+    //         unloaded document again, replacing the one that just committed.
+    if (auto const& active_entry_identity = target_navigable->active_session_history_entry_identity();
+        active_entry_identity.has_value() && active_entry_identity->document_state_id != request.target_entry.document_state_id) {
+        finish_history_operation(operation.operation_id, Web::HTML::HistoryStepResult::NoMatchingEntry, {});
+        return;
+    }
 
     // AD-HOC: Admission staged targetEntry so entry-addressed updates made before this queue position are retained.
     auto target_entry = target_navigable->take_pending_same_document_session_history_entry(

--- a/Tests/LibWeb/Text/expected/navigation/pushstate-while-unloading-does-not-resurrect-document.txt
+++ b/Tests/LibWeb/Text/expected/navigation/pushstate-while-unloading-does-not-resurrect-document.txt
@@ -1,0 +1,1 @@
+PASS (stale pushState was dropped)

--- a/Tests/LibWeb/Text/input/navigation/pushstate-while-unloading-does-not-resurrect-document.html
+++ b/Tests/LibWeb/Text/input/navigation/pushstate-while-unloading-does-not-resurrect-document.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<!-- A document still runs script while it is being unloaded for a cross-document navigation (pagehide, unload). A
+     pushState() from there queues a same-document finalization that reaches the session history traversal queue only
+     after the new document has been activated. That finalization targets an entry of a document that is no longer
+     active, so it has to be dropped. It used to be applied as a cross-document traversal instead, which fetched the
+     unloaded document again and replaced the document that had just finished loading. -->
+<script>
+    asyncTest(async done => {
+        if (location.hash === "#pushed-while-unloading") {
+            // Only the stale pushState() can load this URL; the "?loaded" document reports that as its failure.
+            return;
+        }
+        if (location.search.includes("loaded")) {
+            let reported = false;
+            const report = message => {
+                if (reported) return;
+                reported = true;
+                println(message);
+                done();
+            };
+            window.addEventListener("pagehide", () => report("FAIL: the stale pushState() unloaded the new document"));
+            // The stale finalization sits in the traversal queue ahead of this barrier.
+            await internals.flushSessionHistoryTraversalQueue();
+            report("PASS (stale pushState was dropped)");
+            return;
+        }
+        window.addEventListener("pagehide", () => history.pushState({}, "", "#pushed-while-unloading"));
+        const next = new URL(location.href);
+        next.search = "?loaded";
+        internals.loadURL(next.href);
+    });
+</script>


### PR DESCRIPTION
A document keeps running script while it is being unloaded for a cross-document navigation (pagehide, unload, and timers that fire during the commit). A pushState() from there queues a same-document finalization that reaches the session history traversal queue only after the new document has been activated.

The queue-position check for that finalization was skipped on purpose so that back-to-back synchronous pushState() calls both survive, but that also let the stale finalization through: its target entry belongs to a document that is no longer active, so the changing-navigable job treated it as a cross-document traversal, fetched the unloaded document again, and replaced the document that had just committed. When the resurrected page navigates on its own, a UI-initiated load racing it is superseded.

This was the cause of the intermittent CI timeouts in whichever test ran after HTML/load-during-session-history-push-flood.html on the same test-web view: the runner's pre-navigation to about:blank was superseded by the resurrected flood page reloading itself, so about:blank never finished loading and the next test timed out.

Drop the finalization when its target entry's document state is not the navigable's active document state. Back-to-back pushState() calls share the active document's state, so they are still applied.