### PR TITLE
LibWeb: Fix incremental style and layout updates on YouTube

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1702,7 +1702,10 @@ void Element::set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason reaso
     // A newly inserted element already has its entire subtree scheduled for construction. Its
     // initial style computation cannot require rebuilding an existing principal box, so keep
     // the insertion-specific invalidation on its parent instead of widening it to StyleChange.
-    if (!layout_node && may_reuse_layout_node_for_child_list_insertion())
+    // An existing display:none element can have the same marker after a child insertion; its box
+    // presence change must still schedule the new box for insertion into the retained parent.
+    if (!layout_node && may_reuse_layout_node_for_child_list_insertion()
+        && rebuild_root != CSS::LayoutTreeRebuildRoot::BoxPresenceChange)
         return;
     if (rebuild_root == CSS::LayoutTreeRebuildRoot::BoxPresenceChange && apply_box_presence_change_in_place(reason))
         return;

--- a/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
@@ -741,8 +741,12 @@ unsafe fn plan_style_computation(
                 !longhand_is_selected(&computed_property_words, property_id)
                     || property_has_independent_computed_closure(property_id)
             });
-        has_computed_property_selection =
-            retained_selection.computed_property_closure_is_exact || only_independent_properties_changed;
+        // A full initial mask can mean the retained selection could not represent an inherited
+        // change. Independent transition properties do not make that missing input safe to skip.
+        // An empty initial mask means neither cascade winners nor inherited groups changed and is
+        // normalized above only because the driver cannot process an empty group selection.
+        has_computed_property_selection = retained_selection.computed_property_closure_is_exact
+            || (input.initial_computed_group_mask != input.all_computed_groups && only_independent_properties_changed);
     }
     (
         has_monospace_font_family,

--- a/Tests/LibWeb/Text/expected/css/style-engine/inherited-style-during-transition-selection.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/inherited-style-during-transition-selection.txt
@@ -1,2 +1,2 @@
 hidden player: hidden
-revealed player: hidden
+revealed player: visible

--- a/Tests/LibWeb/Text/expected/css/style-engine/inherited-style-during-transition-selection.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/inherited-style-during-transition-selection.txt
@@ -1,0 +1,2 @@
+hidden player: hidden
+revealed player: hidden

--- a/Tests/LibWeb/Text/expected/layout-tree-update/display-none-box-with-concurrent-child-insertion.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/display-none-box-with-concurrent-child-insertion.txt
@@ -1,2 +1,2 @@
-player top: 30
-below top: 0
+player top: 0
+below top: 20

--- a/Tests/LibWeb/Text/expected/layout-tree-update/display-none-box-with-concurrent-child-insertion.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/display-none-box-with-concurrent-child-insertion.txt
@@ -1,0 +1,2 @@
+player top: 30
+below top: 0

--- a/Tests/LibWeb/Text/input/css/style-engine/inherited-style-during-transition-selection.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/inherited-style-during-transition-selection.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .hidden { visibility: hidden; }
+    .changed { color: green; }
+    ytd-player {
+        transition: border-radius 0.3s cubic-bezier(0.05, 0, 0, 1);
+    }
+    ytd-player.alternate { transition-duration: 0.4s; }
+</style>
+<div id="outer">
+    <div>
+        <div>
+            <ytd-player id="player"><span id="descendant"></span></ytd-player>
+        </div>
+    </div>
+</div>
+<script>
+    test(() => {
+        const outer = document.getElementById("outer");
+        const player = document.getElementById("player");
+        const descendant = document.getElementById("descendant");
+        internals.updateStyle();
+
+        // Force a full recompute while hiding the player, then settle the transition definition.
+        outer.classList.add("hidden");
+        player.classList.add("alternate");
+        internals.updateStyle();
+        println(`hidden player: ${getComputedStyle(player).visibility}`);
+
+        player.classList.remove("alternate");
+        internals.updateStyle();
+
+        // The descendant mutation puts the player in the inheritance closure before its inherited
+        // visibility reaction is derived.
+        outer.classList.remove("hidden");
+        descendant.classList.add("changed");
+        internals.updateStyle();
+        println(`revealed player: ${getComputedStyle(player).visibility}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/display-none-box-with-concurrent-child-insertion.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/display-none-box-with-concurrent-child-insertion.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #player { height: 20px; }
+    #below { height: 30px; }
+    .hidden { display: none; }
+</style>
+<div id="theater"></div>
+<div id="primary">
+    <div id="player"><div id="player-container"></div></div>
+    <div id="below"></div>
+</div>
+<script>
+    test(() => {
+        const theater = document.getElementById("theater");
+        const player = document.getElementById("player");
+        const playerContainer = document.getElementById("player-container");
+        const below = document.getElementById("below");
+        document.body.offsetHeight;
+
+        player.classList.add("hidden");
+        theater.append(playerContainer);
+        document.body.offsetHeight;
+
+        player.append(playerContainer);
+        player.classList.remove("hidden");
+        document.body.offsetHeight;
+
+        println(`player top: ${player.offsetTop}`);
+        println(`below top: ${below.offsetTop}`);
+    });
+</script>


### PR DESCRIPTION
Fix two incremental update bugs exposed by YouTube’s player:

- Preserve inherited properties when retained transition selection cannot represent a full inherited change. This prevents the video from remaining hidden after navigating from the home page.
- Prioritize box-presence changes over pending child-list insertions. This keeps the player in DOM order when leaving theater mode instead of placing it after the comments.

Fixes #11267