### PR TITLE
Move per-node layout walks behind single arena queries

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8256,37 +8256,13 @@ void Document::update_compositor_animations()
         return false;
     };
 
-    auto transform_subtree_is_clipped_outside = [](Element const& animated_target, CSSPixelRect const& root_bounds) {
+    auto transform_subtree_is_clipped_outside = [this, &visual_context_tree](Element const& animated_target, CSSPixelRect const& root_bounds) {
         auto const* layout_node = animated_target.unsafe_layout_node();
-        if (!layout_node || !Painting::has_committed_box(*layout_node) || root_bounds.is_empty())
+        if (!layout_node)
             return false;
-        if (auto const* target_box = as_if<Layout::Box>(*layout_node)) {
-            if (Painting::is_fixed_position(*target_box) || target_box->abspos_descendant_escapes())
-                return false;
-        }
-
-        bool has_disjoint_clip = false;
-        for (auto const* ancestor = layout_node->parent(); ancestor; ancestor = ancestor->parent()) {
-            auto const* ancestor_box = as_if<Layout::Box>(*ancestor);
-            if (!ancestor_box)
-                continue;
-            if (!Painting::has_committed_box(*ancestor_box) || Painting::is_fixed_position(*ancestor_box))
-                return false;
-
-            bool has_content_clip = ancestor_box->overflow_x() != CSS::Overflow::Visible
-                || ancestor_box->overflow_y() != CSS::Overflow::Visible;
-            if (has_content_clip) {
-                auto clip_rect = Painting::transform_rect_to_viewport(*ancestor_box, Painting::absolute_padding_box_rect(*ancestor_box), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
-                if (!clip_rect.edge_adjacent_intersects(root_bounds))
-                    has_disjoint_clip = true;
-            }
-
-            // A transform outside the disjoint clip could move the clip into the observation root without updating
-            // its main-thread geometry. Transforms inside the clip can only move content within the clipped region.
-            if (has_disjoint_clip && (ancestor_box->has_css_transform() || ancestor_box->is_sticky_position()))
-                return false;
-        }
-        return has_disjoint_clip;
+        return Layout::RustFFI::layout_arena_transform_subtree_is_clipped_outside(
+            layout_node->arena_handle(), Layout::Node::slot_id(layout_node), root_bounds,
+            Painting::rect_to_viewport_transform(*this, visual_context_tree));
     };
 
     auto observation_has_another_transform_animation = [&](Element const& animated_target, Element const& observation_target, Animations::KeyframeEffect const& current_effect) {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6595,63 +6595,24 @@ void Document::queue_an_intersection_observer_entry(IntersectionObserver::Inters
 // https://www.w3.org/TR/intersection-observer/#compute-the-intersection
 static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect target_rect, IntersectionObserver::IntersectionObserver const& observer, Layout::Box const* root_layout_box, CSSPixelRect const& root_bounds, Painting::AccumulatedVisualContextTree const& visual_context_tree)
 {
-    // 1. Let intersectionRect be the result of getting the bounding box for target.
-    auto intersection_rect = target_rect;
-
-    // 2. Let container be the containing block of target.
-    // 3. While container is not root:
-    auto const* target_layout_node = target->layout_node();
-    if (target_layout_node && Painting::has_committed_box(*target_layout_node)) {
-        for (auto const* container_box = target_layout_node->containing_block(); container_box; container_box = container_box->containing_block()) {
-            // Stop when we reach the intersection root.
-            if (container_box == root_layout_box)
-                break;
-            if (!Painting::has_committed_box(*container_box))
-                break;
-
-            // FIXME: 3.1. If container is the document of a nested browsing context, update
-            //             intersectionRect by clipping to the viewport of the document, and update
-            //             container to be the browsing context container of container.
-
-            // NOTE: Steps 3.2 (map to container coordinate space) and 3.5 (update container) are
-            //       unnecessary here because get_bounding_client_rect() and transform_rect_to_viewport()
-            //       already produce viewport-relative coordinates.
-
-            // 3.3. If container is a scroll container, apply the observer’s [[scrollMargin]]
-            //      to the container’s clip rect.
-            // 3.4. If container has a content clip or a css clip-path property, update intersectionRect
-            //      by applying container’s clip.
-            // FIXME: Handle clip-path.
-            auto overflow_x = container_box->overflow_x();
-            auto overflow_y = container_box->overflow_y();
-            bool has_content_clip = overflow_x != CSS::Overflow::Visible || overflow_y != CSS::Overflow::Visible;
-            if (has_content_clip) {
-                auto clip_rect = Painting::transform_rect_to_viewport(*container_box, Painting::absolute_padding_box_rect(*container_box), visual_context_tree, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
-
-                // Apply scroll margin to expand the scrollport for scroll containers.
-                auto& scroll_margin = observer.scroll_margin_values();
-                if (container_box->is_scroll_container() && !scroll_margin.is_empty()) {
-                    clip_rect.inflate(
-                        scroll_margin[0].to_px(clip_rect.height()),
-                        scroll_margin[1].to_px(clip_rect.width()),
-                        scroll_margin[2].to_px(clip_rect.height()),
-                        scroll_margin[3].to_px(clip_rect.width()));
-                }
-
-                intersection_rect.intersect(clip_rect);
-            }
-        }
-    }
-
-    // FIXME: 4. Map intersectionRect to the coordinate space of root.
-
-    // 5. Update intersectionRect by intersecting it with the root intersection rectangle.
-    intersection_rect.intersect(root_bounds);
-
-    // FIXME: 6. Map intersectionRect to the coordinate space of the viewport of the document containing target.
-
-    // 7. Return intersectionRect.
-    return intersection_rect;
+    auto& document = target->document();
+    auto const& scroll_margin = observer.scroll_margin_values();
+    auto inflate_scroll_container_clip_rect_by_scroll_margin = [](void* context, CSSPixelRect clip_rect) -> CSSPixelRect {
+        auto const& scroll_margin = *static_cast<Vector<CSS::LengthPercentage> const*>(context);
+        if (scroll_margin.is_empty())
+            return clip_rect;
+        clip_rect.inflate(
+            scroll_margin[0].to_px(clip_rect.height()),
+            scroll_margin[1].to_px(clip_rect.width()),
+            scroll_margin[2].to_px(clip_rect.height()),
+            scroll_margin[3].to_px(clip_rect.width()));
+        return clip_rect;
+    };
+    return Layout::RustFFI::layout_arena_intersection_observer_intersection_rect(
+        document.layout_node_arena().handle(), Layout::Node::slot_id(target->layout_node()), target_rect,
+        Layout::Node::slot_id(root_layout_box), root_bounds,
+        Painting::rect_to_viewport_transform(document, visual_context_tree),
+        const_cast<Vector<CSS::LengthPercentage>*>(&scroll_margin), inflate_scroll_container_clip_rect_by_scroll_margin);
 }
 
 // https://www.w3.org/TR/intersection-observer/#run-the-update-intersection-observations-steps

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2939,25 +2939,10 @@ bool Document::can_compute_client_rects_without_accumulated_visual_contexts_upda
     if (!m_needs_accumulated_visual_contexts_update || !m_layout_root)
         return false;
 
-    for (auto const* node = &layout_node; node; node = node->parent()) {
-        if (node->is_svg_box() || node->is_svg_svg_box() || node->is_svg_foreign_object_box())
-            return false;
-
-        auto const* node_with_style = as_if<Layout::NodeWithStyle>(*node);
-        if (!node_with_style)
-            continue;
-        if (node_with_style->has_css_transform() || node_with_style->perspective().has_value() || node_with_style->is_sticky_position())
-            return false;
-        if (auto const* box = as_if<Layout::Box>(*node);
-            box && (box->compensates_for_horizontal_scroll() || box->compensates_for_vertical_scroll()))
-            return false;
-        // A scroll container's contents move, but its own border box does not.
-        if (node != &layout_node) {
-            if (!Painting::scroll_offset(*node).is_zero())
-                return false;
-        }
-    }
-    return true;
+    auto navigable = this->navigable();
+    bool viewport_scroll_offset_is_zero = !navigable || navigable->viewport_scroll_offset().is_zero();
+    return Layout::RustFFI::layout_arena_can_compute_client_rects_without_visual_context_update(
+        layout_node.arena_handle(), Layout::Node::slot_id(&layout_node), viewport_scroll_offset_is_zero);
 }
 
 void Document::set_normal_link_color(Optional<Color> color)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2551,21 +2551,11 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
 void Document::collect_boxes_with_auto_content_visibility()
 {
     Vector<Layout::RustFFI::NodeSlotId> boxes_with_auto_content_visibility;
-    unsafe_layout_node()->for_each_in_inclusive_subtree([&](Layout::Node& node) {
-        switch (node.kind()) {
-        case Layout::RustFFI::NodeKind::SVGMaskBox:
-        case Layout::RustFFI::NodeKind::SVGClipBox:
-        case Layout::RustFFI::NodeKind::SVGPatternBox:
-            return TraversalDecision::SkipChildrenAndContinue;
-        default:
-            break;
-        }
-        auto const* node_with_style = as_if<Layout::NodeWithStyle>(node);
-        if (Painting::has_committed_box(node) && node.dom_node() && node.dom_node()->is_element()
-            && node_with_style && node_with_style->content_visibility() == CSS::ContentVisibility::Auto)
-            boxes_with_auto_content_visibility.append(Painting::committed_row_slot(node));
-        return TraversalDecision::Continue;
-    });
+    Layout::RustFFI::layout_arena_collect_boxes_with_auto_content_visibility(
+        layout_node_arena().handle(), Layout::Node::slot_id(unsafe_layout_node()), &boxes_with_auto_content_visibility,
+        [](void* context, Layout::RustFFI::NodeSlotId slot) {
+            static_cast<Vector<Layout::RustFFI::NodeSlotId>*>(context)->append(slot);
+        });
     paint_state().set_boxes_with_auto_content_visibility(move(boxes_with_auto_content_visibility));
 }
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2714,141 +2714,62 @@ bool Element::serializes_as_void() const
     return is_void_element() || local_name().is_one_of(HTML::TagNames::basefont, HTML::TagNames::bgsound, HTML::TagNames::frame, HTML::TagNames::keygen);
 }
 
-static CSSPixelRect bounding_rect_from_client_rects(Vector<CSSPixelRect> const& list)
+template<typename QueryResult>
+static QueryResult query_client_rects_after_layout_update(Element const& element, auto&& query)
 {
-    // 2. If the list is empty return a DOMRect object whose x, y, width and height members are zero.
-    if (list.size() == 0)
-        return { 0, 0, 0, 0 };
+    auto& document = element.document();
+    if (!document.navigable())
+        return QueryResult {};
 
-    // 3. If all rectangles in list have zero width or height, return the first rectangle in list.
-    auto all_rectangle_has_zero_width_or_height = true;
-    for (auto i = 0u; i < list.size(); ++i) {
-        auto const& rect = list.at(i);
-        if (rect.width() != 0 && rect.height() != 0) {
-            all_rectangle_has_zero_width_or_height = false;
-            break;
-        }
-    }
-    if (all_rectangle_has_zero_width_or_height)
-        return list.at(0);
+    // NOTE: Ensure that layout is up-to-date before looking at metrics.
+    const_cast<Document&>(document).update_layout_if_needed_for_node(element, UpdateLayoutReason::ElementGetClientRects);
 
-    // 4. Otherwise, return a DOMRect object describing the smallest rectangle that includes all of the rectangles in
-    //    list of which the height or width is not zero.
-    auto bounding_rect = list.at(0);
-    for (auto i = 1u; i < list.size(); ++i) {
-        auto const& rect = list.at(i);
-        if (rect.width() == 0 || rect.height() == 0)
-            continue;
-        bounding_rect.unite(rect);
-    }
-    return bounding_rect;
+    // 1. If the element on which it was invoked does not have an associated layout box return an empty DOMRectList
+    //    object and stop this algorithm.
+    auto const* layout_node = element.layout_node();
+    if (!layout_node)
+        return QueryResult {};
+
+    if (document.can_compute_client_rects_without_accumulated_visual_contexts_update(*layout_node))
+        return query(*layout_node, Painting::identity_rect_to_viewport_transform());
+
+    // NOTE: Make sure CSS transforms are resolved before they are used to calculate the rect position.
+    const_cast<Document&>(document).update_paint_and_hit_testing_properties_if_needed();
+
+    auto visual_context_tree = document.visual_context_tree();
+    return query(*layout_node, Painting::rect_to_viewport_transform(document, visual_context_tree));
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect
 CSSPixelRect Element::get_bounding_client_rect() const
 {
     // 1. Let list be the result of invoking getClientRects() on element.
-    return bounding_rect_from_client_rects(get_client_rects());
-}
-
-enum class VisualContextTransform {
-    Apply,
-    Identity,
-};
-
-static void append_border_box_rect(Vector<CSSPixelRect>& rects, Layout::Node const& layout_node, VisualContextTransform visual_context_transform, Painting::AccumulatedVisualContextTree const* visual_context_tree = nullptr)
-{
-    auto absolute_rect = Painting::absolute_border_box_rect(layout_node);
-    if (visual_context_transform == VisualContextTransform::Identity)
-        rects.append(absolute_rect);
-    else if (visual_context_tree)
-        rects.append(Painting::transform_rect_to_viewport(layout_node, absolute_rect, *visual_context_tree, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
-    else
-        rects.append(Painting::transform_rect_to_viewport(layout_node, absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
-}
-
-static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element const& element, VisualContextTransform visual_context_transform = VisualContextTransform::Apply, Painting::AccumulatedVisualContextTree const* visual_context_tree = nullptr)
-{
-    // 1. If the element on which it was invoked does not have an associated layout box return an empty DOMRectList
-    //    object and stop this algorithm.
-    auto const* layout_node = element.layout_node();
-    if (!layout_node)
-        return {};
-
-    // FIXME: 2. If the element has an associated SVG layout box return a DOMRectList object containing a single
-    //          DOMRect object that describes the bounding box of the element as defined by the SVG specification,
-    //          applying the transforms that apply to the element and its ancestors.
-
-    // 3. Return a DOMRectList object containing DOMRect objects in content order, one for each box fragment,
-    // describing its border area (including those with a height or width of zero) with the following constraints:
-    // - Apply the transforms that apply to the element and its ancestors.
-    // FIXME: - If the element on which the method was invoked has a computed value for the display property of table
-    //          or inline-table include both the table box and the caption box, if any, but not the anonymous container box.
-    // FIXME: - Replace each anonymous block box with its child box(es) and repeat this until no anonymous block boxes
-    //          are left in the final list.
-
-    Vector<CSSPixelRect> rects;
-    if (Painting::is_inline_paintable(*layout_node)) {
-        Vector<CSSPixelRect> piece_border_box_rects;
-        Painting::inline_piece_border_box_rects(*layout_node, piece_border_box_rects);
-        for (auto const& absolute_rect : piece_border_box_rects) {
-            if (visual_context_transform == VisualContextTransform::Identity)
-                rects.append(absolute_rect);
-            else if (visual_context_tree)
-                rects.append(Painting::transform_rect_to_viewport(*layout_node, absolute_rect, *visual_context_tree, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
-            else
-                rects.append(Painting::transform_rect_to_viewport(*layout_node, absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
-        }
-        // An inline element whose content is only interrupting blocks generates no line fragments, but per CSSOM
-        // we still report its (zero-sized) border area instead of an empty list.
-        if (rects.is_empty())
-            append_border_box_rect(rects, *layout_node, visual_context_transform, visual_context_tree);
-        return rects;
-    }
-
-    if (Painting::has_committed_box(*layout_node))
-        append_border_box_rect(rects, *layout_node, visual_context_transform, visual_context_tree);
-
-    return rects;
+    return query_client_rects_after_layout_update<CSSPixelRect>(*this, [](Layout::Node const& layout_node, auto const& rect_to_viewport_transform) {
+        return Painting::bounding_client_rect(layout_node, rect_to_viewport_transform);
+    });
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
 Vector<CSSPixelRect> Element::get_client_rects() const
 {
-    auto navigable = document().navigable();
-    if (!navigable)
-        return {};
-
-    // NOTE: Ensure that layout is up-to-date before looking at metrics.
-    const_cast<Document&>(document()).update_layout_if_needed_for_node(*this, UpdateLayoutReason::ElementGetClientRects);
-
-    if (!layout_node())
-        return {};
-
-    if (document().can_compute_client_rects_without_accumulated_visual_contexts_update(*layout_node()))
-        return compute_client_rects_assuming_layout_clean(*this, VisualContextTransform::Identity);
-
-    // NOTE: Make sure CSS transforms are resolved before they are used to calculate the rect position.
-    const_cast<Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
-
-    return compute_client_rects_assuming_layout_clean(*this);
-}
-
-Vector<CSSPixelRect> Element::client_rects_assuming_layout_clean() const
-{
-    if (!document().navigable())
-        return {};
-    return compute_client_rects_assuming_layout_clean(*this);
+    return query_client_rects_after_layout_update<Vector<CSSPixelRect>>(*this, [](Layout::Node const& layout_node, auto const& rect_to_viewport_transform) {
+        return Painting::client_rects(layout_node, rect_to_viewport_transform);
+    });
 }
 
 CSSPixelRect Element::bounding_client_rect_assuming_layout_clean() const
 {
-    return bounding_rect_from_client_rects(client_rects_assuming_layout_clean());
+    if (!document().navigable())
+        return {};
+    return bounding_client_rect_assuming_layout_clean(document().visual_context_tree());
 }
 
 CSSPixelRect Element::bounding_client_rect_assuming_layout_clean(Painting::AccumulatedVisualContextTree const& visual_context_tree) const
 {
-    return bounding_rect_from_client_rects(compute_client_rects_assuming_layout_clean(*this, VisualContextTransform::Apply, &visual_context_tree));
+    auto const* layout_node = this->layout_node();
+    if (!layout_node)
+        return {};
+    return Painting::bounding_client_rect(*layout_node, Painting::rect_to_viewport_transform(document(), visual_context_tree));
 }
 
 int Element::client_top() const

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -574,7 +574,6 @@ public:
 
     [[nodiscard]] Vector<CSSPixelRect> get_client_rects() const;
 
-    [[nodiscard]] Vector<CSSPixelRect> client_rects_assuming_layout_clean() const;
     [[nodiscard]] CSSPixelRect bounding_client_rect_assuming_layout_clean() const;
     [[nodiscard]] CSSPixelRect bounding_client_rect_assuming_layout_clean(Painting::AccumulatedVisualContextTree const&) const;
 

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -1226,7 +1226,8 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
     document.update_layout(DOM::UpdateLayoutReason::RangeGetClientRects);
 
     Vector<GC::Root<Geometry::DOMRect>> rects;
-    bool did_update_paint_and_hit_testing_properties = false;
+    Optional<Painting::AccumulatedVisualContextTree> visual_context_tree;
+    auto rect_to_viewport_transform = Painting::identity_rect_to_viewport_transform();
 
     // FIXME: take Range collapsed into consideration
     // 2. Iterate the node included in Range
@@ -1296,11 +1297,10 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
                 continue;
             }
 
-            auto apply_visual_context_transform = did_update_paint_and_hit_testing_properties;
-            if (!apply_visual_context_transform && !document.can_compute_client_rects_without_accumulated_visual_contexts_update(*mapping.primary())) {
+            if (!visual_context_tree.has_value() && !document.can_compute_client_rects_without_accumulated_visual_contexts_update(*mapping.primary())) {
                 document.update_paint_and_hit_testing_properties_if_needed();
-                did_update_paint_and_hit_testing_properties = true;
-                apply_visual_context_transform = true;
+                visual_context_tree = document.visual_context_tree();
+                rect_to_viewport_transform = Painting::rect_to_viewport_transform(document, *visual_context_tree);
             }
 
             size_t filter_dom_start = 0;
@@ -1324,24 +1324,11 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
 
             auto text_slots = mapping.slot_ids();
 
-            struct RangeRectContext {
-                Vector<GC::Root<Geometry::DOMRect>>& rects;
-                bool apply_visual_context_transform { false };
-            } context { rects, apply_visual_context_transform };
-
             Layout::RustFFI::layout_arena_text_range_rects(
                 mapping.primary()->arena_handle(), text_slots.data(), text_slots.size(),
                 to_underlying(selection_state), start_offset(), end_offset(), filter_dom_start, filter_dom_end,
-                &context, [](void* context_pointer, void* containing_block_shell, CSSPixelRect rect) {
-                    auto& context = *static_cast<RangeRectContext*>(context_pointer);
-                    auto transformed_rect = rect;
-
-                    if (context.apply_visual_context_transform) {
-                        if (auto const* containing_block = static_cast<Layout::Node const*>(containing_block_shell))
-                            transformed_rect = Painting::transform_rect_to_viewport(*containing_block, rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
-                    }
-
-                    context.rects.append(Geometry::DOMRect::create(transformed_rect.to_type<float>()));
+                rect_to_viewport_transform, &rects, [](void* context, CSSPixelRect rect) {
+                    static_cast<Vector<GC::Root<Geometry::DOMRect>>*>(context)->append(Geometry::DOMRect::create(rect.to_type<float>()));
                 });
         }
     }

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -558,14 +558,7 @@ Utf16String HTMLElement::outer_text()
 
 static bool any_ancestor_establishes_a_fixed_position_containing_block(Layout::NodeWithStyle const& node)
 {
-    // https://www.w3.org/TR/css-position-3/#fixed-positioning-containing-block
-    // The containing block is established by the nearest ancestor box that establishes an fixed positioning containing
-    // block, with the bounds of the containing block determined identically to the absolute positioning containing block.
-    for (auto ancestor = node.containing_block(); ancestor; ancestor = ancestor->containing_block()) {
-        if (ancestor->establishes_a_fixed_positioning_containing_block())
-            return true;
-    }
-    return false;
+    return Layout::RustFFI::layout_arena_any_ancestor_establishes_a_fixed_position_containing_block(node.arena_handle(), Layout::Node::slot_id(&node));
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-htmlelement-scrollparent

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -48,11 +48,6 @@ public:
     void notify_content_navigable_of_committed_viewport();
     bool has_saved_abspos_layout_inputs() const { return has_flag(RustFFI::NodeFlag::HasSavedAbsposLayoutInputs); }
 
-    // Whether an absolutely or fixed positioned descendant of this box has its containing
-    // block outside this box's subtree, so the descendant's layout escapes the subtree.
-    // Re-derived whenever containing block pointers are recomputed.
-    bool abspos_descendant_escapes() const { return has_flag(RustFFI::NodeFlag::AbsposDescendantEscapes); }
-
     Box(DOM::Document&, GC::Ptr<DOM::Node>, CSS::LayoutStyle, RustFFI::NodeKind = RustFFI::NodeKind::Box);
     Box(DOM::Document&, BindToPreparedArenaSlot, RustFFI::NodeSlotId, RustFFI::NodeKind);
 

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -53,9 +53,6 @@ public:
     // Re-derived whenever containing block pointers are recomputed.
     bool abspos_descendant_escapes() const { return has_flag(RustFFI::NodeFlag::AbsposDescendantEscapes); }
 
-    bool compensates_for_horizontal_scroll() const { return has_flag(RustFFI::NodeFlag::CompensatesForHorizontalScroll); }
-    bool compensates_for_vertical_scroll() const { return has_flag(RustFFI::NodeFlag::CompensatesForVerticalScroll); }
-
     Box(DOM::Document&, GC::Ptr<DOM::Node>, CSS::LayoutStyle, RustFFI::NodeKind = RustFFI::NodeKind::Box);
     Box(DOM::Document&, BindToPreparedArenaSlot, RustFFI::NodeSlotId, RustFFI::NodeKind);
 

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -272,9 +272,7 @@ public:
     bool is_svg_clip_box() const { return kind() == RustFFI::NodeKind::SVGClipBox; }
     bool is_svg_mask_box() const { return kind() == RustFFI::NodeKind::SVGMaskBox; }
     bool is_svg_pattern_box() const { return kind() == RustFFI::NodeKind::SVGPatternBox; }
-    bool is_svg_svg_box() const { return kind() == RustFFI::NodeKind::SVGSVGBox; }
     bool is_svg_graphics_box() const { return RustFFI::layout_node_kind_is_svg_graphics_box(kind()); }
-    bool is_svg_foreign_object_box() const { return kind() == RustFFI::NodeKind::SVGForeignObjectBox; }
     bool is_replaced_box() const { return RustFFI::layout_node_kind_is_replaced_box(kind()); }
     bool is_list_item_box() const { return kind() == RustFFI::NodeKind::ListItemBox; }
     bool is_list_item_marker_box() const { return kind() == RustFFI::NodeKind::ListItemMarkerBox; }

--- a/Libraries/LibWeb/Page/AutoScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/AutoScrollHandler.cpp
@@ -112,22 +112,16 @@ CSSPixelPoint AutoScrollHandler::process(CSSPixelPoint mouse_position)
 
 GC::Ptr<DOM::Element> AutoScrollHandler::find_scrollable_ancestor(Layout::Node const& layout_node)
 {
-    for (auto const* current = &layout_node; current; current = current->containing_block()) {
-        if (!Painting::has_committed_box(*current))
-            continue;
-        if (Painting::could_be_scrolled_by_wheel_event(*current)) {
-            if (auto* element = as_if<DOM::Element>(current->dom_node()))
-                return const_cast<DOM::Element*>(element);
-        }
+    auto const* scrollable_box = Painting::first_wheel_scrollable_box_in_containing_block_chain(layout_node);
+    if (!scrollable_box)
+        return {};
 
-        // The viewport is always a potential scroll container, but may not report has_scrollable_overflow() and its DOM
-        // node is Document (not Element).
-        if (Painting::is_viewport_paintable(*current) && Painting::could_be_scrolled_by_wheel_event(*current)) {
-            if (auto scrolling_element = current->document().scrolling_element())
-                return const_cast<DOM::Element*>(scrolling_element.ptr());
-        }
-    }
-    return {};
+    // The viewport is always a potential scroll container, but may not report has_scrollable_overflow() and its DOM
+    // node is Document (not Element).
+    if (scrollable_box->is_viewport())
+        return const_cast<DOM::Element*>(scrollable_box->document().scrolling_element().ptr());
+
+    return const_cast<DOM::Element*>(as_if<DOM::Element>(scrollable_box->dom_node()));
 }
 
 // Returns the layout node that manages the scrollport for an auto-scroll container element. When the element is the

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -724,34 +724,14 @@ static VisualViewportPanAxes visual_viewport_pan_axes_for_scroll_step(DOM::Docum
 
 static Layout::Node* scrolling_box_for_scroll_step(Layout::Node& target, CSSPixelPoint delta)
 {
-    auto scrolling_box_moved_by = [](Layout::Node const& node, CSSPixelPoint delta) {
-        return Painting::clamp_scroll_offset(node, Painting::scroll_offset(node) + delta) != Painting::scroll_offset(node);
-    };
-
-    auto deltas_the_scrolling_box_accepts = [](Layout::Node const& node, CSSPixelPoint delta) {
-        if (!Painting::could_be_scrolled_by_wheel_event(node, Painting::ScrollDirection::Horizontal))
-            delta.set_x(0);
-        if (!Painting::could_be_scrolled_by_wheel_event(node, Painting::ScrollDirection::Vertical))
-            delta.set_y(0);
-        return delta;
-    };
-
-    for (Layout::Node* node = &target; node && !node->is_viewport(); node = node->containing_block()) {
-        auto accepted_delta = deltas_the_scrolling_box_accepts(*node, delta);
-        if (!accepted_delta.is_zero() && scrolling_box_moved_by(*node, accepted_delta))
-            return node;
-    }
+    auto* scrolling_box = Painting::scrolling_box_for_scroll_step_in_containing_block_chain(target, delta);
+    if (!scrolling_box)
+        return nullptr;
 
     // The viewport is scrolled by the default action itself rather than by the chain above, so it comes last.
-    auto* viewport_layout_node = target.document().layout_node();
-    if (!viewport_layout_node)
+    if (scrolling_box->is_viewport() && !visual_viewport_pan_axes_for_scroll_step(target.document(), delta.x().to_double(), delta.y().to_double()).is_empty())
         return nullptr;
-    auto accepted_delta = deltas_the_scrolling_box_accepts(*viewport_layout_node, delta);
-    if (accepted_delta.is_zero() || !scrolling_box_moved_by(*viewport_layout_node, accepted_delta))
-        return nullptr;
-    if (!visual_viewport_pan_axes_for_scroll_step(target.document(), delta.x().to_double(), delta.y().to_double()).is_empty())
-        return nullptr;
-    return viewport_layout_node;
+    return scrolling_box;
 }
 
 EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, double wheel_delta_x, double wheel_delta_y, WheelDeltaPrecision wheel_delta_precision, ScrollGesturePhase scroll_gesture_phase, bool async_scroll_performed_default_action, Optional<AsyncScrollOperation>* async_scroll_operation)

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -712,11 +712,6 @@ CSSPixelRect transform_reference_box(Layout::Node const& node)
 
 CSSPixelRect transform_rect_to_viewport(Layout::Node const& node, CSSPixelRect const& rect, AccumulatedVisualContextTree::IncludeVisualViewportTransform include_visual_viewport_transform)
 {
-    return transform_rect_to_viewport(node, rect, node.document().visual_context_tree(), include_visual_viewport_transform);
-}
-
-CSSPixelRect transform_rect_to_viewport(Layout::Node const& node, CSSPixelRect const& rect, AccumulatedVisualContextTree const& visual_context_tree, AccumulatedVisualContextTree::IncludeVisualViewportTransform include_visual_viewport_transform)
-{
     auto const* row = committed_row(node);
     if (!row)
         return {};
@@ -724,7 +719,7 @@ CSSPixelRect transform_rect_to_viewport(Layout::Node const& node, CSSPixelRect c
     if (!document.layout_node() || !has_committed_box(*document.layout_node()))
         return rect;
     auto pixel_ratio = static_cast<float>(document.page().client().device_pixels_per_css_pixel());
-    auto result = visual_context_tree.transform_rect_to_viewport(
+    auto result = document.visual_context_tree().transform_rect_to_viewport(
         row->accumulated_visual_context.spatial, rect.to_type<float>() * pixel_ratio,
         document.scroll_state_snapshot(), include_visual_viewport_transform);
     return (result * (1.f / pixel_ratio)).to_type<CSSPixels>();

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -950,13 +950,38 @@ void clear_cached_overflow_data(Layout::Node const& node)
     Layout::RustFFI::layout_arena_paintable_clear_cached_overflow_data(node.arena_handle(), committed_row_slot(node));
 }
 
-void inline_piece_border_box_rects(Layout::Node const& node, Vector<CSSPixelRect>& rects)
+Layout::RustFFI::FfiRectToViewportTransform identity_rect_to_viewport_transform()
 {
-    Layout::RustFFI::layout_arena_inline_paintable_piece_border_box_rects(
-        node.arena_handle(), committed_row_slot(node), &rects,
+    return {};
+}
+
+Layout::RustFFI::FfiRectToViewportTransform rect_to_viewport_transform(DOM::Document const& document, AccumulatedVisualContextTree const& visual_context_tree)
+{
+    if (!document.has_committed_viewport_box())
+        return identity_rect_to_viewport_transform();
+    auto scroll_offsets = document.scroll_state_snapshot().device_offsets();
+    return {
+        .visual_context_tree = visual_context_tree.rust_handle(),
+        .scroll_offsets = scroll_offsets.data(),
+        .scroll_offsets_len = scroll_offsets.size(),
+        .device_pixels_per_css_pixel = static_cast<float>(document.page().client().device_pixels_per_css_pixel()),
+    };
+}
+
+Vector<CSSPixelRect> client_rects(Layout::Node const& node, Layout::RustFFI::FfiRectToViewportTransform const& rect_to_viewport_transform)
+{
+    Vector<CSSPixelRect> rects;
+    Layout::RustFFI::layout_arena_client_rects(
+        node.arena_handle(), committed_row_slot(node), rect_to_viewport_transform, &rects,
         [](void* context, CSSPixelRect rect) {
             static_cast<Vector<CSSPixelRect>*>(context)->append(rect);
         });
+    return rects;
+}
+
+CSSPixelRect bounding_client_rect(Layout::Node const& node, Layout::RustFFI::FfiRectToViewportTransform const& rect_to_viewport_transform)
+{
+    return Layout::RustFFI::layout_arena_bounding_client_rect(node.arena_handle(), committed_row_slot(node), rect_to_viewport_transform);
 }
 
 CSSPixelPoint cumulative_scroll_compensation(Layout::Node const& node)

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -72,7 +72,6 @@ WEB_API bool is_svg_svg_paintable(Layout::Node const&);
 WEB_API bool is_svg_path_paintable(Layout::Node const&);
 
 WEB_API CSSPixelRect transform_rect_to_viewport(Layout::Node const&, CSSPixelRect const&, AccumulatedVisualContextTree::IncludeVisualViewportTransform = AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes);
-WEB_API CSSPixelRect transform_rect_to_viewport(Layout::Node const&, CSSPixelRect const&, AccumulatedVisualContextTree const&, AccumulatedVisualContextTree::IncludeVisualViewportTransform = AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes);
 WEB_API Optional<CSSPixelPoint> transform_point_to_local(Layout::Node const&, CSSPixelPoint);
 WEB_API CSSPixelPoint inverse_transform_point(Layout::Node const&, CSSPixelPoint);
 WEB_API CSSPixelPoint transform_to_local_coordinates(Layout::Node const&, CSSPixelPoint);

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -106,7 +106,11 @@ WEB_API void repaint_after_style_change(Layout::Node const&, CSS::RequiredInvali
 WEB_API void clear_overflow_data(Layout::Node const&);
 WEB_API void clear_cached_overflow_data(Layout::Node const&);
 
-WEB_API void inline_piece_border_box_rects(Layout::Node const&, Vector<CSSPixelRect>&);
+WEB_API Layout::RustFFI::FfiRectToViewportTransform identity_rect_to_viewport_transform();
+WEB_API Layout::RustFFI::FfiRectToViewportTransform rect_to_viewport_transform(DOM::Document const&, AccumulatedVisualContextTree const&);
+WEB_API Vector<CSSPixelRect> client_rects(Layout::Node const&, Layout::RustFFI::FfiRectToViewportTransform const&);
+WEB_API CSSPixelRect bounding_client_rect(Layout::Node const&, Layout::RustFFI::FfiRectToViewportTransform const&);
+
 WEB_API CSSPixelPoint cumulative_scroll_compensation(Layout::Node const&);
 
 }

--- a/Libraries/LibWeb/Painting/Scrolling.cpp
+++ b/Libraries/LibWeb/Painting/Scrolling.cpp
@@ -291,27 +291,57 @@ ScrollHandled set_scroll_offset_from_user_input(Layout::Node& node, CSSPixelPoin
     return scroll_handled;
 }
 
-ScrollHandled wheel_scroll(Layout::Node& node, double wheel_delta_x, double wheel_delta_y)
+struct ViewportWheelOverflow {
+    u8 x;
+    u8 y;
+};
+
+static ViewportWheelOverflow viewport_wheel_overflow(DOM::Document const& document)
 {
-    if (node.is_viewport())
-        return ScrollHandled::No;
-    auto axes = wheel_scrollable_axes(node);
-    if (!axes.horizontal)
-        wheel_delta_x = 0;
-    if (!axes.vertical)
-        wheel_delta_y = 0;
-    if (wheel_delta_x == 0 && wheel_delta_y == 0)
-        return ScrollHandled::No;
-    return scroll_by(node, wheel_delta_x, wheel_delta_y);
+    return {
+        .x = to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Horizontal)),
+        .y = to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Vertical)),
+    };
+}
+
+static CSSPixelPoint scroll_offset_of_layout_node_shell(void* layout_node_shell)
+{
+    return scroll_offset(*static_cast<Layout::Node const*>(layout_node_shell));
 }
 
 ScrollHandled wheel_scroll_along_containing_block_chain(Layout::Node& node, double wheel_delta_x, double wheel_delta_y)
 {
-    for (auto* current = &node; current; current = current->containing_block()) {
-        if (wheel_scroll(*current, wheel_delta_x, wheel_delta_y) == ScrollHandled::Yes)
+    struct WheelScrollableBox {
+        Layout::Node* node;
+        double accepted_delta_x;
+        double accepted_delta_y;
+    };
+    Vector<WheelScrollableBox, 4> wheel_scrollable_boxes;
+    auto overflow = viewport_wheel_overflow(node.document());
+    Layout::RustFFI::layout_arena_for_each_wheel_scrollable_box_in_containing_block_chain(
+        node.arena_handle(), committed_row_slot(node), wheel_delta_x, wheel_delta_y, overflow.x, overflow.y, scroll_offset_of_layout_node_shell,
+        &wheel_scrollable_boxes, [](void* context, void* layout_node_shell, double accepted_delta_x, double accepted_delta_y) {
+            static_cast<Vector<WheelScrollableBox, 4>*>(context)->append({ static_cast<Layout::Node*>(layout_node_shell), accepted_delta_x, accepted_delta_y });
+        });
+    for (auto const& wheel_scrollable_box : wheel_scrollable_boxes) {
+        if (scroll_by(*wheel_scrollable_box.node, wheel_scrollable_box.accepted_delta_x, wheel_scrollable_box.accepted_delta_y) == ScrollHandled::Yes)
             return ScrollHandled::Yes;
     }
     return ScrollHandled::No;
+}
+
+Layout::Node* scrolling_box_for_scroll_step_in_containing_block_chain(Layout::Node& target, CSSPixelPoint delta)
+{
+    auto overflow = viewport_wheel_overflow(target.document());
+    return static_cast<Layout::Node*>(Layout::RustFFI::layout_arena_scrolling_box_for_scroll_step(
+        target.arena_handle(), committed_row_slot(target), viewport_row_slot(target.document()), delta, overflow.x, overflow.y, scroll_offset_of_layout_node_shell));
+}
+
+Layout::Node* first_wheel_scrollable_box_in_containing_block_chain(Layout::Node const& node)
+{
+    auto overflow = viewport_wheel_overflow(node.document());
+    return static_cast<Layout::Node*>(Layout::RustFFI::layout_arena_first_wheel_scrollable_box_in_containing_block_chain(
+        node.arena_handle(), committed_row_slot(node), overflow.x, overflow.y));
 }
 
 static void scroll_into_view(Layout::Node& node, CSSPixelRect rect)

--- a/Libraries/LibWeb/Painting/Scrolling.h
+++ b/Libraries/LibWeb/Painting/Scrolling.h
@@ -47,8 +47,10 @@ WEB_API Optional<Compositor::AsyncScrollNodeStableID> async_scroll_node_stable_i
 ScrollHandled set_scroll_offset(Layout::Node&, CSSPixelPoint);
 ScrollHandled set_scroll_offset_from_user_input(Layout::Node&, CSSPixelPoint);
 ScrollHandled scroll_by(Layout::Node&, double delta_x, double delta_y);
-ScrollHandled wheel_scroll(Layout::Node&, double wheel_delta_x, double wheel_delta_y);
 ScrollHandled wheel_scroll_along_containing_block_chain(Layout::Node&, double wheel_delta_x, double wheel_delta_y);
+
+WEB_API Layout::Node* scrolling_box_for_scroll_step_in_containing_block_chain(Layout::Node&, CSSPixelPoint delta);
+WEB_API Layout::Node* first_wheel_scrollable_box_in_containing_block_chain(Layout::Node const&);
 void scroll_text_offset_into_view(DOM::Text const&, size_t offset, TextAffinity = TextAffinity::Downstream, ScrollBlockDirection = ScrollBlockDirection::Yes);
 
 }

--- a/Libraries/LibWeb/Rust/src/css/css_pixels.rs
+++ b/Libraries/LibWeb/Rust/src/css/css_pixels.rs
@@ -429,6 +429,10 @@ impl CssPixelRect {
         self.set_top(new_top);
         self.set_bottom(new_bottom);
     }
+    pub fn edge_adjacent_intersects(self, other: Self) -> bool {
+        self.left().max(other.left()) <= self.right().min(other.right())
+            && self.top().max(other.top()) <= self.bottom().min(other.bottom())
+    }
     pub fn intersected(self, other: Self) -> Self {
         let left = self.left().max(other.left());
         let right = self.right().min(other.right());

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -1243,14 +1243,25 @@ impl LayoutNodeArena {
         root: NodeSlotId,
         mut callback: impl FnMut(NodeSlotId),
     ) {
+        self.for_each_node_in_layout_subtree_in_pre_order_with_pruning(root, |node| {
+            callback(node);
+            true
+        });
+    }
+
+    pub(crate) fn for_each_node_in_layout_subtree_in_pre_order_with_pruning(
+        &self,
+        root: NodeSlotId,
+        mut visit_node_and_report_whether_to_descend: impl FnMut(NodeSlotId) -> bool,
+    ) {
         let mut current = root;
         loop {
-            callback(current);
+            let descend_into_children = visit_node_and_report_whether_to_descend(current);
             let data = self.data(current);
             let (parent, first_child, next_sibling) =
                 { (data.parent.get(), data.first_child.get(), data.next_sibling.get()) };
 
-            if !first_child.is_invalid() {
+            if descend_into_children && !first_child.is_invalid() {
                 current = first_child;
                 continue;
             }
@@ -2401,6 +2412,14 @@ impl LayoutNodeArena {
             return std::ptr::null_mut();
         }
         self.dom_nodes[id.slot_index() as usize].get()
+    }
+
+    pub(crate) fn node_dom_node_is_element(&self, id: NodeSlotId) -> bool {
+        if self.node_dom_node(id).is_null() {
+            return false;
+        }
+        let kind = self.data(id).kind.get();
+        kind != NodeKind::Viewport && !crate::layout::node_facts::kind_is_text(kind)
     }
 
     pub(crate) fn previous_dom_backed_or_generated_node(

--- a/Libraries/LibWeb/Rust/src/painting/chrome_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/chrome_geometry.rs
@@ -168,28 +168,30 @@ pub(crate) fn wheel_scrollable_axes(
     axes
 }
 
-pub(crate) fn minimum_scroll_offset(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelPoint {
-    let Some(overflow) = paintable_geometry::scrollable_overflow_rect(arena, slot) else {
-        return CssPixelPoint::default();
-    };
+pub(crate) fn scroll_offset_bounds(
+    arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+) -> Option<(CssPixelPoint, CssPixelPoint)> {
+    let overflow = paintable_geometry::scrollable_overflow_rect(arena, slot)?;
     let scrollport = paintable_geometry::absolute_padding_box_rect(arena, slot);
     let zero = CssPixels::from_raw(0);
-    CssPixelPoint::new(
+    let minimum = CssPixelPoint::new(
         (overflow.left() - scrollport.left()).min(zero),
         (overflow.top() - scrollport.top()).min(zero),
-    )
+    );
+    let maximum = CssPixelPoint::new(
+        (overflow.right() - scrollport.right()).max(zero),
+        (overflow.bottom() - scrollport.bottom()).max(zero),
+    );
+    Some((minimum, maximum))
+}
+
+pub(crate) fn minimum_scroll_offset(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelPoint {
+    scroll_offset_bounds(arena, slot).map_or(CssPixelPoint::default(), |(minimum, _)| minimum)
 }
 
 pub(crate) fn maximum_scroll_offset(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelPoint {
-    let Some(overflow) = paintable_geometry::scrollable_overflow_rect(arena, slot) else {
-        return CssPixelPoint::default();
-    };
-    let scrollport = paintable_geometry::absolute_padding_box_rect(arena, slot);
-    let zero = CssPixels::from_raw(0);
-    CssPixelPoint::new(
-        (overflow.right() - scrollport.right()).max(zero),
-        (overflow.bottom() - scrollport.bottom()).max(zero),
-    )
+    scroll_offset_bounds(arena, slot).map_or(CssPixelPoint::default(), |(_, maximum)| maximum)
 }
 
 pub(crate) fn scrollbar_is_enlarged(

--- a/Libraries/LibWeb/Rust/src/painting/client_rects.rs
+++ b/Libraries/LibWeb/Rust/src/painting/client_rects.rs
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use crate::css::css_pixels::{CssPixelRect, CssPixels};
 use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::node_facts;
-use crate::painting::paintable_rows::PaintableRowsRead;
+use crate::painting::node_painting;
+use crate::painting::paintable_geometry;
+use crate::painting::paintable_rows::{PaintableRowsRead, with_inline_pieces};
+use crate::painting::rect_to_viewport_transform::{RectToViewportTransform, transform_rect_to_viewport_or_identity};
 use crate::painting::style_queries;
 
 pub(crate) fn can_compute_client_rects_without_visual_context_update(
@@ -51,4 +55,102 @@ pub(crate) fn can_compute_client_rects_without_visual_context_update(
         node = data.parent.get();
     }
     true
+}
+
+fn for_each_inline_piece_border_box_rect(
+    arena: &impl PaintableRowsRead,
+    inline_paintable: NodeSlotId,
+    mut push_rect: impl FnMut(CssPixelRect),
+) {
+    let Some(root) = arena.inline_pieces_root(inline_paintable) else {
+        return;
+    };
+    let root_position = paintable_geometry::absolute_position(arena, root);
+    with_inline_pieces(arena, inline_paintable, |piece, _| {
+        if piece.is_geometry_only_placeholder {
+            return true;
+        }
+        push_rect(CssPixelRect::from(piece.border_box_rect).translated_by(root_position));
+        true
+    });
+}
+
+// https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
+pub(crate) fn for_each_client_rect(
+    arena: &impl PaintableRowsRead,
+    layout_node: NodeSlotId,
+    rect_to_viewport_transform: Option<&RectToViewportTransform<'_>>,
+    mut push_rect: impl FnMut(CssPixelRect),
+) {
+    let mut push_rect_in_viewport_space = |rect: CssPixelRect| {
+        push_rect(transform_rect_to_viewport_or_identity(
+            rect_to_viewport_transform,
+            arena,
+            layout_node,
+            rect,
+        ));
+    };
+    let row_is_populated = arena.paintable_row_is_populated(layout_node);
+
+    // FIXME: 2. If the element has an associated SVG layout box return a DOMRectList object containing a single
+    //          DOMRect object that describes the bounding box of the element as defined by the SVG specification,
+    //          applying the transforms that apply to the element and its ancestors.
+
+    // 3. Return a DOMRectList object containing DOMRect objects in content order, one for each box fragment,
+    // describing its border area (including those with a height or width of zero) with the following constraints:
+    // - Apply the transforms that apply to the element and its ancestors.
+    // FIXME: - If the element on which the method was invoked has a computed value for the display property of table
+    //          or inline-table include both the table box and the caption box, if any, but not the anonymous container box.
+    // FIXME: - Replace each anonymous block box with its child box(es) and repeat this until no anonymous block boxes
+    //          are left in the final list.
+    if row_is_populated && node_painting::is_fragmented_inline(arena, layout_node) {
+        let mut pushed_a_piece_rect = false;
+        for_each_inline_piece_border_box_rect(arena, layout_node, |piece_border_box_rect| {
+            pushed_a_piece_rect = true;
+            push_rect_in_viewport_space(piece_border_box_rect);
+        });
+        // An inline element whose content is only interrupting blocks generates no line fragments, but per CSSOM
+        // we still report its (zero-sized) border area instead of an empty list.
+        if !pushed_a_piece_rect {
+            push_rect_in_viewport_space(paintable_geometry::absolute_border_box_rect(arena, layout_node));
+        }
+        return;
+    }
+
+    if row_is_populated {
+        push_rect_in_viewport_space(paintable_geometry::absolute_border_box_rect(arena, layout_node));
+    }
+}
+
+// https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect
+pub(crate) fn bounding_client_rect(
+    arena: &impl PaintableRowsRead,
+    layout_node: NodeSlotId,
+    rect_to_viewport_transform: Option<&RectToViewportTransform<'_>>,
+) -> CssPixelRect {
+    // 1. Let list be the result of invoking getClientRects() on element.
+    let zero = CssPixels::from_integer(0);
+    let mut first_rect = None;
+    let mut union_of_rects_with_nonzero_width_and_height: Option<CssPixelRect> = None;
+    for_each_client_rect(arena, layout_node, rect_to_viewport_transform, |rect| {
+        first_rect.get_or_insert(rect);
+        if rect.width == zero || rect.height == zero {
+            return;
+        }
+        match &mut union_of_rects_with_nonzero_width_and_height {
+            None => union_of_rects_with_nonzero_width_and_height = Some(rect),
+            Some(union) => union.unite(rect),
+        }
+    });
+
+    // 2. If the list is empty return a DOMRect object whose x, y, width and height members are zero.
+    let Some(first_rect) = first_rect else {
+        return CssPixelRect::default();
+    };
+
+    // 3. If all rectangles in list have zero width or height, return the first rectangle in list.
+
+    // 4. Otherwise, return a DOMRect object describing the smallest rectangle that includes all of the rectangles in
+    //    list of which the height or width is not zero.
+    union_of_rects_with_nonzero_width_and_height.unwrap_or(first_rect)
 }

--- a/Libraries/LibWeb/Rust/src/painting/client_rects.rs
+++ b/Libraries/LibWeb/Rust/src/painting/client_rects.rs
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::node_facts;
+use crate::painting::paintable_rows::PaintableRowsRead;
+use crate::painting::style_queries;
+
+pub(crate) fn can_compute_client_rects_without_visual_context_update(
+    arena: &impl PaintableRowsRead,
+    layout_node: NodeSlotId,
+    viewport_scroll_offset_is_zero: bool,
+) -> bool {
+    let mut node = layout_node;
+    while let Some(data) = arena.node_data_if_live(node) {
+        let kind = data.kind.get();
+        if node_facts::kind_is_svg_box(kind) || kind == NodeKind::SVGSVGBox || kind == NodeKind::SVGForeignObjectBox {
+            return false;
+        }
+
+        if !node_facts::has_flag(data, NodeFlag::HasStyle) {
+            node = data.parent.get();
+            continue;
+        }
+        if let Some(style) = arena.node_style_if_live(node)
+            && (style_queries::has_css_transform(arena, node, style)
+                || style.transform().has_perspective
+                || style_queries::is_sticky_position(style))
+        {
+            return false;
+        }
+        let compensates_for_scroll =
+            NodeFlag::CompensatesForHorizontalScroll as u32 | NodeFlag::CompensatesForVerticalScroll as u32;
+        if data.flags.get() & compensates_for_scroll != 0 {
+            return false;
+        }
+        // A scroll container's contents move, but its own border box does not.
+        if node != layout_node {
+            let scroll_offset_is_zero = if kind == NodeKind::Viewport {
+                viewport_scroll_offset_is_zero
+            } else {
+                !node_facts::has_flag(data, NodeFlag::HasScrollOffset)
+            };
+            if !scroll_offset_is_zero && arena.paintable_row_is_populated(node) {
+                return false;
+            }
+        }
+        node = data.parent.get();
+    }
+    true
+}

--- a/Libraries/LibWeb/Rust/src/painting/content_visibility.rs
+++ b/Libraries/LibWeb/Rust/src/painting/content_visibility.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::css::css_enums::content_visibility;
+use crate::layout::node_data::NodeSlotId;
+use crate::painting::node_painting;
+use crate::painting::paintable_rows::PaintableRowsRead;
+
+pub(crate) fn for_each_box_with_auto_content_visibility(
+    arena: &impl PaintableRowsRead,
+    root: NodeSlotId,
+    mut push_box: impl FnMut(NodeSlotId),
+) {
+    if !arena.slot_is_live(root) {
+        return;
+    }
+    arena.for_each_node_in_layout_subtree_in_pre_order_with_pruning(root, |node| {
+        if node_painting::forms_unconnected_subtree(arena.data(node).kind.get()) {
+            return false;
+        }
+        if !arena.node_dom_node_is_element(node) || !arena.paintable_row_is_populated(node) {
+            return true;
+        }
+        let content_visibility_is_auto = arena
+            .node_style_if_live(node)
+            .is_some_and(|style| style.content_visibility() == content_visibility::AUTO);
+        if content_visibility_is_auto {
+            push_box(node);
+        }
+        true
+    });
+}

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -2561,7 +2561,8 @@ pub unsafe extern "C" fn layout_arena_visual_line_offset_closest_to_inline_coord
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document
-/// thread. `node_slots` must point at `node_slot_count` valid slots.
+/// thread. `node_slots` must point at `node_slot_count` valid slots, and
+/// `rect_to_viewport_transform` must satisfy `rect_to_viewport_transform_from_ffi`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_text_range_rects(
     arena: *mut c_void,
@@ -2572,11 +2573,13 @@ pub unsafe extern "C" fn layout_arena_text_range_rects(
     range_end_offset: usize,
     filter_dom_start: usize,
     filter_dom_end: usize,
+    rect_to_viewport_transform: FfiRectToViewportTransform,
     context: *mut c_void,
-    push_rect: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiCssPixelRect),
+    push_rect: unsafe extern "C" fn(*mut c_void, FfiCssPixelRect),
 ) {
     let arena = unsafe { arena_from_handle(arena) };
     let paintable_rows = arena.paintable_rows();
+    let rect_to_viewport_transform = unsafe { rect_to_viewport_transform_from_ffi(&rect_to_viewport_transform) };
 
     // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
     let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
@@ -2595,8 +2598,19 @@ pub unsafe extern "C" fn layout_arena_text_range_rects(
             range_end_offset,
         );
 
-        // SAFETY: The consumer handles a null shell and copies the rect synchronously.
-        unsafe { push_rect(context, arena.shell_if_live(block), rect.into()) };
+        let rect_in_viewport_space = if arena.slot_is_live(block) {
+            crate::painting::rect_to_viewport_transform::transform_rect_to_viewport_or_identity(
+                rect_to_viewport_transform.as_ref(),
+                &paintable_rows,
+                block,
+                rect,
+            )
+        } else {
+            rect
+        };
+
+        // SAFETY: The consumer copies the plain-data rect synchronously.
+        unsafe { push_rect(context, rect_in_viewport_space.into()) };
         true
     });
 }

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::css::css_pixels::{CssPixelRect, CssPixels};
+use crate::css::css_pixels::{CssPixelPoint, CssPixelRect, CssPixels};
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::layout::used_values::FfiCssPixelPoint;
@@ -18,6 +18,7 @@ use crate::painting::host::FfiRecordedDisplayList;
 use crate::painting::paintable_data::*;
 use crate::painting::paintable_rows::{PaintableRowsRead, with_inline_pieces};
 use crate::painting::rect_to_viewport_transform::RectToViewportTransform;
+use crate::painting::scroll_chain::ViewportWheelOverflow;
 use std::ffi::c_void;
 use std::rc::Rc;
 
@@ -236,6 +237,101 @@ pub unsafe extern "C" fn layout_arena_paintable_maximum_scroll_offset(
 ) -> FfiCssPixelPoint {
     let arena = unsafe { arena_from_handle(arena) };
     crate::painting::chrome_geometry::maximum_scroll_offset(&arena.paintable_rows(), slot).into()
+}
+
+fn scroll_offset_reader(
+    arena: &LayoutNodeArena,
+    scroll_offset_of_layout_node: unsafe extern "C" fn(*mut c_void) -> FfiCssPixelPoint,
+) -> impl Fn(NodeSlotId) -> CssPixelPoint {
+    move |node| {
+        // SAFETY: The C++ host reads the offset of a live layout node shell synchronously.
+        unsafe { scroll_offset_of_layout_node(arena.node_shell(node)) }.into()
+    }
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread. The
+/// host callback receives live layout node shells.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_scrolling_box_for_scroll_step(
+    arena: *mut c_void,
+    target: NodeSlotId,
+    viewport: NodeSlotId,
+    delta: FfiCssPixelPoint,
+    viewport_wheel_overflow_x: u8,
+    viewport_wheel_overflow_y: u8,
+    scroll_offset_of_layout_node: unsafe extern "C" fn(*mut c_void) -> FfiCssPixelPoint,
+) -> *mut c_void {
+    let arena = unsafe { arena_from_handle(arena) };
+    let scrolling_box = crate::painting::scroll_chain::scrolling_box_for_scroll_step(
+        &arena.paintable_rows(),
+        target,
+        viewport,
+        delta.into(),
+        ViewportWheelOverflow {
+            x: viewport_wheel_overflow_x,
+            y: viewport_wheel_overflow_y,
+        },
+        &scroll_offset_reader(arena, scroll_offset_of_layout_node),
+    );
+    arena.shell_if_live(scrolling_box)
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread. The
+/// host callback receives live layout node shells.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_for_each_wheel_scrollable_box_in_containing_block_chain(
+    arena: *mut c_void,
+    start: NodeSlotId,
+    wheel_delta_x: f64,
+    wheel_delta_y: f64,
+    viewport_wheel_overflow_x: u8,
+    viewport_wheel_overflow_y: u8,
+    scroll_offset_of_layout_node: unsafe extern "C" fn(*mut c_void) -> FfiCssPixelPoint,
+    context: *mut c_void,
+    push_scrollable_box: unsafe extern "C" fn(*mut c_void, *mut c_void, f64, f64),
+) {
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::scroll_chain::for_each_wheel_scrollable_box_in_containing_block_chain(
+        &arena.paintable_rows(),
+        start,
+        wheel_delta_x,
+        wheel_delta_y,
+        ViewportWheelOverflow {
+            x: viewport_wheel_overflow_x,
+            y: viewport_wheel_overflow_y,
+        },
+        &scroll_offset_reader(arena, scroll_offset_of_layout_node),
+        |node, accepted_delta_x, accepted_delta_y| {
+            // SAFETY: The C++ callback appends the shell and deltas to a caller-owned collection.
+            unsafe { push_scrollable_box(context, arena.node_shell(node), accepted_delta_x, accepted_delta_y) };
+        },
+    );
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_first_wheel_scrollable_box_in_containing_block_chain(
+    arena: *mut c_void,
+    start: NodeSlotId,
+    viewport_wheel_overflow_x: u8,
+    viewport_wheel_overflow_y: u8,
+) -> *mut c_void {
+    let arena = unsafe { arena_from_handle(arena) };
+    let scrollable_box = crate::painting::scroll_chain::first_wheel_scrollable_box_in_containing_block_chain(
+        &arena.paintable_rows(),
+        start,
+        ViewportWheelOverflow {
+            x: viewport_wheel_overflow_x,
+            y: viewport_wheel_overflow_y,
+        },
+    );
+    arena.shell_if_live(scrollable_box)
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -2257,6 +2257,23 @@ pub unsafe extern "C" fn layout_arena_inline_paintable_piece_border_box_rects(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_can_compute_client_rects_without_visual_context_update(
+    arena: *mut c_void,
+    layout_node: NodeSlotId,
+    viewport_scroll_offset_is_zero: bool,
+) -> bool {
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::client_rects::can_compute_client_rects_without_visual_context_update(
+        &arena.paintable_rows(),
+        layout_node,
+        viewport_scroll_offset_is_zero,
+    )
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_inline_paintable_has_content_pieces(
     arena: *mut c_void,
     inline_paintable: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -2328,6 +2328,27 @@ pub unsafe extern "C" fn layout_arena_intersection_observer_intersection_rect(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_collect_boxes_with_auto_content_visibility(
+    arena: *mut c_void,
+    root: NodeSlotId,
+    context: *mut c_void,
+    push_box: unsafe extern "C" fn(*mut c_void, NodeSlotId),
+) {
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::content_visibility::for_each_box_with_auto_content_visibility(
+        &arena.paintable_rows(),
+        root,
+        |slot| {
+            // SAFETY: The C++ callback appends the slot id to a caller-owned collection.
+            unsafe { push_box(context, slot) };
+        },
+    );
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_can_compute_client_rects_without_visual_context_update(
     arena: *mut c_void,
     layout_node: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -2294,6 +2294,27 @@ pub unsafe extern "C" fn layout_arena_bounding_client_rect(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread, and
 /// `rect_to_viewport_transform` must satisfy `rect_to_viewport_transform_from_ffi`.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_transform_subtree_is_clipped_outside(
+    arena: *mut c_void,
+    target: NodeSlotId,
+    root_bounds: FfiCssPixelRect,
+    rect_to_viewport_transform: FfiRectToViewportTransform,
+) -> bool {
+    let arena = unsafe { arena_from_handle(arena) };
+    let rect_to_viewport_transform = unsafe { rect_to_viewport_transform_from_ffi(&rect_to_viewport_transform) };
+    crate::painting::intersection_observer::transform_subtree_is_clipped_outside(
+        &arena.paintable_rows(),
+        target,
+        root_bounds.into(),
+        rect_to_viewport_transform.as_ref(),
+    )
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread, and
+/// `rect_to_viewport_transform` must satisfy `rect_to_viewport_transform_from_ffi`.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_intersection_observer_intersection_rect(
     arena: *mut c_void,
     target: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -16,7 +16,8 @@ use crate::painting::display_list::commands::SpatialNodeIndex;
 use crate::painting::force_dark::ForceDarkRole;
 use crate::painting::host::FfiRecordedDisplayList;
 use crate::painting::paintable_data::*;
-use crate::painting::paintable_rows::PaintableRowsRead;
+use crate::painting::paintable_rows::{PaintableRowsRead, with_inline_pieces};
+use crate::painting::rect_to_viewport_transform::RectToViewportTransform;
 use std::ffi::c_void;
 use std::rc::Rc;
 
@@ -2208,49 +2209,72 @@ pub unsafe extern "C" fn layout_arena_paintable_empty_line_caret_rect(
     result
 }
 
-fn with_inline_pieces(
-    arena: &impl PaintableRowsRead,
-    inline_paintable: NodeSlotId,
-    mut callback: impl FnMut(&InlineBoxPieceRecord, &PaintableData) -> bool,
-) {
-    let Some(root) = arena.inline_pieces_root(inline_paintable) else {
-        return;
-    };
-    let data = arena.paintable_data(inline_paintable);
-    let root_side = arena.paintable_side_data(root);
-    for piece_index in &arena.paintable_side_data(inline_paintable).piece_indices {
-        let piece = &root_side.inline_box_pieces[*piece_index as usize];
-        if !callback(piece, data) {
-            return;
-        }
+#[repr(C)]
+pub struct FfiRectToViewportTransform {
+    pub visual_context_tree: *const c_void,
+    pub scroll_offsets: *const libgfx_rust::FloatPoint,
+    pub scroll_offsets_len: usize,
+    pub device_pixels_per_css_pixel: f32,
+}
+
+/// SAFETY: A non-null `visual_context_tree` must be a live retained tree handle and `scroll_offsets`
+/// must address `scroll_offsets_len` points for as long as the returned borrow lives.
+unsafe fn rect_to_viewport_transform_from_ffi(
+    transform: &FfiRectToViewportTransform,
+) -> Option<RectToViewportTransform<'_>> {
+    if transform.visual_context_tree.is_null() {
+        return None;
     }
+    Some(RectToViewportTransform {
+        visual_context_tree: unsafe { tree_from_handle(transform.visual_context_tree) },
+        scroll_offsets: unsafe { ffi_slice(transform.scroll_offsets, transform.scroll_offsets_len) },
+        device_pixels_per_css_pixel: transform.device_pixels_per_css_pixel,
+    })
 }
 
 /// # Safety
 ///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread, and
+/// `rect_to_viewport_transform` must satisfy `rect_to_viewport_transform_from_ffi`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_inline_paintable_piece_border_box_rects(
+pub unsafe extern "C" fn layout_arena_client_rects(
     arena: *mut c_void,
-    inline_paintable: NodeSlotId,
+    layout_node: NodeSlotId,
+    rect_to_viewport_transform: FfiRectToViewportTransform,
     context: *mut c_void,
     push_rect: unsafe extern "C" fn(*mut c_void, FfiCssPixelRect),
 ) {
     let arena = unsafe { arena_from_handle(arena) };
-    let paintable_rows = arena.paintable_rows();
-    let Some(root) = paintable_rows.inline_pieces_root(inline_paintable) else {
-        return;
-    };
-    let root_position = crate::painting::paintable_geometry::absolute_position(&paintable_rows, root);
-    with_inline_pieces(&paintable_rows, inline_paintable, |piece, _| {
-        if piece.is_geometry_only_placeholder {
-            return true;
-        }
-        let rect = crate::css::css_pixels::CssPixelRect::from(piece.border_box_rect).translated_by(root_position);
-        // SAFETY: The consumer copies the plain-data rect synchronously.
-        unsafe { push_rect(context, rect.into()) };
-        true
-    });
+    let rect_to_viewport_transform = unsafe { rect_to_viewport_transform_from_ffi(&rect_to_viewport_transform) };
+    crate::painting::client_rects::for_each_client_rect(
+        &arena.paintable_rows(),
+        layout_node,
+        rect_to_viewport_transform.as_ref(),
+        |rect| {
+            // SAFETY: The consumer copies the plain-data rect synchronously.
+            unsafe { push_rect(context, rect.into()) };
+        },
+    );
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread, and
+/// `rect_to_viewport_transform` must satisfy `rect_to_viewport_transform_from_ffi`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_bounding_client_rect(
+    arena: *mut c_void,
+    layout_node: NodeSlotId,
+    rect_to_viewport_transform: FfiRectToViewportTransform,
+) -> FfiCssPixelRect {
+    let arena = unsafe { arena_from_handle(arena) };
+    let rect_to_viewport_transform = unsafe { rect_to_viewport_transform_from_ffi(&rect_to_viewport_transform) };
+    crate::painting::client_rects::bounding_client_rect(
+        &arena.paintable_rows(),
+        layout_node,
+        rect_to_viewport_transform.as_ref(),
+    )
+    .into()
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::css::css_pixels::CssPixels;
+use crate::css::css_pixels::{CssPixelRect, CssPixels};
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::layout::used_values::FfiCssPixelPoint;
@@ -2279,6 +2279,41 @@ pub unsafe extern "C" fn layout_arena_bounding_client_rect(
 
 /// # Safety
 ///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread, and
+/// `rect_to_viewport_transform` must satisfy `rect_to_viewport_transform_from_ffi`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_intersection_observer_intersection_rect(
+    arena: *mut c_void,
+    target: NodeSlotId,
+    target_rect: FfiCssPixelRect,
+    intersection_root: NodeSlotId,
+    root_bounds: FfiCssPixelRect,
+    rect_to_viewport_transform: FfiRectToViewportTransform,
+    context: *mut c_void,
+    inflate_scroll_container_clip_rect_by_scroll_margin: unsafe extern "C" fn(
+        *mut c_void,
+        FfiCssPixelRect,
+    ) -> FfiCssPixelRect,
+) -> FfiCssPixelRect {
+    let arena = unsafe { arena_from_handle(arena) };
+    let rect_to_viewport_transform = unsafe { rect_to_viewport_transform_from_ffi(&rect_to_viewport_transform) };
+    crate::painting::intersection_observer::intersection_rect(
+        &arena.paintable_rows(),
+        target,
+        target_rect.into(),
+        intersection_root,
+        root_bounds.into(),
+        rect_to_viewport_transform.as_ref(),
+        |clip_rect: CssPixelRect| -> CssPixelRect {
+            // SAFETY: The callback copies the plain-data rect synchronously.
+            unsafe { inflate_scroll_container_clip_rect_by_scroll_margin(context, clip_rect.into()) }.into()
+        },
+    )
+    .into()
+}
+
+/// # Safety
+///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_can_compute_client_rects_without_visual_context_update(
@@ -2343,7 +2378,7 @@ pub unsafe extern "C" fn layout_arena_inline_paintable_first_piece_position(
     let border_widths = crate::painting::paintable_geometry::committed_border(arena, inline_paintable);
     let padding_widths = crate::painting::paintable_geometry::committed_padding(arena, inline_paintable);
     with_inline_pieces(&paintable_rows, inline_paintable, |piece, _data| {
-        let border_rect = crate::css::css_pixels::CssPixelRect::from(piece.border_box_rect);
+        let border_rect = CssPixelRect::from(piece.border_box_rect);
         let rect = if piece.is_geometry_only_placeholder {
             border_rect
         } else {

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -311,6 +311,18 @@ pub unsafe extern "C" fn layout_arena_node_establishes_a_fixed_positioning_conta
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_any_ancestor_establishes_a_fixed_position_containing_block(
+    arena: *mut c_void,
+    node: NodeSlotId,
+) -> bool {
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::style_queries::any_ancestor_establishes_a_fixed_position_containing_block(arena, node)
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_node_has_css_transform(arena: *mut c_void, node: NodeSlotId) -> bool {
     let arena = unsafe { arena_from_handle(arena) };
     let Some(style) = arena.node_style_if_live(node) else {

--- a/Libraries/LibWeb/Rust/src/painting/intersection_observer.rs
+++ b/Libraries/LibWeb/Rust/src/painting/intersection_observer.rs
@@ -5,13 +5,14 @@
  */
 
 use crate::css::computed_value_views::ComputedValuesView;
-use crate::css::css_enums::overflow;
+use crate::css::css_enums::{overflow, positioning};
 use crate::css::css_pixels::CssPixelRect;
-use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_data::{NodeFlag, NodeSlotId};
 use crate::layout::node_facts;
 use crate::painting::paintable_geometry;
 use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::rect_to_viewport_transform::{RectToViewportTransform, transform_rect_to_viewport_or_identity};
+use crate::painting::style_queries;
 
 fn content_clip_rect_in_viewport_space(
     arena: &impl PaintableRowsRead,
@@ -95,4 +96,58 @@ pub(crate) fn intersection_rect(
 
     // 7. Return intersectionRect.
     intersection_rect
+}
+
+pub(crate) fn transform_subtree_is_clipped_outside(
+    arena: &impl PaintableRowsRead,
+    target: NodeSlotId,
+    root_bounds: CssPixelRect,
+    rect_to_viewport_transform: Option<&RectToViewportTransform<'_>>,
+) -> bool {
+    if !arena.paintable_row_is_populated(target) || root_bounds.is_empty() {
+        return false;
+    }
+    let target_data = arena.data(target);
+    if node_facts::kind_is_box(target_data.kind.get())
+        && (style_queries::is_fixed_position(arena, target)
+            || node_facts::has_flag(target_data, NodeFlag::AbsposDescendantEscapes))
+    {
+        return false;
+    }
+
+    let mut has_disjoint_clip = false;
+    let mut ancestor = target_data.parent.get();
+    while let Some(ancestor_data) = arena.node_data_if_live(ancestor) {
+        let parent = ancestor_data.parent.get();
+        if node_facts::kind_is_box(ancestor_data.kind.get()) {
+            if !arena.paintable_row_is_populated(ancestor) {
+                return false;
+            }
+            let Some(style) = arena.node_style_if_live(ancestor) else {
+                ancestor = parent;
+                continue;
+            };
+            if style.box_values().position == positioning::FIXED {
+                return false;
+            }
+
+            if let Some(clip_rect) =
+                content_clip_rect_in_viewport_space(arena, ancestor, style, rect_to_viewport_transform)
+                && !clip_rect.edge_adjacent_intersects(root_bounds)
+            {
+                has_disjoint_clip = true;
+            }
+
+            // A transform outside the disjoint clip could move the clip into the observation root without updating
+            // its main-thread geometry. Transforms inside the clip can only move content within the clipped region.
+            if has_disjoint_clip
+                && (style_queries::has_css_transform(arena, ancestor, style)
+                    || style_queries::is_sticky_position(style))
+            {
+                return false;
+            }
+        }
+        ancestor = parent;
+    }
+    has_disjoint_clip
 }

--- a/Libraries/LibWeb/Rust/src/painting/intersection_observer.rs
+++ b/Libraries/LibWeb/Rust/src/painting/intersection_observer.rs
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::css::computed_value_views::ComputedValuesView;
+use crate::css::css_enums::overflow;
+use crate::css::css_pixels::CssPixelRect;
+use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_facts;
+use crate::painting::paintable_geometry;
+use crate::painting::paintable_rows::PaintableRowsRead;
+use crate::painting::rect_to_viewport_transform::{RectToViewportTransform, transform_rect_to_viewport_or_identity};
+
+fn content_clip_rect_in_viewport_space(
+    arena: &impl PaintableRowsRead,
+    node: NodeSlotId,
+    style: ComputedValuesView<'_>,
+    rect_to_viewport_transform: Option<&RectToViewportTransform<'_>>,
+) -> Option<CssPixelRect> {
+    let has_content_clip = style.overflow_x() != overflow::VISIBLE || style.overflow_y() != overflow::VISIBLE;
+    if !has_content_clip {
+        return None;
+    }
+    Some(transform_rect_to_viewport_or_identity(
+        rect_to_viewport_transform,
+        arena,
+        node,
+        paintable_geometry::absolute_padding_box_rect(arena, node),
+    ))
+}
+
+// https://www.w3.org/TR/intersection-observer/#compute-the-intersection
+pub(crate) fn intersection_rect(
+    arena: &impl PaintableRowsRead,
+    target: NodeSlotId,
+    target_rect: CssPixelRect,
+    intersection_root: NodeSlotId,
+    root_bounds: CssPixelRect,
+    rect_to_viewport_transform: Option<&RectToViewportTransform<'_>>,
+    mut inflate_scroll_container_clip_rect_by_scroll_margin: impl FnMut(CssPixelRect) -> CssPixelRect,
+) -> CssPixelRect {
+    // 1. Let intersectionRect be the result of getting the bounding box for target.
+    let mut intersection_rect = target_rect;
+
+    // 2. Let container be the containing block of target.
+    // 3. While container is not root:
+    if arena.paintable_row_is_populated(target) {
+        let mut container = arena.node_containing_block_if_live(target);
+        while let Some(container_slot) = container {
+            // Stop when we reach the intersection root.
+            if container_slot == intersection_root {
+                break;
+            }
+            if !arena.paintable_row_is_populated(container_slot) {
+                break;
+            }
+
+            // FIXME: 3.1. If container is the document of a nested browsing context, update
+            //             intersectionRect by clipping to the viewport of the document, and update
+            //             container to be the browsing context container of container.
+
+            // NOTE: Steps 3.2 (map to container coordinate space) and 3.5 (update container) are
+            //       unnecessary here because get_bounding_client_rect() and transform_rect_to_viewport()
+            //       already produce viewport-relative coordinates.
+
+            // 3.3. If container is a scroll container, apply the observer’s [[scrollMargin]]
+            //      to the container’s clip rect.
+            // 3.4. If container has a content clip or a css clip-path property, update intersectionRect
+            //      by applying container’s clip.
+            // FIXME: Handle clip-path.
+            if let Some(style) = arena.node_style_if_live(container_slot)
+                && let Some(mut clip_rect) =
+                    content_clip_rect_in_viewport_space(arena, container_slot, style, rect_to_viewport_transform)
+            {
+                // Apply scroll margin to expand the scrollport for scroll containers.
+                let container_kind = arena.data(container_slot).kind.get();
+                if node_facts::kind_and_style_make_scroll_container(container_kind, Some(style)) {
+                    clip_rect = inflate_scroll_container_clip_rect_by_scroll_margin(clip_rect);
+                }
+
+                intersection_rect = intersection_rect.intersected(clip_rect);
+            }
+            container = arena.node_containing_block_if_live(container_slot);
+        }
+    }
+
+    // FIXME: 4. Map intersectionRect to the coordinate space of root.
+
+    // 5. Update intersectionRect by intersecting it with the root intersection rectangle.
+    intersection_rect = intersection_rect.intersected(root_bounds);
+
+    // FIXME: 6. Map intersectionRect to the coordinate space of the viewport of the document containing target.
+
+    // 7. Return intersectionRect.
+    intersection_rect
+}

--- a/Libraries/LibWeb/Rust/src/painting/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/mod.rs
@@ -25,6 +25,7 @@ pub mod paintable_data;
 pub mod paintable_geometry;
 pub(crate) mod paintable_rows;
 pub mod record;
+pub(crate) mod rect_to_viewport_transform;
 pub mod scrollable_overflow;
 pub mod selection;
 pub mod stacking_context;

--- a/Libraries/LibWeb/Rust/src/painting/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/mod.rs
@@ -7,6 +7,7 @@
 pub mod border_radii;
 mod caret;
 pub(crate) mod chrome_geometry;
+pub(crate) mod client_rects;
 mod devtools_layout;
 pub mod display_list;
 mod dump;

--- a/Libraries/LibWeb/Rust/src/painting/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/mod.rs
@@ -8,6 +8,7 @@ pub mod border_radii;
 mod caret;
 pub(crate) mod chrome_geometry;
 pub(crate) mod client_rects;
+pub(crate) mod content_visibility;
 mod devtools_layout;
 pub mod display_list;
 mod dump;

--- a/Libraries/LibWeb/Rust/src/painting/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/mod.rs
@@ -28,6 +28,7 @@ pub mod paintable_geometry;
 pub(crate) mod paintable_rows;
 pub mod record;
 pub(crate) mod rect_to_viewport_transform;
+pub(crate) mod scroll_chain;
 pub mod scrollable_overflow;
 pub mod selection;
 pub mod stacking_context;

--- a/Libraries/LibWeb/Rust/src/painting/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/mod.rs
@@ -17,6 +17,7 @@ pub mod force_dark;
 pub mod fragment_ownership;
 pub mod hit_test;
 pub mod host;
+pub(crate) mod intersection_observer;
 pub(crate) mod node_painting;
 pub(crate) mod paint_order;
 pub mod paint_state;

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -927,3 +927,21 @@ impl LayoutNodeArena {
         })
     }
 }
+
+pub(crate) fn with_inline_pieces(
+    arena: &impl PaintableRowsRead,
+    inline_paintable: NodeSlotId,
+    mut callback: impl FnMut(&InlineBoxPieceRecord, &PaintableData) -> bool,
+) {
+    let Some(root) = arena.inline_pieces_root(inline_paintable) else {
+        return;
+    };
+    let data = arena.paintable_data(inline_paintable);
+    let root_side = arena.paintable_side_data(root);
+    for piece_index in &arena.paintable_side_data(inline_paintable).piece_indices {
+        let piece = &root_side.inline_box_pieces[*piece_index as usize];
+        if !callback(piece, data) {
+            return;
+        }
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/rect_to_viewport_transform.rs
+++ b/Libraries/LibWeb/Rust/src/painting/rect_to_viewport_transform.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::css::css_pixels::{CssPixelRect, CssPixels};
+use crate::layout::node_data::NodeSlotId;
+use crate::painting::paintable_rows::PaintableRowsRead;
+use crate::painting::visual_context::{IncludeVisualViewportTransform, VisualContextTree};
+use libgfx_rust::{FloatPoint, FloatRect};
+
+pub(crate) struct RectToViewportTransform<'a> {
+    pub visual_context_tree: &'a VisualContextTree,
+    pub scroll_offsets: &'a [FloatPoint],
+    pub device_pixels_per_css_pixel: f32,
+}
+
+impl RectToViewportTransform<'_> {
+    pub(crate) fn transform_rect_to_viewport(
+        &self,
+        arena: &impl PaintableRowsRead,
+        node: NodeSlotId,
+        rect: CssPixelRect,
+    ) -> CssPixelRect {
+        if !arena.paintable_row_is_populated(node) {
+            return CssPixelRect::default();
+        }
+        let pixel_ratio = self.device_pixels_per_css_pixel;
+        let device_rect = FloatRect {
+            x: rect.x.to_float() * pixel_ratio,
+            y: rect.y.to_float() * pixel_ratio,
+            width: rect.width.to_float() * pixel_ratio,
+            height: rect.height.to_float() * pixel_ratio,
+        };
+        let spatial = arena.paintable_data(node).accumulated_visual_context.spatial;
+        let transformed = self.visual_context_tree.transform_rect_to_viewport(
+            spatial,
+            device_rect,
+            self.scroll_offsets,
+            IncludeVisualViewportTransform::No,
+        );
+        let inverse_pixel_ratio = 1.0 / pixel_ratio;
+        CssPixelRect {
+            x: CssPixels::nearest_value_for_f32(transformed.x * inverse_pixel_ratio),
+            y: CssPixels::nearest_value_for_f32(transformed.y * inverse_pixel_ratio),
+            width: CssPixels::nearest_value_for_f32(transformed.width * inverse_pixel_ratio),
+            height: CssPixels::nearest_value_for_f32(transformed.height * inverse_pixel_ratio),
+        }
+    }
+}
+
+pub(crate) fn transform_rect_to_viewport_or_identity(
+    transform: Option<&RectToViewportTransform<'_>>,
+    arena: &impl PaintableRowsRead,
+    node: NodeSlotId,
+    rect: CssPixelRect,
+) -> CssPixelRect {
+    match transform {
+        None => rect,
+        Some(transform) => transform.transform_rect_to_viewport(arena, node, rect),
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/scroll_chain.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scroll_chain.rs
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::css::css_pixels::{CssPixelPoint, CssPixels};
+use crate::layout::node_data::{NodeKind, NodeSlotId};
+use crate::painting::chrome_geometry;
+use crate::painting::paintable_rows::PaintableRowsRead;
+
+#[derive(Clone, Copy)]
+pub(crate) struct ViewportWheelOverflow {
+    pub x: u8,
+    pub y: u8,
+}
+
+fn wheel_scrollable_axes(
+    arena: &impl PaintableRowsRead,
+    node: NodeSlotId,
+    viewport_wheel_overflow: ViewportWheelOverflow,
+) -> chrome_geometry::PhysicalAxes {
+    chrome_geometry::wheel_scrollable_axes(arena, node, viewport_wheel_overflow.x, viewport_wheel_overflow.y)
+}
+
+fn accepted_wheel_delta(
+    arena: &impl PaintableRowsRead,
+    node: NodeSlotId,
+    viewport_wheel_overflow: ViewportWheelOverflow,
+    delta: CssPixelPoint,
+) -> CssPixelPoint {
+    let axes = wheel_scrollable_axes(arena, node, viewport_wheel_overflow);
+    let zero = CssPixels::from_raw(0);
+    CssPixelPoint::new(
+        if axes.horizontal { delta.x } else { zero },
+        if axes.vertical { delta.y } else { zero },
+    )
+}
+
+fn clamp_scroll_offset(arena: &impl PaintableRowsRead, node: NodeSlotId, offset: CssPixelPoint) -> CssPixelPoint {
+    let Some((minimum_offset, maximum_offset)) = chrome_geometry::scroll_offset_bounds(arena, node) else {
+        return offset;
+    };
+    CssPixelPoint::new(
+        offset.x.clamp(minimum_offset.x, maximum_offset.x),
+        offset.y.clamp(minimum_offset.y, maximum_offset.y),
+    )
+}
+
+fn scrolling_box_moved_by(
+    arena: &impl PaintableRowsRead,
+    node: NodeSlotId,
+    delta: CssPixelPoint,
+    scroll_offset_of_layout_node: &dyn Fn(NodeSlotId) -> CssPixelPoint,
+) -> bool {
+    let current_offset = scroll_offset_of_layout_node(node);
+    clamp_scroll_offset(arena, node, current_offset.translated(delta.x, delta.y)) != current_offset
+}
+
+pub(crate) fn scrolling_box_for_scroll_step(
+    arena: &impl PaintableRowsRead,
+    target: NodeSlotId,
+    viewport: NodeSlotId,
+    delta: CssPixelPoint,
+    viewport_wheel_overflow: ViewportWheelOverflow,
+    scroll_offset_of_layout_node: &dyn Fn(NodeSlotId) -> CssPixelPoint,
+) -> NodeSlotId {
+    let scroll_step_moves = |node: NodeSlotId| {
+        let accepted_delta = accepted_wheel_delta(arena, node, viewport_wheel_overflow, delta);
+        accepted_delta != CssPixelPoint::default()
+            && scrolling_box_moved_by(arena, node, accepted_delta, scroll_offset_of_layout_node)
+    };
+
+    let mut node = target;
+    while let Some(data) = arena.node_data_if_live(node) {
+        if data.kind.get() == NodeKind::Viewport {
+            break;
+        }
+        if scroll_step_moves(node) {
+            return node;
+        }
+        node = data.containing_block.get();
+    }
+
+    if arena.slot_is_live(viewport) && scroll_step_moves(viewport) {
+        return viewport;
+    }
+    NodeSlotId::INVALID
+}
+
+pub(crate) fn for_each_wheel_scrollable_box_in_containing_block_chain(
+    arena: &impl PaintableRowsRead,
+    start: NodeSlotId,
+    wheel_delta_x: f64,
+    wheel_delta_y: f64,
+    viewport_wheel_overflow: ViewportWheelOverflow,
+    scroll_offset_of_layout_node: &dyn Fn(NodeSlotId) -> CssPixelPoint,
+    mut push_scrollable_box: impl FnMut(NodeSlotId, f64, f64),
+) {
+    let mut node = start;
+    while let Some(data) = arena.node_data_if_live(node) {
+        if data.kind.get() != NodeKind::Viewport {
+            let axes = wheel_scrollable_axes(arena, node, viewport_wheel_overflow);
+            let accepted_delta_x = if axes.horizontal { wheel_delta_x } else { 0.0 };
+            let accepted_delta_y = if axes.vertical { wheel_delta_y } else { 0.0 };
+            if accepted_delta_x != 0.0 || accepted_delta_y != 0.0 {
+                push_scrollable_box(node, accepted_delta_x, accepted_delta_y);
+                let accepted_delta = CssPixelPoint::new(
+                    CssPixels::nearest_value_for(accepted_delta_x),
+                    CssPixels::nearest_value_for(accepted_delta_y),
+                );
+                if scrolling_box_moved_by(arena, node, accepted_delta, scroll_offset_of_layout_node) {
+                    return;
+                }
+            }
+        }
+        node = data.containing_block.get();
+    }
+}
+
+pub(crate) fn first_wheel_scrollable_box_in_containing_block_chain(
+    arena: &impl PaintableRowsRead,
+    start: NodeSlotId,
+    viewport_wheel_overflow: ViewportWheelOverflow,
+) -> NodeSlotId {
+    let mut node = start;
+    while let Some(data) = arena.node_data_if_live(node) {
+        let backed_by_element_or_viewport =
+            data.kind.get() == NodeKind::Viewport || arena.node_dom_node_is_element(node);
+        if backed_by_element_or_viewport && arena.paintable_row_is_populated(node) {
+            let axes = wheel_scrollable_axes(arena, node, viewport_wheel_overflow);
+            if axes.horizontal || axes.vertical {
+                return node;
+            }
+        }
+        node = data.containing_block.get();
+    }
+    NodeSlotId::INVALID
+}

--- a/Libraries/LibWeb/Rust/src/painting/style_queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/style_queries.rs
@@ -553,6 +553,10 @@ pub(crate) fn is_fixed_position(arena: &LayoutNodeArena, node: NodeSlotId) -> bo
     position(arena, node) == positioning::FIXED
 }
 
+pub(crate) fn is_sticky_position(style: ComputedValuesView<'_>) -> bool {
+    style.box_values().position == positioning::STICKY
+}
+
 pub(crate) fn is_floating(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
     arena
         .node_data_if_live(node)

--- a/Libraries/LibWeb/Rust/src/painting/style_queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/style_queries.rs
@@ -311,6 +311,23 @@ pub(crate) fn establishes_positioning_containing_blocks(arena: &LayoutNodeArena,
     (false, false)
 }
 
+pub(crate) fn any_ancestor_establishes_a_fixed_position_containing_block(
+    arena: &LayoutNodeArena,
+    node: NodeSlotId,
+) -> bool {
+    // https://www.w3.org/TR/css-position-3/#fixed-positioning-containing-block
+    // The containing block is established by the nearest ancestor box that establishes an fixed positioning containing
+    // block, with the bounds of the containing block determined identically to the absolute positioning containing block.
+    let mut ancestor = arena.node_containing_block_if_live(node);
+    while let Some(ancestor_slot) = ancestor {
+        if establishes_positioning_containing_blocks(arena, ancestor_slot).1 {
+            return true;
+        }
+        ancestor = arena.node_containing_block_if_live(ancestor_slot);
+    }
+    false
+}
+
 pub(crate) fn has_css_transform(arena: &LayoutNodeArena, node: NodeSlotId, style: ComputedValuesView<'_>) -> bool {
     let transform = style.transform();
     let has_transform = !transform.transformations.pointer.is_null()


### PR DESCRIPTION
Several CSSOM and scrolling paths walked layout nodes one at a time from C++, paying an FFI hop per tree link and per paintable accessor. Each walk now runs inside the layout arena as one query; DOM-owned facts cross as parameters or a callback.

Ported: the getClientRects fast path, Element client rects and the bounding fold, the intersection observer clip chain, Range text rect mapping, the fixed-position containing block walk, content-visibility box collection, the compositor offscreen-clip test, and the containing block scroll chain used by wheel, keyboard and autoscroll.

Layout and paint updates, DOM traversal, scroll offset storage and scroll settlement stay in C++. Helpers that lost their last caller are deleted.