### PR TITLE
LibWeb: Follow the spec when creating navigation timing entries

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -130,6 +130,7 @@
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Editing/EditingHistory.h>
+#include <LibWeb/Fetch/Fetching/Checks.h>
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
 #include <LibWeb/Fetch/Infrastructure/FetchRecord.h>
 #include <LibWeb/Fetch/Infrastructure/FetchTimingInfo.h>
@@ -505,7 +506,8 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
     //    active sandboxing flag set: navigationParams's final sandboxing flag set
     //    FIXME: opener policy: navigationParams's opener policy
     //    load timing info: loadTimingInfo
-    //    FIXME: was created via cross-origin redirects: navigationParams's response's has cross-origin redirects
+    //    FIXME: was created via cross-origin redirects: true if navigationParams's response's redirect taint is not
+    //           "same-origin"; otherwise false
     //    during-loading navigation ID for WebDriver BiDi: navigationParams's id
     //    URL: creationURL
     //    current document readiness: "loading"
@@ -544,26 +546,6 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
     // 10. Set window's associated Document to document.
     window->set_associated_document(*document);
 
-    bool has_cross_origin_redirects = false;
-    if (!navigation_params.response->url_list().is_empty()) {
-        auto initial_origin = navigation_params.response->url_list().first().origin();
-        for (auto const& url : navigation_params.response->url_list()) {
-            if (!url.origin().is_same_origin(initial_origin)) {
-                has_cross_origin_redirects = true;
-                break;
-            }
-        }
-    }
-    auto redirect_count = navigation_params.request && !has_cross_origin_redirects ? navigation_params.request->redirect_count() : 0;
-    NavigationTiming::PerformanceNavigationTiming::create_navigation_timing_entry(
-        *document,
-        timing_info,
-        redirect_count,
-        navigation_params.navigation_timing_type,
-        navigation_params.response->cache_state(),
-        navigation_params.response->body_info(),
-        navigation_params.response->status());
-
     // 11. Set document's internal ancestor origin objects list to the result of running the internal ancestor origin
     //     objects list creation steps given document and navigationParams's iframe element referrer policy.
     document->set_internal_ancestor_origin_objects_list(document->internal_ancestor_origin_objects_list_creation_steps(navigation_params.iframe_element_referrer_policy));
@@ -589,24 +571,66 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
         }
     }
 
+    // NOTE: Step 16 is treated as the else branch of step 15. Otherwise, redirectCount is undefined when the fetch
+    //       controller is null, and two navigation timing entries are created when it is non-null. Since both branches
+    //       consume redirectCount, perform steps 15.2 and 15.3 before selecting the branch.
+
+    // 15.2. Let redirectCount be 0.
+    u16 redirect_count = 0;
+    if (navigation_params.request) {
+        auto const& request = *navigation_params.request;
+
+        // 15.3. If navigationParams's response's redirect taint is "same-origin", or all of the following are true:
+        auto may_expose_redirect_count = navigation_params.response->redirect_taint() == Fetch::Infrastructure::RedirectTaint::SameOrigin;
+        if (!may_expose_redirect_count) {
+            // - navigationParams's request's client is null, or navigationParams's request's referrer is not "no-referrer", and
+            auto request_has_eligible_referrer = !request.referrer().has<Fetch::Infrastructure::Request::Referrer>()
+                || request.referrer().get<Fetch::Infrastructure::Request::Referrer>() != Fetch::Infrastructure::Request::Referrer::NoReferrer;
+
+            // - navigation TAO check given navigationParams's response and navigationParams's origin returns success,
+            may_expose_redirect_count = (!request.client() || request_has_eligible_referrer)
+                && Fetch::Fetching::navigation_tao_check(*navigation_params.response, navigation_params.origin);
+        }
+
+        // then set redirectCount to navigationParams's request's redirect count.
+        if (may_expose_redirect_count)
+            redirect_count = request.redirect_count();
+    }
+
+    // 15. If navigationParams's fetch controller is not null:
+    if (navigation_params.fetch_controller) {
+        // 1. Let fullTimingInfo be the result of extracting the full timing info from navigationParams's fetch controller.
+        auto full_timing_info = navigation_params.fetch_controller->extract_full_timing_info();
+
+        // 4. Create the navigation timing entry for document, given fullTimingInfo, redirectCount, navigationTimingType,
+        //    navigationParams's response's service worker timing info, and navigationParams's response's body info.
+        NavigationTiming::PerformanceNavigationTiming::create_navigation_timing_entry(
+            *document,
+            full_timing_info,
+            redirect_count,
+            navigation_params.navigation_timing_type,
+            navigation_params.response->cache_state(),
+            navigation_params.response->body_info(),
+            navigation_params.response->status());
+    }
+
+    // 16. Create the navigation timing entry for document, with navigationParams's response's timing info,
+    //     redirectCount, navigationParams's navigation timing type, and navigationParams's response's service worker timing info.
+    else {
+        NavigationTiming::PerformanceNavigationTiming::create_navigation_timing_entry(
+            *document,
+            timing_info,
+            redirect_count,
+            navigation_params.navigation_timing_type,
+            navigation_params.response->cache_state(),
+            navigation_params.response->body_info(),
+            navigation_params.response->status());
+    }
+
     // AD-HOC: Retain the navigation fetch controller so aborting the document can cancel the main resource after
     //         response commitment. Navigation fetches are not included in the document's subresource fetch group.
     if (navigation_params.fetch_controller)
         document->m_ongoing_navigation_fetch_controller = navigation_params.fetch_controller;
-
-    // FIXME: 15. If navigationParams's fetch controller is not null:
-    //            1. Let fullTimingInfo be the result of extracting the full timing info from navigationParams's fetch controller.
-    //            2. Let redirectCount be 0.
-    //            3. If navigationParams's response's has cross-origin redirects is false, or all of the following are true:
-    //                - navigationParams's request's client is null, or navigationParams's request's referrer is not "no-referrer", and
-    //                - navigation TAO check given navigationParams's response and navigationParams's origin returns success,
-    //               then set redirectCount to navigationParams's request's redirect count.
-    //            4. Create the navigation timing entry for document, given fullTimingInfo, redirectCount, navigationTimingType,
-    //               navigationParams's response's service worker timing info, and navigationParams's response's body info.
-
-    // FIXME: 16. Create the navigation timing entry for document, with navigationParams's response's timing info,
-    //        redirectCount, navigationParams's navigation timing type, and navigationParams's response's service
-    //        worker timing info.
 
     // 17. If navigationParams's response has a `Refresh` header, then:
     if (auto maybe_refresh = navigation_params.response->header_list()->get("Refresh"sv); maybe_refresh.has_value()) {

--- a/Libraries/LibWeb/Fetch/Fetching/Checks.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Checks.cpp
@@ -82,4 +82,25 @@ bool tao_check(Infrastructure::Request const& request, Infrastructure::Response 
     return false;
 }
 
+// https://fetch.spec.whatwg.org/#navigation-tao-check
+bool navigation_tao_check(Infrastructure::Response const& response, URL::Origin const& destination_origin)
+{
+    // 1. For each taoValues of response's navigation timing allow values list:
+    for (auto const& tao_values : response.navigation_timing_allow_values_list()) {
+        // 1. If taoValues contains "*", then continue.
+        if (tao_values.contains_slow("*"sv))
+            continue;
+
+        // 2. If taoValues contains destinationOrigin, serialized, then continue.
+        if (tao_values.contains_slow(destination_origin.serialize()))
+            continue;
+
+        // 3. Return failure.
+        return false;
+    }
+
+    // 2. Return success.
+    return true;
+}
+
 }

--- a/Libraries/LibWeb/Fetch/Fetching/Checks.h
+++ b/Libraries/LibWeb/Fetch/Fetching/Checks.h
@@ -7,11 +7,13 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <LibURL/Forward.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Fetch::Fetching {
 
 [[nodiscard]] bool cors_check(Infrastructure::Request const&, Infrastructure::Response const&);
 [[nodiscard]] bool tao_check(Infrastructure::Request const&, Infrastructure::Response const&);
+[[nodiscard]] bool navigation_tao_check(Infrastructure::Response const&, URL::Origin const& destination_origin);
 
 }

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -679,11 +679,16 @@ GC::Ptr<PendingResponse> main_fetch(JS::Realm& realm, Infrastructure::FetchParam
             // 17. Set internalResponse’s redirect taint to request’s redirect-taint.
             internal_response->set_redirect_taint(request->redirect_taint());
 
-            // 18. If request’s timing allow failed flag is unset, then set internalResponse’s timing allow passed flag.
+            // 18. If request is a navigation request, then set internalResponse's navigation timing allow values list
+            //     to a clone of request's navigation timing allow values list.
+            if (request->is_navigation_request())
+                internal_response->set_navigation_timing_allow_values_list(request->navigation_timing_allow_values_list());
+
+            // 19. If request’s timing allow failed flag is unset, then set internalResponse’s timing allow passed flag.
             if (!request->timing_allow_failed())
                 internal_response->set_timing_allow_passed(true);
 
-            // 19. If response is not a network error and any of the following returns blocked
+            // 20. If response is not a network error and any of the following returns blocked
             if (!response->is_network_error() && (
                     // - should internalResponse to request be blocked as mixed content
                     MixedContent::should_response_to_request_be_blocked_as_mixed_content(request, internal_response) == Infrastructure::RequestOrResponseBlocking::Blocked
@@ -697,7 +702,7 @@ GC::Ptr<PendingResponse> main_fetch(JS::Realm& realm, Infrastructure::FetchParam
                 response = internal_response = Infrastructure::Response::network_error("Response was blocked"_string);
             }
 
-            // 20. If response’s type is "opaque", internalResponse’s status is 206, internalResponse’s range-requested
+            // 21. If response’s type is "opaque", internalResponse’s status is 206, internalResponse’s range-requested
             //     flag is set, and request’s header list does not contain `Range`, then set response and
             //     internalResponse to a network error.
             // NOTE: Traditionally, APIs accept a ranged response even if a range was not requested. This prevents a
@@ -710,14 +715,14 @@ GC::Ptr<PendingResponse> main_fetch(JS::Realm& realm, Infrastructure::FetchParam
                 response = internal_response = Infrastructure::Response::network_error("Response has status 206 and 'range-requested' flag set, but request has no 'Range' header"_string);
             }
 
-            // 21. If response is not a network error and either request’s method is `HEAD` or `CONNECT`, or
+            // 22. If response is not a network error and either request’s method is `HEAD` or `CONNECT`, or
             //     internalResponse’s status is a null body status, set internalResponse’s body to null and disregard
             //     any enqueuing toward it (if any).
             // NOTE: This standardizes the error handling for servers that violate HTTP.
             if (!response->is_network_error() && (request->method().is_one_of("HEAD"sv, "CONNECT"sv) || Infrastructure::is_null_body_status(internal_response->status())))
                 internal_response->set_body({});
 
-            // 22. If request’s integrity metadata is not the empty string, then:
+            // 23. If request’s integrity metadata is not the empty string, then:
             if (!request->integrity_metadata().is_empty()) {
                 // 1. Let processBodyError be this step: run fetch response handover given fetchParams and a network
                 //    error.
@@ -749,7 +754,7 @@ GC::Ptr<PendingResponse> main_fetch(JS::Realm& realm, Infrastructure::FetchParam
                 // 4. Fully read response’s body given processBody and processBodyError.
                 response->body()->fully_read(realm, process_body, process_body_error, fetch_params.task_destination());
             }
-            // 23. Otherwise, run fetch response handover given fetchParams and response.
+            // 24. Otherwise, run fetch response handover given fetchParams and response.
             else {
                 fetch_response_handover(realm, fetch_params, *response);
             }
@@ -792,7 +797,16 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
             timing_info->set_server_timing_headers(server_timing_headers.release_value());
     }
 
-    // AD-HOC: We extract steps 1-3 of processResponseEndOfBody into a separate lambda so we can also call it from
+    // https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object
+    // NOTE: The create and initialize a Document object algorithm extracts full timing info for navigation requests
+    //       whose destination can also be "embed", "frame", "iframe", or "object".
+
+    // 3. If fetchParams's request's destination is "document", then set fetchParams's controller's full timing info
+    //    to fetchParams's timing info.
+    if (fetch_params.request()->is_navigation_request())
+        fetch_params.controller()->set_full_timing_info(fetch_params.timing_info());
+
+    // AD-HOC: We extract steps 1-2 of processResponseEndOfBody into a separate lambda so we can also call it from
     //         the error path. The fetch spec only runs processResponseEndOfBody on successful body read (via the
     //         transform stream's flush algorithm). However, processResponseConsumeBody is called for both success
     //         and failure, and specs like HTML's preload algorithm expect to be able to call reportTiming from
@@ -802,12 +816,7 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
         // 1. Let unsafeEndTime be the unsafe shared current time.
         auto unsafe_end_time = HighResolutionTime::unsafe_shared_current_time();
 
-        // 2. If fetchParams’s request’s destination is "document", then set fetchParams’s controller’s full timing
-        //    info to fetchParams’s timing info.
-        if (fetch_params.request()->destination() == Infrastructure::Request::Destination::Document)
-            fetch_params.controller()->set_full_timing_info(fetch_params.timing_info());
-
-        // 3. Set fetchParams’s controller’s report timing steps to the following steps given a global object global:
+        // 2. Set fetchParams’s controller’s report timing steps to the following steps given a global object global:
         fetch_params.controller()->set_report_timing_steps([&response, &fetch_params, timing_info, unsafe_end_time](JS::Object& global) mutable {
             // 1. If fetchParams’s request’s URL’s scheme is not an HTTP(S) scheme, then return.
             if (!Infrastructure::is_http_or_https_scheme(fetch_params.request()->url().scheme()))
@@ -863,7 +872,7 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
 
     // 3. Let processResponseEndOfBody be the following steps:
     auto process_response_end_of_body = [&fetch_params, &response, setup_report_timing_steps] {
-        // 1-3. (See setup_report_timing_steps above)
+        // 1-2. (See setup_report_timing_steps above)
         setup_report_timing_steps();
 
         // 4. Let processResponseEndOfBodyTask be the following steps:
@@ -1404,11 +1413,16 @@ GC::Ref<PendingResponse> http_fetch(JS::Realm& realm, Infrastructure::FetchParam
 
         // 6. If internalResponse’s status is a redirect status:
         if (Infrastructure::is_redirect_status(internal_response->status())) {
-            // FIXME: 1. If internalResponse’s status is not 303, request’s body is non-null, and the connection uses HTTP/2,
+            // 1. If request is a navigation request, then append to request's navigation timing allow values list
+            //    given request and internalResponse.
+            if (request->is_navigation_request())
+                request->append_to_navigation_timing_allow_values_list(*internal_response);
+
+            // FIXME: 2. If internalResponse’s status is not 303, request’s body is non-null, and the connection uses HTTP/2,
             //           then user agents may, and are even encouraged to, transmit an RST_STREAM frame.
             // NOTE: 303 is excluded as certain communities ascribe special status to it.
 
-            // 2. Switch on request’s redirect mode:
+            // 3. Switch on request’s redirect mode:
             switch (request->redirect_mode()) {
             // -> "error"
             case Infrastructure::Request::RedirectMode::Error:

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/Fetch/Fetching/PendingResponse.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
 
 namespace Web::Fetch::Infrastructure {
@@ -264,6 +265,7 @@ GC::Ref<Request> Request::clone(JS::Realm& realm) const
     new_request->set_prevent_no_cache_cache_control_header_modification(m_prevent_no_cache_cache_control_header_modification);
     new_request->set_done(m_done);
     new_request->set_timing_allow_failed(m_timing_allow_failed);
+    new_request->m_navigation_timing_allow_values_list = m_navigation_timing_allow_values_list;
 
     // 2. If request’s body is non-null, set newRequest’s body to the result of cloning request’s body.
     if (auto const* body = m_body.get_pointer<GC::Ref<Body>>())
@@ -271,6 +273,23 @@ GC::Ref<Request> Request::clone(JS::Realm& realm) const
 
     // 3. Return newRequest.
     return new_request;
+}
+
+// https://fetch.spec.whatwg.org/#append-to-a-requests-navigation-timing-allow-values-list
+void Request::append_to_navigation_timing_allow_values_list(Response const& response)
+{
+    // 1. Assert: request is a navigation request.
+    VERIFY(is_navigation_request());
+
+    // 2. Let taoValues be the result of getting, decoding, and splitting `Timing-Allow-Origin` from response's header list.
+    auto tao_values = response.header_list()->get_decode_and_split("Timing-Allow-Origin"sv);
+
+    // 3. If taoValues is null, then set taoValues to « ».
+    if (!tao_values.has_value())
+        tao_values = Vector<String> {};
+
+    // 4. Append taoValues to request's navigation timing allow values list.
+    m_navigation_timing_allow_values_list.append(tao_values.release_value());
 }
 
 // https://fetch.spec.whatwg.org/#concept-request-add-range-header

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -31,6 +31,8 @@
 
 namespace Web::Fetch::Infrastructure {
 
+class Response;
+
 // https://fetch.spec.whatwg.org/#concept-request
 class WEB_API Request final : public JS::Cell {
     GC_CELL(Request, JS::Cell);
@@ -290,6 +292,9 @@ public:
     [[nodiscard]] bool timing_allow_failed() const { return m_timing_allow_failed; }
     void set_timing_allow_failed(bool timing_allow_failed) { m_timing_allow_failed = timing_allow_failed; }
 
+    [[nodiscard]] Vector<Vector<String>> const& navigation_timing_allow_values_list() const { return m_navigation_timing_allow_values_list; }
+    void append_to_navigation_timing_allow_values_list(Response const&);
+
     [[nodiscard]] URL::URL& url();
     [[nodiscard]] URL::URL const& url() const;
     [[nodiscard]] URL::URL& current_url();
@@ -519,6 +524,10 @@ private:
     // https://fetch.spec.whatwg.org/#timing-allow-failed
     // A request has an associated timing allow failed flag. Unless stated otherwise, it is unset.
     bool m_timing_allow_failed { false };
+
+    // https://fetch.spec.whatwg.org/#request-navigation-timing-allow-values-list
+    // A request has an associated navigation timing allow values list (a list of lists of strings). Unless stated otherwise, it is « ».
+    Vector<Vector<String>> m_navigation_timing_allow_values_list;
 
     // Non-standard
     Vector<GC::Ref<Fetching::PendingResponse>> m_pending_responses;

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -209,7 +209,9 @@ GC::Ref<Response> Response::clone(JS::Realm& realm) const
     new_response->set_range_requested(m_range_requested);
     new_response->set_request_includes_credentials(m_request_includes_credentials);
     new_response->set_timing_allow_passed(m_timing_allow_passed);
+    new_response->set_navigation_timing_allow_values_list(m_navigation_timing_allow_values_list);
     new_response->set_body_info(m_body_info);
+    new_response->set_redirect_taint(m_redirect_taint);
     new_response->set_javascript_bytecode_cache(m_javascript_bytecode_cache);
     new_response->set_javascript_bytecode_cache_vary_key(m_javascript_bytecode_cache_vary_key);
     if (m_request_server_request.has_value())

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -115,6 +115,9 @@ public:
     [[nodiscard]] virtual bool timing_allow_passed() const { return m_timing_allow_passed; }
     virtual void set_timing_allow_passed(bool timing_allow_passed) { m_timing_allow_passed = timing_allow_passed; }
 
+    [[nodiscard]] virtual Vector<Vector<String>> const& navigation_timing_allow_values_list() const { return m_navigation_timing_allow_values_list; }
+    virtual void set_navigation_timing_allow_values_list(Vector<Vector<String>> navigation_timing_allow_values_list) { m_navigation_timing_allow_values_list = move(navigation_timing_allow_values_list); }
+
     [[nodiscard]] virtual BodyInfo const& body_info() const { return m_body_info; }
     virtual void set_body_info(BodyInfo body_info) { m_body_info = move(body_info); }
 
@@ -125,8 +128,8 @@ public:
     [[nodiscard]] Optional<NonnullRefPtr<HTTP::HeaderList>> const& javascript_bytecode_cache_memory_cache_request_headers() const { return m_javascript_bytecode_cache_memory_cache_request_headers; }
     void set_javascript_bytecode_cache_memory_cache_request_headers(Optional<NonnullRefPtr<HTTP::HeaderList>> request_headers) { m_javascript_bytecode_cache_memory_cache_request_headers = move(request_headers); }
 
-    [[nodiscard]] RedirectTaint redirect_taint() const { return m_redirect_taint; }
-    void set_redirect_taint(RedirectTaint redirect_taint) { m_redirect_taint = redirect_taint; }
+    [[nodiscard]] virtual RedirectTaint redirect_taint() const { return m_redirect_taint; }
+    virtual void set_redirect_taint(RedirectTaint redirect_taint) { m_redirect_taint = redirect_taint; }
 
     [[nodiscard]] bool is_aborted_network_error() const;
     [[nodiscard]] bool is_network_error() const;
@@ -204,6 +207,10 @@ private:
     // A response has an associated timing allow passed flag, which is initially unset.
     bool m_timing_allow_passed { false };
 
+    // https://fetch.spec.whatwg.org/#response-navigation-timing-allow-values-list
+    // A response has an associated navigation timing allow values list (a list of lists of strings). Unless stated otherwise, it is « ».
+    Vector<Vector<String>> m_navigation_timing_allow_values_list;
+
     // https://fetch.spec.whatwg.org/#concept-response-body-info
     // A response has an associated body info (a response body info). Unless stated otherwise, it is a new response body info.
     BodyInfo m_body_info;
@@ -274,8 +281,14 @@ public:
     [[nodiscard]] virtual bool timing_allow_passed() const override { return m_internal_response->timing_allow_passed(); }
     virtual void set_timing_allow_passed(bool timing_allow_passed) override { m_internal_response->set_timing_allow_passed(timing_allow_passed); }
 
+    [[nodiscard]] virtual Vector<Vector<String>> const& navigation_timing_allow_values_list() const override { return m_internal_response->navigation_timing_allow_values_list(); }
+    virtual void set_navigation_timing_allow_values_list(Vector<Vector<String>> navigation_timing_allow_values_list) override { m_internal_response->set_navigation_timing_allow_values_list(move(navigation_timing_allow_values_list)); }
+
     [[nodiscard]] virtual BodyInfo const& body_info() const override { return m_internal_response->body_info(); }
     virtual void set_body_info(BodyInfo body_info) override { m_internal_response->set_body_info(move(body_info)); }
+
+    [[nodiscard]] virtual RedirectTaint redirect_taint() const override { return m_internal_response->redirect_taint(); }
+    virtual void set_redirect_taint(RedirectTaint redirect_taint) override { m_internal_response->set_redirect_taint(redirect_taint); }
     [[nodiscard]] virtual Optional<RequestServerRequest> const& request_server_request() const override { return m_internal_response->request_server_request(); }
     virtual void set_request_server_request(RequestServerRequest request) override { m_internal_response->set_request_server_request(move(request)); }
     virtual void release_request_transfer_lease() const override { m_internal_response->release_request_transfer_lease(); }

--- a/Libraries/LibWeb/HTML/NavigationParamsDescriptor.cpp
+++ b/Libraries/LibWeb/HTML/NavigationParamsDescriptor.cpp
@@ -44,6 +44,7 @@ static NavigationRequestDescriptor create_navigation_request_descriptor(Fetch::I
     return {
         .url_list = request.url_list(),
         .method = request.method(),
+        .client_is_null = !request.client(),
         .referrer = request.referrer(),
         .referrer_policy = request.referrer_policy(),
         .policy_container = serialize_request_policy_container(request),
@@ -87,6 +88,8 @@ static NavigationResponseDescriptor create_navigation_response_descriptor(Fetch:
         .headers = move(headers),
         .network_error_message = response.network_error_message(),
         .timing_allow_passed = response.timing_allow_passed(),
+        .navigation_timing_allow_values_list = response.navigation_timing_allow_values_list(),
+        .redirect_taint = response.redirect_taint(),
         .body = move(body),
     };
 }
@@ -179,7 +182,8 @@ static GC::Ptr<Fetch::Infrastructure::Request> create_navigation_request_from_de
     auto request = Fetch::Infrastructure::Request::create(realm.vm());
     request->set_url_list(descriptor->url_list);
     request->set_method(descriptor->method);
-    request->set_client(&navigable.active_document()->relevant_settings_object());
+    if (!descriptor->client_is_null)
+        request->set_client(&navigable.active_document()->relevant_settings_object());
     request->set_referrer(descriptor->referrer);
     request->set_referrer_policy(descriptor->referrer_policy);
     request->set_policy_container(create_a_policy_container_from_serialized_policy_container(descriptor->policy_container));
@@ -259,6 +263,8 @@ static ErrorOr<GC::Ref<Fetch::Infrastructure::Response>> create_navigation_respo
     response->set_status_message(move(descriptor.status_message));
     response->set_header_list(HTTP::HeaderList::create(move(descriptor.headers)));
     response->set_timing_allow_passed(descriptor.timing_allow_passed);
+    response->set_navigation_timing_allow_values_list(move(descriptor.navigation_timing_allow_values_list));
+    response->set_redirect_taint(descriptor.redirect_taint);
 
     if (descriptor.body.has<ByteBuffer>()) {
         response->set_body(Fetch::Infrastructure::byte_sequence_as_body(realm, descriptor.body.get<ByteBuffer>().bytes()));
@@ -378,6 +384,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::HTML::NavigationRequestDescriptor co
 {
     TRY(encoder.encode(request.url_list));
     TRY(encoder.encode(request.method));
+    TRY(encoder.encode(request.client_is_null));
     TRY(encoder.encode(request.referrer));
     TRY(encoder.encode(request.referrer_policy));
     TRY(encoder.encode(request.policy_container));
@@ -391,6 +398,7 @@ ErrorOr<Web::HTML::NavigationRequestDescriptor> decode(Decoder& decoder)
     return Web::HTML::NavigationRequestDescriptor {
         .url_list = TRY(decoder.decode<Vector<URL::URL>>()),
         .method = TRY(decoder.decode<ByteString>()),
+        .client_is_null = TRY(decoder.decode<bool>()),
         .referrer = TRY(decoder.decode<Web::Fetch::Infrastructure::Request::ReferrerType>()),
         .referrer_policy = TRY(decoder.decode<Web::ReferrerPolicy::ReferrerPolicy>()),
         .policy_container = TRY(decoder.decode<Web::HTML::SerializedPolicyContainer>()),
@@ -424,6 +432,8 @@ ErrorOr<void> encode(Encoder& encoder, Web::HTML::NavigationResponseDescriptor c
     TRY(encoder.encode(response.headers));
     TRY(encoder.encode(response.network_error_message));
     TRY(encoder.encode(response.timing_allow_passed));
+    TRY(encoder.encode(response.navigation_timing_allow_values_list));
+    TRY(encoder.encode(response.redirect_taint));
     TRY(encoder.encode(response.body));
     return {};
 }
@@ -438,6 +448,8 @@ ErrorOr<Web::HTML::NavigationResponseDescriptor> decode(Decoder& decoder)
         .headers = TRY(decoder.decode<Vector<HTTP::Header>>()),
         .network_error_message = TRY(decoder.decode<Optional<String>>()),
         .timing_allow_passed = TRY(decoder.decode<bool>()),
+        .navigation_timing_allow_values_list = TRY(decoder.decode<Vector<Vector<String>>>()),
+        .redirect_taint = TRY(decoder.decode<Web::Fetch::Infrastructure::RedirectTaint>()),
         .body = TRY(decoder.decode<Web::HTML::NavigationResponseBody>()),
     };
 }

--- a/Libraries/LibWeb/HTML/NavigationParamsDescriptor.h
+++ b/Libraries/LibWeb/HTML/NavigationParamsDescriptor.h
@@ -37,6 +37,11 @@ namespace Web::HTML {
 struct NavigationRequestDescriptor {
     Vector<URL::URL> url_list;
     ByteString method;
+
+    // https://fetch.spec.whatwg.org/#concept-request-client
+    // Preserve whether the request's client is null for the redirect count exposure check performed after a process swap.
+    bool client_is_null { false };
+
     Fetch::Infrastructure::Request::ReferrerType referrer;
     ReferrerPolicy::ReferrerPolicy referrer_policy { ReferrerPolicy::DEFAULT_REFERRER_POLICY };
     SerializedPolicyContainer policy_container;
@@ -59,6 +64,15 @@ struct NavigationResponseDescriptor {
     Vector<HTTP::Header> headers;
     Optional<String> network_error_message;
     bool timing_allow_passed { false };
+
+    // https://fetch.spec.whatwg.org/#response-navigation-timing-allow-values-list
+    // Preserve the redirect chain's TAO values for the navigation TAO check performed after a process swap.
+    Vector<Vector<String>> navigation_timing_allow_values_list;
+
+    // https://fetch.spec.whatwg.org/#response-redirect-taint
+    // Preserve the response's redirect taint for the `redirect taint is "same-origin"` check performed after a process swap.
+    Fetch::Infrastructure::RedirectTaint redirect_taint { Fetch::Infrastructure::RedirectTaint::SameOrigin };
+
     NavigationResponseBody body;
 };
 

--- a/Tests/LibWeb/Text/expected/navigation-timing-redirect-count.txt
+++ b/Tests/LibWeb/Text/expected/navigation-timing-redirect-count.txt
@@ -1,2 +1,3 @@
 cross-origin redirect count: 0
+cross-origin-with-tao redirect count: 2
 same-origin redirect count: 1

--- a/Tests/LibWeb/Text/input/navigation-timing-redirect-count.html
+++ b/Tests/LibWeb/Text/input/navigation-timing-redirect-count.html
@@ -5,7 +5,7 @@
         const server = httpTestServer();
         const token = crypto.randomUUID();
 
-        async function createRedirectedDocument(label, crossOrigin) {
+        async function createRedirectedDocument(label, crossOrigin, timingAllowOrigin) {
             const finalURL = new URL(await server.createEcho("GET", `/navigation-timing-redirect-final-${label}-${token}`, {
                 status: 200,
                 headers: { "Content-Type": "text/html" },
@@ -18,29 +18,82 @@
                 `,
             }));
             if (crossOrigin)
-                finalURL.hostname = uniqueLocalhostHostname("navigation-timing-redirect");
+                finalURL.hostname = uniqueLocalhostHostname("navigation-timing-redirect-final");
+
+            let location = finalURL.href;
+            if (crossOrigin) {
+                const intermediateHeaders = { Location: finalURL.href };
+                if (timingAllowOrigin)
+                    intermediateHeaders["Timing-Allow-Origin"] = finalURL.origin;
+
+                const intermediateURL = new URL(await server.createEcho("GET", `/navigation-timing-redirect-intermediate-${label}-${token}`, {
+                    status: 302,
+                    headers: intermediateHeaders,
+                }));
+                intermediateURL.hostname = uniqueLocalhostHostname("navigation-timing-redirect-intermediate");
+                location = intermediateURL.href;
+            }
+
+            const headers = { Location: location };
+            if (timingAllowOrigin)
+                headers["Timing-Allow-Origin"] = finalURL.origin;
 
             return server.createEcho("GET", `/navigation-timing-redirect-initial-${label}-${token}`, {
                 status: 302,
-                headers: { Location: finalURL.href },
+                headers,
             });
         }
 
-        const results = [];
+        const navigations = [];
+        for (const [label, crossOrigin, timingAllowOrigin] of [
+            ["cross-origin", true, false],
+            ["cross-origin-with-tao", true, true],
+            ["same-origin", false, false],
+        ]) {
+            navigations.push({
+                label,
+                url: await createRedirectedDocument(label, crossOrigin, timingAllowOrigin),
+            });
+        }
+
         addEventListener("message", event => {
-            results.push(event.data);
-            if (results.length !== 2)
+            if (event.data.type !== "navigation-timing-redirect-counts")
                 return;
 
+            const results = event.data.results;
             results.sort((a, b) => a.label.localeCompare(b.label));
             for (const result of results)
                 println(`${result.label} redirect count: ${result.redirectCount}`);
             done();
         });
 
-        for (const [label, crossOrigin] of [["cross-origin", true], ["same-origin", false]]) {
+        const runnerURL = await server.createEcho("GET", `/navigation-timing-redirect-runner-${token}`, {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: `
+                <!DOCTYPE html>
+                <body>
+                <script>
+                    const navigations = ${JSON.stringify(navigations)};
+                    const results = [];
+                    addEventListener("message", event => {
+                        results.push(event.data);
+                        if (results.length === navigations.length)
+                            parent.postMessage({ type: "navigation-timing-redirect-counts", results }, "*");
+                    });
+
+                    for (const navigation of navigations) {
+                        const frame = document.createElement("iframe");
+                        frame.src = navigation.url;
+                        document.body.appendChild(frame);
+                    }
+                <\/script>
+            `,
+        });
+
+        {
             const frame = document.createElement("iframe");
-            frame.src = await createRedirectedDocument(label, crossOrigin);
+            frame.src = runnerURL;
             document.body.appendChild(frame);
         }
     });


### PR DESCRIPTION
- Create the entry at the specified point in Document initialization.

- Apply navigation TAO checks before exposing redirect counts.

- Preserve request and response state across process transfers.