### PR TITLE
Tests: Start the leaving animation from its pending play task

### DIFF
--- a/Tests/LibWeb/Text/input/css/compositor-animation-intersection-observer.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-intersection-observer.html
@@ -115,8 +115,6 @@
         observationRoot.append(leavingTarget);
         document.body.append(observationRoot);
         observationRoot.scrollIntoView();
-        const leavingAnimation = leavingTarget.getAnimations()[0];
-        leavingAnimation.startTime = document.timeline.currentTime;
         leavingTarget.getBoundingClientRect();
 
         let resolveInitialLeavingObservation;


### PR DESCRIPTION
compositor-animation-intersection-observer set the leaving animation's startTime from document.timeline.currentTime. When another animation skips its per-frame tick, that getter returns a fresh wall-clock sample, which can be later than the frame timestamp of a rendering update that is already queued. That update then sees the animation in its before phase, skips the main-thread style sample, and arms the compositor wakeup timer for the active start. The sample lands one frame later.

The test resets the style counters after the initial observation and one animation frame, so on a slow machine the deferred sample counted against "observation timer builds no animation overlays". The Linux release and arm64 sanitizer jobs failed this way six times on 2026-09-04. Throttling WebContent to a 20% duty cycle with SIGSTOP and SIGCONT reproduced it in 7 of 20 runs.

Let the CSS animation start through its pending play task instead. The task runs in the same rendering update that samples the effect and delivers the initial observation, so the reset always comes after the startup sample. With the throttle the test now passes 30 of 30.