### PR TITLE
LibJS+LibWeb: Make [FIXME] IDL members unobservable to JavaScript

### DIFF
--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -40,6 +40,12 @@ static auto& intrinsic_accessor_map()
     return *intrinsics;
 }
 
+static auto& unimplemented_property_map()
+{
+    static NeverDestroyed<GC::WeakHashMap<GC::Ptr<Object const>, HashTable<Utf16FlyString>>> unimplemented_properties;
+    return *unimplemented_properties;
+}
+
 // Heap-allocated property storage layout:
 //   [u32 capacity] [u32 padding] [Value 0] [Value 1] ...
 // The accessors below are the only code that depends on this allocation layout.
@@ -191,6 +197,8 @@ Object::~Object()
     free_indexed_elements();
     if (has_intrinsic_accessors())
         intrinsic_accessor_map().remove(this);
+    if (has_unimplemented_properties())
+        unimplemented_property_map().remove(this);
     if (!named_storage_is_inline())
         HeapValueStorage::deallocate(m_named_properties.data());
 }
@@ -1002,21 +1010,18 @@ ThrowCompletionOr<Optional<PropertyDescriptor>> Object::internal_get_own_propert
 {
     // 1. If O does not have an own property with key P, return undefined.
     auto maybe_storage_entry = storage_get(property_key);
-    if (!maybe_storage_entry.has_value())
+    if (!maybe_storage_entry.has_value()) {
+        // AD-HOC: Report accesses to unimplemented IDL properties without making them observable to JavaScript.
+        if (is_unimplemented_property(property_key) && vm().on_unimplemented_property_access)
+            vm().on_unimplemented_property_access(*this, property_key);
         return Optional<PropertyDescriptor> {};
+    }
 
     // 2. Let D be a newly created Property Descriptor with no fields.
     PropertyDescriptor descriptor;
 
     // 3. Let X be O's own property whose key is P.
     auto [value, attributes, property_offset] = *maybe_storage_entry;
-
-    // AD-HOC: Properties with the [[Unimplemented]] attribute are used for reporting unimplemented IDL interfaces.
-    if (attributes.is_unimplemented()) {
-        if (vm().on_unimplemented_property_access)
-            vm().on_unimplemented_property_access(*this, property_key);
-        descriptor.unimplemented = true;
-    }
 
     // 4. If X is a data property, then
     if (!value.is_accessor()) {
@@ -1586,6 +1591,21 @@ void Object::define_direct_accessor(PropertyKey const& property_key, GC::Ptr<Fun
         if (setter)
             accessor->set_setter(setter);
     }
+}
+
+void Object::define_unimplemented_property(Utf16FlyString const& property_name)
+{
+    m_flags |= Flag::HasUnimplementedProperties;
+    unimplemented_property_map().ensure(this).set(property_name);
+}
+
+bool Object::is_unimplemented_property(PropertyKey const& property_key) const
+{
+    if (!has_unimplemented_properties() || !property_key.is_string())
+        return false;
+
+    auto properties = unimplemented_property_map().get(this);
+    return properties.has_value() && properties->contains(property_key.as_string());
 }
 
 Optional<ValueAndAttributes> Object::get_engine_private_property(GC::Ref<Symbol> key) const

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -239,6 +239,7 @@ public:
     Value get_without_side_effects(PropertyKey const&) const;
 
     void define_direct_property(PropertyKey const& property_key, Value value, PropertyAttributes attributes) { (void)storage_set(property_key, { value, attributes }); }
+    void define_unimplemented_property(Utf16FlyString const& property_name);
     Optional<ValueAndAttributes> get_engine_private_property(GC::Ref<Symbol>) const;
     void set_engine_private_property(GC::Ref<Symbol>, Value);
     void delete_engine_private_property(GC::Ref<Symbol>);
@@ -450,6 +451,7 @@ private:
         static constexpr u16 IsPlatformObject = 1 << 9;
         static constexpr u16 IsDirectGetterFunction = 1 << 10;
         static constexpr u16 IsGlobalObject = 1 << 11;
+        static constexpr u16 HasUnimplementedProperties = 1 << 12;
     };
 
     u16 m_flags { Flag::IsExtensible };
@@ -472,6 +474,9 @@ private:
     bool named_storage_is_inline() const { return m_named_properties == m_inline_named_storage; }
     size_t named_storage_external_memory_size() const;
     size_t indexed_storage_external_memory_size() const;
+
+    [[nodiscard]] bool has_unimplemented_properties() const { return m_flags & Flag::HasUnimplementedProperties; }
+    [[nodiscard]] bool is_unimplemented_property(PropertyKey const&) const;
 
 public:
     static constexpr u32 INLINE_NAMED_PROPERTY_CAPACITY = 2;

--- a/Libraries/LibJS/Runtime/PropertyAttributes.h
+++ b/Libraries/LibJS/Runtime/PropertyAttributes.h
@@ -19,8 +19,6 @@ struct Attribute {
         Writable = 1 << 0,
         Enumerable = 1 << 1,
         Configurable = 1 << 2,
-        // AD-HOC: This is used for reporting unimplemented IDL interfaces.
-        Unimplemented = 1 << 3,
     };
 };
 
@@ -35,8 +33,6 @@ public:
     [[nodiscard]] constexpr bool is_writable() const { return m_bits & Attribute::Writable; }
     [[nodiscard]] constexpr bool is_enumerable() const { return m_bits & Attribute::Enumerable; }
     [[nodiscard]] constexpr bool is_configurable() const { return m_bits & Attribute::Configurable; }
-    [[nodiscard]] constexpr bool is_unimplemented() const { return m_bits & Attribute::Unimplemented; }
-
     constexpr void set_writable(bool writable = true)
     {
         if (writable)

--- a/Libraries/LibJS/Runtime/PropertyDescriptor.h
+++ b/Libraries/LibJS/Runtime/PropertyDescriptor.h
@@ -33,7 +33,7 @@ public:
     // Not a standard abstract operation, but "If every field in Desc is absent".
     [[nodiscard]] bool is_empty() const
     {
-        return !value.has_value() && !get.has_value() && !set.has_value() && !writable.has_value() && !enumerable.has_value() && !configurable.has_value() && !unimplemented.has_value();
+        return !value.has_value() && !get.has_value() && !set.has_value() && !writable.has_value() && !enumerable.has_value() && !configurable.has_value();
     }
 
     void visit_edges(GC::Cell::Visitor&);
@@ -44,8 +44,6 @@ public:
     Optional<bool> writable {};
     Optional<bool> enumerable {};
     Optional<bool> configurable {};
-    Optional<bool> unimplemented {};
-
     Optional<u32> property_offset {};
 };
 
@@ -70,8 +68,6 @@ struct Formatter<JS::PropertyDescriptor> : Formatter<FormatString> {
             TRY(parts.try_append(Utf16String::formatted("[[Enumerable]]: {}", *property_descriptor.enumerable)));
         if (property_descriptor.configurable.has_value())
             TRY(parts.try_append(Utf16String::formatted("[[Configurable]]: {}", *property_descriptor.configurable)));
-        if (property_descriptor.unimplemented.has_value())
-            TRY(parts.try_append(Utf16String::formatted("[[Unimplemented]]: {}", *property_descriptor.unimplemented)));
         return Formatter<Utf16String> {}.format(builder, Utf16String::formatted("PropertyDescriptor {{ {} }}", Utf16String::join(", "sv, parts)));
     }
 };

--- a/Libraries/LibWeb/CSS/CSSNumericValue.idl
+++ b/Libraries/LibWeb/CSS/CSSNumericValue.idl
@@ -34,7 +34,7 @@ interface CSSNumericValue : CSSStyleValue {
     [ImplementedAs=equals_for_bindings] boolean equals(CSSNumberish... value);
 
     CSSUnitValue to(USVString unit);
-    // FIXME: CSSMathSum toSum(USVString... units);
+    [FIXME] CSSMathSum toSum(USVString... units);
     [ImplementedAs=type_for_bindings] CSSNumericType type();
 
     [Exposed=Window] static CSSNumericValue parse(USVString cssText);

--- a/Libraries/LibWeb/DOM/Document.idl
+++ b/Libraries/LibWeb/DOM/Document.idl
@@ -58,7 +58,7 @@ dictionary ImportNodeOptions {
 partial interface Document {
     // FIXME: parseHTMLUnsafe is missing the ParseHTMLUnsafeOptions parameter.
     [NeedsCallerRealm, ImplementedInBindings] static Document parseHTMLUnsafe((TrustedHTML or DOMString) html);
-    // FIXME: static Document parseHTML(DOMString html, optional SetHTMLOptions options = {});
+    [FIXME] static Document parseHTML(DOMString html, optional SetHTMLOptions options = {});
 
     // resource metadata management
     [PutForwards=href, LegacyUnforgeable] readonly attribute Location? location;
@@ -136,8 +136,8 @@ partial interface Document {
 // https://w3c.github.io/pointerlock/#extensions-to-the-document-interface
 // FIXME: Move this to a proper home when we have a pointerlock spec folder.
 partial interface Document {
-    // FIXME: attribute EventHandler onpointerlockchange;
-    // FIXME: attribute EventHandler onpointerlockerror;
+    [FIXME] attribute EventHandler onpointerlockchange;
+    [FIXME] attribute EventHandler onpointerlockerror;
     undefined exitPointerLock();
 };
 

--- a/Libraries/LibWeb/DOM/Element.idl
+++ b/Libraries/LibWeb/DOM/Element.idl
@@ -58,7 +58,7 @@ dictionary ShadowRootInit {
 
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
 partial interface Element {
-    // FIXME: [CEReactions] undefined setHTML(DOMString html, optional SetHTMLOptions options = {});
+    [FIXME, CEReactions] undefined setHTML(DOMString html, optional SetHTMLOptions options = {});
     // FIXME: setHTMLUnsafe is missing the SetHTMLUnsafeOptions parameter.
     [CEReactions, ImplementedInBindings] undefined setHTMLUnsafe((TrustedHTML or DOMString) html);
     DOMString getHTML(optional GetHTMLOptions options = {});

--- a/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -18,7 +18,7 @@ enum SlotAssignmentMode { "manual", "named" };
 
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
 partial interface ShadowRoot {
-    // FIXME: [CEReactions] undefined setHTML(DOMString html, optional SetHTMLOptions options = {});
+    [FIXME, CEReactions] undefined setHTML(DOMString html, optional SetHTMLOptions options = {});
     // FIXME: setHTMLUnsafe is missing the SetHTMLUnsafeOptions parameter.
     [CEReactions, ImplementedInBindings] undefined setHTMLUnsafe((TrustedHTML or DOMString) html);
     DOMString getHTML(optional GetHTMLOptions options = {});

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.idl
@@ -13,7 +13,7 @@ interface HTMLCanvasElement : HTMLElement {
 
     USVString toDataURL(optional DOMString type = "image/png", optional any quality);
     undefined toBlob(BlobCallback _callback, optional DOMString type = "image/png", optional any quality);
-    // FIXME: OffscreenCanvas transferControlToOffscreen();
+    [FIXME] OffscreenCanvas transferControlToOffscreen();
 };
 
 callback BlobCallback = undefined (Blob? blob);

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -69,7 +69,7 @@ interface HTMLMediaElement : HTMLElement {
     attribute double volume;
     attribute boolean muted;
     [CEReactions, Reflect="muted"] attribute boolean defaultMuted;
-    // FIXME: [CEReactions] attribute DOMString loading;
+    [FIXME, CEReactions] attribute DOMString loading;
 
     // tracks
     [SameObject, DirectGetter] readonly attribute AudioTrackList audioTracks;

--- a/Libraries/LibWeb/HTML/ImageData.idl
+++ b/Libraries/LibWeb/HTML/ImageData.idl
@@ -17,6 +17,6 @@ interface ImageData {
     readonly attribute unsigned long width;
     readonly attribute unsigned long height;
     readonly attribute ImageDataArray data;
-    // FIXME: readonly attribute ImageDataPixelFormat pixelFormat;
+    [FIXME] readonly attribute ImageDataPixelFormat pixelFormat;
     readonly attribute PredefinedColorSpace colorSpace;
 };

--- a/Libraries/LibWeb/HTML/Location.idl
+++ b/Libraries/LibWeb/HTML/Location.idl
@@ -18,5 +18,5 @@ interface Location { // but see also additional creation steps and overridden in
     // Intentionally not implemented at this stage due to https://github.com/whatwg/html/issues/1918
     // This is not currently implemented by Firefox due to the above, and only seems to be used by
     // ad tech on real sites.
-    // [LegacyUnforgeable, SameObject] readonly attribute DOMStringList ancestorOrigins;
+    [FIXME, LegacyUnforgeable, SameObject] readonly attribute DOMStringList ancestorOrigins;
 };

--- a/Libraries/LibWeb/HTML/Window.idl
+++ b/Libraries/LibWeb/HTML/Window.idl
@@ -40,14 +40,14 @@ interface Window : EventTarget {
     // the user agent
     readonly attribute Navigator navigator;
     [Replaceable, ImplementedAs=navigator] readonly attribute Navigator clientInformation; // legacy alias of .navigator
-    // FIXME: readonly attribute boolean originAgentCluster;
+    [FIXME] readonly attribute boolean originAgentCluster;
 
     // user prompts
     undefined alert();
     undefined alert(DOMString message);
     boolean confirm(optional DOMString message = "");
     DOMString? prompt(optional DOMString message = "", optional DOMString default = "");
-    // FIXME: undefined print();
+    [FIXME] undefined print();
 
     [NeedsCallerRealm] undefined postMessage(any message, USVString targetOrigin, optional sequence<object> transfer = []);
     [NeedsCallerRealm, ImplementedInBindings] undefined postMessage(any message, optional WindowPostMessageOptions options = {});

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -1,6 +1,10 @@
 [Exposed=Nobody]
 interface Internals {
 
+    // These members deliberately remain unimplemented to test [FIXME] binding generation.
+    [FIXME] undefined unimplementedOperationForTesting();
+    [FIXME] readonly attribute boolean unimplementedAttributeForTesting;
+
     undefined signalTestIsDone(DOMString text);
     undefined setTestTimeout(double milliseconds);
     undefined forceIncompatibleVisualContextTreeRebuild();

--- a/Libraries/LibWeb/NotificationsAPI/Notification.idl
+++ b/Libraries/LibWeb/NotificationsAPI/Notification.idl
@@ -3,8 +3,8 @@
 interface Notification : EventTarget {
     constructor(DOMString title, optional NotificationOptions options = {});
 
-    // FIXME: static readonly attribute NotificationPermission permission;
-    // FIXME: [Exposed=Window] static Promise<NotificationPermission> requestPermission(optional NotificationPermissionCallback deprecatedCallback);
+    [FIXME] static readonly attribute NotificationPermission permission;
+    [FIXME, Exposed=Window] static Promise<NotificationPermission> requestPermission(optional NotificationPermissionCallback deprecatedCallback);
 
     static readonly attribute unsigned long maxActions;
 
@@ -22,7 +22,7 @@ interface Notification : EventTarget {
     readonly attribute USVString image;
     readonly attribute USVString icon;
     readonly attribute USVString badge;
-    // FIXME: [SameObject] readonly attribute FrozenArray<unsigned long> vibrate;
+    [FIXME, SameObject] readonly attribute FrozenArray<unsigned long> vibrate;
     readonly attribute EpochTimeStamp timestamp;
     readonly attribute boolean renotify;
     readonly attribute boolean? silent;

--- a/Libraries/LibWeb/WebAudio/OfflineAudioContext.idl
+++ b/Libraries/LibWeb/WebAudio/OfflineAudioContext.idl
@@ -16,7 +16,7 @@ interface OfflineAudioContext : BaseAudioContext {
     [CreatesPromise] Promise<AudioBuffer> startRendering();
     [CreatesPromise] Promise<undefined> resume();
     [CreatesPromise] Promise<undefined> suspend(double suspendTime);
-    // FIXME: Promise<undefined> close();
+    [FIXME] Promise<undefined> close();
     // FIXME: length should be nullable.
     readonly attribute unsigned long length;
     attribute EventHandler oncomplete;

--- a/Meta/Generators/libweb_bindings/attributes.py
+++ b/Meta/Generators/libweb_bindings/attributes.py
@@ -166,9 +166,7 @@ def define_the_regular_attributes(
     interface: Interface,
 ) -> None:
     # 1. Let attributes be the list of regular attributes that are members of definition.
-    attributes = [
-        attribute for attribute in interface.regular_attributes if "FIXME" not in attribute.extended_attributes
-    ]
+    attributes = interface.regular_attributes
 
     # 2. Remove from attributes all the attributes that are unforgeable.
     attributes = [attribute for attribute in attributes if "LegacyUnforgeable" not in attribute.extended_attributes]
@@ -183,9 +181,7 @@ def define_the_unforgeable_attributes(
     interface: Interface,
 ) -> None:
     attributes = [
-        attribute
-        for attribute in interface.regular_attributes
-        if "FIXME" not in attribute.extended_attributes and "LegacyUnforgeable" in attribute.extended_attributes
+        attribute for attribute in interface.regular_attributes if "LegacyUnforgeable" in attribute.extended_attributes
     ]
     define_the_attributes(out, includes, attributes, interface)
 
@@ -203,6 +199,17 @@ def define_the_attributes(
 
     # 1. For each attribute attr of attributes:
     for attribute in attributes:
+        if "FIXME" in attribute.extended_attributes:
+            definition = f'    object.define_unimplemented_property("{attribute.name}"_utf16_fly_string);\n'
+            out.write(
+                wrap_with_extended_attribute_exposure_checks(
+                    includes,
+                    attribute.extended_attributes,
+                    definition,
+                )
+            )
+            continue
+
         getter_name = attribute_getter_callback_name(attribute)
         setter_name = attribute_setter_callback_name(attribute)
         cpp_name = attribute_callback_cpp_name(attribute)
@@ -294,6 +301,8 @@ def define_the_attributes(
 def define_the_static_attributes(out: TextIO, includes: GeneratedIncludes, interface: Interface) -> None:
     for attribute in interface.static_attributes:
         if "FIXME" in attribute.extended_attributes:
+            definition = f'    object.define_unimplemented_property("{attribute.name}"_utf16_fly_string);\n'
+            out.write(wrap_with_extended_attribute_exposure_checks(includes, attribute.extended_attributes, definition))
             continue
         definition = f'    object.define_native_accessor(realm, "{attribute.name}"_utf16_fly_string, {attribute_getter_callback_name(attribute)}, nullptr, default_attributes);\n'
         out.write(wrap_with_extended_attribute_exposure_checks(includes, attribute.extended_attributes, definition))

--- a/Meta/Generators/libweb_bindings/operations.py
+++ b/Meta/Generators/libweb_bindings/operations.py
@@ -181,19 +181,24 @@ def define_the_regular_operations(
             )
         )
 
-    if unforgeable:
-        return
-
     implemented_operation_names = overload_resolution.operation_overload_sets(interface).keys()
+    defined_unimplemented_operation_names = set()
     for operation in interface.regular_operations:
         if "FIXME" not in operation.extended_attributes:
             continue
+        if ("LegacyUnforgeable" in operation.extended_attributes) != unforgeable:
+            continue
         if operation.name in implemented_operation_names:
             continue
+        if operation.name in defined_unimplemented_operation_names:
+            continue
+        defined_unimplemented_operation_names.add(operation.name)
         out.write(
-            f"""    object.define_direct_property("{operation.name}"_utf16_fly_string, JS::js_undefined(), default_attributes | JS::Attribute::Unimplemented);
-
-"""
+            wrap_with_extended_attribute_exposure_checks(
+                includes,
+                operation.extended_attributes,
+                f'    object.define_unimplemented_property("{operation.name}"_utf16_fly_string);\n',
+            )
         )
 
 
@@ -207,6 +212,24 @@ def define_the_static_operations(out: TextIO, includes: GeneratedIncludes, inter
                 f"""    object.define_native_function(realm, "{name}"_utf16_fly_string, {idl_identifier_cpp_name(operation)}, {overload_resolution.operation_overload_set_length(operations)}, JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable);
 
 """,
+            )
+        )
+
+    implemented_operation_names = overload_resolution.operation_overload_sets(interface, static=True).keys()
+    defined_unimplemented_operation_names = set()
+    for operation in interface.static_operations:
+        if "FIXME" not in operation.extended_attributes:
+            continue
+        if operation.name in implemented_operation_names:
+            continue
+        if operation.name in defined_unimplemented_operation_names:
+            continue
+        defined_unimplemented_operation_names.add(operation.name)
+        out.write(
+            wrap_with_extended_attribute_exposure_checks(
+                includes,
+                operation.extended_attributes,
+                f'    object.define_unimplemented_property("{operation.name}"_utf16_fly_string);\n',
             )
         )
 

--- a/Tests/LibWeb/Text/expected/Internals/fixme-members.txt
+++ b/Tests/LibWeb/Text/expected/Internals/fixme-members.txt
@@ -1,0 +1,10 @@
+operation is absent from the instance: true
+operation is absent from the prototype: true
+operation has no descriptor: true
+operation is absent from own keys: true
+reading operation produces undefined: true
+calling operation throws TypeError: true
+operation can be overridden: overridden
+operation is absent after deleting the override: true
+attribute is absent: true
+reading attribute produces undefined: true

--- a/Tests/LibWeb/Text/expected/wpt-import/speech-api/idlharness.https.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/speech-api/idlharness.https.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 250 tests
 
-189 Pass
-61 Fail
+185 Pass
+65 Fail
 Fail	idl_test setup
 Pass	idl_test validation
 Pass	Partial interface Window: original interface defined
@@ -57,7 +57,7 @@ Fail	SpeechRecognition interface: new SpeechRecognition() must inherit property 
 Fail	SpeechRecognition interface: new SpeechRecognition() must inherit property "phrases" with the proper type
 Fail	SpeechRecognition interface: new SpeechRecognition() must inherit property "start()" with the proper type
 Fail	SpeechRecognition interface: new SpeechRecognition() must inherit property "start(MediaStreamTrack)" with the proper type
-Pass	SpeechRecognition interface: calling start(MediaStreamTrack) on new SpeechRecognition() with too few arguments must throw TypeError
+Fail	SpeechRecognition interface: calling start(MediaStreamTrack) on new SpeechRecognition() with too few arguments must throw TypeError
 Fail	SpeechRecognition interface: new SpeechRecognition() must inherit property "stop()" with the proper type
 Fail	SpeechRecognition interface: new SpeechRecognition() must inherit property "abort()" with the proper type
 Pass	SpeechRecognition interface: new SpeechRecognition() must inherit property "available(SpeechRecognitionOptions)" with the proper type
@@ -144,9 +144,9 @@ Pass	SpeechGrammarList interface: new SpeechGrammarList() must inherit property 
 Pass	SpeechGrammarList interface: new SpeechGrammarList() must inherit property "item(unsigned long)" with the proper type
 Pass	SpeechGrammarList interface: calling item(unsigned long) on new SpeechGrammarList() with too few arguments must throw TypeError
 Fail	SpeechGrammarList interface: new SpeechGrammarList() must inherit property "addFromURI(DOMString, optional float)" with the proper type
-Pass	SpeechGrammarList interface: calling addFromURI(DOMString, optional float) on new SpeechGrammarList() with too few arguments must throw TypeError
+Fail	SpeechGrammarList interface: calling addFromURI(DOMString, optional float) on new SpeechGrammarList() with too few arguments must throw TypeError
 Fail	SpeechGrammarList interface: new SpeechGrammarList() must inherit property "addFromString(DOMString, optional float)" with the proper type
-Pass	SpeechGrammarList interface: calling addFromString(DOMString, optional float) on new SpeechGrammarList() with too few arguments must throw TypeError
+Fail	SpeechGrammarList interface: calling addFromString(DOMString, optional float) on new SpeechGrammarList() with too few arguments must throw TypeError
 Pass	SpeechRecognitionPhrase interface: existence and properties of interface object
 Pass	SpeechRecognitionPhrase interface object length
 Pass	SpeechRecognitionPhrase interface object name
@@ -177,7 +177,7 @@ Pass	SpeechSynthesis interface: speechSynthesis must inherit property "speaking"
 Pass	SpeechSynthesis interface: speechSynthesis must inherit property "paused" with the proper type
 Pass	SpeechSynthesis interface: speechSynthesis must inherit property "onvoiceschanged" with the proper type
 Fail	SpeechSynthesis interface: speechSynthesis must inherit property "speak(SpeechSynthesisUtterance)" with the proper type
-Pass	SpeechSynthesis interface: calling speak(SpeechSynthesisUtterance) on speechSynthesis with too few arguments must throw TypeError
+Fail	SpeechSynthesis interface: calling speak(SpeechSynthesisUtterance) on speechSynthesis with too few arguments must throw TypeError
 Pass	SpeechSynthesis interface: speechSynthesis must inherit property "cancel()" with the proper type
 Fail	SpeechSynthesis interface: speechSynthesis must inherit property "pause()" with the proper type
 Fail	SpeechSynthesis interface: speechSynthesis must inherit property "resume()" with the proper type

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 1780 tests
 
-1127 Pass
-653 Fail
+1095 Pass
+685 Fail
 Pass	idl_test setup
 Pass	idl_test validation
 Pass	Partial interface Document: original interface defined
@@ -462,7 +462,7 @@ Pass	SVGSVGElement interface: objects.svg must inherit property "createSVGMatrix
 Pass	SVGSVGElement interface: objects.svg must inherit property "createSVGRect()" with the proper type
 Pass	SVGSVGElement interface: objects.svg must inherit property "createSVGTransform()" with the proper type
 Fail	SVGSVGElement interface: objects.svg must inherit property "createSVGTransformFromMatrix(optional DOMMatrix2DInit)" with the proper type
-Pass	SVGSVGElement interface: calling createSVGTransformFromMatrix(optional DOMMatrix2DInit) on objects.svg with too few arguments must throw TypeError
+Fail	SVGSVGElement interface: calling createSVGTransformFromMatrix(optional DOMMatrix2DInit) on objects.svg with too few arguments must throw TypeError
 Pass	SVGSVGElement interface: objects.svg must inherit property "getElementById(DOMString)" with the proper type
 Pass	SVGSVGElement interface: calling getElementById(DOMString) on objects.svg with too few arguments must throw TypeError
 Pass	SVGSVGElement interface: objects.svg must inherit property "suspendRedraw(unsigned long)" with the proper type
@@ -724,7 +724,7 @@ Pass	SVGTransform interface: objects.svg.createSVGTransform() must inherit prope
 Fail	SVGTransform interface: objects.svg.createSVGTransform() must inherit property "matrix" with the proper type
 Pass	SVGTransform interface: objects.svg.createSVGTransform() must inherit property "angle" with the proper type
 Fail	SVGTransform interface: objects.svg.createSVGTransform() must inherit property "setMatrix(optional DOMMatrix2DInit)" with the proper type
-Pass	SVGTransform interface: calling setMatrix(optional DOMMatrix2DInit) on objects.svg.createSVGTransform() with too few arguments must throw TypeError
+Fail	SVGTransform interface: calling setMatrix(optional DOMMatrix2DInit) on objects.svg.createSVGTransform() with too few arguments must throw TypeError
 Pass	SVGTransform interface: objects.svg.createSVGTransform() must inherit property "setTranslate(float, float)" with the proper type
 Pass	SVGTransform interface: calling setTranslate(float, float) on objects.svg.createSVGTransform() with too few arguments must throw TypeError
 Pass	SVGTransform interface: objects.svg.createSVGTransform() must inherit property "setScale(float, float)" with the proper type
@@ -872,9 +872,9 @@ Pass	SVGRectElement interface: objects.rect must inherit property "rx" with the 
 Pass	SVGRectElement interface: objects.rect must inherit property "ry" with the proper type
 Pass	SVGGeometryElement interface: objects.rect must inherit property "pathLength" with the proper type
 Fail	SVGGeometryElement interface: objects.rect must inherit property "isPointInFill(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.rect with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.rect with too few arguments must throw TypeError
 Fail	SVGGeometryElement interface: objects.rect must inherit property "isPointInStroke(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.rect with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.rect with too few arguments must throw TypeError
 Pass	SVGGeometryElement interface: objects.rect must inherit property "getTotalLength()" with the proper type
 Pass	SVGGeometryElement interface: objects.rect must inherit property "getPointAtLength(float)" with the proper type
 Pass	SVGGeometryElement interface: calling getPointAtLength(float) on objects.rect with too few arguments must throw TypeError
@@ -906,9 +906,9 @@ Pass	SVGCircleElement interface: objects.circle must inherit property "cy" with 
 Pass	SVGCircleElement interface: objects.circle must inherit property "r" with the proper type
 Pass	SVGGeometryElement interface: objects.circle must inherit property "pathLength" with the proper type
 Fail	SVGGeometryElement interface: objects.circle must inherit property "isPointInFill(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.circle with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.circle with too few arguments must throw TypeError
 Fail	SVGGeometryElement interface: objects.circle must inherit property "isPointInStroke(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.circle with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.circle with too few arguments must throw TypeError
 Pass	SVGGeometryElement interface: objects.circle must inherit property "getTotalLength()" with the proper type
 Pass	SVGGeometryElement interface: objects.circle must inherit property "getPointAtLength(float)" with the proper type
 Pass	SVGGeometryElement interface: calling getPointAtLength(float) on objects.circle with too few arguments must throw TypeError
@@ -942,9 +942,9 @@ Pass	SVGEllipseElement interface: objects.ellipse must inherit property "rx" wit
 Pass	SVGEllipseElement interface: objects.ellipse must inherit property "ry" with the proper type
 Pass	SVGGeometryElement interface: objects.ellipse must inherit property "pathLength" with the proper type
 Fail	SVGGeometryElement interface: objects.ellipse must inherit property "isPointInFill(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.ellipse with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.ellipse with too few arguments must throw TypeError
 Fail	SVGGeometryElement interface: objects.ellipse must inherit property "isPointInStroke(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.ellipse with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.ellipse with too few arguments must throw TypeError
 Pass	SVGGeometryElement interface: objects.ellipse must inherit property "getTotalLength()" with the proper type
 Pass	SVGGeometryElement interface: objects.ellipse must inherit property "getPointAtLength(float)" with the proper type
 Pass	SVGGeometryElement interface: calling getPointAtLength(float) on objects.ellipse with too few arguments must throw TypeError
@@ -978,9 +978,9 @@ Pass	SVGLineElement interface: objects.line must inherit property "x2" with the 
 Pass	SVGLineElement interface: objects.line must inherit property "y2" with the proper type
 Pass	SVGGeometryElement interface: objects.line must inherit property "pathLength" with the proper type
 Fail	SVGGeometryElement interface: objects.line must inherit property "isPointInFill(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.line with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.line with too few arguments must throw TypeError
 Fail	SVGGeometryElement interface: objects.line must inherit property "isPointInStroke(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.line with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.line with too few arguments must throw TypeError
 Pass	SVGGeometryElement interface: objects.line must inherit property "getTotalLength()" with the proper type
 Pass	SVGGeometryElement interface: objects.line must inherit property "getPointAtLength(float)" with the proper type
 Pass	SVGGeometryElement interface: calling getPointAtLength(float) on objects.line with too few arguments must throw TypeError
@@ -1042,9 +1042,9 @@ Fail	SVGPolylineElement interface: objects.polyline must inherit property "point
 Fail	SVGPolylineElement interface: objects.polyline must inherit property "animatedPoints" with the proper type
 Pass	SVGGeometryElement interface: objects.polyline must inherit property "pathLength" with the proper type
 Fail	SVGGeometryElement interface: objects.polyline must inherit property "isPointInFill(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.polyline with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.polyline with too few arguments must throw TypeError
 Fail	SVGGeometryElement interface: objects.polyline must inherit property "isPointInStroke(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.polyline with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.polyline with too few arguments must throw TypeError
 Pass	SVGGeometryElement interface: objects.polyline must inherit property "getTotalLength()" with the proper type
 Pass	SVGGeometryElement interface: objects.polyline must inherit property "getPointAtLength(float)" with the proper type
 Pass	SVGGeometryElement interface: calling getPointAtLength(float) on objects.polyline with too few arguments must throw TypeError
@@ -1074,9 +1074,9 @@ Fail	SVGPolygonElement interface: objects.polygon must inherit property "points"
 Fail	SVGPolygonElement interface: objects.polygon must inherit property "animatedPoints" with the proper type
 Pass	SVGGeometryElement interface: objects.polygon must inherit property "pathLength" with the proper type
 Fail	SVGGeometryElement interface: objects.polygon must inherit property "isPointInFill(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.polygon with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInFill(optional DOMPointInit) on objects.polygon with too few arguments must throw TypeError
 Fail	SVGGeometryElement interface: objects.polygon must inherit property "isPointInStroke(optional DOMPointInit)" with the proper type
-Pass	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.polygon with too few arguments must throw TypeError
+Fail	SVGGeometryElement interface: calling isPointInStroke(optional DOMPointInit) on objects.polygon with too few arguments must throw TypeError
 Pass	SVGGeometryElement interface: objects.polygon must inherit property "getTotalLength()" with the proper type
 Pass	SVGGeometryElement interface: objects.polygon must inherit property "getPointAtLength(float)" with the proper type
 Pass	SVGGeometryElement interface: calling getPointAtLength(float) on objects.polygon with too few arguments must throw TypeError
@@ -1147,19 +1147,19 @@ Fail	SVGTextContentElement interface: objects.text must inherit property "length
 Pass	SVGTextContentElement interface: objects.text must inherit property "getNumberOfChars()" with the proper type
 Fail	SVGTextContentElement interface: objects.text must inherit property "getComputedTextLength()" with the proper type
 Fail	SVGTextContentElement interface: objects.text must inherit property "getSubStringLength(unsigned long, unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.text with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.text with too few arguments must throw TypeError
 Pass	SVGTextContentElement interface: objects.text must inherit property "getStartPositionOfChar(unsigned long)" with the proper type
 Pass	SVGTextContentElement interface: calling getStartPositionOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.text must inherit property "getEndPositionOfChar(unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.text must inherit property "getExtentOfChar(unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.text must inherit property "getRotationOfChar(unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.text must inherit property "getCharNumAtPosition(optional DOMPointInit)" with the proper type
-Pass	SVGTextContentElement interface: calling getCharNumAtPosition(optional DOMPointInit) on objects.text with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getCharNumAtPosition(optional DOMPointInit) on objects.text with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.text must inherit property "selectSubString(unsigned long, unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.text with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.text with too few arguments must throw TypeError
 Pass	SVGGraphicsElement interface: objects.text must inherit property "transform" with the proper type
 Pass	SVGGraphicsElement interface: objects.text must inherit property "getBBox(optional SVGBoundingBoxOptions)" with the proper type
 Pass	SVGGraphicsElement interface: calling getBBox(optional SVGBoundingBoxOptions) on objects.text with too few arguments must throw TypeError
@@ -1193,19 +1193,19 @@ Fail	SVGTextContentElement interface: objects.tspan must inherit property "lengt
 Pass	SVGTextContentElement interface: objects.tspan must inherit property "getNumberOfChars()" with the proper type
 Fail	SVGTextContentElement interface: objects.tspan must inherit property "getComputedTextLength()" with the proper type
 Fail	SVGTextContentElement interface: objects.tspan must inherit property "getSubStringLength(unsigned long, unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.tspan with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.tspan with too few arguments must throw TypeError
 Pass	SVGTextContentElement interface: objects.tspan must inherit property "getStartPositionOfChar(unsigned long)" with the proper type
 Pass	SVGTextContentElement interface: calling getStartPositionOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.tspan must inherit property "getEndPositionOfChar(unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.tspan must inherit property "getExtentOfChar(unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.tspan must inherit property "getRotationOfChar(unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.tspan must inherit property "getCharNumAtPosition(optional DOMPointInit)" with the proper type
-Pass	SVGTextContentElement interface: calling getCharNumAtPosition(optional DOMPointInit) on objects.tspan with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getCharNumAtPosition(optional DOMPointInit) on objects.tspan with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.tspan must inherit property "selectSubString(unsigned long, unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.tspan with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.tspan with too few arguments must throw TypeError
 Pass	SVGGraphicsElement interface: objects.tspan must inherit property "transform" with the proper type
 Pass	SVGGraphicsElement interface: objects.tspan must inherit property "getBBox(optional SVGBoundingBoxOptions)" with the proper type
 Pass	SVGGraphicsElement interface: calling getBBox(optional SVGBoundingBoxOptions) on objects.tspan with too few arguments must throw TypeError
@@ -1260,19 +1260,19 @@ Fail	SVGTextContentElement interface: objects.textPath must inherit property "le
 Pass	SVGTextContentElement interface: objects.textPath must inherit property "getNumberOfChars()" with the proper type
 Fail	SVGTextContentElement interface: objects.textPath must inherit property "getComputedTextLength()" with the proper type
 Fail	SVGTextContentElement interface: objects.textPath must inherit property "getSubStringLength(unsigned long, unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.textPath with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.textPath with too few arguments must throw TypeError
 Pass	SVGTextContentElement interface: objects.textPath must inherit property "getStartPositionOfChar(unsigned long)" with the proper type
 Pass	SVGTextContentElement interface: calling getStartPositionOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.textPath must inherit property "getEndPositionOfChar(unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.textPath must inherit property "getExtentOfChar(unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.textPath must inherit property "getRotationOfChar(unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.textPath must inherit property "getCharNumAtPosition(optional DOMPointInit)" with the proper type
-Pass	SVGTextContentElement interface: calling getCharNumAtPosition(optional DOMPointInit) on objects.textPath with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling getCharNumAtPosition(optional DOMPointInit) on objects.textPath with too few arguments must throw TypeError
 Fail	SVGTextContentElement interface: objects.textPath must inherit property "selectSubString(unsigned long, unsigned long)" with the proper type
-Pass	SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.textPath with too few arguments must throw TypeError
+Fail	SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.textPath with too few arguments must throw TypeError
 Pass	SVGGraphicsElement interface: objects.textPath must inherit property "transform" with the proper type
 Pass	SVGGraphicsElement interface: objects.textPath must inherit property "getBBox(optional SVGBoundingBoxOptions)" with the proper type
 Pass	SVGGraphicsElement interface: calling getBBox(optional SVGBoundingBoxOptions) on objects.textPath with too few arguments must throw TypeError

--- a/Tests/LibWeb/Text/expected/wpt-import/web-animations/idlharness.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/web-animations/idlharness.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 230 tests
 
-163 Pass
-67 Fail
+162 Pass
+68 Fail
 Pass	idl_test setup
 Pass	idl_test validation
 Pass	Partial interface Document: original interface defined
@@ -66,7 +66,7 @@ Pass	Stringification of document.timeline
 Fail	AnimationTimeline interface: document.timeline must inherit property "currentTime" with the proper type
 Pass	AnimationTimeline interface: document.timeline must inherit property "duration" with the proper type
 Fail	AnimationTimeline interface: document.timeline must inherit property "play(optional AnimationEffect?)" with the proper type
-Pass	AnimationTimeline interface: calling play(optional AnimationEffect?) on document.timeline with too few arguments must throw TypeError
+Fail	AnimationTimeline interface: calling play(optional AnimationEffect?) on document.timeline with too few arguments must throw TypeError
 Pass	Animation interface: existence and properties of interface object
 Pass	Animation interface object length
 Pass	Animation interface object name

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/idlharness.https.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/idlharness.https.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 1163 tests
 
-892 Pass
-271 Fail
+888 Pass
+275 Fail
 Fail	idl_test setup
 Pass	idl_test validation
 Pass	Partial interface Element: member names are unique
@@ -86,9 +86,9 @@ Fail	AudioContext interface: calling setSinkId((DOMString or AudioSinkOptions)) 
 Pass	AudioContext interface: context must inherit property "createMediaElementSource(HTMLMediaElement)" with the proper type
 Pass	AudioContext interface: calling createMediaElementSource(HTMLMediaElement) on context with too few arguments must throw TypeError
 Fail	AudioContext interface: context must inherit property "createMediaStreamSource(MediaStream)" with the proper type
-Pass	AudioContext interface: calling createMediaStreamSource(MediaStream) on context with too few arguments must throw TypeError
+Fail	AudioContext interface: calling createMediaStreamSource(MediaStream) on context with too few arguments must throw TypeError
 Fail	AudioContext interface: context must inherit property "createMediaStreamTrackSource(MediaStreamTrack)" with the proper type
-Pass	AudioContext interface: calling createMediaStreamTrackSource(MediaStreamTrack) on context with too few arguments must throw TypeError
+Fail	AudioContext interface: calling createMediaStreamTrackSource(MediaStreamTrack) on context with too few arguments must throw TypeError
 Fail	AudioContext interface: context must inherit property "createMediaStreamDestination()" with the proper type
 Pass	BaseAudioContext interface: context must inherit property "destination" with the proper type
 Pass	BaseAudioContext interface: context must inherit property "sampleRate" with the proper type
@@ -114,7 +114,7 @@ Pass	BaseAudioContext interface: calling createDelay(optional double) on context
 Pass	BaseAudioContext interface: context must inherit property "createDynamicsCompressor()" with the proper type
 Pass	BaseAudioContext interface: context must inherit property "createGain()" with the proper type
 Fail	BaseAudioContext interface: context must inherit property "createIIRFilter(sequence<double>, sequence<double>)" with the proper type
-Pass	BaseAudioContext interface: calling createIIRFilter(sequence<double>, sequence<double>) on context with too few arguments must throw TypeError
+Fail	BaseAudioContext interface: calling createIIRFilter(sequence<double>, sequence<double>) on context with too few arguments must throw TypeError
 Pass	BaseAudioContext interface: context must inherit property "createOscillator()" with the proper type
 Pass	BaseAudioContext interface: context must inherit property "createPanner()" with the proper type
 Pass	BaseAudioContext interface: context must inherit property "createPeriodicWave(sequence<float>, sequence<float>, optional PeriodicWaveConstraints)" with the proper type
@@ -175,7 +175,7 @@ Pass	BaseAudioContext interface: calling createDelay(optional double) on new Off
 Pass	BaseAudioContext interface: new OfflineAudioContext(1, 1, sample_rate) must inherit property "createDynamicsCompressor()" with the proper type
 Pass	BaseAudioContext interface: new OfflineAudioContext(1, 1, sample_rate) must inherit property "createGain()" with the proper type
 Fail	BaseAudioContext interface: new OfflineAudioContext(1, 1, sample_rate) must inherit property "createIIRFilter(sequence<double>, sequence<double>)" with the proper type
-Pass	BaseAudioContext interface: calling createIIRFilter(sequence<double>, sequence<double>) on new OfflineAudioContext(1, 1, sample_rate) with too few arguments must throw TypeError
+Fail	BaseAudioContext interface: calling createIIRFilter(sequence<double>, sequence<double>) on new OfflineAudioContext(1, 1, sample_rate) with too few arguments must throw TypeError
 Pass	BaseAudioContext interface: new OfflineAudioContext(1, 1, sample_rate) must inherit property "createOscillator()" with the proper type
 Pass	BaseAudioContext interface: new OfflineAudioContext(1, 1, sample_rate) must inherit property "createPanner()" with the proper type
 Pass	BaseAudioContext interface: new OfflineAudioContext(1, 1, sample_rate) must inherit property "createPeriodicWave(sequence<float>, sequence<float>, optional PeriodicWaveConstraints)" with the proper type

--- a/Tests/LibWeb/Text/input/Internals/fixme-members.html
+++ b/Tests/LibWeb/Text/input/Internals/fixme-members.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const prototype = Object.getPrototypeOf(internals);
+
+        println(`operation is absent from the instance: ${!("unimplementedOperationForTesting" in internals)}`);
+        println(`operation is absent from the prototype: ${!Object.hasOwn(prototype, "unimplementedOperationForTesting")}`);
+        println(`operation has no descriptor: ${Object.getOwnPropertyDescriptor(prototype, "unimplementedOperationForTesting") === undefined}`);
+        println(`operation is absent from own keys: ${!Reflect.ownKeys(prototype).includes("unimplementedOperationForTesting")}`);
+        println(`reading operation produces undefined: ${internals.unimplementedOperationForTesting === undefined}`);
+
+        try {
+            internals.unimplementedOperationForTesting();
+        } catch (error) {
+            println(`calling operation throws TypeError: ${error instanceof TypeError}`);
+        }
+
+        prototype.unimplementedOperationForTesting = () => "overridden";
+        println(`operation can be overridden: ${internals.unimplementedOperationForTesting()}`);
+        delete prototype.unimplementedOperationForTesting;
+        println(`operation is absent after deleting the override: ${!("unimplementedOperationForTesting" in internals)}`);
+
+        println(`attribute is absent: ${!("unimplementedAttributeForTesting" in internals)}`);
+        println(`reading attribute produces undefined: ${internals.unimplementedAttributeForTesting === undefined}`);
+    });
+</script>


### PR DESCRIPTION
Register unimplemented IDL members out of band instead of defining them as properties with an undefined value. This preserves diagnostic logging when they are accessed while making them behave like ordinary absent properties.

This behavior applies to both methods and attributes.

Regarding the updated `idlharness` expectations - these tests are now *correctly* failing. They previously passed by happenstance, as the old `[FIXME]` implementation exposed unimplemented members as `undefined`. So we were effectively calling `undefined()` in these tests, which threw the `TypeError` the tests are looking for, but for a very wrong reason.