### PR TITLE
LibGfx: Evict the least recently used half of a font's shaped texts

### DIFF
--- a/Libraries/LibGfx/Rust/src/text_layout.rs
+++ b/Libraries/LibGfx/Rust/src/text_layout.rs
@@ -159,7 +159,7 @@ impl ShapedText {
 
 const SINGLE_ASCII_SHAPE_CACHE_SIZE: usize = 128;
 const MAX_SHAPE_CACHE_FONTS: usize = 64;
-const MAX_SHAPE_CACHE_TEXTS_PER_FONT: usize = 4096;
+const MAX_SHAPE_CACHE_TEXTS_PER_FONT: usize = 16384;
 
 #[derive(Clone, Copy)]
 struct ShapeParams {

--- a/Libraries/LibGfx/Rust/src/text_layout.rs
+++ b/Libraries/LibGfx/Rust/src/text_layout.rs
@@ -191,12 +191,17 @@ struct ShapeForParams {
     shape: CachedShape,
 }
 
+struct ShapesForText {
+    last_used_tick: u64,
+    shapes: Vec<ShapeForParams>,
+}
+
 type FastMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
 
 struct FontShapeCache {
     last_used_tick: u64,
     single_ascii_common_shapes: [Option<Box<CachedShape>>; SINGLE_ASCII_SHAPE_CACHE_SIZE],
-    shapes_by_text: FastMap<Box<[u16]>, Vec<ShapeForParams>>,
+    shapes_by_text: FastMap<Box<[u16]>, ShapesForText>,
 }
 
 impl Default for FontShapeCache {
@@ -212,6 +217,7 @@ impl Default for FontShapeCache {
 impl FontShapeCache {
     fn shape_for(
         &mut self,
+        tick: u64,
         text: &[u16],
         params: ShapeParams,
         shape_uncached: impl FnOnce() -> CachedShape,
@@ -228,14 +234,22 @@ impl FontShapeCache {
 
         if !self.shapes_by_text.contains_key(text) {
             if self.shapes_by_text.len() >= MAX_SHAPE_CACHE_TEXTS_PER_FONT {
-                self.shapes_by_text.clear();
+                self.evict_least_recently_used_texts();
             }
-            self.shapes_by_text.insert(Box::from(text), Vec::new());
+            self.shapes_by_text.insert(
+                Box::from(text),
+                ShapesForText {
+                    last_used_tick: tick,
+                    shapes: Vec::new(),
+                },
+            );
         }
-        let shapes = self
+        let entry = self
             .shapes_by_text
             .get_mut(text)
             .expect("the entry was inserted just above");
+        entry.last_used_tick = tick;
+        let shapes = &mut entry.shapes;
         let index = shapes
             .iter()
             .position(|entry| entry.params.matches(&params))
@@ -247,6 +261,14 @@ impl FontShapeCache {
                 shapes.len() - 1
             });
         &shapes[index].shape
+    }
+
+    fn evict_least_recently_used_texts(&mut self) {
+        let mut ticks: Vec<u64> = self.shapes_by_text.values().map(|entry| entry.last_used_tick).collect();
+        let median_index = ticks.len() / 2;
+        let (_, median_tick, _) = ticks.select_nth_unstable(median_index);
+        let threshold = *median_tick;
+        self.shapes_by_text.retain(|_, entry| entry.last_used_tick > threshold);
     }
 }
 
@@ -270,7 +292,7 @@ impl ShapingCache {
         }
         let font_cache = self.caches_by_font_id.entry(font_id).or_default();
         font_cache.last_used_tick = self.tick;
-        font_cache.shape_for(text, params, shape_uncached)
+        font_cache.shape_for(self.tick, text, params, shape_uncached)
     }
 
     fn evict_least_recently_used_font(&mut self) {
@@ -463,12 +485,15 @@ mod shaping_cache_tests {
     }
 
     #[test]
-    fn overflowing_the_per_font_text_capacity_clears_that_font_only() {
+    fn overflowing_the_per_font_text_capacity_evicts_the_least_recently_used_half_of_that_font() {
         let mut cache = ShapingCache::default();
-        for text_index in 0..MAX_SHAPE_CACHE_TEXTS_PER_FONT as u32 {
-            let text: Vec<u16> = format!("text-{text_index}").encode_utf16().collect();
-            cache.shape_for(1, &text, params_with_letter_spacing(0.0), || shape_with_glyph_count(1));
+        let texts: Vec<Vec<u16>> = (0..MAX_SHAPE_CACHE_TEXTS_PER_FONT)
+            .map(|text_index| format!("text-{text_index}").encode_utf16().collect())
+            .collect();
+        for text in &texts {
+            cache.shape_for(1, text, params_with_letter_spacing(0.0), || shape_with_glyph_count(1));
         }
+        cache.shape_for(1, &texts[0], params_with_letter_spacing(0.0), || unreachable!());
         let other_font_text: Vec<u16> = "other".encode_utf16().collect();
         cache.shape_for(2, &other_font_text, params_with_letter_spacing(0.0), || {
             shape_with_glyph_count(1)
@@ -478,7 +503,19 @@ mod shaping_cache_tests {
         cache.shape_for(1, &overflowing_text, params_with_letter_spacing(0.0), || {
             shape_with_glyph_count(1)
         });
-        assert_eq!(cache.caches_by_font_id[&1].shapes_by_text.len(), 1);
+        let font_cache = &cache.caches_by_font_id[&1];
+        assert_eq!(font_cache.shapes_by_text.len(), MAX_SHAPE_CACHE_TEXTS_PER_FONT / 2);
+        assert!(font_cache.shapes_by_text.contains_key(texts[0].as_slice()));
+        assert!(!font_cache.shapes_by_text.contains_key(texts[1].as_slice()));
+        assert!(
+            font_cache
+                .shapes_by_text
+                .contains_key(texts[texts.len() - 1].as_slice())
+        );
+        assert!(font_cache.shapes_by_text.contains_key(overflowing_text.as_slice()));
         assert_eq!(cache.caches_by_font_id[&2].shapes_by_text.len(), 1);
+
+        cache.shape_for(1, &texts[0], params_with_letter_spacing(0.0), || unreachable!());
+        cache.shape_for(1, &overflowing_text, params_with_letter_spacing(0.0), || unreachable!());
     }
 }


### PR DESCRIPTION
The shaping cache held at most 4096 texts per font and dropped all of them when one more arrived, so a document with a larger vocabulary shaped most of its words again on every layout. A font now keeps four times as many texts and, once full, evicts the half that was used least recently, so the words a page keeps laying out stay shaped.

This speeds up the `Editor-TipTap` Speedometer3 tests:

```
Benchmark     Suite                                       Test                   Speedup  Old (Mean ± Range)    New (Mean ± Range)
------------  ------------------------------------------  -------------------  ---------  --------------------  --------------------
Speedometer3  Charts-chartjs                              Draw opaque scatter      1.075  0.10 ± 0.01           0.10 ± 0.00
Speedometer3  Charts-chartjs                              Draw scatter             1.012  0.13 ± 0.00           0.13 ± 0.00
Speedometer3  Charts-chartjs                              Show tooltip             1.368  0.00 ± 0.00           0.00 ± 0.00
Speedometer3  Charts-observable-plot                      Dotted                   1.075  0.07 ± 0.01           0.06 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 20            1.072  0.13 ± 0.01           0.12 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 6             0.987  0.08 ± 0.00           0.08 ± 0.00
Speedometer3  Editor-CodeMirror                           Highlight                1.048  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  Editor-CodeMirror                           Long                     1.015  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  Editor-TipTap                               Highlight                1.398  0.24 ± 0.02           0.17 ± 0.01
Speedometer3  Editor-TipTap                               Long                     1.522  0.17 ± 0.04           0.11 ± 0.01
Speedometer3  NewsSite-Next                               NavigateToPolitics       0.977  0.18 ± 0.03           0.19 ± 0.03
Speedometer3  NewsSite-Next                               NavigateToUS             1.02   0.16 ± 0.01           0.16 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToWorld          1.01   0.18 ± 0.01           0.18 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToPolitics       0.984  0.15 ± 0.00           0.15 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToUS             1.013  0.14 ± 0.01           0.14 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToWorld          0.982  0.15 ± 0.00           0.15 ± 0.01
Speedometer3  Perf-Dashboard                              Render                   1.05   0.06 ± 0.00           0.06 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingPoints          1.029  0.12 ± 0.01           0.12 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingRange           1.008  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  React-Stockcharts-SVG                       PanTheChart              1.066  0.12 ± 0.01           0.11 ± 0.00
Speedometer3  React-Stockcharts-SVG                       Render                   1.02   0.13 ± 0.00           0.13 ± 0.00
Speedometer3  React-Stockcharts-SVG                       ZoomTheChart             1.028  0.46 ± 0.02           0.45 ± 0.02
Speedometer3  TodoMVC-Angular-Complex-DOM                 Adding100Items           1.176  0.13 ± 0.04           0.11 ± 0.00
Speedometer3  TodoMVC-Angular-Complex-DOM                 CompletingAllItems       1.124  0.09 ± 0.02           0.08 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 DeletingAllItems         0.922  0.04 ± 0.00           0.05 ± 0.01
Speedometer3  TodoMVC-Backbone                            Adding100Items           0.995  0.08 ± 0.00           0.08 ± 0.00
Speedometer3  TodoMVC-Backbone                            CompletingAllItems       0.999  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Backbone                            DeletingAllItems         0.972  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      Adding100Items           1.015  0.13 ± 0.01           0.13 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      CompletingAllItems       1.053  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      DeletingAllItems         0.969  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  Adding100Items           1.024  0.15 ± 0.03           0.14 ± 0.03
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  CompletingAllItems       1.001  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  DeletingAllItems         0.991  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     Adding100Items           1.096  0.06 ± 0.01           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     CompletingAllItems       1.018  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     DeletingAllItems         0.968  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  Adding100Items           0.993  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  CompletingAllItems       0.914  0.03 ± 0.00           0.03 ± 0.01
Speedometer3  TodoMVC-Preact-Complex-DOM                  DeletingAllItems         0.908  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   Adding100Items           1.143  0.10 ± 0.02           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   CompletingAllItems       1.045  0.09 ± 0.01           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   DeletingAllItems         1.019  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-React-Redux                         Adding100Items           1.016  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Redux                         CompletingAllItems       0.937  0.12 ± 0.01           0.13 ± 0.02
Speedometer3  TodoMVC-React-Redux                         DeletingAllItems         0.991  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  Adding100Items           1.038  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  CompletingAllItems       1.019  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  DeletingAllItems         1.042  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Vue                                 Adding100Items           0.975  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Vue                                 CompletingAllItems       1.01   0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Vue                                 DeletingAllItems         0.988  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       Adding100Items           1.046  0.07 ± 0.01           0.06 ± 0.00
Speedometer3  TodoMVC-WebComponents                       CompletingAllItems       0.697  0.02 ± 0.00           0.03 ± 0.02
Speedometer3  TodoMVC-WebComponents                       DeletingAllItems         0.96   0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-jQuery                              Adding100Items           1.065  0.21 ± 0.02           0.20 ± 0.01
Speedometer3  TodoMVC-jQuery                              CompletingAllItems       0.978  0.56 ± 0.05           0.57 ± 0.07
Speedometer3  TodoMVC-jQuery                              DeletingAllItems         1.122  0.21 ± 0.04           0.19 ± 0.01

Benchmark     Old Score    New Score      Score Improvement  Old Total Time (s)    New Total Time (s)      Speedup
------------  -----------  -----------  -------------------  --------------------  --------------------  ---------
Speedometer3  4.65 ± 0.13  4.79 ± 0.09                 1.03  5.72 ± 0.22           5.48 ± 0.14               1.044
```