### PR TITLE
LibWeb+LibWebView: Prepare navigate and WindowProxy for remote navigables

### DIFF
--- a/Libraries/LibURL/Origin.cpp
+++ b/Libraries/LibURL/Origin.cpp
@@ -145,15 +145,13 @@ unsigned Traits<URL::Origin>::hash(URL::Origin const& origin)
             | (static_cast<u32>(nonce[3]));
     }
 
+    // NB: Origin equality uses same-origin semantics, which ignore the domain override.
     unsigned hash = origin.scheme().value_or(String {}).hash();
 
     if (origin.port().has_value())
         hash = pair_int_hash(hash, *origin.port());
 
     hash = pair_int_hash(hash, origin.host().serialize().hash());
-
-    if (origin.domain().has_value())
-        hash = pair_int_hash(hash, origin.domain()->serialize().hash());
 
     return hash;
 }

--- a/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
+++ b/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
@@ -289,6 +289,12 @@ bool is_platform_object_same_origin(JS::Object const& object)
     return HTML::current_settings_object().origin().is_same_origin_domain(HTML::relevant_settings_object(object).origin());
 }
 
+bool is_platform_object_same_origin(Location const& location)
+{
+    // 1. Return true if the current settings object's origin is same origin-domain with O's relevant settings object's origin, and false otherwise.
+    return HTML::current_settings_object().origin().is_same_origin_domain(HTML::relevant_settings_object(location.window()).origin());
+}
+
 bool is_platform_object_same_origin(Window const& window)
 {
     // 1. Return true if the current settings object's origin is same origin-domain with O's relevant settings object's origin, and false otherwise.

--- a/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
+++ b/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
@@ -502,7 +502,7 @@ JS::ThrowCompletionOr<bool> cross_origin_set(JS::VM& vm, JS::Object& object, JS:
 }
 
 // 7.2.3.7 CrossOriginOwnPropertyKeys ( O ), https://html.spec.whatwg.org/multipage/browsers.html#crossoriginownpropertykeys-(-o-)
-static GC::RootVector<JS::Value> cross_origin_own_property_keys_impl(Variant<HTML::Location const*, HTML::Window const*> const& object)
+static GC::RootVector<JS::Value> cross_origin_own_property_keys_impl(Vector<CrossOriginProperty> const& properties)
 {
     auto& event_loop = HTML::main_thread_event_loop();
     auto& vm = event_loop.vm();
@@ -511,7 +511,7 @@ static GC::RootVector<JS::Value> cross_origin_own_property_keys_impl(Variant<HTM
     GC::RootVector<JS::Value> keys;
 
     // 2. For each e of CrossOriginProperties(O), append e.[[Property]] to keys.
-    for (auto& entry : cross_origin_properties(object))
+    for (auto const& entry : properties)
         keys.append(JS::PrimitiveString::create(vm, entry.property));
 
     // 3. Return the concatenation of keys and « "then", @@toStringTag, @@hasInstance, @@isConcatSpreadable ».
@@ -524,12 +524,17 @@ static GC::RootVector<JS::Value> cross_origin_own_property_keys_impl(Variant<HTM
 
 GC::RootVector<JS::Value> cross_origin_own_property_keys(HTML::Location const& location)
 {
-    return cross_origin_own_property_keys_impl(Variant<HTML::Location const*, HTML::Window const*> { &location });
+    return cross_origin_own_property_keys_impl(cross_origin_properties(Variant<HTML::Location const*, HTML::Window const*> { &location }));
 }
 
-GC::RootVector<JS::Value> cross_origin_own_property_keys(HTML::Window const& window)
+GC::RootVector<JS::Value> cross_origin_own_property_keys(HTML::Window const&)
 {
-    return cross_origin_own_property_keys_impl(Variant<HTML::Location const*, HTML::Window const*> { &window });
+    return cross_origin_window_own_property_keys();
+}
+
+GC::RootVector<JS::Value> cross_origin_window_own_property_keys()
+{
+    return cross_origin_own_property_keys_impl(cross_origin_window_properties());
 }
 
 }

--- a/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.h
+++ b/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.h
@@ -19,6 +19,7 @@ Vector<CrossOriginProperty> cross_origin_window_properties();
 bool is_cross_origin_accessible_window_property_name(JS::PropertyKey const&);
 JS::ThrowCompletionOr<JS::PropertyDescriptor> cross_origin_property_fallback(JS::VM&, JS::PropertyKey const&);
 bool is_platform_object_same_origin(JS::Object const&);
+bool is_platform_object_same_origin(Location const&);
 bool is_platform_object_same_origin(Window const&);
 Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(JS::Object&, HTML::Location const&, CrossOriginPropertyDescriptorMap&,
     JS::PropertyKey const&);

--- a/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.h
+++ b/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.h
@@ -29,5 +29,6 @@ JS::ThrowCompletionOr<JS::Value> cross_origin_get(JS::VM&, JS::Object const&, JS
 JS::ThrowCompletionOr<bool> cross_origin_set(JS::VM&, JS::Object&, JS::PropertyKey const&, JS::Value, JS::Value receiver);
 GC::RootVector<JS::Value> cross_origin_own_property_keys(HTML::Location const&);
 GC::RootVector<JS::Value> cross_origin_own_property_keys(HTML::Window const&);
+GC::RootVector<JS::Value> cross_origin_window_own_property_keys();
 
 }

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -26,7 +26,6 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
 #include <LibWeb/ContentSecurityPolicy/PolicyList.h>
 #include <LibWeb/ContentSecurityPolicy/Violation.h>
-#include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOM/DocumentLoading.h>
@@ -2610,63 +2609,20 @@ void LocalNavigable::create_navigation_params_for_navigation(NavigationPopulatio
         received_navigation_params);
 }
 
-// https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
-WebIDL::ExceptionOr<void> LocalNavigable::navigate(NavigateParams params)
+WebIDL::ExceptionOr<void> LocalNavigable::continue_navigation_in_active_document_agent(
+    NavigateParams params,
+    ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type,
+    GC::Ref<SourceSnapshotParams> source_snapshot_params,
+    URL::Origin initiator_origin_snapshot,
+    URL::URL initiator_base_url_snapshot)
 {
+    // NB: A WebContent process has one main-thread similar-origin window agent, so a local navigable's active
+    //     document always shares the surrounding agent and step 8 continues here. A navigation the UI process
+    //     requested was delivered by IPC to this agent.
+
     // AD-HOC: Not in the spec but subsequent steps will fail if the navigable doesn't have an active window.
     if (!active_window())
         return {};
-
-    auto source_document = params.source_document;
-    auto exceptions_enabled = params.exceptions_enabled;
-    auto user_involvement = params.user_involvement;
-    auto url = params.url;
-
-    auto& active_document = *this->active_document();
-    auto& realm = HTML::relevant_realm(active_document);
-
-    // 1. Let cspNavigationType be "form-submission" if formDataEntryList is non-null; otherwise "other".
-    auto csp_navigation_type = params.form_data_entry_list.has_value() ? ContentSecurityPolicy::Directives::Directive::NavigationType::FormSubmission : ContentSecurityPolicy::Directives::Directive::NavigationType::Other;
-
-    // 2. Let sourceSnapshotParams be the result of snapshotting source snapshot params given sourceDocument.
-    auto source_snapshot_params = snapshot_source_snapshot_params(source_document);
-
-    // 3. Let initiatorOriginSnapshot be a new opaque origin.
-    auto initiator_origin_snapshot = URL::Origin::create_opaque();
-
-    // 4. Let initiatorBaseURLSnapshot be about:blank.
-    auto initiator_base_url_snapshot = URL::about_blank();
-
-    // 5. If sourceDocument is null:
-    if (!source_document) {
-        // 1. Assert: userInvolvement is "browser UI".
-        VERIFY(user_involvement == UserNavigationInvolvement::BrowserUI);
-
-        // 2. If url's scheme is "javascript", then set initiatorOriginSnapshot to navigable's active document's origin.
-        if (url.scheme() == "javascript"sv)
-            initiator_origin_snapshot = active_document.origin();
-    }
-    // 6. Otherwise:
-    else {
-        // 1. Assert: userInvolvement is not "browser UI".
-        VERIFY(user_involvement != UserNavigationInvolvement::BrowserUI);
-
-        // 2. If sourceDocument's node navigable is not allowed by sandboxing to navigate navigable given sourceSnapshotParams:
-        if (!source_document->navigable()->allowed_by_sandboxing_to_navigate(*this, source_snapshot_params)) {
-            // 1. If exceptionsEnabled is true, then throw a "SecurityError" DOMException.
-            if (exceptions_enabled)
-                return WebIDL::SecurityError::create(realm, "Source document's node navigable is not allowed to navigate"_utf16);
-
-            // 2 Return.
-            return {};
-        }
-
-        // 3. Set initiatorOriginSnapshot to sourceDocument's origin.
-        initiator_origin_snapshot = source_document->origin();
-
-        // 4. Set initiatorBaseURLSnapshot to sourceDocument's document base URL.
-        initiator_base_url_snapshot = source_document->base_url();
-    }
 
     PreparedNavigation navigation {
         .params = move(params),
@@ -2679,7 +2635,7 @@ WebIDL::ExceptionOr<void> LocalNavigable::navigate(NavigateParams params)
     // AD-HOC: A child navigable's session history entry exists canonically only once the UI process has admitted
     //         the creation operation, so navigations that arrive before that acknowledgment queue until it lands.
     //         Top-level traversables are marked ready at creation and never queue here. Keep the values snapshotted
-    //         by steps 1-6 so the eventual continuation starts at step 7.
+    //         by steps 1-7 so the eventual continuation starts at step 8.
     if (!m_has_session_history_entry_and_ready_for_navigation) {
         queue_pending_navigation(move(navigation), PendingNavigationBehavior::Append);
         return {};
@@ -2816,7 +2772,7 @@ void LocalNavigable::continue_navigation_after_population_dispatch(PreparedNavig
     create_navigation_params_for_navigation(move(population_request), source_snapshot_params, move(navigation_params), Bindings::NavigationTimingType::Navigate);
 }
 
-// Continue the navigate algorithm at step 7 with the values snapshotted by steps 1-6 in navigate().
+// Continue the navigate algorithm at step 9 with the values prepared by steps 1-7 in navigate().
 void LocalNavigable::begin_navigation(PreparedNavigation navigation)
 {
     // AD-HOC: Not in the spec but we should not navigate a navigable that has been destroyed.
@@ -2850,18 +2806,9 @@ void LocalNavigable::begin_navigation(PreparedNavigation navigation)
     auto initiator_origin_snapshot = navigation.initiator_origin_snapshot;
     auto initiator_base_url_snapshot = navigation.initiator_base_url_snapshot;
 
-    // 7. Let navigationId be the result of generating a random UUID.
-    // NB: Generating the ID is the responsibility of whichever process requested the navigation. A load
-    //     requested by the UI process carries the ID the UI generated when it recorded the navigation.
-    auto navigation_id = params.navigation_id.value_or_lazy_evaluated([] {
-        auto uuid = Crypto::generate_random_uuid();
-        return Utf16String::from_ascii_without_validation(uuid.bytes());
-    });
-
-    // 8. If the surrounding agent is equal to navigable's active document's relevant agent, then continue these steps.
-    //    Otherwise, queue a global task on the navigation and traversal task source given navigable's active window to continue these steps.
-    // NB: A navigation requested by the UI process was queued by the IPC message that delivered it here,
-    //     while a navigation begun within this process continues in its own agent.
+    VERIFY(params.navigation_id.has_value());
+    // Keep the ID in the prepared navigation in case step 18 queues it behind an ongoing traversal.
+    auto navigation_id = *params.navigation_id;
 
     // 9. If navigable's active document's unload counter is greater than 0,
     //    then invoke WebDriver BiDi navigation failed with navigable and a WebDriver BiDi navigation status whose id

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -193,8 +193,6 @@ public:
 
     void create_navigation_params_for_navigation(NavigationPopulationRequest, GC::Ref<SourceSnapshotParams>, NavigationParamsVariant, Bindings::NavigationTimingType);
 
-    virtual WebIDL::ExceptionOr<void> navigate(NavigateParams) override;
-
     GC::Ptr<DOM::Document> evaluate_javascript_url(URL::URL const&, URL::Origin const& new_document_origin, UserNavigationInvolvement, Utf16String navigation_id);
 
     void reload(Optional<StorageSerializationRecord> navigation_api_state = {}, UserNavigationInvolvement = UserNavigationInvolvement::None);
@@ -362,8 +360,8 @@ private:
         Replace
     };
 
-    // Values produced by steps 1-6 of the navigate algorithm. Keep these when navigation is parked so resumption
-    // continues at step 7 instead of snapshotting a different document state.
+    // Values produced by steps 1-7 of the navigate algorithm. Keep these when navigation is parked so resumption
+    // continues at step 8 instead of snapshotting a different document state.
     struct PreparedNavigation {
         NavigateParams params;
         ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type;
@@ -385,6 +383,12 @@ private:
     };
 
     void begin_navigation(PreparedNavigation);
+    virtual WebIDL::ExceptionOr<void> continue_navigation_in_active_document_agent(
+        NavigateParams,
+        ContentSecurityPolicy::Directives::Directive::NavigationType,
+        GC::Ref<SourceSnapshotParams>,
+        URL::Origin initiator_origin_snapshot,
+        URL::URL initiator_base_url_snapshot) override;
     void continue_navigation_after_population_dispatch(PreparedNavigation, NavigationPopulationRequest);
     void queue_pending_navigation(PreparedNavigation, PendingNavigationBehavior);
     void park_navigation_for_population(Utf16String navigation_id, Optional<PreparedNavigation>, GC::Ref<GC::Function<void(Optional<PreparedNavigation>, Optional<NavigationPopulationRequest>)>> continue_steps);

--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -103,7 +103,7 @@ void LocationWrapper::initialize_location_object(JS::Realm& realm)
 JS::ThrowCompletionOr<JS::Object*> LocationWrapper::internal_get_prototype_of() const
 {
     // 1. If IsPlatformObjectSameOrigin(this) is true, then return ! OrdinaryGetPrototypeOf(this).
-    if (HTML::is_platform_object_same_origin(*this))
+    if (HTML::is_platform_object_same_origin(impl()))
         return MUST(JS::Object::internal_get_prototype_of());
 
     // 2. Return null.
@@ -137,7 +137,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> LocationWrapper::interna
     auto& vm = this->vm();
 
     // 1. If IsPlatformObjectSameOrigin(this) is true, then:
-    if (HTML::is_platform_object_same_origin(*this)) {
+    if (HTML::is_platform_object_same_origin(impl())) {
         // 1. Let desc be OrdinaryGetOwnProperty(this, P).
         auto descriptor = MUST(JS::Object::internal_get_own_property(property_key));
 
@@ -172,7 +172,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> LocationWrapper::interna
 JS::ThrowCompletionOr<bool> LocationWrapper::internal_define_own_property(JS::PropertyKey const& property_key, JS::PropertyDescriptor& descriptor, Optional<JS::PropertyDescriptor>* precomputed_get_own_property)
 {
     // 1. If IsPlatformObjectSameOrigin(this) is true, then:
-    if (HTML::is_platform_object_same_origin(*this)) {
+    if (HTML::is_platform_object_same_origin(impl())) {
         // 1. If the value of the [[DefaultProperties]] internal slot of this contains P, then return false.
         // 2. Return ? OrdinaryDefineOwnProperty(this, P, Desc).
         return Bindings::ordinary_define_own_property_and_preserve_wrapper_if_needed(*this, property_key, descriptor, precomputed_get_own_property);
@@ -188,7 +188,7 @@ JS::ThrowCompletionOr<JS::Value> LocationWrapper::internal_get(JS::PropertyKey c
     auto& vm = this->vm();
 
     // 1. If IsPlatformObjectSameOrigin(this) is true, then return ? OrdinaryGet(this, P, Receiver).
-    if (HTML::is_platform_object_same_origin(*this))
+    if (HTML::is_platform_object_same_origin(impl()))
         return JS::Object::internal_get(property_key, receiver, cacheable_metadata, phase);
 
     // 2. Return ? CrossOriginGet(this, P, Receiver).
@@ -201,7 +201,7 @@ JS::ThrowCompletionOr<bool> LocationWrapper::internal_set(JS::PropertyKey const&
     auto& vm = this->vm();
 
     // 1. If IsPlatformObjectSameOrigin(this) is true, then return ? OrdinarySet(this, P, V, Receiver).
-    if (HTML::is_platform_object_same_origin(*this))
+    if (HTML::is_platform_object_same_origin(impl()))
         return JS::Object::internal_set(property_key, value, receiver, cacheable_metadata, phase);
 
     // 2. Return ? CrossOriginSet(this, P, V, Receiver).
@@ -212,7 +212,7 @@ JS::ThrowCompletionOr<bool> LocationWrapper::internal_set(JS::PropertyKey const&
 JS::ThrowCompletionOr<bool> LocationWrapper::internal_delete(JS::PropertyKey const& property_key)
 {
     // 1. If IsPlatformObjectSameOrigin(this) is true, then return ? OrdinaryDelete(this, P).
-    if (HTML::is_platform_object_same_origin(*this))
+    if (HTML::is_platform_object_same_origin(impl()))
         return JS::Object::internal_delete(property_key);
 
     // 2. Throw a "SecurityError" DOMException.
@@ -223,7 +223,7 @@ JS::ThrowCompletionOr<bool> LocationWrapper::internal_delete(JS::PropertyKey con
 JS::ThrowCompletionOr<GC::RootVector<JS::Value>> LocationWrapper::internal_own_property_keys() const
 {
     // 1. If IsPlatformObjectSameOrigin(this) is true, then return OrdinaryOwnPropertyKeys(this).
-    if (HTML::is_platform_object_same_origin(*this))
+    if (HTML::is_platform_object_same_origin(impl()))
         return JS::Object::internal_own_property_keys();
 
     // 2. Return CrossOriginOwnPropertyKeys(this).

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -4,9 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Crypto/Crypto.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
 #include <LibWeb/HTML/SourceSnapshotParams.h>
+#include <LibWeb/HTML/UserNavigationInvolvement.h>
+#include <LibWeb/WebIDL/DOMException.h>
 
 namespace Web::HTML {
 
@@ -39,6 +44,80 @@ GC::Ref<Navigable> Navigable::top_level_traversable()
 
     // 3. Return navigable.
     return navigable;
+}
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
+WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
+{
+    auto source_document = params.source_document;
+
+    // 1. Let cspNavigationType be "form-submission" if formDataEntryList is non-null; otherwise "other".
+    auto csp_navigation_type = params.form_data_entry_list.has_value()
+        ? ContentSecurityPolicy::Directives::Directive::NavigationType::FormSubmission
+        : ContentSecurityPolicy::Directives::Directive::NavigationType::Other;
+
+    // 2. Let sourceSnapshotParams be the result of snapshotting source snapshot params given sourceDocument.
+    auto source_snapshot_params = snapshot_source_snapshot_params(source_document);
+
+    // 3. Let initiatorOriginSnapshot be a new opaque origin.
+    auto initiator_origin_snapshot = URL::Origin::create_opaque();
+
+    // 4. Let initiatorBaseURLSnapshot be about:blank.
+    auto initiator_base_url_snapshot = URL::about_blank();
+
+    // 5. If sourceDocument is null:
+    if (!source_document) {
+        // 1. Assert: userInvolvement is "browser UI".
+        VERIFY(params.user_involvement == UserNavigationInvolvement::BrowserUI);
+
+        // 2. If url's scheme is "javascript", then set initiatorOriginSnapshot to navigable's active document's origin.
+        if (params.url.scheme() == "javascript"sv) {
+            auto origin = active_document_origin();
+            if (!origin.has_value())
+                return {};
+            initiator_origin_snapshot = origin.release_value();
+        }
+    }
+    // 6. Otherwise:
+    else {
+        // 1. Assert: userInvolvement is not "browser UI".
+        VERIFY(params.user_involvement != UserNavigationInvolvement::BrowserUI);
+
+        // 2. If sourceDocument's node navigable is not allowed by sandboxing to navigate navigable given
+        //    sourceSnapshotParams:
+        if (!source_document->navigable()->allowed_by_sandboxing_to_navigate(*this, source_snapshot_params)) {
+            // 1. If exceptionsEnabled is true, then throw a "SecurityError" DOMException.
+            if (params.exceptions_enabled)
+                return WebIDL::SecurityError::create("Source document's node navigable is not allowed to navigate"_utf16);
+
+            // 2. Return.
+            return {};
+        }
+
+        // 3. Set initiatorOriginSnapshot to sourceDocument's origin.
+        initiator_origin_snapshot = source_document->origin();
+
+        // 4. Set initiatorBaseURLSnapshot to sourceDocument's document base URL.
+        initiator_base_url_snapshot = source_document->base_url();
+    }
+
+    // 7. Let navigationId be the result of generating a random UUID.
+    // NB: Generating the ID is the responsibility of whichever process requested the navigation. A load
+    //     requested by the UI process carries the ID the UI generated when it recorded the navigation.
+    params.navigation_id = params.navigation_id.value_or_lazy_evaluated([] {
+        auto uuid = Crypto::generate_random_uuid();
+        return Utf16String::from_ascii_without_validation(uuid.bytes());
+    });
+
+    // 8. If the surrounding agent is equal to navigable's active document's relevant agent, then continue these
+    //    steps. Otherwise, queue a global task on the navigation and traversal task source given navigable's active
+    //    window to continue these steps.
+    return continue_navigation_in_active_document_agent(
+        move(params),
+        csp_navigation_type,
+        source_snapshot_params,
+        move(initiator_origin_snapshot),
+        move(initiator_base_url_snapshot));
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#allowed-to-navigate

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -10,6 +10,7 @@
 #include <LibGC/Ptr.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibURL/URL.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/CrossProcessId.h>
@@ -39,7 +40,7 @@ public:
     virtual Optional<URL::URL> active_document_url() const = 0;
     virtual Optional<URL::Origin> active_document_origin() const = 0;
 
-    virtual WebIDL::ExceptionOr<void> navigate(NavigateParams) = 0;
+    WebIDL::ExceptionOr<void> navigate(NavigateParams);
 
     bool allowed_by_sandboxing_to_navigate(Navigable const& target, SourceSnapshotParams const&) const;
 
@@ -47,6 +48,14 @@ protected:
     Navigable() = default;
     void set_id(CrossProcessId id) { m_id = id; }
     void set_parent(GC::Ptr<Navigable> parent) { m_parent = parent; }
+
+    virtual WebIDL::ExceptionOr<void> continue_navigation_in_active_document_agent(
+        NavigateParams,
+        ContentSecurityPolicy::Directives::Directive::NavigationType,
+        GC::Ref<SourceSnapshotParams>,
+        URL::Origin initiator_origin_snapshot,
+        URL::URL initiator_base_url_snapshot)
+        = 0;
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1465,12 +1465,8 @@ Optional<Utf16String> Window::prompt(Optional<Utf16String> const& message, Optio
     return result;
 }
 
-// https://html.spec.whatwg.org/multipage/web-messaging.html#window-post-message-steps
-WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Realm& realm, JS::Value message, PostMessageOptions const& options)
+WebIDL::ExceptionOr<Window::PreparedPostMessage> Window::prepare_post_message(JS::Realm& realm, JS::Value message, PostMessageOptions const& options)
 {
-    // 1. Let targetRealm be targetWindow's realm.
-    auto& target_realm = this->principal_realm();
-
     // 2. Let incumbentSettings be the incumbent settings object.
     auto& incumbent_settings = incumbent_settings_object();
 
@@ -1502,58 +1498,89 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Realm& realm, JS
     // 7. Let serializeWithTransferResult be StructuredSerializeWithTransfer(message, transfer). Rethrow any exceptions.
     auto serialize_with_transfer_result = TRY(structured_serialize_with_transfer(realm, message, transfer));
 
+    // NB: The task queued by step 8 reads incumbentSettings in its steps 2 and 3. Snapshot those values here.
+    // 8.2. Let origin be the incumbentSettings's origin.
+    auto source_origin = incumbent_settings.origin();
+
+    // 8.3. Let source be the WindowProxy object corresponding to incumbentSettings's global object (a Window object).
+    auto source = GC::Ref { as<WindowProxy>(incumbent_settings.realm().global_environment().global_this_value()) };
+
+    return PreparedPostMessage {
+        .serialize_with_transfer_result = move(serialize_with_transfer_result),
+        .target_origin = move(target_origin),
+        .source_origin = move(source_origin),
+        .source = source,
+    };
+}
+
+// https://html.spec.whatwg.org/multipage/web-messaging.html#window-post-message-steps
+WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Realm& realm, JS::Value message, PostMessageOptions const& options)
+{
+    // 1. Let targetRealm be targetWindow's realm.
+    // NB: Taken from targetWindow when the queued task delivers the message.
+
+    // 2-7.
+    auto prepared = TRY(prepare_post_message(realm, message, options));
+
     // 8. Queue a global task on the posted message task source given targetWindow to run the following steps:
-    queue_global_task(Task::Source::PostedMessage, relevant_global_object(*this), GC::create_function(GC::Heap::the(), [this, serialize_with_transfer_result = move(serialize_with_transfer_result), target_origin = move(target_origin), &incumbent_settings, &target_realm]() mutable {
-        // 1. If the targetOrigin argument is not a single literal U+002A ASTERISK character (*) and targetWindow's
-        //    associated Document's origin is not same origin with targetOrigin, then return.
-        // NOTE: Due to step 4 and 5 above, the only time it's not '*' is if target_origin contains an Origin.
-        if (!target_origin.has<Utf16String>()) {
-            auto const& actual_target_origin = target_origin.get<URL::Origin>();
-            if (!document()->origin().is_same_origin(actual_target_origin))
-                return;
-        }
-
-        // 2. Let origin be the incumbentSettings's origin.
-        auto const& origin = incumbent_settings.origin();
-
-        // 3. Let source be the WindowProxy object corresponding to incumbentSettings's global object (a Window object).
-        auto& source = as<WindowProxy>(incumbent_settings.realm().global_environment().global_this_value());
-
-        TemporaryExecutionContext temporary_execution_context { target_realm, TemporaryExecutionContext::CallbacksEnabled::Yes };
-
-        // 4. Let deserializeRecord be StructuredDeserializeWithTransfer(serializeWithTransferResult, targetRealm).
-        auto deserialize_record_or_error = structured_deserialize_with_transfer(serialize_with_transfer_result, target_realm);
-
-        // If this throws an exception, catch it, fire an event named messageerror at targetWindow, using MessageEvent,
-        // with its origin initialized to origin and the source attribute initialized to source, and then return.
-        if (deserialize_record_or_error.is_exception()) {
-            MessageEventInit message_event_init { {}, JS::js_null(), Utf16String {}, Utf16String {}, {}, GC::Ref { source } };
-
-            auto message_error_event = MessageEvent::create(target_realm.global_object(), EventNames::messageerror, message_event_init, origin);
-            dispatch_event(message_error_event);
-            return;
-        }
-
-        // 5. Let messageClone be deserializeRecord.[[Deserialized]].
-        auto deserialize_record = deserialize_record_or_error.release_value();
-        auto message_clone = deserialize_record.deserialized;
-
-        // 6. Let newPorts be a new frozen array consisting of all MessagePort objects in deserializeRecord.[[TransferredValues]],
-        //    if any, maintaining their relative order.
-        // FIXME: Use a FrozenArray
-        auto new_ports = Bindings::message_ports_from_transferred_values(deserialize_record.transferred_values);
-
-        // 7. Fire an event named message at targetWindow, using MessageEvent, with its origin initialized to origin,
-        //    the source attribute initialized to source, the data attribute initialized to messageClone, and the ports
-        //    attribute initialized to newPorts.
-        MessageEventInit message_event_init { {}, message_clone, Utf16String {}, Utf16String {}, move(new_ports), GC::Ref { source } };
-
-        auto message_event = MessageEvent::create(target_realm.global_object(), EventNames::message, message_event_init, origin);
-        message_event->set_is_trusted(true);
-        dispatch_event(message_event);
+    queue_global_task(Task::Source::PostedMessage, relevant_global_object(*this), GC::create_function(GC::Heap::the(), [this, prepared = move(prepared)]() mutable {
+        deliver_posted_message(move(prepared.serialize_with_transfer_result), prepared.target_origin, prepared.source_origin, prepared.source);
     }));
 
     return {};
+}
+
+void Window::deliver_posted_message(SerializedTransferRecord serialize_with_transfer_result, Variant<Utf16String, URL::Origin> const& target_origin, URL::Origin const& origin, GC::Ref<WindowProxy> source)
+{
+    // 1. Let targetRealm be targetWindow's realm.
+    auto& target_realm = principal_realm();
+
+    // 1. If the targetOrigin argument is not a single literal U+002A ASTERISK character (*) and targetWindow's
+    //    associated Document's origin is not same origin with targetOrigin, then return.
+    // NOTE: Due to step 4 and 5 above, the only time it's not '*' is if target_origin contains an Origin.
+    if (!target_origin.has<Utf16String>()) {
+        auto const& actual_target_origin = target_origin.get<URL::Origin>();
+        if (!document()->origin().is_same_origin(actual_target_origin))
+            return;
+    }
+
+    // 2. Let origin be the incumbentSettings's origin.
+    // 3. Let source be the WindowProxy object corresponding to incumbentSettings's global object (a Window object).
+    // NB: Both were snapshotted by prepare_post_message().
+    NullableMessageEventSource source_for_event { source };
+
+    TemporaryExecutionContext temporary_execution_context { target_realm, TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+    // 4. Let deserializeRecord be StructuredDeserializeWithTransfer(serializeWithTransferResult, targetRealm).
+    auto deserialize_record_or_error = structured_deserialize_with_transfer(serialize_with_transfer_result, target_realm);
+
+    // If this throws an exception, catch it, fire an event named messageerror at targetWindow, using MessageEvent,
+    // with its origin initialized to origin and the source attribute initialized to source, and then return.
+    if (deserialize_record_or_error.is_exception()) {
+        MessageEventInit message_event_init { {}, JS::js_null(), Utf16String {}, Utf16String {}, {}, source_for_event };
+
+        auto message_error_event = MessageEvent::create(target_realm.global_object(), EventNames::messageerror, message_event_init, origin);
+        dispatch_event(message_error_event);
+        return;
+    }
+
+    // 5. Let messageClone be deserializeRecord.[[Deserialized]].
+    auto deserialize_record = deserialize_record_or_error.release_value();
+    auto message_clone = deserialize_record.deserialized;
+
+    // 6. Let newPorts be a new frozen array consisting of all MessagePort objects in deserializeRecord.[[TransferredValues]],
+    //    if any, maintaining their relative order.
+    // FIXME: Use a FrozenArray
+    auto new_ports = Bindings::message_ports_from_transferred_values(deserialize_record.transferred_values);
+
+    // 7. Fire an event named message at targetWindow, using MessageEvent, with its origin initialized to origin,
+    //    the source attribute initialized to source, the data attribute initialized to messageClone, and the ports
+    //    attribute initialized to newPorts.
+    MessageEventInit message_event_init { {}, message_clone, Utf16String {}, Utf16String {}, move(new_ports), source_for_event };
+
+    auto message_event = MessageEvent::create(target_realm.global_object(), EventNames::message, message_event_init, origin);
+    message_event->set_is_trusted(true);
+    dispatch_event(message_event);
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -221,6 +221,14 @@ public:
         Utf16String target_origin;
     };
     WebIDL::ExceptionOr<void> post_message(JS::Realm&, JS::Value message, PostMessageOptions const&);
+    struct PreparedPostMessage {
+        SerializedTransferRecord serialize_with_transfer_result;
+        Variant<Utf16String, URL::Origin> target_origin;
+        URL::Origin source_origin;
+        GC::Ref<WindowProxy> source;
+    };
+    static WebIDL::ExceptionOr<PreparedPostMessage> prepare_post_message(JS::Realm&, JS::Value message, PostMessageOptions const&);
+    void deliver_posted_message(SerializedTransferRecord, Variant<Utf16String, URL::Origin> const& target_origin, URL::Origin const& source_origin, GC::Ref<WindowProxy> source);
 
     Variant<GC::Ref<DOM::Event>, Empty> event() const;
 

--- a/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -31,13 +31,13 @@ GC::Ref<WindowProxy> WindowProxy::create(JS::Realm& realm)
     return realm.create<WindowProxy>(realm);
 }
 
-// 7.4 The WindowProxy exotic object, https://html.spec.whatwg.org/multipage/window-object.html#the-windowproxy-exotic-object
+// 7.2.3 The WindowProxy exotic object, https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-windowproxy-exotic-object
 WindowProxy::WindowProxy(JS::Realm& realm)
     : PlatformObject(realm, MayInterfereWithIndexedPropertyAccess::Yes)
 {
 }
 
-// 7.4.1 [[GetPrototypeOf]] ( ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-getprototypeof
+// 7.2.3.1 [[GetPrototypeOf]] ( ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-getprototypeof
 JS::ThrowCompletionOr<JS::Object*> WindowProxy::internal_get_prototype_of() const
 {
     // 1. Let W be the value of the [[Window]] internal slot of this.
@@ -50,28 +50,28 @@ JS::ThrowCompletionOr<JS::Object*> WindowProxy::internal_get_prototype_of() cons
     return nullptr;
 }
 
-// 7.4.2 [[SetPrototypeOf]] ( V ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-setprototypeof
+// 7.2.3.2 [[SetPrototypeOf]] ( V ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-setprototypeof
 JS::ThrowCompletionOr<bool> WindowProxy::internal_set_prototype_of(Object* prototype)
 {
     // 1. Return ! SetImmutablePrototype(this, V).
     return MUST(set_immutable_prototype(prototype));
 }
 
-// 7.4.3 [[IsExtensible]] ( ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-isextensible
+// 7.2.3.3 [[IsExtensible]] ( ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-isextensible
 JS::ThrowCompletionOr<bool> WindowProxy::internal_is_extensible() const
 {
     // 1. Return true.
     return true;
 }
 
-// 7.4.4 [[PreventExtensions]] ( ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-preventextensions
+// 7.2.3.4 [[PreventExtensions]] ( ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-preventextensions
 JS::ThrowCompletionOr<bool> WindowProxy::internal_prevent_extensions()
 {
     // 1. Return false.
     return false;
 }
 
-// 7.4.5 [[GetOwnProperty]] ( P ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-getownproperty
+// 7.2.3.5 [[GetOwnProperty]] ( P ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-getownproperty
 JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> WindowProxy::internal_get_own_property(JS::PropertyKey const& property_key) const
 {
     auto& vm = this->vm();
@@ -144,7 +144,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> WindowProxy::internal_ge
     return TRY(cross_origin_property_fallback(vm, property_key));
 }
 
-// 7.4.6 [[DefineOwnProperty]] ( P, Desc ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-defineownproperty
+// 7.2.3.6 [[DefineOwnProperty]] ( P, Desc ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-defineownproperty
 JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::PropertyKey const& property_key, JS::PropertyDescriptor& descriptor, Optional<JS::PropertyDescriptor>*)
 {
     // 1. Let W be the value of the [[Window]] internal slot of this.
@@ -164,8 +164,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::Proper
     return throw_completion(m_window->principal_realm(), WebIDL::SecurityError::create(Utf16String::formatted("Can't define property '{}' on cross-origin object", property_key)));
 }
 
-// 7.4.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-get
-// https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-get
+// 7.2.3.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-get
 JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheableGetPropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
 {
     auto& vm = this->vm();
@@ -205,8 +204,7 @@ JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const
     return cross_origin_get(vm, *this, property_key, receiver);
 }
 
-// 7.4.8 [[Set]] ( P, V, Receiver ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-set
-// https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-set
+// 7.2.3.8 [[Set]] ( P, V, Receiver ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-set
 JS::ThrowCompletionOr<bool> WindowProxy::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheableSetPropertyMetadata*, PropertyLookupPhase)
 {
     auto& vm = this->vm();
@@ -231,7 +229,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_set(JS::PropertyKey const& pro
     return cross_origin_set(vm, *this, property_key, value, receiver);
 }
 
-// 7.4.9 [[Delete]] ( P ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-delete
+// 7.2.3.9 [[Delete]] ( P ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-delete
 JS::ThrowCompletionOr<bool> WindowProxy::internal_delete(JS::PropertyKey const& property_key)
 {
     // 1. Let W be the value of the [[Window]] internal slot of this.
@@ -259,7 +257,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_delete(JS::PropertyKey const& 
     return throw_completion(m_window->principal_realm(), WebIDL::SecurityError::create(Utf16String::formatted("Can't delete property '{}' on cross-origin object", property_key)));
 }
 
-// 7.4.10 [[OwnPropertyKeys]] ( ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-ownpropertykeys
+// 7.2.3.10 [[OwnPropertyKeys]] ( ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-ownpropertykeys
 JS::ThrowCompletionOr<GC::RootVector<JS::Value>> WindowProxy::internal_own_property_keys() const
 {
     auto& event_loop = main_thread_event_loop();
@@ -267,28 +265,21 @@ JS::ThrowCompletionOr<GC::RootVector<JS::Value>> WindowProxy::internal_own_prope
 
     // 1. Let W be the value of the [[Window]] internal slot of this.
 
-    // 2. Let keys be a new empty List.
-    GC::RootVector<JS::Value> keys;
-
-    // 3. Let maxProperties be W's associated Document's document-tree child navigables's size.
+    // 2. Let maxProperties be W's associated Document's document-tree child navigables's size.
     auto max_properties = m_window->associated_document().document_tree_child_navigables().size();
 
-    // 4. Let index be 0.
-    // 5. Repeat while index < maxProperties,
-    for (size_t i = 0; i < max_properties; ++i) {
-        // 1. Add ! ToString(index) as the last element of keys.
+    // 3. Let keys be the range 0 to maxProperties, exclusive.
+    GC::RootVector<JS::Value> keys;
+    for (size_t i = 0; i < max_properties; ++i)
         keys.append(JS::PrimitiveString::create_from_unsigned_integer(vm, i));
 
-        // 2. Increment index by 1.
-    }
-
-    // 6. If IsPlatformObjectSameOrigin(W) is true, then return the concatenation of keys and OrdinaryOwnPropertyKeys(W).
+    // 4. If IsPlatformObjectSameOrigin(W) is true, then return the concatenation of keys and OrdinaryOwnPropertyKeys(W).
     if (is_platform_object_same_origin(*m_window)) {
         keys.extend(MUST(Bindings::platform_object_for_window(*m_window, realm()).internal_own_property_keys()));
         return keys;
     }
 
-    // 7. Return the concatenation of keys and ! CrossOriginOwnPropertyKeys(W).
+    // 5. Return the concatenation of keys and ! CrossOriginOwnPropertyKeys(W).
     keys.extend(cross_origin_own_property_keys(*m_window));
     return keys;
 }

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1196,6 +1196,11 @@ Utf16String Internals::dump_site_isolation_process_tree()
     return dump_string_to_utf16(window().associated_document().page().client().dump_site_isolation_process_tree_for_testing());
 }
 
+void Internals::crash_remote_frame_processes()
+{
+    window().associated_document().page().client().crash_remote_frame_processes_for_testing();
+}
+
 GC::Ref<WebIDL::Promise> Internals::flush_session_history_traversal_queue()
 {
     auto& realm = window().principal_realm();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -174,6 +174,7 @@ public:
     bool register_session_store_tab();
     Utf16String dump_session_store_tab_state();
     Utf16String dump_site_isolation_process_tree();
+    void crash_remote_frame_processes();
     GC::Ref<WebIDL::Promise> flush_session_history_traversal_queue();
     bool has_html_parser_end_state(DOM::Document& document) { return document.has_html_parser_end_state(); }
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -153,6 +153,7 @@ interface Internals {
     boolean registerSessionStoreTab();
     DOMString dumpSessionStoreTabState();
     DOMString dumpSiteIsolationProcessTree();
+    undefined crashRemoteFrameProcesses();
     Promise<undefined> flushSessionHistoryTraversalQueue();
 
     boolean hasHTMLParserEndState(Document document);

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -494,6 +494,7 @@ public:
     virtual void page_did_destroy_child_frame(HTML::CrossProcessId) { }
     virtual Optional<Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(HTML::CrossProcessId) const { return {}; }
     virtual String dump_site_isolation_process_tree_for_testing() { return {}; }
+    virtual void crash_remote_frame_processes_for_testing() { }
     virtual Gfx::Palette palette() const = 0;
     virtual DevicePixelRect screen_rect() const = 0;
     virtual double zoom_level() const = 0;

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -387,15 +387,14 @@ bool CanonicalNavigable::navigation_population_matches(WebContentClient const& c
     return m_ongoing_navigation.has_value()
         && m_ongoing_navigation->navigation_id == navigation_id
         && m_ongoing_navigation->phase == OngoingNavigation::Phase::Populating
-        && m_ongoing_navigation->population_worker_client.ptr() == &client
-        && m_ongoing_navigation->population_worker_page_id == page_id;
+        && navigation_population_worker_matches(client, page_id);
 }
 
-void CanonicalNavigable::did_finish_navigation_params_creation()
+bool CanonicalNavigable::navigation_population_worker_matches(WebContentClient const& client, u64 page_id) const
 {
-    VERIFY(m_ongoing_navigation.has_value());
-    m_ongoing_navigation->population_worker_client = {};
-    m_ongoing_navigation->population_worker_page_id = 0;
+    return m_ongoing_navigation.has_value()
+        && m_ongoing_navigation->population_worker_client.ptr() == &client
+        && m_ongoing_navigation->population_worker_page_id == page_id;
 }
 
 void CanonicalNavigable::set_navigation_host(WebContentClient& client, u64 page_id)
@@ -403,6 +402,10 @@ void CanonicalNavigable::set_navigation_host(WebContentClient& client, u64 page_
     auto& ongoing_navigation = ensure_ongoing_navigation();
     ongoing_navigation.host_client = client;
     ongoing_navigation.host_page_id = page_id;
+
+    // The population worker conducts the navigation until the hosting process takes over.
+    ongoing_navigation.population_worker_client = {};
+    ongoing_navigation.population_worker_page_id = 0;
 }
 
 bool CanonicalNavigable::navigation_host_matches(WebContentClient const& client, u64 page_id) const
@@ -414,11 +417,7 @@ bool CanonicalNavigable::navigation_host_matches(WebContentClient const& client,
 
 bool CanonicalNavigable::navigation_owner_matches(WebContentClient const& client, u64 page_id) const
 {
-    if (!m_ongoing_navigation.has_value())
-        return false;
-    auto population_worker_matches = m_ongoing_navigation->population_worker_client.ptr() == &client
-        && m_ongoing_navigation->population_worker_page_id == page_id;
-    return population_worker_matches || navigation_host_matches(client, page_id);
+    return navigation_population_worker_matches(client, page_id) || navigation_host_matches(client, page_id);
 }
 
 bool CanonicalNavigable::navigation_transaction_matches(Utf16String const& navigation_id, WebContentClient const& client, u64 page_id) const

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -161,7 +161,7 @@ public:
     void clear_ongoing_navigation();
     void set_navigation_population_worker(WebContentClient&, u64 page_id);
     bool navigation_population_matches(WebContentClient const&, u64 page_id, Utf16String const& navigation_id) const;
-    void did_finish_navigation_params_creation();
+    bool navigation_population_worker_matches(WebContentClient const&, u64 page_id) const;
     void set_navigation_host(WebContentClient&, u64 page_id);
     bool navigation_host_matches(WebContentClient const&, u64 page_id) const;
     bool navigation_owner_matches(WebContentClient const&, u64 page_id) const;

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -108,6 +108,11 @@ void SiteIsolationManager::remove_page(WebContentClient& client, u64 page_id)
     // frames belong to their subtrees and follow them out.
     while (!host->children().is_empty())
         remove_child_frame_subtree(*host->children().last());
+
+    // If the page hosted a child frame's content, the frame node itself belongs to its container's process and stays
+    // in the tree, but its content is gone with this client. Collapse it back to local and let the container know.
+    if (host->has_remote_host() && &host->remote_host_client() == &client)
+        transition_child_frame_to_local(*host);
 }
 
 void SiteIsolationManager::remove_all_pages_for_client(WebContentClient& client)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -631,7 +631,7 @@ protected:
 
     IsPrivate m_is_private { IsPrivate::No };
 
-    URL::URL m_url;
+    URL::URL m_url { URL::about_blank() };
     Utf16String m_title;
     Optional<String> m_favicon_hash;
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -138,6 +138,12 @@ Optional<WebContentClient&> WebContentClient::client_for_compositor_context_id(W
 void WebContentClient::die()
 {
     m_process_lost = true;
+
+    // The transport's peer-EOF and the process-exit notification race, and an embedded-only client can be destroyed
+    // by this path before the process monitor looks it up. The removal is map-driven, so whichever path runs second
+    // finds nothing left to do.
+    SiteIsolationManager::the().remove_all_pages_for_client(*this);
+
     cancel_navigation_transactions();
     fail_renderer_owned_downloads();
 }
@@ -2306,6 +2312,19 @@ Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse 
 Messages::WebContentClient::DidRequestSiteIsolationProcessTreeForTestingResponse WebContentClient::did_request_site_isolation_process_tree_for_testing(u64 page_id)
 {
     return { SiteIsolationManager::the().dump_process_tree(*this, page_id) };
+}
+
+void WebContentClient::did_request_crash_of_remote_frame_processes_for_testing(u64 page_id)
+{
+    auto* host = navigable_for_page(page_id);
+    if (!host)
+        return;
+
+    host->for_each_in_subtree([](CanonicalNavigable& child_frame) {
+        if (child_frame.has_remote_host())
+            child_frame.remote_host_client().async_debug_request(child_frame.remote_host_page_id(), "crash-current-page"sv, ""sv);
+        return IterationDecision::Continue;
+    });
 }
 
 void WebContentClient::did_reset_session_history_for_testing(u64 page_id, Web::HTML::SessionHistoryEntryDescriptor active_entry)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -342,6 +342,23 @@ Optional<CanonicalNavigable&> WebContentClient::hosted_navigable_for_page(u64 pa
     return {};
 }
 
+// A navigation's population steps run in the process recorded as its population worker at admission, which is
+// the process with the live source document. That is not necessarily the process hosting the target's document.
+Optional<CanonicalNavigable&> WebContentClient::population_worker_navigable_for_page(u64 page_id, Web::HTML::CrossProcessId navigable_id)
+{
+    if (auto navigable = hosted_navigable_for_page(page_id, navigable_id); navigable.has_value())
+        return navigable;
+
+    auto* page_host = navigable_for_page(page_id);
+    if (!page_host)
+        return {};
+
+    auto navigable = page_host->top_level_traversable().find(navigable_id);
+    if (!navigable.has_value() || !navigable->navigation_population_worker_matches(*this, page_id))
+        return {};
+    return *navigable;
+}
+
 Optional<CanonicalNavigable&> WebContentClient::child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id)
 {
     auto* host = navigable_for_page(page_id);
@@ -627,7 +644,7 @@ void WebContentClient::did_request_navigation_start(u64 page_id, Web::HTML::Cros
 
 void WebContentClient::did_complete_navigation_unload_check(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id)
 {
-    auto navigable = hosted_navigable_for_page(page_id, navigable_id);
+    auto navigable = population_worker_navigable_for_page(page_id, navigable_id);
     if (!navigable.has_value())
         return;
 
@@ -729,7 +746,7 @@ void WebContentClient::did_request_navigation_population(u64 page_id, Web::HTML:
 
 void WebContentClient::did_finish_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id, Optional<Web::HTML::NavigationPopulationResult> result)
 {
-    auto navigable = hosted_navigable_for_page(page_id, navigable_id);
+    auto navigable = population_worker_navigable_for_page(page_id, navigable_id);
     if (!navigable.has_value()) {
         if (result.has_value())
             NavigationLoader::discard(m_is_private, *result);
@@ -767,7 +784,6 @@ void WebContentClient::did_finish_navigation_params_creation(u64 page_id, Web::H
 
     // Steps 1-4 have produced final navigation params. Keep the pending entry in
     // sync with redirects before choosing the process that will run step 5.
-    navigable->did_finish_navigation_params_creation();
     ongoing_navigation->phase = CanonicalNavigable::OngoingNavigation::Phase::AwaitingResponseBody;
     ongoing_navigation->loader->did_finish_navigation_params_creation(result.release_value());
     ongoing_navigation->url = ongoing_navigation->loader->request().history_entry.url;
@@ -782,13 +798,13 @@ void WebContentClient::did_finish_navigation_params_creation(u64 page_id, Web::H
             navigable.clear_ongoing_navigation();
         };
         if (!succeeded) {
-            if (auto navigable = self->hosted_navigable_for_page(page_id, navigable_id); navigable.has_value())
+            if (auto navigable = self->population_worker_navigable_for_page(page_id, navigable_id); navigable.has_value())
                 cancel_navigation(*navigable);
             return;
         }
         if (self->continue_navigation_population_in_selected_process(page_id, navigable_id, navigation_id))
             return;
-        if (auto navigable = self->hosted_navigable_for_page(page_id, navigable_id); navigable.has_value()) {
+        if (auto navigable = self->population_worker_navigable_for_page(page_id, navigable_id); navigable.has_value()) {
             auto const& ongoing_navigation = navigable->ongoing_navigation();
             if (ongoing_navigation.has_value() && ongoing_navigation->navigation_id == navigation_id)
                 cancel_navigation(*navigable);
@@ -798,7 +814,7 @@ void WebContentClient::did_finish_navigation_params_creation(u64 page_id, Web::H
 
 void WebContentClient::did_fail_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id)
 {
-    auto navigable = hosted_navigable_for_page(page_id, navigable_id);
+    auto navigable = population_worker_navigable_for_page(page_id, navigable_id);
     if (!navigable.has_value())
         return;
 
@@ -1010,7 +1026,7 @@ Messages::WebContentClient::DidStartDownloadResponse WebContentClient::did_start
     // identifiers preserve the original RequestServer transfer lease, so only the process and navigation that
     // received that response may claim it, and only while its population is in flight.
     bool matches_in_flight_navigation = false;
-    if (auto navigable = hosted_navigable_for_page(page_id, navigable_id); navigable.has_value()) {
+    if (auto navigable = population_worker_navigable_for_page(page_id, navigable_id); navigable.has_value()) {
         auto const& ongoing_navigation = navigable->ongoing_navigation();
         if (ongoing_navigation.has_value()
             && ongoing_navigation->navigation_id == navigation_id

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -104,6 +104,7 @@ public:
     // awaiting a detached close remains open; it still coordinates its own close.
     bool is_page_open(u64 page_id) const;
     Optional<CanonicalNavigable&> hosted_navigable_for_page(u64 page_id, Web::HTML::CrossProcessId navigable_id);
+    Optional<CanonicalNavigable&> population_worker_navigable_for_page(u64 page_id, Web::HTML::CrossProcessId navigable_id);
 
     void begin_top_level_load(ViewImplementation&, u64 page_id, Optional<Utf16String> navigation_id, URL::URL const& url);
 

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -291,6 +291,7 @@ private:
     virtual void did_request_set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState) override;
     virtual Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse did_request_ui_process_session_history_for_testing(u64 page_id) override;
     virtual Messages::WebContentClient::DidRequestSiteIsolationProcessTreeForTestingResponse did_request_site_isolation_process_tree_for_testing(u64 page_id) override;
+    virtual void did_request_crash_of_remote_frame_processes_for_testing(u64 page_id) override;
     virtual void request_history_operation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationParameters) override;
     virtual void history_operation_ready(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationReadyResult) override;
     virtual void history_step_unload_cancelation_result(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult result, Web::HTML::UnloadPromptShown unload_prompt_shown) override;

--- a/Meta/Linters/check_libweb_realm_mentions.py
+++ b/Meta/Linters/check_libweb_realm_mentions.py
@@ -54,8 +54,8 @@ ALLOWED_REALM_MENTIONS = {
     "Geometry": (8, 8, "geometry constructors and structured clone still materialize JS-facing geometry objects"),
     "HTML": (
         64,
-        208,
-        "HTML algorithms still contain structured serialization, canvas, navigation transfer/reconstruction, worker, and event realm use",
+        210,
+        "HTML algorithms still contain structured serialization, including posted-message preparation, canvas, navigation transfer/reconstruction, worker, and event realm use",
     ),
     "IndexedDB": (
         14,

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1459,6 +1459,11 @@ String PageClient::dump_site_isolation_process_tree_for_testing()
     return client().did_request_site_isolation_process_tree_for_testing(m_id);
 }
 
+void PageClient::crash_remote_frame_processes_for_testing()
+{
+    client().async_did_request_crash_of_remote_frame_processes_for_testing(m_id);
+}
+
 bool PageClient::page_did_request_capture_session_history_snapshot_for_testing()
 {
     return client().did_request_capture_session_history_snapshot_for_testing(m_id);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -182,6 +182,7 @@ private:
     virtual void page_did_destroy_child_frame(Web::HTML::CrossProcessId frame_id) override;
     virtual Optional<Web::Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(Web::HTML::CrossProcessId) const override;
     virtual String dump_site_isolation_process_tree_for_testing() override;
+    virtual void crash_remote_frame_processes_for_testing() override;
     virtual Gfx::Palette palette() const override;
     virtual Web::DevicePixelRect screen_rect() const override { return m_all_screen_rects[m_main_screen_index]; }
     virtual size_t screen_count() const override { return m_all_screen_rects.size(); }

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -211,6 +211,7 @@ endpoint WebContentClient
     did_request_set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state) =|
     did_request_ui_process_session_history_for_testing(u64 page_id) => (String session_history)
     did_request_site_isolation_process_tree_for_testing(u64 page_id) => (String process_tree)
+    did_request_crash_of_remote_frame_processes_for_testing(u64 page_id) =|
     request_history_operation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationParameters parameters) =|
     history_operation_ready(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationReadyResult result) =|
     history_step_unload_cancelation_result(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult result, Web::HTML::UnloadPromptShown unload_prompt_shown) =|

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/HashMap.h>
 #include <LibTest/TestCase.h>
 
 #include <LibURL/Parser.h>
@@ -713,6 +714,18 @@ TEST_CASE(same_origin_domain)
     EXPECT(!a_relaxed.is_same_origin_domain(c_relaxed));
     EXPECT(!a_relaxed.is_same_origin_domain(http_relaxed));
     EXPECT(!opaque1.is_same_origin_domain(a_relaxed));
+}
+
+TEST_CASE(origin_hash_uses_same_origin_semantics)
+{
+    auto origin = URL::Origin { "https"_string, "a.ladybird.org"_string, 443 };
+    auto origin_with_domain = URL::Origin { "https"_string, "a.ladybird.org"_string, 443, "ladybird.org"_string };
+
+    EXPECT_EQ(origin, origin_with_domain);
+
+    HashMap<URL::Origin, int> origins;
+    origins.set(origin, 42);
+    EXPECT_EQ(origins.get(origin_with_domain), Optional<int> { 42 });
 }
 
 // resource:// URLs are internal browser resources. They share a single tuple origin regardless

--- a/Tests/LibWeb/Text/expected/SiteIsolation/iframe/cross-site-iframe-process-crash-collapses-frame.txt
+++ b/Tests/LibWeb/Text/expected/SiteIsolation/iframe/cross-site-iframe-process-crash-collapses-frame.txt
@@ -1,0 +1,4 @@
+WebContent#0
+  iframe#0: remote WebContent#1
+WebContent#0
+  iframe#0: local

--- a/Tests/LibWeb/Text/input/SiteIsolation/iframe/cross-site-iframe-process-crash-collapses-frame.html
+++ b/Tests/LibWeb/Text/input/SiteIsolation/iframe/cross-site-iframe-process-crash-collapses-frame.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const httpServer = httpTestServer();
+        const runId = crypto.randomUUID();
+
+        const childUrl = new URL(
+            await httpServer.createEcho("GET", `/oop-iframe-crash-child-${runId}`, {
+                status: 200,
+                headers: { "Content-Type": "text/html" },
+                body: "<!DOCTYPE html>child",
+            })
+        );
+        childUrl.hostname = uniqueLocalhostHostname("oop-iframe-crash");
+
+        const iframe = document.createElement("iframe");
+        iframe.src = childUrl;
+        document.body.appendChild(iframe);
+
+        if (!(await waitForCondition(() => remoteFrameCount() === 1))) {
+            println("iframe did not become remote");
+            return;
+        }
+        println(internals.dumpSiteIsolationProcessTree().trimEnd());
+
+        internals.crashRemoteFrameProcesses();
+
+        if (!(await waitForCondition(() => remoteFrameCount() === 0))) {
+            println("iframe did not collapse to local after its process crashed");
+            return;
+        }
+        println(internals.dumpSiteIsolationProcessTree().trimEnd());
+    });
+</script>


### PR DESCRIPTION
Preparatory commits for the next site isolation changes.

The first four are standalone fixes. The rest are refactors with no
behavior change that stop navigate(), window.postMessage() and Location
assuming a navigable's document is local, so the followups that keeps
WindowProxy identity across process swaps can build on them.