### PR TITLE
LibWeb: Reduce style engine setup work

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2410,6 +2410,13 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
         end_style_stabilization_epoch();
     };
 
+    // Keep shared style records alive across both style and layout, so temporary views
+    // during layout tree construction and layout do not need individual record pins.
+    style_computer().begin_style_record_view_epoch();
+    ScopeGuard end_style_record_view_epoch = [&] {
+        style_computer().end_style_record_view_epoch();
+    };
+
     constexpr u64 ordinary_stabilization_round_limit = 8;
     // Size-query dependencies point from a descendant to an ancestor query container. They are
     // therefore acyclic, and a coherent style/layout pass can settle at least one more level of

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -3092,6 +3092,74 @@ mod tests {
     }
 
     #[test]
+    fn preallocated_siblings_keep_their_disconnected_before_rows() {
+        for split_batches in [false, true] {
+            let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
+            let mut nodes = [0_u32; 4];
+            engine.allocate_style_nodes(&mut nodes);
+            let root = StyleNodeID::from_raw(nodes[0]).unwrap();
+            engine.apply_transaction_batch(
+                &[FfiTreeDelta {
+                    node: nodes[0],
+                    old_connected: false,
+                    new_connected: true,
+                    old_relations: no_relations(),
+                    new_relations: no_relations(),
+                }],
+                (&[], &[]),
+                &[],
+                &[],
+                &[],
+                &[],
+            );
+            let transaction = engine.take_transaction();
+            engine.release_transaction(transaction);
+
+            let arrivals: Vec<_> = (1..nodes.len())
+                .map(|index| FfiTreeDelta {
+                    node: nodes[index],
+                    old_connected: false,
+                    new_connected: true,
+                    old_relations: no_relations(),
+                    new_relations: FfiTreeRelations {
+                        parent: nodes[0],
+                        previous_element_sibling: if index == 1 { 0 } else { nodes[index - 1] },
+                        next_element_sibling: nodes.get(index + 1).copied().unwrap_or(0),
+                        ..no_relations()
+                    },
+                })
+                .collect();
+            let chunk_size = if split_batches { 1 } else { arrivals.len() };
+            for chunk in arrivals.chunks(chunk_size) {
+                engine.apply_transaction_batch(chunk, (&[], &[]), &[], &[], &[], &[]);
+                // Selector queries may install the current rows before style is observed.
+                engine.prepare_selector_query();
+            }
+            let transaction = engine.take_transaction();
+            for raw in &nodes[1..] {
+                let node = StyleNodeID::from_raw(*raw).unwrap();
+                let input = transaction
+                    .inputs
+                    .iter()
+                    .find(|input| input.key == InputKey::TreeRelations(node))
+                    .unwrap();
+                assert_eq!(input.old, InputValue::TreeRelations(None));
+                assert!(
+                    transaction
+                        .inputs
+                        .iter()
+                        .any(|input| input.key == InputKey::LocalFeature(node, LocalFeatureKey::ArrivingFacts))
+                );
+            }
+            assert_eq!(
+                engine.tree().preorder(root).collect::<Vec<_>>(),
+                nodes.map(|raw| StyleNodeID::from_raw(raw).unwrap())
+            );
+            engine.release_transaction(transaction);
+        }
+    }
+
+    #[test]
     fn element_arrival_rows_install_intrinsic_facts() {
         assert_eq!(size_of::<FfiElementArrival>(), 28);
         let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -1205,6 +1205,12 @@ impl StyleEngine {
             .tree_staging
             .current_row(node, Some(self.settled_tree_relations(node)));
         let mut new = old.expect("a pending neighbour must remain connected");
+        // A subtree can preallocate sibling identities before publishing their insertions. Such
+        // a neighbour has no parent yet; its own insertion will supply its links. Synthesizing a
+        // connected before-row here would hide that arrival from transaction normalization.
+        if new.parent.is_none() {
+            return;
+        }
         update(&mut new);
         self.stage_tree_row(node, old, Some(new));
     }

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -2825,13 +2825,9 @@ impl SelectorPrograms {
                 self.program_index,
             ];
             cached [self.program_memory.bytes()];
-            nested [self
-                .entry_ids_by_program
-                .iter()
-                .flatten()
-                .map(|entries| size_of_val(entries.as_ref()))
-                .sum::<usize>()
-                ];
+            // Each live entry identity occupies exactly one slot in a boxed program entry list.
+            // Settling after each rule must not walk every program already compiled.
+            nested [(self.entry_locations.len() - self.vacant_entries.len()) * size_of::<EntryID>()];
             skip [self.memory];
         }
     }
@@ -7846,6 +7842,52 @@ mod tests {
         }));
         assert_ne!(first, different);
         assert_eq!(programs.len(), 2);
+    }
+
+    #[test]
+    fn live_entry_identities_account_for_program_entry_storage() {
+        let make_program = |first: u32, count: u32| {
+            let mut builder = SelectorProgramBuilder::new();
+            for index in first..first + count {
+                let root = builder.push_feature(FeatureTest::Class(StyleAtomID(index)));
+                builder.push_entry(root);
+            }
+            builder.finish()
+        };
+        let check = |programs: &SelectorPrograms| {
+            let allocated_entries: usize = programs
+                .entry_ids_by_program
+                .iter()
+                .flatten()
+                .map(|entries| entries.len())
+                .sum();
+            assert_eq!(
+                programs.entry_locations.len() - programs.vacant_entries.len(),
+                allocated_entries
+            );
+            assert_eq!(programs.entry_locations.iter().flatten().count(), allocated_entries);
+        };
+        for mut programs in [SelectorPrograms::new(), SelectorPrograms::for_replay()] {
+            check(&programs);
+            let first = programs.add(make_program(1, 5));
+            let retained = programs.add(make_program(10, 2));
+            assert_eq!(first, programs.add(make_program(1, 5)));
+            check(&programs);
+
+            let mut referenced = vec![false; programs.len()];
+            referenced[retained.0 as usize] = true;
+            programs.sweep_unreferenced(&referenced);
+            check(&programs);
+            // Reuse only part of the vacant entry space, then exhaust it and grow again.
+            programs.add(make_program(20, 3));
+            check(&programs);
+            programs.add(make_program(30, 7));
+            check(&programs);
+            programs.sweep_unreferenced(&[]);
+            check(&programs);
+            programs.add(make_program(40, 1));
+            check(&programs);
+        }
     }
 
     #[test]

--- a/Tests/LibWeb/Text/expected/css/style-engine/computed-style-record-view-pins.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/computed-style-record-view-pins.txt
@@ -1,2 +1,3 @@
+initial layout record view pins unchanged: true
 style update record view pins unchanged: true
 computed style record view pins increased: true

--- a/Tests/LibWeb/Text/input/css/style-engine/computed-style-record-view-pins.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/computed-style-record-view-pins.html
@@ -10,9 +10,17 @@
     test(() => {
         document.body.offsetWidth;
         let before = internals.styleEngineCounters().computedStyleRecordViewPins;
+        const subtree = document.createElement("div");
+        subtree.innerHTML = "<div><span>text</span></div>".repeat(100);
+        document.body.appendChild(subtree);
+        subtree.offsetWidth;
+        let after = internals.styleEngineCounters().computedStyleRecordViewPins;
+        println(`initial layout record view pins unchanged: ${after === before}`);
+
+        before = after;
         target.classList.add("changed");
         target.offsetWidth;
-        let after = internals.styleEngineCounters().computedStyleRecordViewPins;
+        after = internals.styleEngineCounters().computedStyleRecordViewPins;
         println(`style update record view pins unchanged: ${after === before}`);
 
         before = after;


### PR DESCRIPTION
Tighten three hot paths in style setup:

- Preserve preallocated sibling arrivals instead of routing them as mutations, reducing a StyleBench media-query flush from 225 ms to 61 ms.
- Keep shared style records alive across layout, eliminating over 120,000 temporary record pins in an ordinary StyleBench setup.
- Account for selector entry storage in constant time, reducing a 20,000-rule StyleBench setup from 252 ms to 181 ms.

Add coverage for split sibling arrival batches, layout-time record views, and selector program storage accounting.