### PR TITLE
LibWeb: Reduce style and empty-box layout overhead

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -37,7 +37,6 @@
 #include <LibWeb/CSS/StyleValues/ImageSetStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
-#include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OpacityValueStyleValue.h>
@@ -1147,49 +1146,9 @@ QuotesData ComputedValues::InheritedListValues::quotes_value() const
     return result;
 }
 
-ComputedContentData ComputedValues::ContentValues::computed_content_value() const
+NonnullRefPtr<StyleValue const> ComputedValues::ContentValues::computed_content_value() const
 {
-    auto value = animation_style_value(content);
-    if (value->is_keyword()) {
-        ComputedContentData result;
-        result.type = value->to_keyword() == Keyword::None ? ComputedContentData::Type::None : ComputedContentData::Type::Normal;
-        return result;
-    }
-
-    auto append_item = [](StyleValue const& item, Vector<ComputedContentItem>& items) {
-        if (item.is_string()) {
-            items.append(item.as_string().string_value().to_utf16_string());
-        } else if (item.is_keyword()) {
-            items.append(item.to_keyword());
-        } else if (item.is_counter()) {
-            auto const& counter = item.as_counter();
-            ComputedContentCounter computed_counter {
-                .function = counter.function_type() == CounterStyleValue::CounterFunction::Counters ? ComputedContentCounter::Function::Counters : ComputedContentCounter::Function::Counter,
-                .name = counter.counter_name(),
-                .join_string = counter.join_string(),
-                .style = counter.counter_style()->as_counter_style().value().visit(
-                    [](Utf16FlyString const& name) -> Variant<Utf16FlyString, ComputedContentCounter::SymbolsFunction> { return name; },
-                    [](CounterStyleStyleValue::SymbolsFunction const& symbols) -> Variant<Utf16FlyString, ComputedContentCounter::SymbolsFunction> {
-                        return ComputedContentCounter::SymbolsFunction { .type = symbols.type, .symbols = symbols.symbols };
-                    }),
-            };
-            items.append(move(computed_counter));
-        } else {
-            VERIFY(item.is_abstract_image());
-            items.append(NonnullRefPtr<AbstractImageStyleValue const> { item.as_abstract_image() });
-        }
-    };
-
-    ComputedContentData result;
-    result.type = ComputedContentData::Type::List;
-    auto const& content_value = value->as_content();
-    for (auto const& item : content_value.content().values())
-        append_item(item, result.items);
-    if (auto const* alt_text = content_value.alt_text()) {
-        for (auto const& item : alt_text->values())
-            append_item(item, result.alt_text);
-    }
-    return result;
+    return animation_style_value(content);
 }
 
 bool ComputedValues::ContentValues::content_is_normal() const
@@ -2060,54 +2019,11 @@ static ContentDataAndQuoteNestingLevel resolve_content(StyleValue const& value, 
     return { {}, quote_nesting_level };
 }
 
-static NonnullRefPtr<StyleValue const> computed_content_item_style_value(ComputedContentItem const& item)
-{
-    return item.visit(
-        [](Utf16String const& string) -> NonnullRefPtr<StyleValue const> { return StringStyleValue::create(string); },
-        [](Keyword keyword) -> NonnullRefPtr<StyleValue const> { return KeywordStyleValue::create(keyword); },
-        [](ComputedContentCounter const& counter) -> NonnullRefPtr<StyleValue const> {
-            auto counter_style = CounterStyleStyleValue::create(counter.style.visit(
-                [](Utf16FlyString const& name) -> Variant<Utf16FlyString, CounterStyleStyleValue::SymbolsFunction> { return name; },
-                [](ComputedContentCounter::SymbolsFunction const& symbols) -> Variant<Utf16FlyString, CounterStyleStyleValue::SymbolsFunction> {
-                    return CounterStyleStyleValue::SymbolsFunction { .type = symbols.type, .symbols = symbols.symbols };
-                }));
-            if (counter.function == ComputedContentCounter::Function::Counters)
-                return CounterStyleValue::create_counters(counter.name, counter.join_string, move(counter_style));
-            return CounterStyleValue::create_counter(counter.name, move(counter_style));
-        },
-        [](NonnullRefPtr<AbstractImageStyleValue const> const& image) -> NonnullRefPtr<StyleValue const> { return image; });
-}
-
 ContentDataAndQuoteNestingLevel ComputedValues::resolved_content(DOM::AbstractElement& element_reference, u32 initial_quote_nesting_level, NotifyListItemCounterRendered notify_list_item_counter_rendered) const
 {
-    // The content value resolve_content() consumes is rebuilt from the content group's data
-    // rather than minted from the longhand table: the group holds the live image style values
-    // whose loads this style already started, and layout must receive those exact objects.
-    auto computed_content_value = computed_content();
-    auto content_style_value = [&]() -> NonnullRefPtr<StyleValue const> {
-        switch (computed_content_value.type) {
-        case ComputedContentData::Type::Normal:
-            return KeywordStyleValue::create(Keyword::Normal);
-        case ComputedContentData::Type::None:
-            return KeywordStyleValue::create(Keyword::None);
-        case ComputedContentData::Type::List: {
-            StyleValueVector items;
-            for (auto const& item : computed_content_value.items)
-                items.append(computed_content_item_style_value(item));
-            StyleValueVector alt_text;
-            for (auto const& item : computed_content_value.alt_text)
-                alt_text.append(computed_content_item_style_value(item));
-            ValueComparingRefPtr<StyleValueList const> alt_text_style_value;
-            if (!alt_text.is_empty())
-                alt_text_style_value = StyleValueList::create(move(alt_text), StyleValueList::Separator::Space);
-            return ContentStyleValue::create(
-                StyleValueList::create(move(items), StyleValueList::Separator::Space),
-                move(alt_text_style_value));
-        }
-        }
-        VERIFY_NOT_REACHED();
-    }();
-    return resolve_content(content_style_value, quotes(), element_reference, initial_quote_nesting_level, notify_list_item_counter_rendered);
+    // Read the content group's value directly, including the resource context attached to its images.
+    auto value = computed_content();
+    return resolve_content(value, quotes(), element_reference, initial_quote_nesting_level, notify_list_item_counter_rendered);
 }
 
 }

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -846,43 +846,6 @@ enum class NotifyListItemCounterRendered : u8 {
     Yes,
 };
 
-struct ComputedContentCounter {
-    enum class Function : u8 {
-        Counter,
-        Counters,
-    };
-
-    struct SymbolsFunction {
-        SymbolsType type;
-        Vector<Utf16FlyString> symbols;
-
-        bool operator==(SymbolsFunction const&) const = default;
-    };
-
-    Function function;
-    Utf16FlyString name;
-    Utf16FlyString join_string;
-    Variant<Utf16FlyString, SymbolsFunction> style;
-
-    bool operator==(ComputedContentCounter const&) const = default;
-};
-
-using ComputedContentItem = Variant<Utf16String, Keyword, ComputedContentCounter, NonnullRefPtr<AbstractImageStyleValue const>>;
-
-struct ComputedContentData {
-    enum class Type : u8 {
-        Normal,
-        None,
-        List,
-    };
-
-    Type type { Type::Normal };
-    Vector<ComputedContentItem> items;
-    Vector<ComputedContentItem> alt_text;
-
-    bool operator==(ComputedContentData const&) const = default;
-};
-
 struct CounterData {
     Utf16FlyString name;
     bool is_reversed;
@@ -1277,7 +1240,7 @@ public:
     PreferredColorScheme color_scheme() const { return m_inherited.ui->color_scheme_value(); }
     ContentVisibility content_visibility() const { return static_cast<ContentVisibility>(m_inherited.box->content_visibility); }
     ReadonlySpan<ComputedValuesFFI::ComputedCursor> cursor() const { return m_inherited.ui->cursor_span(); }
-    ComputedContentData computed_content() const { return m_noninherited.content_data->computed_content_value(); }
+    NonnullRefPtr<StyleValue const> computed_content() const { return m_noninherited.content_data->computed_content_value(); }
     bool content_is_normal() const { return m_noninherited.content_data->content_is_normal(); }
     bool content_uses_list_item_counter() const { return m_noninherited.content_data->content_uses_list_item_counter(); }
     ContentDataAndQuoteNestingLevel resolved_content(DOM::AbstractElement&, u32 initial_quote_nesting_level, NotifyListItemCounterRendered) const;
@@ -1844,7 +1807,7 @@ public:
         static constexpr size_t style_group_index = to_underlying(StyleGroupIndex::ContentValues);
         static constexpr auto style_group_lifecycle = ComputedValuesFFI::StyleGroupLifecycle::Content;
 
-        ComputedContentData computed_content_value() const;
+        NonnullRefPtr<StyleValue const> computed_content_value() const;
         bool content_is_normal() const;
         bool content_uses_list_item_counter() const;
         Vector<CounterData, 0> counter_increment_value() const;

--- a/Libraries/LibWeb/CSS/GeneratedContent.cpp
+++ b/Libraries/LibWeb/CSS/GeneratedContent.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/GeneratedContent.h>
+#include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Node.h>
 
@@ -15,8 +16,9 @@ static bool style_affects_generated_content_state(ComputedValues const& style)
 {
     if (!style.counter_increment().is_empty() || !style.counter_reset().is_empty() || !style.counter_set().is_empty())
         return true;
-    return any_of(style.computed_content().items, [](ComputedContentItem const& item) {
-        return item.has<Keyword>() && first_is_one_of(item.get<Keyword>(), Keyword::OpenQuote, Keyword::CloseQuote, Keyword::NoOpenQuote, Keyword::NoCloseQuote);
+    auto content = style.computed_content();
+    return content->is_content() && any_of(content->as_content().content().values(), [](auto const& item) {
+        return item->is_keyword() && first_is_one_of(item->to_keyword(), Keyword::OpenQuote, Keyword::CloseQuote, Keyword::NoOpenQuote, Keyword::NoCloseQuote);
     });
 }
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -66,6 +66,9 @@
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CounterStyleStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CounterStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
@@ -3750,13 +3753,16 @@ static void report_shared_custom_property_environment_change(DOM::AbstractElemen
         *did_change_custom_properties = true;
 }
 
-static bool computed_content_depends_on_counter_style_environment(ComputedContentData const& content)
+static bool computed_content_depends_on_counter_style_environment(StyleValue const& content)
 {
-    auto item_depends_on_counter_style_environment = [](ComputedContentItem const& item) {
-        return item.has<ComputedContentCounter>() && item.get<ComputedContentCounter>().style.has<Utf16FlyString>();
+    if (!content.is_content())
+        return false;
+    auto item_depends_on_counter_style_environment = [](auto const& item) {
+        return item->is_counter() && item->as_counter().counter_style()->as_counter_style().value().template has<Utf16FlyString>();
     };
-    return any_of(content.items, item_depends_on_counter_style_environment)
-        || any_of(content.alt_text, item_depends_on_counter_style_environment);
+    auto const& content_value = content.as_content();
+    return any_of(content_value.content().values(), item_depends_on_counter_style_environment)
+        || (content_value.alt_text() && any_of(content_value.alt_text()->values(), item_depends_on_counter_style_environment));
 }
 
 StyleEngine::StyleRecordDelta StyleComputer::publish_computed_style_inputs(DOM::AbstractElement abstract_element, ComputedValues const& values) const

--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -243,7 +243,11 @@ void record_element_connected(DOM::Element& element)
 
 void publish_pending_element_features(StyleEngine& style_engine, StyleComputer& style_computer)
 {
-    for (auto node : style_engine.take_deferred_element_initial_features()) {
+    auto nodes = style_engine.take_deferred_element_initial_features().values();
+    // Feature postings are ordered by node identity. Publish arrivals in that order so growing
+    // their indexes appends members instead of repeatedly searching and splitting posting chunks.
+    quick_sort(nodes);
+    for (auto node : nodes) {
         if (auto element = style_computer.element_for_style_node(node))
             record_element_initial_features(*element);
     }
@@ -303,7 +307,7 @@ static void publish_element_selector_features(StyleEngine& style_engine, DOM::El
     auto is_slot = is<HTML::HTMLSlotElement>(element);
     StyleAtomID namespace_atom;
     if (auto const& namespace_uri = element.namespace_uri(); namespace_uri.has_value() && !namespace_uri->is_empty())
-        namespace_atom = style_engine.intern_case_sensitive_text_atom(namespace_uri->view());
+        namespace_atom = style_engine.intern_atom(*namespace_uri);
 
     publish_feature(StyleEngineFFI::FfiFeatureKind::TagName, StyleAtomID {}, StyleEngineFFI::FfiFeatureValueKind::Atom, style_engine.intern_atom(element.local_name()));
     if (auto folded_name = element.local_name().to_ascii_lowercase(); folded_name != element.local_name())
@@ -329,15 +333,17 @@ static void publish_element_selector_features(StyleEngine& style_engine, DOM::El
     auto states = SelectorMatching::element_states(element);
     for (size_t index = 0; index < to_underlying(PseudoClass::__Count); ++index) {
         auto pseudo_class = static_cast<PseudoClass>(index);
+        if (!states.get(pseudo_class))
+            continue;
         auto fact = state_fact_for(pseudo_class);
-        if (fact.has_value() && states.get(pseudo_class))
+        if (fact.has_value())
             style_engine.record_state_delta({ .node = node.value(), .fact = *fact, .new_value = true });
     }
 
     auto const language = element.lang_view();
     auto language_atom = language.has_value() ? style_engine.intern_language_atom(*language) : StyleAtomID {};
-    auto const directionality = element.directionality() == DOM::Element::Directionality::Rtl ? "rtl"sv : "ltr"sv;
-    auto directionality_atom = style_engine.intern_text_atom(Utf16View { directionality });
+    auto const directionality = element.directionality() == DOM::Element::Directionality::Rtl ? "rtl"_utf16_fly_string : "ltr"_utf16_fly_string;
+    auto directionality_atom = style_engine.intern_atom(directionality);
     if (invalidate_language_cache == InvalidateLanguageCache::Yes)
         element.invalidate_lang_value();
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -52,6 +52,7 @@
 #include <LibWeb/CSS/StylePropertyMap.h>
 #include <LibWeb/CSS/StyleSheetInvalidation.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
@@ -1726,10 +1727,10 @@ void Element::set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason reaso
         set_needs_layout_tree_update(true, reason);
 }
 
-static bool content_displays_a_counter(CSS::ComputedContentData const& content)
+static bool content_displays_a_counter(CSS::StyleValue const& content)
 {
-    return any_of(content.items, [](CSS::ComputedContentItem const& item) {
-        return item.has<CSS::ComputedContentCounter>();
+    return content.is_content() && any_of(content.as_content().content().values(), [](auto const& item) {
+        return item->is_counter();
     });
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/CSS/PseudoElement.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
+#include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
@@ -445,15 +446,14 @@ static Box& create_content_image_box(DOM::Document& document, GC::Ptr<DOM::Eleme
     return image_box;
 }
 
-static CSS::AbstractImageStyleValue const* content_replacement_image(CSS::ComputedContentData const& content)
+static CSS::AbstractImageStyleValue const* content_replacement_image(CSS::StyleValue const& content)
 {
-    if (content.type != CSS::ComputedContentData::Type::List
-        || content.items.size() != 1
-        || !content.items.first().has<NonnullRefPtr<CSS::AbstractImageStyleValue const>>()) {
+    if (!content.is_content())
         return nullptr;
-    }
-
-    return content.items.first().get<NonnullRefPtr<CSS::AbstractImageStyleValue const>>().ptr();
+    auto const& items = content.as_content().content().values();
+    if (items.size() != 1 || !items.first()->is_abstract_image())
+        return nullptr;
+    return &items.first()->as_abstract_image();
 }
 
 struct FirstLetterTextSlices {
@@ -580,17 +580,12 @@ static CSS::PseudoElement css_pseudo_element(RustFFI::FfiPseudoElement pseudo_el
     VERIFY_NOT_REACHED();
 }
 
-static RustFFI::FfiComputedContentType ffi_computed_content_type(CSS::ComputedContentData::Type content_type)
+static RustFFI::FfiComputedContentType ffi_computed_content_type(CSS::StyleValue const& content)
 {
-    switch (content_type) {
-    case CSS::ComputedContentData::Type::Normal:
-        return RustFFI::FfiComputedContentType::Normal;
-    case CSS::ComputedContentData::Type::None:
-        return RustFFI::FfiComputedContentType::None;
-    case CSS::ComputedContentData::Type::List:
-        return RustFFI::FfiComputedContentType::List;
-    }
-    VERIFY_NOT_REACHED();
+    if (content.is_keyword())
+        return content.to_keyword() == CSS::Keyword::None ? RustFFI::FfiComputedContentType::None : RustFFI::FfiComputedContentType::Normal;
+    VERIFY(content.is_content());
+    return RustFFI::FfiComputedContentType::List;
 }
 
 struct PseudoElementFrame {
@@ -682,8 +677,9 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 };
             }
             frame.display = computed_values->display();
-            auto const computed_content_type = computed_values->computed_content().type;
-            frame.replacement_image = content_replacement_image(computed_values->computed_content());
+            auto const computed_content = computed_values->computed_content();
+            auto const computed_content_type = ffi_computed_content_type(computed_content);
+            frame.replacement_image = content_replacement_image(computed_content);
             if (pseudo_element == CSS::PseudoElement::Marker)
                 frame.originating_list_box = element.unsafe_layout_node()->is_list_item_box() ? static_cast<BlockContainer*>(element.unsafe_layout_node()) : nullptr;
             auto const normal_marker_has_content = frame.originating_list_box
@@ -691,7 +687,7 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             return {
                 .has_style = true,
                 .pseudo_element = ffi_pseudo,
-                .content_type = ffi_computed_content_type(computed_content_type),
+                .content_type = computed_content_type,
                 .display_is_none = frame.display.is_none(),
                 .display_is_contents = frame.display.is_contents(),
                 .display_is_list_item = frame.display.is_list_item(),
@@ -800,7 +796,7 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             auto computed_values = element_reference.computed_style();
             VERIFY(computed_values);
             if (auto* marker = frame.layout_node->is_list_item_marker_box() ? static_cast<BlockContainer*>(frame.layout_node) : nullptr;
-                marker && computed_values->computed_content().type == CSS::ComputedContentData::Type::Normal) {
+                marker && computed_values->content_is_normal()) {
                 VERIFY(frame.originating_list_box);
                 frame.resolved_content = resolve_normal_marker_content(element_reference, *frame.originating_list_box, *marker);
                 frame.layout_node->set_content(frame.resolved_content);

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -175,12 +175,23 @@ impl StyleRecordView<'_> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct StyleRecord {
     groups: ComputedGroupSetID,
+    inherited_groups: InheritedGroupSetID,
     custom_properties: CustomPropertyEnvironmentID,
     fixed_metadata: ComputedFixedMetadataID,
     longhand_table: Option<ComputedLonghandTableID>,
+}
+
+impl Hash for StyleRecord {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // The inherited subset is derived from the groups, so it contributes no useful entropy.
+        self.groups.hash(state);
+        self.custom_properties.hash(state);
+        self.fixed_metadata.hash(state);
+        self.longhand_table.hash(state);
+    }
 }
 
 pub struct ComputedMetadataInput<'a> {
@@ -1085,6 +1096,7 @@ impl ComputedGroupSets {
         });
         let new_record = StyleRecord {
             groups: group_set,
+            inherited_groups: parent_inherited,
             custom_properties: old_record.custom_properties,
             fixed_metadata: old_record.fixed_metadata,
             longhand_table,
@@ -1518,6 +1530,7 @@ impl ComputedGroupSets {
 
         let style_record = StyleRecord {
             groups: identity,
+            inherited_groups: inherited_identity,
             custom_properties: custom_property_environment_identity,
             fixed_metadata: computed_fixed_metadata_identity,
             longhand_table: longhand_table_identity,
@@ -1677,9 +1690,10 @@ impl ComputedGroupSets {
             .filter(|&previous| self.style_records_equal_by_value(previous, requested_style_record_identity))
             .unwrap_or(requested_style_record_identity);
         let record = *self.style_records.get_index(style_record_identity.index())?;
-        let group_identities = self.group_identities(record.groups);
-        let inherited_groups = &group_identities[..inherited_group_count];
-        let (inherited_identity, new_inherited_group_set) = self.intern_inherited_group_set(inherited_groups);
+        // The inherited subset is immutable along with the complete style record. Sharing a
+        // record must not reconstruct its group identities and intern the same subset again.
+        let inherited_identity = record.inherited_groups;
+        assert_eq!(self.inherited_sets[inherited_identity].len(), inherited_group_count);
 
         let is_pseudo = target.is_pseudo();
         let (
@@ -1770,7 +1784,7 @@ impl ComputedGroupSets {
             new_groups: 0,
             canonical_output_groups_reused: 0,
             new_group_set: false,
-            new_inherited_group_set,
+            new_inherited_group_set: false,
             new_custom_property_environment: false,
             new_computed_fixed_metadata: false,
             new_style_record: false,
@@ -1798,7 +1812,10 @@ impl ComputedGroupSets {
         let Some(second) = self.style_records.get_index(second.index()) else {
             return false;
         };
-        if first.custom_properties != second.custom_properties || first.fixed_metadata != second.fixed_metadata {
+        if first.custom_properties != second.custom_properties
+            || first.fixed_metadata != second.fixed_metadata
+            || self.inherited_sets[first.inherited_groups].len() != self.inherited_sets[second.inherited_groups].len()
+        {
             return false;
         }
         let first_groups = &self.sets[first.groups].payloads;
@@ -2172,6 +2189,7 @@ impl ComputedGroupSets {
                 ComputedReachability::mark(&mut reachable.style_records, identity);
                 let record = self.style_records.get(identity);
                 ComputedReachability::mark(&mut reachable.sets, record.groups);
+                ComputedReachability::mark(&mut reachable.inherited_sets, record.inherited_groups);
                 ComputedReachability::mark(&mut reachable.custom_property_environments, record.custom_properties);
                 ComputedReachability::mark(&mut reachable.fixed_metadata, record.fixed_metadata);
                 if let Some(longhand_table) = record.longhand_table {
@@ -2966,6 +2984,33 @@ mod tests {
         assert_eq!(sets.base_style_record_pins[&base_style_record], 1);
         sets.unpin_style_record(style_record.raw());
         assert!(sets.base_style_record_pins.is_empty());
+    }
+
+    #[test]
+    fn pinned_style_record_retains_its_inherited_group_set_for_sharing() {
+        let mut sets = ComputedGroupSets::default();
+        let donor = sets.publish(None, &[], 0, 1, metadata(0, 0, 0));
+        let record = donor.style_record_identity.raw();
+        sets.pin_style_record(record);
+        sets.reclaim_unreachable();
+        assert_eq!(sets.inherited_sets.live_len(), 1);
+
+        let node = StyleNodeID::element(1);
+        for kind in [u8::MAX, 1, 2] {
+            let target = ComputedStyleTarget::new(node, kind);
+            let shared = sets.assign_shared_style_record(target, record, 0, false).unwrap();
+            assert_eq!(shared.style_record_identity, donor.style_record_identity);
+            assert!(!shared.new_inherited_group_set);
+            assert!(shared.inherited_node_handle_changed);
+            let unchanged = sets.assign_shared_style_record(target, record, 0, false).unwrap();
+            assert!(!unchanged.inherited_node_handle_changed);
+        }
+        sets.unpin_style_record(record);
+        sets.reclaim_unreachable();
+        assert_eq!(sets.inherited_sets.live_len(), 1);
+        sets.remove(node);
+        sets.reclaim_unreachable();
+        assert_eq!(sets.inherited_sets.live_len(), 0);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -2020,7 +2020,7 @@ pub(crate) fn layout_inside_child(
         );
     };
     if !force_independent_context_run
-        && layout_mode == LayoutMode::IntrinsicSizing
+        && (layout_mode == LayoutMode::IntrinsicSizing || !facts.node_has_size_containment())
         && matches!(
             input.participation,
             ParticipationInParentFormattingContext::AtomicInline
@@ -2028,8 +2028,8 @@ pub(crate) fn layout_inside_child(
         && formatting_context_type_created_by_box(facts) == Some(FfiFormattingContextType::Block)
         && run.callbacks.first_child(child).is_invalid()
     {
-        // OPTIMIZATION: An empty atomic block has no formatting-context body output. Size it directly in the
-        // parent measurement instead of constructing a child run for both min-content and max-content layout.
+        // OPTIMIZATION: An empty atomic block has no formatting-context body output. Size it in the
+        // parent run, which will also construct its fragment when placing the box.
         let sizing = run.sizing();
         sizing.dimension_atomic_root(
             child,
@@ -2045,6 +2045,20 @@ pub(crate) fn layout_inside_child(
             Some(CssPixels::default()),
             || unreachable!("an empty atomic block has a zero automatic content block size"),
         );
+        if layout_mode == LayoutMode::Normal
+            && !sizing.box_is_sized_as_replaced_element(
+                child,
+                input.available_space,
+                input.containing_block_constraints,
+            )
+        {
+            sizing.resolve_used_block_size_if_not_treated_as_auto(
+                child,
+                input.available_space,
+                input.containing_block_constraints,
+            );
+        }
+        store_derived_baselines(&used, DerivedBaselines::default());
         note_skipped_child_dependency();
         return ChildLayoutOutcome::Skipped;
     }

--- a/Tests/LibWeb/Text/expected/empty-inline-block-sizing.txt
+++ b/Tests/LibWeb/Text/expected/empty-inline-block-sizing.txt
@@ -1,0 +1,27 @@
+automatic, empty: PASS
+automatic, populated: PASS
+automatic, empty again: PASS
+fixed box, empty: PASS
+fixed box, populated: PASS
+fixed box, empty again: PASS
+border box, empty: PASS
+border box, populated: PASS
+border box, empty again: PASS
+min and max, empty: PASS
+min and max, populated: PASS
+min and max, empty again: PASS
+percentages, empty: PASS
+percentages, populated: PASS
+percentages, empty again: PASS
+aspect ratio, empty: PASS
+aspect ratio, populated: PASS
+aspect ratio, empty again: PASS
+hidden overflow, empty: PASS
+hidden overflow, populated: PASS
+hidden overflow, empty again: PASS
+scrollable overflow, empty: PASS
+scrollable overflow, populated: PASS
+scrollable overflow, empty again: PASS
+size containment, empty: PASS
+size containment, populated: PASS
+size containment, empty again: PASS

--- a/Tests/LibWeb/Text/input/empty-inline-block-sizing.html
+++ b/Tests/LibWeb/Text/input/empty-inline-block-sizing.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    .container { width: 200px; height: 100px; font: 16px/20px monospace; }
+    .target { display: inline-block; background: green; }
+    .child { width: 0; height: 0; }
+</style>
+<script>
+    test(() => {
+        const cases = [
+            ["automatic", ""],
+            ["fixed box", "width: 40px; height: 12px; padding: 3px; border: 2px solid; margin: 5px"],
+            ["border box", "box-sizing: border-box; width: 40px; height: 20px; padding: 3px; border: 2px solid"],
+            ["min and max", "min-width: 20px; max-width: 50px; min-height: 15px; max-height: 30px"],
+            ["percentages", "width: 30%; height: 20%; padding: 5%; margin: 2%"],
+            ["aspect ratio", "width: 40px; aspect-ratio: 2"],
+            ["hidden overflow", "width: 40px; height: 12px; overflow: hidden"],
+            ["scrollable overflow", "width: 40px; height: 12px; overflow: scroll"],
+            ["size containment", "contain: size; contain-intrinsic-size: 25px 30px"],
+        ];
+        for (const [name, declarations] of cases) {
+            const make = () => {
+                const container = document.createElement("div");
+                container.className = "container";
+                const target = document.createElement("span");
+                target.className = "target";
+                target.style.cssText = declarations;
+                container.append(target, "X");
+                document.body.append(container);
+                return { container, target };
+            };
+            const actual = make();
+            const control = make();
+            const child = document.createElement("div");
+            child.className = "child";
+            control.target.append(child);
+            const dimensions = ({ container, target }) => {
+                const rect = target.getBoundingClientRect();
+                const outer = container.getBoundingClientRect();
+                return [rect.x - outer.x, rect.y - outer.y, rect.width, rect.height].join(",");
+            };
+            for (const phase of ["empty", "populated", "empty again"]) {
+                if (phase === "populated") {
+                    child.style.height = "7px";
+                    actual.target.append(child.cloneNode());
+                } else if (phase === "empty again") {
+                    actual.target.replaceChildren();
+                    child.style.height = "0px";
+                }
+                const observed = dimensions(actual);
+                const expected = dimensions(control);
+                println(`${name}, ${phase}: ${observed === expected ? "PASS" : `${observed} != ${expected}`}`);
+            }
+            actual.container.remove();
+            control.container.remove();
+        }
+    });
+</script>


### PR DESCRIPTION
Reduce repeated work across style planning, shared computed styles, generated content, and empty inline-block layout.

- Publish initial selector features in node identity order and avoid unnecessary atom and pseudo-class processing.
- Retain inherited group identities in shared style records instead of reconstructing and reinterning them.
- Read generated content directly from its retained computed value.
- Size empty inline-block boxes within their parent layout run while preserving sizing, containment, and baseline behavior.

In large StyleBench suites, the initial feature publication changes reduce style planning time by roughly 10 ms.