### PR TITLE
LibWeb: Index old first children when reconstructing sibling geometry

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -1518,9 +1518,18 @@ impl StyleEngine {
         parents.sort_unstable();
         parents.dedup();
 
+        // Index the fallback first children once. Scanning every staged row for each parent
+        // would make batches with many newly created or removed subtrees quadratic.
+        let mut before_first_children = HashMap::default();
         for &(node, before, _) in &staged_rows {
             if before.is_none() {
                 view.mark_before_absent(node);
+            }
+            if let Some(relations) = before
+                && let Some(parent) = relations.parent
+                && relations.previous_element_sibling.is_none()
+            {
+                before_first_children.entry(parent).or_insert(node);
             }
         }
 
@@ -1534,15 +1543,7 @@ impl StyleEngine {
             let mut child = self
                 .tree_staging
                 .before_first_child(parent, resident_first)
-                .or_else(|| {
-                    staged_rows.iter().find_map(|&(node, before, _)| {
-                        before
-                            .is_some_and(|relations| {
-                                relations.parent == Some(parent) && relations.previous_element_sibling.is_none()
-                            })
-                            .then_some(node)
-                    })
-                });
+                .or_else(|| before_first_children.get(&parent).copied());
             let mut sequence = Vec::new();
             while let Some(node) = child {
                 assert!(

--- a/Tests/LibWeb/Text/expected/css/style-engine/clone-and-remove-subtrees.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/clone-and-remove-subtrees.txt
@@ -1,0 +1,7 @@
+Initial color: rgb(0, 0, 0)
+After removing clones: rgb(0, 0, 0)
+With clones: rgb(255, 0, 0)
+First clone: rgb(0, 128, 0)
+Last clone: rgb(0, 0, 255)
+Remaining clone: rgb(0, 0, 255)
+After removing all children: rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/input/css/style-engine/clone-and-remove-subtrees.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/clone-and-remove-subtrees.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    #container:has(.branch) { color: red; }
+    #container > :first-child { color: green; }
+    #container > :last-child { color: blue; }
+</style>
+<div id="container"></div>
+<script>
+    test(() => {
+        const container = document.getElementById("container");
+        let tree = document.createElement("div");
+        tree.className = "branch";
+        for (let depth = 0; depth < 4; ++depth) {
+            const parent = document.createElement("div");
+            for (let child = 0; child < 4; ++child)
+                parent.appendChild(tree.cloneNode(true));
+            tree = parent;
+        }
+
+        println(`Initial color: ${getComputedStyle(container).color}`);
+        for (let iteration = 0; iteration < 512; ++iteration) {
+            const clone = tree.cloneNode(true);
+            container.appendChild(clone);
+            for (let move = 0; move < 10; ++move)
+                container.appendChild(clone);
+            clone.remove();
+        }
+        println(`After removing clones: ${getComputedStyle(container).color}`);
+
+        container.append(tree.cloneNode(true), tree.cloneNode(true));
+        println(`With clones: ${getComputedStyle(container).color}`);
+        println(`First clone: ${getComputedStyle(container.firstChild).color}`);
+        println(`Last clone: ${getComputedStyle(container.lastChild).color}`);
+        container.firstChild.remove();
+        println(`Remaining clone: ${getComputedStyle(container.firstChild).color}`);
+        container.replaceChildren();
+        println(`After removing all children: ${getComputedStyle(container).color}`);
+    });
+</script>


### PR DESCRIPTION
Avoid scanning all staged tree rows for every parent that needs a fallback old first child. Batches of cloned subtrees inserted and removed before a style flush can contain hundreds of thousands of rows, making these repeated scans quadratic and stalling the CloneNodes benchmark.

Index frozen first children by parent once per transaction and preserve the existing fallback selection. Add a test that batches subtree clones, moves, and removals before flushing style, then checks relational and positional selectors.