### PR TITLE
LibWeb: Reduce repeated work in incremental style updates

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -1096,7 +1096,6 @@ impl StyleEngine {
                                 node,
                                 source,
                                 cascade_input,
-                                retained_answer_dispatch.unwrap(),
                                 cascade_winners_are_complete,
                             )
                         })

--- a/Libraries/LibWeb/Rust/src/css/style/input_routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/input_routing.rs
@@ -27,13 +27,6 @@ pub(super) fn routing_keys_for_input(input: &NormalizedInput) -> Vec<RoutingKey>
     keys
 }
 
-#[must_use]
-pub(super) fn input_routes_on_key(input: &NormalizedInput, required: RoutingKey) -> bool {
-    let mut routes = false;
-    for_each_routing_key(input, |key| routes |= key == required);
-    routes
-}
-
 fn for_each_routing_key(input: &NormalizedInput, mut publish: impl FnMut(RoutingKey)) {
     match input.key {
         InputKey::LocalFeature(_, feature) => for_each_feature_routing_key(feature, input.old, input.new, publish),

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -3208,19 +3208,12 @@ impl StyleEngine {
         node: StyleNodeID,
         source: StyleNodeID,
         cascade_input: MatchAnswerID,
-        dispatch: &RuleDispatch,
         cascade_winners_are_complete: bool,
     ) -> Option<PublishedMatchAnswer> {
-        let compact = Rc::clone(self.match_answers.answer(cascade_input)?);
-        let mut matches = compact
-            .iter()
-            .copied()
-            .map(|entry| {
-                let cascade_order = dispatch.cascade_order_for_entry(entry.rule, entry.program, entry.entry)?;
-                entry.materialize(node, &self.programs, cascade_order)
-            })
-            .collect::<Option<Vec<_>>>()?;
-        self.order_matches_in_cascade(&mut matches, false);
+        // Both nodes use this completion batch's document dispatch. The source already proved
+        // this answer, and the catalog can materialize it if a consumer needs individual matches.
+        // Most consumers use the cascade identity directly, so keep it shared until then.
+        self.match_answers.answer(cascade_input)?;
         let published_rows =
             self.winner_groups
                 .copy_node_rows(source, node, self.program.version(), &mut self.memory)?;
@@ -3231,7 +3224,7 @@ impl StyleEngine {
         Some(PublishedMatchAnswer {
             node,
             cascade_input: Some(cascade_input),
-            matches: Some(matches.into_boxed_slice()),
+            matches: None,
             cascade_winners_are_complete,
             observed: false,
         })
@@ -3245,7 +3238,7 @@ impl StyleEngine {
     }
 
     /// Whether sharing this compaction avoids enough declaration candidates to cover its fixed
-    /// identity lookup, compact payload materialization, and winner-row copy costs.
+    /// identity lookup and winner-row copy costs.
     pub(super) fn shared_cascade_completion_is_profitable(
         &self,
         answer: MatchAnswerID,

--- a/Libraries/LibWeb/Rust/src/css/style/mod.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/mod.rs
@@ -224,7 +224,6 @@ use index::PostingKey;
 use index::RuleDispatch;
 use index::StyleAtomID;
 use index::StyleNodeFacts;
-use input_routing::input_routes_on_key;
 use input_routing::routing_keys_for_input;
 use memory::BudgetInputs;
 use memory::DeviceClass;

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -2504,9 +2504,13 @@ impl PrefixStates {
             };
             local_facts
         };
-        let positional_bits = match evaluation.positional_bits(node, counters) {
-            Ok(bits) => bits,
-            Err(incomplete) => return PrefixTransitionLookup::Missing(PrefixTransitionGap::Incomplete(incomplete)),
+        let positional_bits = if positional_truth_stable && old.is_some() {
+            self.positional_bits_of(node)
+        } else {
+            match evaluation.positional_bits(node, counters) {
+                Ok(bits) => bits,
+                Err(incomplete) => return PrefixTransitionLookup::Missing(PrefixTransitionGap::Incomplete(incomplete)),
+            }
         };
         let entering = EnteringStates {
             parent: parent_state,

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -2795,6 +2795,18 @@ impl StyleEngine {
         }
 
         if retained_winners_are_current {
+            let mut changed_routing_keys = Vec::new();
+            for input in &transaction.inputs {
+                changed_routing_keys.extend(routing_keys_for_input(input));
+                if let InputKey::LocalFeature(_, LocalFeatureKey::Attribute(name)) = input.key {
+                    changed_routing_keys.extend(self.facts.attribute_name_keys(name).map(RoutingKey::AttributeName));
+                }
+            }
+            changed_routing_keys.sort_unstable();
+            changed_routing_keys.dedup();
+            let changed_key_bytes = (changed_routing_keys.capacity() * size_of::<RoutingKey>()) as u64;
+            self.memory
+                .reserve_required(MemoryCategory::BatchScratch, changed_key_bytes);
             let before = pending.len();
             let mut released_route_bytes = 0;
             let mut inexact_answer_regions = Vec::new();
@@ -2805,7 +2817,7 @@ impl StyleEngine {
                     routing.rule_of(key.route),
                     program,
                     entry,
-                    transaction,
+                    &changed_routing_keys,
                 );
                 if !keep {
                     released_route_bytes += (routed_regions.capacity() * size_of::<ImpactRegion>()) as u64;
@@ -2813,6 +2825,7 @@ impl StyleEngine {
                 }
                 keep
             });
+            self.memory.release(MemoryCategory::BatchScratch, changed_key_bytes);
             self.memory.release(MemoryCategory::BatchScratch, released_route_bytes);
             let inexact_answer_region_bytes = (inexact_answer_regions.capacity() * size_of::<ImpactRegion>()) as u64;
             self.memory
@@ -3305,7 +3318,7 @@ impl StyleEngine {
         rule: RuleID,
         program: SelectorProgramID,
         entry_index: u32,
-        transaction: &StyleTransaction,
+        changed_routing_keys: &[RoutingKey],
     ) -> bool {
         let winner_program_version = self.program.version();
         if !matches!(
@@ -3325,6 +3338,80 @@ impl StyleEngine {
         let dispatch_key = compiled.dispatch_key(entry);
         if !dispatch_key.has_selector_posting() {
             return false;
+        }
+        // The proof has a cheap half and an expensive half. The cheap half compares the changed
+        // rule against the exact retained priority; only when it can not win is the expensive half
+        // needed, which walks the winner's transpose sites to prove the transaction does not touch
+        // that winner. Ask the cheap question first.
+        let retained_winner_program = |previous: PropertyWinner, property| {
+            let WinnerSource::Rule(winner_rule) = previous.source else {
+                return None;
+            };
+            if !self
+                .program
+                .declared_properties_of(winner_rule)
+                .iter()
+                .any(|declaration| declaration.property == property)
+            {
+                return None;
+            }
+            let program = self.program.rule_version(winner_rule).selector_program?;
+            let compiled = self.programs.get(program);
+            if compiled.can_leave_its_scope() || compiled.entries().iter().any(|entry| entry.scope_root.is_some()) {
+                return None;
+            }
+
+            Some(program)
+        };
+        let retained_winner_ignores_transaction = |program: SelectorProgramID| {
+            let compiled = self.programs.get(program);
+            for (entry_index, entry) in compiled.entries().iter().enumerate() {
+                if entry.pseudo_element.is_some() {
+                    continue;
+                }
+                let mut reads_changed_input = false;
+                compiled.collect_transpose_entry_points(entry_index, |site| {
+                    reads_changed_input |= changed_routing_keys.binary_search(&site.key).is_ok();
+                });
+                if reads_changed_input {
+                    return false;
+                }
+            }
+            true
+        };
+        let state_is_unaffected = |state| {
+            self.program.declared_properties_of(rule).iter().all(|declaration| {
+                let Some(previous) = self.winner_groups.winner_in_state(state, declaration.property) else {
+                    return false;
+                };
+                let changed_priority = self.cascade_priority_of(
+                    rule,
+                    TreeScopeID::DOCUMENT,
+                    entry.specificity,
+                    u32::MAX,
+                    declaration.important,
+                );
+                let Some(previous_program) = retained_winner_program(previous, declaration.property) else {
+                    return false;
+                };
+                changed_priority <= previous.priority && retained_winner_ignores_transaction(previous_program)
+            })
+        };
+
+        // A single affected candidate disproves the route-wide claim. Ask before collecting
+        // every distinct winner state, since a failed proof needs none of that collection.
+        if let Lookup::Known(posting) = self.facts.postings().lookup(dispatch_key)
+            && let Some(node) = posting.candidates().next()
+        {
+            let Lookup::Known(&(state, _)) = self
+                .winner_groups
+                .lookup(WinnerGroupKey::current(node, winner_program_version))
+            else {
+                return false;
+            };
+            if !state_is_unaffected(state) {
+                return false;
+            }
         }
         // Rules dispatched under one key all walk the same posting, and the winner column is
         // stable for the routing pass, so the distinct-state collection is shared through a
@@ -3392,82 +3479,7 @@ impl StyleEngine {
         }
         let states = states_with_moved_features.as_deref().unwrap_or(posting_states.as_ref());
 
-        // The proof has a cheap half and an expensive half. The cheap half compares the changed
-        // rule against the exact retained priority; only when it can not win is the expensive half
-        // needed, which walks the winner's transpose sites to prove the transaction does not touch
-        // that winner. Ask the cheap question first.
-        let retained_winner_program = |previous: PropertyWinner, property| {
-            let WinnerSource::Rule(winner_rule) = previous.source else {
-                return None;
-            };
-            if !self
-                .program
-                .declared_properties_of(winner_rule)
-                .iter()
-                .any(|declaration| declaration.property == property)
-            {
-                return None;
-            }
-            let program = self.program.rule_version(winner_rule).selector_program?;
-            let compiled = self.programs.get(program);
-            if compiled.can_leave_its_scope() || compiled.entries().iter().any(|entry| entry.scope_root.is_some()) {
-                return None;
-            }
-
-            Some(program)
-        };
-        let retained_winner_ignores_transaction = |program: SelectorProgramID| {
-            let compiled = self.programs.get(program);
-            for (entry_index, entry) in compiled.entries().iter().enumerate() {
-                if entry.pseudo_element.is_some() {
-                    continue;
-                }
-                let mut reads_changed_input = false;
-                compiled.collect_transpose_entry_points(entry_index, |site| {
-                    reads_changed_input |= self.transaction_changes_routing_key(transaction, site.key);
-                });
-                if reads_changed_input {
-                    return false;
-                }
-            }
-            true
-        };
-        states.iter().all(|&state| {
-            self.program.declared_properties_of(rule).iter().all(|declaration| {
-                let Some(previous) = self.winner_groups.winner_in_state(state, declaration.property) else {
-                    return false;
-                };
-                let changed_priority = self.cascade_priority_of(
-                    rule,
-                    TreeScopeID::DOCUMENT,
-                    entry.specificity,
-                    u32::MAX,
-                    declaration.important,
-                );
-                let Some(previous_program) = retained_winner_program(previous, declaration.property) else {
-                    return false;
-                };
-                changed_priority <= previous.priority && retained_winner_ignores_transaction(previous_program)
-            })
-        })
-    }
-
-    #[must_use]
-    pub(super) fn transaction_changes_routing_key(&self, transaction: &StyleTransaction, key: RoutingKey) -> bool {
-        transaction.inputs.iter().any(|input| {
-            if input_routes_on_key(input, key) {
-                return true;
-            }
-            let InputKey::LocalFeature(_, LocalFeatureKey::Attribute(changed)) = input.key else {
-                return false;
-            };
-            let RoutingKey::AttributeName(required) = key else {
-                return false;
-            };
-            self.facts
-                .attribute_name_keys(changed)
-                .any(|candidate| candidate == required)
-        })
+        states.iter().copied().all(state_is_unaffected)
     }
 
     /// Finish local routes after all normalized inputs have contributed their regions.

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -2969,8 +2969,10 @@ impl StyleEngine {
                 let mut visited = Vec::new();
                 let mut changed_nodes = Vec::new();
                 let mut prefix_delta_arena = PrefixDeltaArena::default();
+                let positional_workspace = MatchEvaluationWorkspace::default();
                 let old_evaluator = MatchEvaluator::new(&self.tree, resident_facts)
-                    .with_transaction_fact_view(view, TransactionFactSide::Before);
+                    .with_transaction_fact_view(view, TransactionFactSide::Before)
+                    .with_match_workspace(&positional_workspace, MatchEvaluationSide::OldTree);
                 let old_evaluation = PrefixEvaluation::new(
                     dispatch.prefixes(),
                     &self.tree,
@@ -2981,7 +2983,8 @@ impl StyleEngine {
                     None,
                 );
                 let new_evaluator = MatchEvaluator::new(&self.tree, resident_facts)
-                    .with_transaction_fact_view(view, TransactionFactSide::After);
+                    .with_transaction_fact_view(view, TransactionFactSide::After)
+                    .with_match_workspace(&positional_workspace, MatchEvaluationSide::Current);
                 let new_evaluation = PrefixEvaluation::new(
                     dispatch.prefixes(),
                     &self.tree,
@@ -3001,6 +3004,7 @@ impl StyleEngine {
                         + (changed_node_capacity * size_of::<StyleNodeID>()) as u64
                         + selection_bytes
                         + delta_capacity_bytes
+                        + positional_workspace.capacity_bytes()
                 };
                 let mut charged_bytes = workspace_bytes(
                     pending_nodes.capacity(),

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5131,13 +5131,19 @@ fn shared_retained_answer_completion_reuses_compact_cascade_state() {
             nodes[3],
             nodes[2],
             cascade_input,
-            &dispatch,
             first.cascade_winners_are_complete,
         )
         .unwrap();
 
     assert_eq!(second.cascade_input, Some(cascade_input));
-    assert_eq!(second.matches.as_ref().unwrap().len(), 1);
+    assert!(second.matches.is_none());
+    engine
+        .published_match_answers
+        .push(second, &mut engine.memory, &mut engine.counters);
+    engine.published_match_answers.sort();
+    let materialized = engine.consume_published_match_answer(nodes[3]).unwrap();
+    assert_eq!(materialized.len(), 1);
+    assert_eq!(materialized[0].node, nodes[3]);
     assert_eq!(
         engine.counters().get(Counter::CascadeMatchesBeforeCompaction),
         compaction_rows

--- a/Tests/LibWeb/Text/expected/css/style-engine/prefix-positional-truth-across-feature-and-tree-changes.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/prefix-positional-truth-across-feature-and-tree-changes.txt
@@ -1,0 +1,1 @@
+mismatches: 0

--- a/Tests/LibWeb/Text/input/css/style-engine/prefix-positional-truth-across-feature-and-tree-changes.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/prefix-positional-truth-across-feature-and-tree-changes.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .sequence .leaf { color: black }
+    .active > div:nth-of-type(2n) .leaf { color: red }
+    .active > :nth-last-child(3n) .leaf { color: blue }
+    .active > :empty { background-color: green }
+</style>
+<div id="root"></div>
+<script>
+    test(() => {
+        const sequences = [];
+        for (let sequenceIndex = 0; sequenceIndex < 3; ++sequenceIndex) {
+            const sequence = document.createElement("section");
+            sequence.className = "sequence";
+            for (let index = 0; index < 48; ++index) {
+                const child = document.createElement(index % 3 ? "div" : "span");
+                child.innerHTML = '<span class="leaf"></span>';
+                sequence.append(child);
+            }
+            root.append(sequence);
+            sequences.push(sequence);
+        }
+
+        let mismatches = 0;
+        const check = () => {
+            internals.updateStyle();
+            for (const sequence of sequences) {
+                const active = sequence.classList.contains("active");
+                let divIndex = 0;
+                for (let index = 0; index < sequence.children.length; ++index) {
+                    const child = sequence.children[index];
+                    if (child.localName === "div")
+                        ++divIndex;
+                    const leaf = child.firstElementChild;
+                    if (leaf) {
+                        const expected = !active ? "rgb(0, 0, 0)"
+                            : child.localName === "div" && divIndex % 2 === 0 ? "rgb(255, 0, 0)"
+                            : (sequence.children.length - index) % 3 === 0 ? "rgb(0, 0, 255)"
+                            : "rgb(0, 0, 0)";
+                        if (getComputedStyle(leaf).color !== expected)
+                            ++mismatches;
+                    }
+                    const expectedBackground = active && !child.hasChildNodes()
+                        ? "rgb(0, 128, 0)" : "rgba(0, 0, 0, 0)";
+                    if (getComputedStyle(child).backgroundColor !== expectedBackground)
+                        ++mismatches;
+                }
+            }
+        };
+
+        check();
+        for (let round = 0; round < 4; ++round) {
+            sequences.forEach(sequence => sequence.classList.add("active"));
+            check();
+            for (const sequence of sequences) {
+                sequence.prepend(document.createElement("div"));
+                sequence.children[8].replaceChildren();
+                sequence.children[12].remove();
+            }
+            check();
+            sequences.forEach(sequence => sequence.classList.remove("active"));
+            check();
+            for (const sequence of sequences) {
+                sequence.firstElementChild.remove();
+                sequence.append(sequence.firstElementChild);
+            }
+            check();
+        }
+        println(`mismatches: ${mismatches}`);
+    });
+</script>


### PR DESCRIPTION
Reduce repeated work during incremental style updates by reusing positional selector inputs across prefix convergence, collecting changed routing keys once, and rejecting affected cascade routes before building complete winner-state sets.

Keep shared retained cascade answers compact through publication and materialize matched rules only when a consumer requests them. Add coverage for positional selectors across class changes and batched insertions, removals, and moves.
