### PR TITLE
LibRegex: Filter alternative starts using two leading literals

### DIFF
--- a/Libraries/LibRegex/Rust/src/vm.rs
+++ b/Libraries/LibRegex/Rust/src/vm.rs
@@ -1112,10 +1112,8 @@ fn analyze_start_position_hint(instructions: &[Instruction], start: usize) -> Op
         }
     }
 
-    // Keep this hint narrowly scoped to `(^|literal)` prefixes. Wider literal
-    // sets require a single-pass scanner; repeated `find_code_unit()` probes
-    // per literal turn miss-heavy inputs quadratic.
-    if hint.includes_input_start && hint.literal_code_units.len() == 1 {
+    // Limit the set to two literals so each candidate needs at most two comparisons.
+    if (1..=2).contains(&hint.literal_code_units.len()) {
         Some(hint)
     } else {
         None
@@ -1124,15 +1122,22 @@ fn analyze_start_position_hint(instructions: &[Instruction], start: usize) -> Op
 
 #[inline(always)]
 fn next_literal_start_from_hint<I: Input>(input: I, start: usize, hint: &StartPositionHint) -> Option<usize> {
-    let [literal] = hint.literal_code_units.as_slice() else {
-        return None;
-    };
-
     if hint.includes_input_start && start == 0 {
         return Some(0);
     }
 
-    input.next_literal_start(start, *literal)
+    match hint.literal_code_units.as_slice() {
+        [literal] => input.next_literal_start(start, *literal),
+        [first, second] => {
+            // Scan once for either literal. Searching the remaining suffix separately
+            // for each literal would repeatedly rescan it when one literal is absent.
+            (start..input.len()).find(|&pos| {
+                let code_unit = input.code_unit(pos);
+                code_unit == *first || code_unit == *second
+            })
+        }
+        _ => None,
+    }
 }
 
 /// Analyze the program to extract optimization hints.

--- a/Tests/LibRegex/TestRegex.cpp
+++ b/Tests/LibRegex/TestRegex.cpp
@@ -276,6 +276,97 @@ TEST_CASE(leading_start_or_separator_prefix_preserves_behavior)
     EXPECT_EQ(regex.test(u"a=1; baz=qux"sv, 0), regex::MatchResult::NoMatch);
 }
 
+TEST_CASE(leading_literal_alternatives_preserve_line_endings)
+{
+    auto regex = compile_regex("\\r\\n?|\\n"sv);
+
+    for (auto subject : { Utf16View { "one\r\ntwo\nthree\rfour"sv }, u"one\r\ntwo\nthree\rfour"sv }) {
+        EXPECT_EQ(regex.find_all(subject, 0), 3);
+        EXPECT_EQ(regex.find_all_match(0).start, 3);
+        EXPECT_EQ(regex.find_all_match(0).end, 5);
+        EXPECT_EQ(regex.find_all_match(1).start, 8);
+        EXPECT_EQ(regex.find_all_match(1).end, 9);
+        EXPECT_EQ(regex.find_all_match(2).start, 14);
+        EXPECT_EQ(regex.find_all_match(2).end, 15);
+
+        EXPECT_EQ(regex.exec(subject, 4), regex::MatchResult::Match);
+        EXPECT_EQ(regex.capture_slot(0), 4);
+        EXPECT_EQ(regex.capture_slot(1), 5);
+        EXPECT_EQ(regex.test(subject, subject.length_in_code_units()), regex::MatchResult::NoMatch);
+    }
+
+    EXPECT_EQ(regex.test(u""sv, 0), regex::MatchResult::NoMatch);
+    EXPECT_EQ(regex.test(u"no line endings"sv, 0), regex::MatchResult::NoMatch);
+}
+
+TEST_CASE(leading_literal_alternatives_preserve_captures_and_match_order)
+{
+    auto regex = compile_regex("(abb*)|(acc*)|(dd*)"sv);
+
+    for (auto subject : { Utf16View { "xxazddabbb"sv }, u"xxazddabbb"sv }) {
+        EXPECT_EQ(regex.exec(subject, 0), regex::MatchResult::Match);
+        EXPECT_EQ(regex.capture_slot(0), 4);
+        expect_capture_eq(regex, subject, 0, "dd"sv);
+        expect_capture_unmatched(regex, 1);
+        expect_capture_unmatched(regex, 2);
+        expect_capture_eq(regex, subject, 3, "dd"sv);
+
+        EXPECT_EQ(regex.exec(subject, 6), regex::MatchResult::Match);
+        expect_capture_eq(regex, subject, 1, "abbb"sv);
+        expect_capture_unmatched(regex, 2);
+        expect_capture_unmatched(regex, 3);
+    }
+
+    auto ordered = compile_regex("(ab)|(abb*)|(cc*)"sv);
+    EXPECT_EQ(ordered.exec(u"xxabbb"sv, 0), regex::MatchResult::Match);
+    expect_capture_eq(ordered, u"xxabbb"sv, 1, "ab"sv);
+    expect_capture_unmatched(ordered, 2);
+    expect_capture_unmatched(ordered, 3);
+}
+
+TEST_CASE(leading_literal_alternatives_preserve_assertions_and_flags)
+{
+    struct Test {
+        StringView pattern;
+        Utf16View subject;
+        size_t start;
+        i32 match_start;
+        i32 match_end;
+        regex::ECMAScriptCompileFlags flags {};
+    };
+
+    static constexpr Test tests[] {
+        { "^|aa*|bb*"sv, u"xxbb"sv, 0, 0, 0 },
+        { "^|aa*|bb*"sv, u"xxbb"sv, 1, 2, 4 },
+        { "^|aa*|bb*"sv, u"xx"sv, 2, -1, -1 },
+        { "^x|aa*|bb*"sv, u"zzaabb"sv, 0, 2, 4 },
+        { "aa*|bb*|"sv, u"xx"sv, 0, 0, 0 },
+        { "aa*|bb*|$"sv, u"xx"sv, 0, 2, 2 },
+        { "a*|bb*"sv, u"xx"sv, 0, 0, 0 },
+        { "aa*|bb*"sv, u"xxBB"sv, 0, 2, 4, { .ignore_case = true } },
+        { "(?i:aa*)|bb*"sv, u"xxAA"sv, 0, 2, 4 },
+        { "^x|aa*|bb*"sv, u"zz\nx"sv, 0, 3, 4, { .multiline = true } },
+        { "aa*|bb*"sv, u"xxbb"sv, 0, -1, -1, { .sticky = true } },
+        { "aa*|bb*"sv, u"xxbb"sv, 2, 2, 4, { .sticky = true } },
+        { "\\b(?:aa*|bb*)"sv, u"xa bb"sv, 0, 3, 5 },
+        { "(?<=x)aa*|bb*"sv, u"xxaa"sv, 0, 2, 4 },
+        { "éé*|bb*"sv, u"xxéé"sv, 0, 2, 4 },
+        { "\\uD83D|bb*"sv, u"x😀"sv, 0, 1, 2 },
+        { "\\uD83D|bb*"sv, u"x😀bb"sv, 0, 3, 5, { .unicode = true } },
+        { "aa*|bb*|cc*"sv, u"xxcc"sv, 0, 2, 4 },
+    };
+
+    for (auto const& test : tests) {
+        auto regex = compile_regex(test.pattern, test.flags);
+        auto result = regex.exec(test.subject, test.start);
+        EXPECT_EQ(result, test.match_start < 0 ? regex::MatchResult::NoMatch : regex::MatchResult::Match);
+        if (result == regex::MatchResult::Match) {
+            EXPECT_EQ(regex.capture_slot(0), test.match_start);
+            EXPECT_EQ(regex.capture_slot(1), test.match_end);
+        }
+    }
+}
+
 TEST_CASE(required_literal_prefilter_preserves_assignment_extractors)
 {
     auto regex = MUST(compile_regex_result("(?:^|;)\\s*foo=([^;]*)"sv, {}));


### PR DESCRIPTION
Extend the existing start-position hint to accept up to two distinct leading literal code units. Scan forward once for either literal before entering the VM, preserving alternative order and capture behavior.

This avoids repeated backtracking and register snapshots at impossible starting positions for patterns such as `/\r\n?|\n/`.

This improves the performance of the `Editor-CodeMirror/Long` Speedometer3 test:
```
Benchmark     Suite                                       Test                   Speedup  Old (Mean ± Range)    New (Mean ± Range)
------------  ------------------------------------------  -------------------  ---------  --------------------  --------------------
Speedometer3  Charts-chartjs                              Draw opaque scatter      1.055  0.10 ± 0.01           0.09 ± 0.00
Speedometer3  Charts-chartjs                              Draw scatter             1.276  0.17 ± 0.11           0.14 ± 0.02
Speedometer3  Charts-chartjs                              Show tooltip             1.183  0.00 ± 0.00           0.00 ± 0.00
Speedometer3  Charts-observable-plot                      Dotted                   0.918  0.06 ± 0.00           0.06 ± 0.01
Speedometer3  Charts-observable-plot                      Stacked by 20            1.022  0.12 ± 0.01           0.12 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 6             1.015  0.08 ± 0.01           0.08 ± 0.01
Speedometer3  Editor-CodeMirror                           Highlight                0.959  0.03 ± 0.00           0.03 ± 0.01
Speedometer3  Editor-CodeMirror                           Long                     1.673  0.06 ± 0.01           0.03 ± 0.00
Speedometer3  Editor-TipTap                               Highlight                0.966  0.19 ± 0.02           0.19 ± 0.02
Speedometer3  Editor-TipTap                               Long                     0.785  0.13 ± 0.03           0.17 ± 0.12
Speedometer3  NewsSite-Next                               NavigateToPolitics       0.973  0.17 ± 0.00           0.17 ± 0.01
Speedometer3  NewsSite-Next                               NavigateToUS             1.05   0.17 ± 0.01           0.16 ± 0.01
Speedometer3  NewsSite-Next                               NavigateToWorld          0.971  0.18 ± 0.02           0.18 ± 0.02
Speedometer3  NewsSite-Nuxt                               NavigateToPolitics       1.07   0.16 ± 0.02           0.15 ± 0.01
Speedometer3  NewsSite-Nuxt                               NavigateToUS             0.844  0.14 ± 0.00           0.16 ± 0.06
Speedometer3  NewsSite-Nuxt                               NavigateToWorld          1.201  0.17 ± 0.06           0.14 ± 0.00
Speedometer3  Perf-Dashboard                              Render                   0.998  0.06 ± 0.01           0.06 ± 0.01
Speedometer3  Perf-Dashboard                              SelectingPoints          1.044  0.12 ± 0.01           0.11 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingRange           1.003  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  React-Stockcharts-SVG                       PanTheChart              1.029  0.12 ± 0.02           0.11 ± 0.01
Speedometer3  React-Stockcharts-SVG                       Render                   0.769  0.13 ± 0.02           0.16 ± 0.11
Speedometer3  React-Stockcharts-SVG                       ZoomTheChart             1.006  0.45 ± 0.03           0.44 ± 0.03
Speedometer3  TodoMVC-Angular-Complex-DOM                 Adding100Items           1.002  0.12 ± 0.02           0.12 ± 0.02
Speedometer3  TodoMVC-Angular-Complex-DOM                 CompletingAllItems       0.923  0.07 ± 0.00           0.08 ± 0.02
Speedometer3  TodoMVC-Angular-Complex-DOM                 DeletingAllItems         1.014  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Backbone                            Adding100Items           0.914  0.07 ± 0.00           0.08 ± 0.02
Speedometer3  TodoMVC-Backbone                            CompletingAllItems       0.998  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Backbone                            DeletingAllItems         1.024  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      Adding100Items           0.994  0.13 ± 0.02           0.13 ± 0.02
Speedometer3  TodoMVC-JavaScript-ES5                      CompletingAllItems       0.994  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      DeletingAllItems         0.999  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  Adding100Items           0.933  0.12 ± 0.01           0.12 ± 0.02
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  CompletingAllItems       1.123  0.06 ± 0.02           0.05 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  DeletingAllItems         0.98   0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     Adding100Items           0.961  0.05 ± 0.01           0.05 ± 0.01
Speedometer3  TodoMVC-Lit-Complex-DOM                     CompletingAllItems       0.996  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     DeletingAllItems         0.999  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  Adding100Items           1.043  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  CompletingAllItems       1.028  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  DeletingAllItems         0.865  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   Adding100Items           1.008  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   CompletingAllItems       0.974  0.09 ± 0.01           0.10 ± 0.01
Speedometer3  TodoMVC-React-Complex-DOM                   DeletingAllItems         1.12   0.06 ± 0.01           0.05 ± 0.00
Speedometer3  TodoMVC-React-Redux                         Adding100Items           0.988  0.09 ± 0.01           0.09 ± 0.01
Speedometer3  TodoMVC-React-Redux                         CompletingAllItems       1.013  0.12 ± 0.00           0.11 ± 0.00
Speedometer3  TodoMVC-React-Redux                         DeletingAllItems         1.024  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  Adding100Items           1.039  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  CompletingAllItems       1.034  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  DeletingAllItems         1.252  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Vue                                 Adding100Items           1.014  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Vue                                 CompletingAllItems       1.02   0.04 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Vue                                 DeletingAllItems         1.009  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       Adding100Items           1.016  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-WebComponents                       CompletingAllItems       1.048  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       DeletingAllItems         0.949  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-jQuery                              Adding100Items           1.008  0.19 ± 0.06           0.19 ± 0.06
Speedometer3  TodoMVC-jQuery                              CompletingAllItems       1.003  0.38 ± 0.01           0.38 ± 0.01
Speedometer3  TodoMVC-jQuery                              DeletingAllItems         1.005  0.18 ± 0.10           0.18 ± 0.10

Benchmark     Old Score    New Score      Score Improvement  Old Total Time (s)    New Total Time (s)      Speedup
------------  -----------  -----------  -------------------  --------------------  --------------------  ---------
Speedometer3  4.89 ± 0.22  4.98 ± 0.23                1.019  5.29 ± 0.28           5.28 ± 0.31               1.001
```

No observed effect in any of the regex specific benchmarks in `js-benchmarks`.