### PR TITLE
Clamp nested setTimeout calls to 4ms after 5 levels, per spec (and make politico.com stop consuming really-excessive CPU)

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -116,6 +116,11 @@ public:
     [[nodiscard]] TaskID id() const { return m_id; }
     Source source() const { return m_source; }
     Priority priority() const { return m_priority; }
+
+    // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-nesting-level
+    u32 timer_nesting_level() const { return m_timer_nesting_level; }
+    void set_timer_nesting_level(u32 nesting_level) { m_timer_nesting_level = nesting_level; }
+
     void execute();
 
     DOM::Document const* document() const;
@@ -131,6 +136,7 @@ private:
     TaskID m_id {};
     Source m_source { Source::Unspecified };
     Priority m_priority { Priority::Normal };
+    u32 m_timer_nesting_level { 0 };
     GC::Ref<GC::Function<void()>> m_steps;
     GC::Ptr<DOM::Document const> m_document;
 

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -39,6 +39,7 @@
 #include <LibWeb/HTML/EventSource.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/PromiseRejectionEvent.h>
+#include <LibWeb/HTML/Scripting/Agent.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
@@ -643,7 +644,6 @@ void WindowOrWorkerGlobalScopeMixin::clear_timeout(i32 id)
     if (auto timer = m_timers.get(id); timer.has_value())
         timer.value()->stop();
     m_timers.remove(id);
-    m_timer_nesting_levels.remove(id);
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-clearinterval
@@ -652,7 +652,6 @@ void WindowOrWorkerGlobalScopeMixin::clear_interval(i32 id)
     if (auto timer = m_timers.get(id); timer.has_value())
         timer.value()->stop();
     m_timers.remove(id);
-    m_timer_nesting_levels.remove(id);
 }
 
 void WindowOrWorkerGlobalScopeMixin::clear_map_of_active_timers()
@@ -660,7 +659,6 @@ void WindowOrWorkerGlobalScopeMixin::clear_map_of_active_timers()
     for (auto& it : m_timers)
         it.value->stop();
     m_timers.clear();
-    m_timer_nesting_levels.clear();
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps
@@ -674,9 +672,12 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
 
     // 3. If the surrounding agent's event loop's currently running task is a task that was created by this algorithm,
     //    then let nesting level be the task's timer nesting level. Otherwise, let nesting level be 0.
+    // NB: Only a task created by this algorithm carries a nonzero timer nesting level — so reading the level of
+    //     whatever task is running covers both cases. A microtask counts as its own task here — so a timer scheduled
+    //     from one starts over at 0 even when the checkpoint follows a deeply-nested timer callback.
     u32 nesting_level = 0;
-    if (previous_id.has_value())
-        nesting_level = m_timer_nesting_levels.get(previous_id.value()).value_or(0);
+    if (auto currently_running_task = relevant_agent(relevant_global_object(*this)).event_loop->currently_running_task())
+        nesting_level = currently_running_task->timer_nesting_level();
 
     // 4. If timeout is less than 0, then set timeout to 0.
     if (timeout < 0)
@@ -793,7 +794,6 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
         // 10. Otherwise, remove global's map of active timers[id].
         case Repeat::No:
             m_timers.remove(id);
-            m_timer_nesting_levels.remove(id);
             break;
         }
     }));
@@ -802,14 +802,21 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
     nesting_level++;
 
     // 11. Set task's timer nesting level to nesting level.
-    m_timer_nesting_levels.set(id, nesting_level);
-
     // 12. Let completionStep be an algorithm step which queues a global task on the timer task source given global to run task.
-    Function<void()> completion_step = [this, task = move(task)]() mutable {
-        queue_global_task(Task::Source::TimerTask, relevant_global_object(*this), GC::create_function(GC::Heap::the(), [this, task] {
+    // NB: The task the event loop runs is the one completionStep queues — so that's what carries step 11's nesting
+    //     level. queue_global_task() creates its task internally; so, this queues one by hand to get at it — and a
+    //     fresh one per firing, since a repeating timer's next firing can queue before the previous task has run.
+    Function<void()> completion_step = [this, task = move(task), nesting_level]() mutable {
+        auto& global = relevant_global_object(*this);
+        GC::Ptr<DOM::Document const> document;
+        if (auto* window = window_from_global_object(global))
+            document = &window->associated_document();
+        auto queued_task = Task::create(Task::Source::TimerTask, document, GC::create_function(GC::Heap::the(), [this, task] {
             HTML::TemporaryExecutionContext execution_context { relevant_settings_object(*this), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
             task->function()();
         }));
+        queued_task->set_timer_nesting_level(nesting_level);
+        relevant_agent(global).event_loop->task_queue().add(queued_task);
     };
 
     // 13. Set uniqueHandle to the result of running steps after a timeout given global, "setTimeout/setInterval",

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -154,9 +154,6 @@ private:
     IDAllocator m_timer_id_allocator;
     HashMap<int, GC::Ref<Timer>> m_timers;
 
-    // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-nesting-level
-    HashMap<i32, u32> m_timer_nesting_levels;
-
     // https://www.w3.org/TR/performance-timeline/#performance-timeline
     // Each global object has:
     // - a performance observer task queued flag

--- a/Tests/LibWeb/Text/expected/HTML/timer-nesting-level-settimeout-chain.txt
+++ b/Tests/LibWeb/Text/expected/HTML/timer-nesting-level-settimeout-chain.txt
@@ -1,0 +1,2 @@
+A chain of 30 nested setTimeout(f, 0) calls takes at least 90ms: true
+Timers fired in the order: unclamped timer from the microtask, clamped timer from the callback

--- a/Tests/LibWeb/Text/input/HTML/timer-nesting-level-settimeout-chain.html
+++ b/Tests/LibWeb/Text/input/HTML/timer-nesting-level-settimeout-chain.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // The timer initialization steps clamp a timeout below 4ms up to 4ms once the timer nesting level exceeds 5, and a
+    // setTimeout() call made from inside a timer callback inherits the callback's nesting level, so a chain of nested
+    // setTimeout(f, 0) calls slows to one hop per 4ms after its first few hops. A chain of 30 hops therefore takes at
+    // least 24 * 4ms = 96ms, while an unclamped one finishes in well under a millisecond.
+    asyncTest(done => {
+        const start = performance.now();
+        let hop = 0;
+        const step = () => {
+            if (++hop < 30) {
+                setTimeout(step, 0);
+                return;
+            }
+            const elapsed = performance.now() - start;
+            println(`A chain of 30 nested setTimeout(f, 0) calls takes at least 90ms: ${elapsed >= 90}`);
+            testTimerScheduledFromMicrotask();
+        };
+        setTimeout(step, 0);
+
+        // A microtask isn't a task created by the timer initialization steps, so a setTimeout() call made during the
+        // microtask checkpoint after a deeply-nested timer callback starts over at nesting level 0: its 0ms timer fires
+        // before the clamped 4ms one that the callback itself scheduled a moment earlier.
+        function testTimerScheduledFromMicrotask() {
+            const order = [];
+            const record = name => {
+                order.push(name);
+                if (order.length === 2) {
+                    println(`Timers fired in the order: ${order.join(", ")}`);
+                    done();
+                }
+            };
+            let depth = 0;
+            const nest = () => {
+                if (++depth < 8) {
+                    setTimeout(nest, 0);
+                    return;
+                }
+                setTimeout(() => record("clamped timer from the callback"), 0);
+                queueMicrotask(() => setTimeout(() => record("unclamped timer from the microtask"), 0));
+            };
+            setTimeout(nest, 0);
+        }
+    });
+</script>


### PR DESCRIPTION
**Problem:** [politico.com](https://www.politico.com/) consumed an (really) excessive amount of CPU.

**Cause:** An ad library served from asadcdn.com polls for a script the content blocker blocks — rescheduling itself with `setTimeout(f, 0)` from inside every callback. And we ran those polls ~71,000 times a second. Chrome and Firefox run the same endless polls at 4ms a hop, a few hundred times a second — which costs nothing noticeable. Our timer-initialization implementation caused that `setTimeout()` call to start over at 0 every time — and never got clamped as intended.

**Fix:** Conform to the spec: Give `HTML::Task` a timer-nesting level, have the completion step set it on the task it queues, and read it back from the currently-running task at the start of the timer initialization steps. So a `setTimeout()` call made from inside a timer callback inherits that callback’s level — and once the level passes 5, a timeout under 4ms gets clamped up to 4ms, as the spec requires. On politico.com, the polls now run about 460 times a second — with non-excessive CPU consumption.
