### PR TITLE
LibWeb: Skip command capture for empty paint phases

### DIFF
--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -102,6 +102,10 @@ pub enum PaintPhase {
 
 impl PaintPhase {
     pub const COUNT: usize = 6;
+
+    const fn bit(self) -> u8 {
+        1 << self as u8
+    }
 }
 pub(crate) struct NestedRecordingState {
     pub(crate) assignments: NestedAssignments,
@@ -154,7 +158,9 @@ pub(crate) struct BasePaintFacts {
     pub is_visible: bool,
     pub empty_cells_property_applies: bool,
     pub has_backdrop_filter: bool,
+    pub has_box_shadow: bool,
     pub paints_border_image: bool,
+    pub paint_phase_mask: u8,
 }
 
 impl<'a> PaintRecorder<'a> {
@@ -311,12 +317,15 @@ impl<'a> PaintRecorder<'a> {
         let has_backdrop_filter = effects.backdrop_filter.operations.length != 0;
         let paints_border_image = crate::painting::style_queries::handle_value(&style.border().border_image_source)
             .is_some_and(|source| matches!(source, crate::css::style_value::StyleValueData::Image { .. }));
-        let facts = BasePaintFacts {
+        let mut facts = BasePaintFacts {
             is_visible,
             empty_cells_property_applies,
             has_backdrop_filter,
+            has_box_shadow: effects.box_shadows.length != 0,
             paints_border_image,
+            paint_phase_mask: 0,
         };
+        facts.paint_phase_mask = paint::paint_phase_mask(self, paintable, style, &facts);
         self.memo_tables.borrow_mut().set_base_paint_facts(paintable, facts);
         facts
     }

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
@@ -693,27 +693,39 @@ pub(crate) fn resolve_mask_layers<'a>(
     )
 }
 
+pub(crate) fn has_background_to_paint(
+    arena: &impl PaintableRowsRead,
+    paintable: NodeSlotId,
+    root_background_source: FfiRootBackgroundSource,
+) -> bool {
+    if body_background_is_propagated_to_root(arena, paintable, root_background_source) {
+        return false;
+    }
+    if style_queries::node_is_root_element(arena, paintable) {
+        return true;
+    }
+    arena.node_style_if_live(paintable).is_some_and(|style| {
+        libgfx_rust::Color(style.background().background_color).alpha() != 0
+            || arena.node_has_compositor_animation_frame(
+                paintable,
+                crate::layout::node_data::CompositorAnimationFrameKind::BackgroundColor,
+            )
+            || style_queries::background_layers_have_image(style)
+    })
+}
+
 pub(crate) fn resolve_background_for_paint<'a>(
     recorder: &PaintRecorder<'a>,
     paintable: NodeSlotId,
 ) -> Option<BackgroundPaintInputs<'a>> {
+    if !has_background_to_paint(recorder.layout_arena, paintable, recorder.inputs.root_background_source) {
+        return None;
+    }
     let source = background_paint_source_from_style_and_geometry(
         recorder.layout_arena,
         paintable,
         recorder.inputs.root_background_source,
     )?;
-    if !source.is_root_element
-        && source.background_color.alpha() == 0
-        && !recorder.layout_arena.node_has_compositor_animation_frame(
-            paintable,
-            crate::layout::node_data::CompositorAnimationFrameKind::BackgroundColor,
-        )
-        && !source
-            .layers_style_if_live
-            .is_some_and(style_queries::background_layers_have_image)
-    {
-        return None;
-    }
     let mut resolved = match source.layers_style_if_live {
         Some(layers_style) => resolve_background_layers(
             recorder,

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
@@ -22,9 +22,58 @@ pub mod table_borders;
 pub mod text;
 pub mod text_decoration;
 
+use crate::css::computed_value_views::ComputedValuesView;
 use crate::layout::node_data::{NodeKind, NodeSlotId};
 use crate::painting::node_painting;
-use crate::painting::record::{PaintPhase, PaintRecorder};
+use crate::painting::record::{BasePaintFacts, PaintPhase, PaintRecorder};
+use crate::painting::style_queries;
+
+pub(crate) fn paint_phase_mask(
+    recorder: &PaintRecorder<'_>,
+    paintable: NodeSlotId,
+    style: ComputedValuesView<'_>,
+    facts: &BasePaintFacts,
+) -> u8 {
+    let kind = recorder.layout_arena.node_kind_if_live(paintable);
+    // SVG painters also track dependencies on other elements, even in phases that
+    // produce no commands. Keep those painters on their regular path.
+    if kind.is_some_and(node_painting::is_svg) {
+        return (1 << PaintPhase::COUNT) - 1;
+    }
+
+    // Foreground painting includes visible descendants of hidden line containers.
+    let mut phases = PaintPhase::Foreground.bit() | PaintPhase::TableCollapsedBorder.bit();
+    if !facts.is_visible {
+        return phases;
+    }
+    if !facts.empty_cells_property_applies {
+        if facts.has_backdrop_filter
+            || facts.has_box_shadow
+            || background_resolution::has_background_to_paint(
+                recorder.layout_arena,
+                paintable,
+                recorder.inputs.root_background_source,
+            )
+        {
+            phases |= PaintPhase::Background.bit();
+        }
+        if facts.paints_border_image || style_queries::has_css_borders(style) {
+            phases |= PaintPhase::Border.bit();
+        }
+    }
+    // Images paint focused image-map area outlines independently of their own outline.
+    if kind == Some(NodeKind::ImageBox) || style_queries::outline_geometry(style).is_some() {
+        phases |= PaintPhase::Outline.bit();
+    }
+    if kind == Some(NodeKind::Viewport)
+        || recorder.data(paintable).own_scroll_node_index
+            != crate::painting::display_list::commands::VISUAL_VIEWPORT_NODE_INDEX
+        || crate::painting::chrome_geometry::has_resizer(recorder.layout_arena, paintable)
+    {
+        phases |= PaintPhase::Overlay.bit();
+    }
+    phases
+}
 
 pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, phase: PaintPhase) {
     let Some(kind) = recorder.layout_arena.node_kind_if_live(paintable) else {
@@ -140,12 +189,14 @@ pub(crate) fn paint_base_with(
     if phase == PaintPhase::Background && !facts.empty_cells_property_applies {
         paint_backdrop_filter(recorder, paintable, &facts);
         paint_background(recorder, paintable);
-        let border_box_rect =
-            crate::painting::paintable_geometry::absolute_border_box_rect(recorder.layout_arena, paintable);
-        let padding_box_rect =
-            crate::painting::paintable_geometry::absolute_padding_box_rect(recorder.layout_arena, paintable);
-        let border_radii = recorder.border_radii(paintable);
-        shadow::paint_box_shadow(recorder, paintable, border_box_rect, padding_box_rect, border_radii);
+        if facts.has_box_shadow {
+            let border_box_rect =
+                crate::painting::paintable_geometry::absolute_border_box_rect(recorder.layout_arena, paintable);
+            let padding_box_rect =
+                crate::painting::paintable_geometry::absolute_padding_box_rect(recorder.layout_arena, paintable);
+            let border_radii = recorder.border_radii(paintable);
+            shadow::paint_box_shadow(recorder, paintable, border_box_rect, padding_box_rect, border_radii);
+        }
     }
     if phase == PaintPhase::Border
         && !crate::painting::paintable_geometry::committed_uses_collapsing_borders_model(

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/outline.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/outline.rs
@@ -23,10 +23,12 @@ pub(crate) fn paint_outline_phase(recorder: &mut PaintRecorder<'_>, paintable: N
         recorder.inputs.window_is_focused,
         recorder.inputs.outline_auto_color.0,
     );
-    let outline_offset = crate::painting::style_queries::outline_offset(recorder.layout_arena, node);
-    let border_box_rect = paintable_geometry::absolute_border_box_rect(recorder.layout_arena, paintable);
-    let border_radii = recorder.border_radii(paintable);
-    paint_outline(recorder, outline, outline_offset, border_box_rect, border_radii);
+    if outline.is_some() {
+        let outline_offset = crate::painting::style_queries::outline_offset(recorder.layout_arena, node);
+        let border_box_rect = paintable_geometry::absolute_border_box_rect(recorder.layout_arena, paintable);
+        let border_radii = recorder.border_radii(paintable);
+        paint_outline(recorder, outline, outline_offset, border_box_rect, border_radii);
+    }
     let facts = recorder.paint_host.outline_facts(recorder.layout_node_shell(paintable));
     paint_focused_area_outline(recorder, paintable, &facts);
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -989,6 +989,13 @@ impl PaintRecorder<'_> {
             self.record_async_scrolling_metadata(paintable);
         }
 
+        // A visually empty phase can still contribute hit-test and scrolling metadata.
+        // Only skip command capture, after recording that metadata above.
+        if self.base_paint_facts(paintable).paint_phase_mask & phase.bit() == 0 {
+            self.recorder.set_accumulated_visual_context(ContextRef::default());
+            return;
+        }
+
         // SVG subtrees are recorded outside per-paintable captures, so path-bearing items are never spliced.
         let phase_context = self.recorder.accumulated_visual_context();
         let cached_commands = if skip_phase_capture || is_nested {

--- a/Tests/LibWeb/Ref/expected/empty-paint-phases-invalidation-ref.html
+++ b/Tests/LibWeb/Ref/expected/empty-paint-phases-invalidation-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    body { margin: 24px; }
+    .row { display: flex; gap: 24px; margin-bottom: 40px; }
+    .box { width: 80px; height: 60px; box-sizing: border-box; border-radius: 8px; }
+    .paint .background { background: green; }
+    .paint .gradient { background: linear-gradient(green, blue); }
+    .paint .shadow { box-shadow: 4px 4px 4px black; }
+    .paint .border { border: 4px solid blue; }
+    .paint .outline { outline: 4px solid purple; }
+    .paint .inline { background: green; border: 2px solid blue; outline: 2px solid purple; }
+</style>
+<div class="row paint">
+    <div class="box background"></div><div class="box gradient"></div>
+    <div class="box shadow"></div><div class="box border"></div>
+    <div class="box outline"></div><div><span class="inline">inline</span></div>
+</div>
+<div class="row">
+    <div class="box background"></div><div class="box gradient"></div>
+    <div class="box shadow"></div><div class="box border"></div>
+    <div class="box outline"></div><div><span class="inline">inline</span></div>
+</div>

--- a/Tests/LibWeb/Ref/input/empty-paint-phases-invalidation.html
+++ b/Tests/LibWeb/Ref/input/empty-paint-phases-invalidation.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/empty-paint-phases-invalidation-ref.html">
+<style>
+    body { margin: 24px; }
+    .row { display: flex; gap: 24px; margin-bottom: 40px; }
+    .box { width: 80px; height: 60px; box-sizing: border-box; border-radius: 8px; }
+    .paint .background { background: green; }
+    .paint .gradient { background: linear-gradient(green, blue); }
+    .paint .shadow { box-shadow: 4px 4px 4px black; }
+    .paint .border { border: 4px solid blue; }
+    .paint .outline { outline: 4px solid purple; }
+    .paint .inline { background: green; border: 2px solid blue; outline: 2px solid purple; }
+</style>
+<div id="initially-empty" class="row">
+    <div class="box background"></div><div class="box gradient"></div>
+    <div class="box shadow"></div><div class="box border"></div>
+    <div class="box outline"></div><div><span class="inline">inline</span></div>
+</div>
+<div id="initially-painted" class="row paint">
+    <div class="box background"></div><div class="box gradient"></div>
+    <div class="box shadow"></div><div class="box border"></div>
+    <div class="box outline"></div><div><span class="inline">inline</span></div>
+</div>
+<script>
+    (async () => {
+        const nextFrame = () => new Promise(resolve => requestAnimationFrame(resolve));
+        // Let each state populate the paint caches before changing phase eligibility.
+        for (let i = 0; i < 3; ++i) {
+            await nextFrame();
+            await nextFrame();
+            document.getElementById("initially-empty").classList.toggle("paint");
+            document.getElementById("initially-painted").classList.toggle("paint");
+        }
+        await nextFrame();
+        await nextFrame();
+        document.documentElement.classList.remove("reftest-wait");
+    })();
+</script>


### PR DESCRIPTION
Display list recording computed geometry and maintained command captures for phases that could not draw anything. Memoize a paint phase mask for each paintable during recording and use it to bypass those captures after recording hit-test and scrolling metadata. Keep SVG dependency tracking, root and animated backgrounds, and image-map focus outlines eligible for their existing painting paths.

Avoid resolving background, shadow, and outline geometry when those decorations are absent. Add a reference test that repeatedly toggles block and inline decorations after their paint caches have been populated.

On a saved YouTube page, full Rust recording time drops from 20.15 ms to 17.43 ms, with identical display-list output and screenshots. Command capture attempts fall from 99,323 to 21,012.