### PR TITLE
Share retained inline output between layout and painting

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1991,7 +1991,7 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, Layout
 
     set_needs_accumulated_visual_contexts_update(true);
 
-    // Selection state lives on committed fragments, which the commit has rebuilt.
+    // A tree update can replace layout nodes referenced by selection state.
     if (auto range = get_selection()->range())
         paint_state().recompute_selection_states(*this, *range);
 

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -210,7 +210,7 @@ pub(crate) struct BlockFormattingContext {
     fragments: Option<std::rc::Rc<fragment_tree::RunFragmentBuilder>>,
     should_collect_devtools_layout_data: bool,
     treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
-    previous_line_data: Option<std::rc::Rc<used_values::LineData>>,
+    previous_line_data: Option<std::rc::Rc<inline_content::InlineContent>>,
     is_line_clamp_container: bool,
     max_lines: Cell<Option<usize>>,
     line_clamp_line_count: Cell<usize>,
@@ -2930,7 +2930,7 @@ impl BlockFormattingContext {
         if facts.children_are_inline() {
             let node_used = self.used(node);
             let line_data = node_used.line_data_ref();
-            if let Some(last_line) = line_data.as_deref().and_then(|data| data.line_boxes.last()) {
+            if let Some(last_line) = line_data.as_deref().and_then(|data| data.last_line()) {
                 let mut block_size = last_line.physical_vertical_end();
                 if last_line.has_block_level_box {
                     let mut margin_state = self.margin_state.borrow_mut();
@@ -3054,8 +3054,8 @@ impl BlockFormattingContext {
         let facts = self.facts(node);
         if facts.children_are_inline() {
             if let Some(data) = self.used(node).line_data_ref() {
-                for line in &data.line_boxes {
-                    let mut inline_size_here = inline_formatting_context::line_physical_horizontal_extent(line);
+                for line in data.lines() {
+                    let mut inline_size_here = line.horizontal_extent;
                     let line_block_start = line.physical_vertical_end() - line.physical_vertical_extent();
                     let line_block_end = line.physical_vertical_end();
                     let mut extra_left = CssPixels::default();
@@ -3104,7 +3104,11 @@ impl BlockFormattingContext {
     pub(crate) fn automatic_content_inline_size(&self) -> CssPixels {
         if self.style(self.root).writing_mode() != writing_mode::HORIZONTAL_TB && self.line_clamp_reached() {
             let used = self.used(self.root);
-            if let Some(line) = used.line_data_ref().as_ref().and_then(|data| data.line_boxes.last()) {
+            if let Some(line) = used
+                .line_data_ref()
+                .as_ref()
+                .and_then(|data| data.building().line_boxes.last())
+            {
                 // https://drafts.csswg.org/css-overflow-4/#block-ellipsis
                 // The block overflow ellipsis is wrapped in an anonymous inline whose parent is the block
                 // container's root inline box. This inline is assigned line-height: 0.
@@ -3326,7 +3330,7 @@ pub(crate) fn automatic_block_size_for_bfc_root(
         // the top content edge and the bottom of the bottommost line box.
         let root_used = records.used_values(root);
         let line_data = root_used.line_data_ref();
-        if let Some(last_line) = line_data.as_ref().and_then(|data| data.line_boxes.last()) {
+        if let Some(last_line) = line_data.as_ref().and_then(|data| data.last_line()) {
             bottom = Some(last_line.physical_vertical_end());
             // A trailing interrupting block's bottom margin cannot collapse out of a BFC root,
             // so it contributes to the root's automatic block size. The line box bottom excludes it.

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -74,7 +74,7 @@ fn commit_subtree(
         }
 
         if !reuses_committed_subtree && let Some(line_data) = &fragment.line_data {
-            has_pending_inline_box_geometry = paintables.set_line_data(node, line_data, fragment.content_inline_size);
+            has_pending_inline_box_geometry = paintables.set_line_data(node, line_data);
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
@@ -214,17 +214,6 @@ pub(super) struct FcRunCacheEntry {
     key: FcRunCacheKey,
     validity: FcRunCacheValidity,
     pub(super) outputs: formatting_context::RunOutputs,
-    /// Keeps every font referenced by cached line data alive: glyph runs
-    /// borrow raw font pointers, and a paint-only style change can drop
-    /// the owning computed values without touching any layout epoch.
-    ///
-    /// Cached line data also holds raw text_utf16 pointers into arena text
-    /// slots, deliberately unretained: replay never re-runs line building,
-    /// commit emits offsets rather than the pointers, and every text change
-    /// bumps epochs before the next probe, so nothing on the replay path
-    /// dereferences them. Any future consumer of cached fragment text must
-    /// snapshot the text alongside the fonts first.
-    retained_fonts: Vec<libgfx_rust::font::RetainedFont>,
 }
 
 impl FcRunCacheEntry {
@@ -414,27 +403,6 @@ impl FcRunCacheArenaStore {
     }
 }
 
-fn collect_line_data_fonts(line_data: &used_values::LineData, fonts: &mut Vec<*const c_void>) {
-    for line in &line_data.line_boxes {
-        for fragment in &line.fragments {
-            if let Some(glyphs) = &fragment.glyphs
-                && !glyphs.font.is_null()
-            {
-                fonts.push(glyphs.font);
-            }
-        }
-    }
-}
-
-fn collect_fragment_tree_fonts(links: &[FragmentLink], fonts: &mut Vec<*const c_void>) {
-    for link in links {
-        if let Some(line_data) = &link.fragment.line_data {
-            collect_line_data_fonts(line_data, fonts);
-        }
-        collect_fragment_tree_fonts(&link.fragment.children, fonts);
-    }
-}
-
 fn run_root_validity(callbacks: &FfiLayoutFcCallbacks, box_: Node) -> FcRunCacheValidity {
     let data = NodeFacts::new(callbacks, box_).data();
     FcRunCacheValidity {
@@ -567,7 +535,7 @@ impl FcRunCacheAttempt {
         }
     }
 
-    pub(super) fn previous_line_data(&self) -> Option<std::rc::Rc<used_values::LineData>> {
+    pub(super) fn previous_line_data(&self) -> Option<std::rc::Rc<inline_content::InlineContent>> {
         let Self::Store {
             structurally_damaged_entry: Some(entry),
             ..
@@ -607,23 +575,10 @@ impl FcRunCacheAttempt {
             store.remove_entry(box_.slot_index());
             return;
         }
-        let mut fonts = Vec::new();
-        if let Some(line_data) = &outputs.root_outcome.line_data {
-            collect_line_data_fonts(line_data, &mut fonts);
-        }
-        collect_fragment_tree_fonts(&root.scoped_descendants, &mut fonts);
-        fonts.sort_unstable();
-        fonts.dedup();
         let entry = FcRunCacheEntry {
             key: *key,
             validity,
             outputs: outputs.clone(),
-            retained_fonts: fonts
-                .into_iter()
-                // SAFETY: every collected font pointer is live during the
-                // pass that produced the line data now being cached.
-                .map(|font| unsafe { libgfx_rust::font::RetainedFont::retain(font) })
-                .collect(),
         };
         if let Some(cached) = shadow_entry {
             verify_cached_entry_against_fresh_run(box_.slot_index(), &cached, &entry);
@@ -651,16 +606,9 @@ fn verify_cached_entry_against_fresh_run(root_slot: u32, cached: &FcRunCacheEntr
         cached.outputs.root_outcome.own_metrics_sealed == fresh.outputs.root_outcome.own_metrics_sealed,
         "run cache shadow: root seal state diverged for slot {root_slot}"
     );
-    let cached_fonts: Vec<_> = cached.retained_fonts.iter().map(|font| font.as_raw()).collect();
-    let fresh_fonts: Vec<_> = fresh.retained_fonts.iter().map(|font| font.as_raw()).collect();
     assert!(
-        cached_fonts == fresh_fonts,
-        "run cache shadow: referenced fonts diverged for slot {root_slot}"
-    );
-    assert_line_data_matches(
-        root_slot,
-        cached.outputs.root_outcome.line_data.as_deref(),
-        fresh.outputs.root_outcome.line_data.as_deref(),
+        cached.outputs.root_outcome.line_data == fresh.outputs.root_outcome.line_data,
+        "run cache shadow: root line data diverged for slot {root_slot}"
     );
     assert_rare_data_matches(
         root_slot,
@@ -706,21 +654,6 @@ macro_rules! shadow_comparable_rare_payloads {
             &$carrier.collapsed_table_borders,
         )
     };
-}
-
-fn line_data_matches(cached: Option<&used_values::LineData>, fresh: Option<&used_values::LineData>) -> bool {
-    cached == fresh
-}
-
-fn assert_line_data_matches(
-    root_slot: u32,
-    cached: Option<&used_values::LineData>,
-    fresh: Option<&used_values::LineData>,
-) {
-    assert!(
-        line_data_matches(cached, fresh),
-        "run cache shadow: root line data diverged for slot {root_slot}"
-    );
 }
 
 fn assert_rare_data_matches(
@@ -901,7 +834,7 @@ fn collect_diverged_fragment_fields(
     if shadow_comparable_rare_payloads!(cached) != shadow_comparable_rare_payloads!(fresh) {
         diverged.push("rare payloads");
     }
-    if !line_data_matches(cached.line_data.as_deref(), fresh.line_data.as_deref()) {
+    if cached.line_data != fresh.line_data {
         diverged.push("line_data");
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -432,7 +432,7 @@ fn resolve_containing_line_box_index(
     assert!(!containing_block.is_invalid());
     let containing_block_used = records.used_values(containing_block);
     let data = containing_block_used.line_data_ref()?;
-    let line = data.line_boxes.get(coordinate.line_box_index)?;
+    let line = data.building().line_boxes.get(coordinate.line_box_index)?;
     if let Some(fragment) = line.fragments.get(coordinate.fragment_index) {
         let (x, y) = fragment.offset();
         debug_assert_eq!(
@@ -643,56 +643,28 @@ pub(crate) fn derive_baselines(
     let facts = NodeFacts::new(callbacks, box_);
     let own_used = records.used_values(box_);
     let own_line_data = own_used.line_data_ref();
-    let line_count = own_line_data.as_ref().map_or(0, |data| data.line_boxes.len());
-    if line_count > 0 {
-        let baseline_for_line_box = |line_index: usize, baseline_set: BaselineSet| -> CssPixels {
-            let (has_block_level_box, block_start, baseline, fragment_count, fragment_node) = {
-                let line = &own_line_data.as_ref().unwrap().line_boxes[line_index];
-                (
-                    line.has_block_level_box,
-                    line.physical_vertical_end() - line.block_length,
-                    line.baseline,
-                    line.fragments.len(),
-                    line.fragments.first().map(|fragment| fragment.layout_node),
-                )
-            };
-            if !has_block_level_box {
-                return block_start + baseline;
+    let mut lines = own_line_data.iter().flat_map(|data| data.lines());
+    let first = lines
+        .find(|line| !line.is_empty)
+        .or_else(|| own_line_data.as_ref()?.lines().next());
+    if let Some(first) = first {
+        let last = lines.rfind(|line| !line.is_empty).unwrap_or(first);
+        let baseline_for_line_box = |line: inline_content::LineRecord, baseline_set: BaselineSet| -> CssPixels {
+            if !line.has_block_level_box {
+                return line.physical_vertical_end() - line.block_length + line.baseline;
             }
-
-            assert_eq!(fragment_count, 1);
-            let fragment_node = fragment_node.expect("block-level line must have one fragment");
+            assert_eq!(line.layout_fragment_count, 1);
+            let fragment_node = line
+                .first_fragment_node
+                .expect("block-level line must have one fragment");
             let block_child_state = records.used_values(fragment_node);
             let child_offset_from_margin_edge = block_child_state.content_offset.get().y
                 - block_child_state.margin_box_top(block_child_state.uses_collapsing_borders_model.get());
             child_offset_from_margin_edge + box_baseline(callbacks, fragment_node, &block_child_state, baseline_set)
         };
-
-        let mut first_line_index = 0;
-        while first_line_index < line_count {
-            let is_empty = own_line_data.as_ref().unwrap().line_boxes[first_line_index].is_empty();
-            if !is_empty {
-                break;
-            }
-            first_line_index += 1;
-        }
-        if first_line_index == line_count {
-            first_line_index = 0;
-        }
-        let first_baseline = baseline_for_line_box(first_line_index, BaselineSet::First);
-
-        let mut last_line_index = line_count - 1;
-        while last_line_index > 0 {
-            let is_empty = own_line_data.as_ref().unwrap().line_boxes[last_line_index].is_empty();
-            if !is_empty {
-                break;
-            }
-            last_line_index -= 1;
-        }
-        let last_baseline = baseline_for_line_box(last_line_index, BaselineSet::Last);
         return DerivedBaselines {
-            first: Some(first_baseline),
-            last: Some(last_baseline),
+            first: Some(baseline_for_line_box(first, BaselineSet::First)),
+            last: Some(baseline_for_line_box(last, BaselineSet::Last)),
         };
     }
 
@@ -793,7 +765,7 @@ pub(crate) struct ChildLayoutResult {
 pub(crate) struct RunRootOutcome {
     pub(super) cells: used_values::UsedValuesCellState,
     pub(super) own_metrics_sealed: bool,
-    pub(super) line_data: Option<std::rc::Rc<used_values::LineData>>,
+    pub(super) line_data: Option<std::rc::Rc<inline_content::InlineContent>>,
     pub(super) rare: Option<used_values::UsedValuesRareData>,
 }
 
@@ -801,7 +773,7 @@ impl RunRootOutcome {
     fn apply_to_record(self, record: &UsedValues) {
         self.cells.apply_to_record(record);
         if let Some(line_data) = self.line_data {
-            *record.line_data_cell().borrow_mut() = line_data;
+            *record.line_data_cell().borrow_mut() = used_values::LineDataState::Finished(line_data);
         }
         if let Some(rare) = self.rare {
             rare.install_present_payloads_into(record);
@@ -1087,7 +1059,7 @@ pub(crate) struct FormattingContextRun {
     pub(crate) should_collect_devtools_layout_data: bool,
     pub(crate) treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
     pub(crate) fragments: Option<std::rc::Rc<fragment_tree::RunFragmentBuilder>>,
-    pub(crate) previous_line_data: Option<std::rc::Rc<used_values::LineData>>,
+    pub(crate) previous_line_data: Option<std::rc::Rc<inline_content::InlineContent>>,
 }
 
 impl FormattingContextRun {
@@ -1105,7 +1077,7 @@ impl FormattingContextRun {
         let root_outcome = RunRootOutcome {
             cells: used_values::UsedValuesCellState::capture(&record),
             own_metrics_sealed: record.own_metrics_are_sealed(),
-            line_data: record.line_data.get().map(std::cell::RefCell::take),
+            line_data: record.finish_line_data(&self.callbacks),
             rare: record.rare_data.get().map(std::cell::RefCell::take),
         };
         RunOutputs {
@@ -1670,7 +1642,7 @@ fn execute_formatting_context_run(
     callbacks: FfiLayoutFcCallbacks,
     input: LayoutInput,
     parent_block: Option<&block_formatting_context::BlockFormattingContext>,
-    previous_line_data: Option<std::rc::Rc<used_values::LineData>>,
+    previous_line_data: Option<std::rc::Rc<inline_content::InlineContent>>,
     table_inline_layout: Option<table_formatting_context::TableInlineLayout>,
 ) -> RunOutputs {
     assert!(!box_.is_invalid());

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -25,7 +25,7 @@ pub(crate) struct Fragment {
     pub(crate) padding_bottom: CssPixels,
     pub(crate) uses_collapsing_borders_model: bool,
     pub(crate) collapsed_table_borders: Option<std::rc::Rc<table_formatting_context::OwnedCollapsedTableBorders>>,
-    pub(crate) line_data: Option<std::rc::Rc<used_values::LineData>>,
+    pub(crate) line_data: Option<std::rc::Rc<inline_content::InlineContent>>,
     pub(crate) grid_layout_data: Option<std::rc::Rc<grid_formatting_context::GridLayoutData>>,
     pub(crate) flex_layout_data: Option<std::rc::Rc<formatting_context::FlexLayoutData>>,
     pub(crate) used_grid_tracks: Option<std::rc::Rc<grid_formatting_context::OwnedUsedGridTracks>>,
@@ -245,7 +245,7 @@ fn snapshot_fragment(
     used: &UsedValues,
 ) -> std::rc::Rc<Fragment> {
     static NEXT_IDENTITY: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
-    let line_data = used.line_data.get().map(std::cell::RefCell::take);
+    let line_data = used.finish_line_data(callbacks);
     let rare_payloads = used.rare_data.get().map(|cell| {
         let mut rare = cell.borrow_mut();
         (

--- a/Libraries/LibWeb/Rust/src/layout/geometry.rs
+++ b/Libraries/LibWeb/Rust/src/layout/geometry.rs
@@ -22,9 +22,10 @@ pub(crate) fn to_logical<T>(writing_mode: u8, horizontal: T, vertical: T) -> (T,
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum AvailableSize {
     Definite(CssPixels),
+    #[default]
     Indefinite,
     MinContent,
     MaxContent,

--- a/Libraries/LibWeb/Rust/src/layout/inline_content.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_content.rs
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::CssPixels;
+use super::geometry::AvailableSize;
+use super::layout_node_arena::LayoutNodeArena;
+use super::node_data::NodeSlotId;
+use super::{formatting_context, inline_formatting_context, used_values};
+use std::rc::Rc;
+
+// Finalized inline output shared by committed fragments, formatting-context caches and painting.
+// Glyph buffers move here from the line builder and own their fonts. No borrowed text or mutable
+// line-building state escapes into a retained output.
+#[derive(Clone, Default, PartialEq)]
+pub struct InlineContent {
+    pub lines: Vec<LineRecord>,
+    pub fragments: Vec<FragmentRecord>,
+    pub inline_box_pieces: Vec<InlineBoxPieceRecord>,
+}
+
+impl PartialEq for GlyphRunRecord {
+    fn eq(&self, other: &Self) -> bool {
+        self.font.as_raw() == other.font.as_raw() && self.glyphs == other.glyphs
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct LineRecord {
+    pub rect: used_values::FfiCssPixelRect,
+    pub fragment_count: u32,
+    pub(crate) layout_fragment_count: usize,
+    pub(crate) first_fragment_node: Option<NodeSlotId>,
+    pub(crate) is_empty: bool,
+    pub(crate) horizontal_extent: CssPixels,
+    pub(crate) reusable_atomic_prefix: bool,
+    pub inline_length: CssPixels,
+    pub inline_length_before_block_ellipsis: Option<CssPixels>,
+    pub block_length: CssPixels,
+    pub block_start: CssPixels,
+    pub block_end: CssPixels,
+    pub baseline: CssPixels,
+    pub block_level_box_block_end_margin: CssPixels,
+    pub direction: u8,
+    pub writing_mode: u8,
+    pub original_available_inline_size: AvailableSize,
+    pub has_break: bool,
+    pub has_forced_break: bool,
+    pub has_block_level_box: bool,
+}
+
+impl LineRecord {
+    pub(crate) fn physical_horizontal_extent(&self) -> CssPixels {
+        super::geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).0
+    }
+
+    pub(crate) fn physical_vertical_extent(&self) -> CssPixels {
+        super::geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).1
+    }
+
+    pub(crate) fn physical_vertical_end(&self) -> CssPixels {
+        super::geometry::to_physical(self.writing_mode, self.inline_length, self.block_end).1
+    }
+}
+
+pub struct GlyphRunRecord {
+    pub glyphs: Vec<libgfx_rust::text_layout::DrawGlyph>,
+    pub font: libgfx_rust::font::RetainedFont,
+}
+
+impl GlyphRunRecord {
+    fn font_ref(&self) -> libgfx_rust::font::FontRef<'_> {
+        // SAFETY: The record's RetainedFont keeps the font live for the
+        // lifetime of the returned borrow.
+        unsafe { libgfx_rust::font::FontRef::from_raw(self.font.as_raw()) }
+    }
+
+    pub fn bounding_box(&self, scale: f32) -> [f32; 4] {
+        libgfx_rust::text_layout::glyph_run_bounding_box(self.font_ref(), &self.glyphs, scale)
+    }
+
+    pub fn glyph_intercepts(&self, scale: f32, y_top: f32, y_bottom: f32) -> Vec<f32> {
+        libgfx_rust::text_layout::glyph_run_glyph_intercepts(self.font_ref(), &self.glyphs, scale, y_top, y_bottom)
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct FragmentRecord {
+    pub layout_node: NodeSlotId,
+    pub style_source: NodeSlotId,
+    pub start: usize,
+    pub length_in_code_units: usize,
+    pub inline_offset: CssPixels,
+    pub block_offset: CssPixels,
+    pub relpos_delta: used_values::FfiCssPixelPoint,
+    pub inline_length: CssPixels,
+    pub block_length: CssPixels,
+    pub border_box_block_start: CssPixels,
+    pub baseline: CssPixels,
+    pub accumulated_vertical_shift: CssPixels,
+    pub direction: u8,
+    pub writing_mode: u8,
+    pub is_block_ellipsis: bool,
+    pub is_atomic_inline: bool,
+    pub white_space_collapse: u8,
+    pub(crate) content_baselines: Option<formatting_context::DerivedBaselines>,
+    pub line_index: u32,
+    pub dom_start_offset_in_node: usize,
+    pub dom_end_offset_in_node: usize,
+    pub dom_end_offset_with_trailing_whitespace: usize,
+    pub trailing_whitespace_length_in_code_units: usize,
+    pub glyph_run: Option<Rc<GlyphRunRecord>>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct InlineBoxPieceRecord {
+    pub node: NodeSlotId,
+    pub first_fragment_index: u32,
+    pub fragment_count: u32,
+    pub line_index: u32,
+    pub border_box_rect: used_values::FfiCssPixelRect,
+    pub relpos_delta: used_values::FfiCssPixelPoint,
+    pub baseline: CssPixels,
+    pub accumulated_vertical_shift: CssPixels,
+    pub present_edges: u8,
+    pub is_geometry_only_placeholder: bool,
+}
+
+impl InlineContent {
+    pub(crate) fn finish(data: used_values::LineData, arena: &LayoutNodeArena, content_inline_size: CssPixels) -> Self {
+        let mut lines = Vec::with_capacity(data.line_boxes.len());
+        let mut fragments = Vec::new();
+        for (line_index, line) in data.line_boxes.into_iter().enumerate() {
+            lines.push(LineRecord {
+                rect: inline_formatting_context::line_rect(&line, content_inline_size),
+                fragment_count: line.visible_fragments().count() as u32,
+                reusable_atomic_prefix: !line.fragments.is_empty()
+                    && !line.has_block_level_box
+                    && line.static_position_markers.is_empty()
+                    && line.inline_box_baselines.is_empty()
+                    && line
+                        .fragments
+                        .iter()
+                        .all(|fragment| fragment.is_atomic_inline && !fragment.is_fully_truncated),
+                ..line.retained_metrics()
+            });
+            for mut fragment in line.fragments {
+                if fragment.is_fully_truncated {
+                    continue;
+                }
+                fragment.record.glyph_run = fragment.glyphs.take().map(|glyph_data| {
+                    Rc::new(GlyphRunRecord {
+                        glyphs: glyph_data.glyphs,
+                        // SAFETY: The layout pass borrowed the font from a live cascade list; retaining
+                        // it here keeps it alive for as long as the fragment record.
+                        font: unsafe { libgfx_rust::font::RetainedFont::retain(glyph_data.font) },
+                    })
+                });
+                fragment.record.line_index = line_index as u32;
+                fragment
+                    .record
+                    .finish_text_offsets(arena, fragment.has_trailing_whitespace);
+                fragments.push(fragment.record);
+            }
+        }
+        let mut pieces = data.inline_box_pieces;
+        for piece in &mut pieces {
+            assert!((piece.first_fragment_index + piece.fragment_count) as usize <= fragments.len());
+            piece.border_box_rect.x += piece.relpos_delta.x;
+            piece.border_box_rect.y += piece.relpos_delta.y;
+            piece.baseline += piece.relpos_delta.y;
+            piece.relpos_delta = used_values::FfiCssPixelPoint::default();
+        }
+        Self {
+            lines,
+            fragments,
+            inline_box_pieces: pieces,
+        }
+    }
+}
+
+impl FragmentRecord {
+    fn finish_text_offsets(&mut self, arena: &LayoutNodeArena, has_trailing_whitespace: bool) {
+        let end = self.start + self.length_in_code_units;
+        self.trailing_whitespace_length_in_code_units = if has_trailing_whitespace {
+            arena.text_content(self.layout_node).map_or(0, |content| {
+                content
+                    .text
+                    .iter()
+                    .skip(end)
+                    .take_while(|&&unit| unit == u16::from(b' ') || unit == u16::from(b'\t'))
+                    .count()
+            })
+        } else {
+            0
+        };
+        let dom_offset =
+            |offset, boundary| arena.dom_offset_for_rendered_text_offset(self.layout_node, offset, boundary);
+        self.dom_start_offset_in_node = dom_offset(self.start, super::RenderedTextBoundary::Start);
+        self.dom_end_offset_in_node = if self.length_in_code_units == 0 {
+            self.dom_start_offset_in_node
+        } else {
+            dom_offset(end, super::RenderedTextBoundary::End)
+        };
+        self.dom_end_offset_with_trailing_whitespace = if self.trailing_whitespace_length_in_code_units == 0 {
+            self.dom_end_offset_in_node
+        } else {
+            dom_offset(
+                end + self.trailing_whitespace_length_in_code_units,
+                super::RenderedTextBoundary::End,
+            )
+        };
+    }
+
+    pub(crate) fn offset(&self) -> (CssPixels, CssPixels) {
+        super::geometry::to_physical(self.writing_mode, self.inline_offset, self.block_offset)
+    }
+
+    pub(crate) fn size(&self) -> (CssPixels, CssPixels) {
+        super::geometry::to_physical(self.writing_mode, self.inline_length, self.block_length)
+    }
+
+    pub(crate) fn physical_horizontal_extent(&self) -> CssPixels {
+        super::geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).0
+    }
+
+    pub(crate) fn physical_vertical_extent(&self) -> CssPixels {
+        super::geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).1
+    }
+}

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -36,7 +36,7 @@ fn truncate_line_at_glyph_boundary(
     let (mut start, mut end) = if keep_from_end {
         (
             glyphs.glyphs.partition_point(|glyph| {
-                fragment.inline_length - CssPixels::nearest_value_for_f32(glyph.x) > available
+                fragment.record.inline_length - CssPixels::nearest_value_for_f32(glyph.x) > available
             }),
             glyphs.glyphs.len(),
         )
@@ -362,27 +362,7 @@ pub(crate) const EDGE_RIGHT: u8 = 1 << 1;
 pub(crate) const EDGE_BOTTOM: u8 = 1 << 2;
 pub(crate) const EDGE_LEFT: u8 = 1 << 3;
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(crate) struct InlineCssPixelRect {
-    pub(crate) x: CssPixels,
-    pub(crate) y: CssPixels,
-    pub(crate) width: CssPixels,
-    pub(crate) height: CssPixels,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct InlineBoxPieceData {
-    pub(crate) node: Node,
-    pub(crate) first_fragment_index: u32,
-    pub(crate) fragment_count: u32,
-    pub(crate) line_index: u32,
-    pub(crate) border_box_rect: InlineCssPixelRect,
-    pub(crate) relpos_delta: FfiCssPixelPoint,
-    pub(crate) baseline: CssPixels,
-    pub(crate) accumulated_vertical_shift: CssPixels,
-    pub(crate) present_edges: u8,
-    pub(crate) is_geometry_only_placeholder: bool,
-}
+pub(crate) use inline_content::InlineBoxPieceRecord as InlineBoxPieceData;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct StagedPiece {
@@ -714,7 +694,7 @@ pub(crate) fn compute(
                             first_fragment_index: line.first_fragment_index.unwrap_or(0),
                             fragment_count: line.fragment_count,
                             line_index: line.line_index as u32,
-                            border_box_rect: InlineCssPixelRect {
+                            border_box_rect: FfiCssPixelRect {
                                 x: position.0,
                                 y: position.1,
                                 ..Default::default()
@@ -760,14 +740,14 @@ pub(crate) fn compute(
             let border_block_length = content_block_length + border_padding_block_low + border_padding_block_high;
             let (inline_box_baseline, inline_box_vertical_shift) = inline_box_anchor();
             let rect = if horizontal {
-                InlineCssPixelRect {
+                FfiCssPixelRect {
                     x: border_inline_start,
                     y: border_block_start,
                     width: border_inline_end - border_inline_start,
                     height: border_block_length,
                 }
             } else {
-                InlineCssPixelRect {
+                FfiCssPixelRect {
                     x: border_block_start,
                     y: border_inline_start,
                     width: border_block_length,
@@ -836,12 +816,12 @@ pub(crate) fn compute(
         context.used(node);
         let line_height = context.style(node).line_height();
         let placeholder_rect = if horizontal {
-            InlineCssPixelRect {
+            FfiCssPixelRect {
                 height: line_height,
                 ..Default::default()
             }
         } else {
-            InlineCssPixelRect {
+            FfiCssPixelRect {
                 width: line_height,
                 ..Default::default()
             }
@@ -1111,14 +1091,14 @@ impl<'context> InlineFormattingContext<'context> {
 
     pub(crate) fn line_data(&self) -> Ref<'_, used_values::LineData> {
         Ref::map(self.containing_used_values.line_data_cell().borrow(), |shared| {
-            &**shared
+            shared.building()
         })
     }
 
     pub(crate) fn line_data_mut(&self) -> RefMut<'_, used_values::LineData> {
         RefMut::map(
             self.containing_used_values.line_data_cell().borrow_mut(),
-            std::rc::Rc::make_mut,
+            used_values::LineDataState::building_mut,
         )
     }
 
@@ -1349,13 +1329,13 @@ impl<'context> InlineFormattingContext<'context> {
 
     fn reusable_atomic_line_prefix(
         &self,
-        previous: &used_values::LineData,
+        previous: &inline_content::InlineContent,
         iterator: &inline_level_iterator::InlineLevelIterator,
     ) -> (Vec<line_box::LineBoxData>, usize) {
         if self.containing_block != self.run.box_
             || !previous.inline_box_pieces.is_empty()
             || previous
-                .line_boxes
+                .lines
                 .iter()
                 .any(|line| line.writing_mode != writing_mode::HORIZONTAL_TB)
             || iterator
@@ -1369,14 +1349,22 @@ impl<'context> InlineFormattingContext<'context> {
         let mut item_index = 0usize;
         let mut reused_lines = Vec::new();
         let mut item_count_before_last_line = 0usize;
-        for line in &previous.line_boxes {
-            if line.fragments.is_empty()
-                || line.has_block_level_box
-                || !line.static_position_markers.is_empty()
-                || !line.inline_box_baselines.is_empty()
-            {
+        let mut fragment_start = 0;
+        for retained_line in &previous.lines {
+            if !retained_line.reusable_atomic_prefix {
                 break;
             }
+            let fragment_end = fragment_start + retained_line.fragment_count as usize;
+            let line = line_box::LineBoxData {
+                record: *retained_line,
+                fragments: previous.fragments[fragment_start..fragment_end]
+                    .iter()
+                    .map(|fragment| line_box_fragment::LineBoxFragmentData::with_record(fragment.clone(), None))
+                    .collect(),
+                static_position_markers: Vec::new(),
+                inline_box_baselines: Vec::new(),
+            };
+            fragment_start = fragment_end;
             let line_item_start = item_index;
             let mut running_inline_length = CssPixels::default();
             let mut matched = true;
@@ -1412,12 +1400,12 @@ impl<'context> InlineFormattingContext<'context> {
                 break;
             }
             item_count_before_last_line = line_item_start;
-            reused_lines.push(line.clone());
+            reused_lines.push(line);
         }
 
         // Additional content can fit on the old final line, so that line is
         // damaged even when every old fragment before the insertion matches.
-        if item_index < iterator.items().len() && reused_lines.len() == previous.line_boxes.len() {
+        if item_index < iterator.items().len() && reused_lines.len() == previous.lines.len() {
             reused_lines.pop();
             item_index = item_count_before_last_line;
         }
@@ -1914,7 +1902,7 @@ impl<'context> InlineFormattingContext<'context> {
             if lines.iter().any(|line| line.has_block_level_box) {
                 lines
                     .last()
-                    .map_or(CssPixels::default(), line_box::LineBoxData::physical_vertical_end)
+                    .map_or(CssPixels::default(), |line| line.physical_vertical_end())
             } else {
                 lines
                     .iter()

--- a/Libraries/LibWeb/Rust/src/layout/line_box.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_box.rs
@@ -39,24 +39,25 @@ pub(crate) struct InlineBoxBaseline {
     pub(crate) accumulated_vertical_shift: CssPixels,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub(crate) struct LineBoxData {
     pub(crate) fragments: Vec<line_box_fragment::LineBoxFragmentData>,
     pub(crate) static_position_markers: Vec<StaticPositionMarker>,
     pub(crate) inline_box_baselines: Vec<InlineBoxBaseline>,
-    pub(crate) inline_length: CssPixels,
-    pub(crate) inline_length_before_block_ellipsis: Option<CssPixels>,
-    pub(crate) block_length: CssPixels,
-    pub(crate) block_start: CssPixels,
-    pub(crate) block_end: CssPixels,
-    pub(crate) baseline: CssPixels,
-    pub(crate) block_level_box_block_end_margin: CssPixels,
-    pub(crate) direction: u8,
-    pub(crate) writing_mode: u8,
-    pub(crate) original_available_inline_size: AvailableSize,
-    pub(crate) has_break: bool,
-    pub(crate) has_forced_break: bool,
-    pub(crate) has_block_level_box: bool,
+    pub(crate) record: inline_content::LineRecord,
+}
+
+impl std::ops::Deref for LineBoxData {
+    type Target = inline_content::LineRecord;
+    fn deref(&self) -> &Self::Target {
+        &self.record
+    }
+}
+
+impl std::ops::DerefMut for LineBoxData {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.record
+    }
 }
 
 impl LineBoxData {
@@ -65,32 +66,23 @@ impl LineBoxData {
             fragments: Vec::new(),
             static_position_markers: Vec::new(),
             inline_box_baselines: Vec::new(),
-            inline_length: CssPixels::default(),
-            inline_length_before_block_ellipsis: None,
-            block_length: CssPixels::default(),
-            block_start: CssPixels::default(),
-            block_end: CssPixels::default(),
-            baseline: CssPixels::default(),
-            block_level_box_block_end_margin: CssPixels::default(),
-            direction,
-            writing_mode,
-            original_available_inline_size: AvailableSize::Indefinite,
-            has_break: false,
-            has_forced_break: false,
-            has_block_level_box: false,
+            record: inline_content::LineRecord {
+                direction,
+                writing_mode,
+                is_empty: true,
+                ..Default::default()
+            },
         }
     }
 
-    pub(crate) fn physical_horizontal_extent(&self) -> CssPixels {
-        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).0
-    }
-
-    pub(crate) fn physical_vertical_extent(&self) -> CssPixels {
-        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).1
-    }
-
-    pub(crate) fn physical_vertical_end(&self) -> CssPixels {
-        geometry::to_physical(self.writing_mode, self.inline_length, self.block_end).1
+    pub(crate) fn retained_metrics(&self) -> inline_content::LineRecord {
+        inline_content::LineRecord {
+            layout_fragment_count: self.fragments.len(),
+            first_fragment_node: self.fragments.first().map(|fragment| fragment.layout_node),
+            is_empty: self.is_empty(),
+            horizontal_extent: inline_formatting_context::line_physical_horizontal_extent(self),
+            ..self.record
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -135,7 +127,7 @@ impl LineBoxData {
                 last.trailing_whitespace = trailing_whitespace;
             }
         } else {
-            let inline_offset = leading_margin + leading_size + self.inline_length;
+            let inline_offset = leading_margin + leading_size + self.record.inline_length;
             let mut fragment = line_box_fragment::LineBoxFragmentData::new(
                 layout_node,
                 start,
@@ -153,7 +145,7 @@ impl LineBoxData {
             fragment.trailing_whitespace = trailing_whitespace;
             self.fragments.push(fragment);
         }
-        self.inline_length += inline_advance(
+        self.record.inline_length += inline_advance(
             leading_margin,
             leading_size,
             content_inline_size,
@@ -168,7 +160,7 @@ impl LineBoxData {
     pub(crate) fn add_static_position_marker(&mut self, box_: Node, preceded_by_inline_box_start_edges: bool) {
         self.static_position_markers.push(StaticPositionMarker {
             box_,
-            inline_offset: self.inline_length,
+            inline_offset: self.record.inline_length,
             block_offset: CssPixels::default(),
             writing_mode: self.writing_mode,
             preceded_by_in_flow_content: !self.fragments.is_empty() || preceded_by_inline_box_start_edges,
@@ -201,8 +193,8 @@ impl LineBoxData {
 
     pub(crate) fn clamp_static_position_markers_to_inline_length(&mut self) {
         for marker in &mut self.static_position_markers {
-            if marker.inline_offset > self.inline_length {
-                marker.inline_offset = self.inline_length;
+            if marker.inline_offset > self.record.inline_length {
+                marker.inline_offset = self.record.inline_length;
             }
         }
     }
@@ -231,7 +223,7 @@ impl LineBoxData {
             whitespace_inline_size += fragment.inline_length;
             trailing_whitespace_inline_size += fragment.inline_length;
             if should_remove {
-                self.inline_length -= fragment.inline_length;
+                self.record.inline_length -= fragment.inline_length;
                 self.fragments.remove(fragment_index);
                 self.clamp_static_position_markers_to_inline_length();
             }
@@ -254,7 +246,7 @@ impl LineBoxData {
             fragment.length_in_code_units -= fragment_trailing_whitespace.length_in_code_units;
             fragment.inline_length -= fragment_trailing_whitespace.inline_size;
             fragment.trailing_whitespace = line_box_fragment::TrailingWhitespace::default();
-            self.inline_length -= fragment_trailing_whitespace.inline_size;
+            self.record.inline_length -= fragment_trailing_whitespace.inline_size;
             self.clamp_static_position_markers_to_inline_length();
         }
 
@@ -282,7 +274,7 @@ impl LineBoxData {
             if whitespace.length_in_code_units == 0 {
                 break;
             }
-            self.inline_length -= whitespace.inline_size;
+            self.record.inline_length -= whitespace.inline_size;
             if whitespace.length_in_code_units == fragment.length_in_code_units {
                 self.fragments.pop();
                 continue;

--- a/Libraries/LibWeb/Rust/src/layout/line_box_fragment.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_box_fragment.rs
@@ -33,36 +33,19 @@ pub(crate) struct TrailingWhitespace {
     pub(crate) inline_size: CssPixels,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub(crate) struct LineBoxFragmentData {
-    pub(crate) layout_node: Node,
-    pub(crate) style_source: Node,
-    pub(crate) start: usize,
-    pub(crate) length_in_code_units: usize,
-    pub(crate) inline_offset: CssPixels,
-    pub(crate) block_offset: CssPixels,
-    pub(crate) relpos_delta: FfiCssPixelPoint,
-    pub(crate) inline_length: CssPixels,
-    pub(crate) block_length: CssPixels,
-    pub(crate) border_box_block_start: CssPixels,
-    pub(crate) baseline: CssPixels,
-    pub(crate) accumulated_vertical_shift: CssPixels,
-    pub(crate) direction: u8,
-    pub(crate) writing_mode: u8,
+    pub(crate) record: inline_content::FragmentRecord,
     pub(crate) glyphs: Option<GlyphData>,
     pub(crate) insert_position: f32,
     pub(crate) current_insert_direction: u8,
     pub(crate) has_trailing_whitespace: bool,
     pub(crate) has_text_overflow_ellipsis: bool,
     pub(crate) has_soft_wrap_opportunity_after: bool,
-    pub(crate) is_block_ellipsis: bool,
     pub(crate) is_fully_truncated: bool,
-    pub(crate) is_atomic_inline: bool,
-    pub(crate) white_space_collapse: u8,
     pub(crate) trailing_whitespace: TrailingWhitespace,
     pub(crate) text_utf16: *const u16,
     pub(crate) text_length_in_code_units: usize,
-    pub(crate) content_baselines: Option<DerivedBaselines>,
 }
 
 #[derive(Clone, Copy)]
@@ -72,6 +55,19 @@ pub(crate) struct FragmentBuildFacts {
     pub(crate) white_space_collapse: u8,
     pub(crate) text_utf16: *const u16,
     pub(crate) text_length_in_code_units: usize,
+}
+
+impl std::ops::Deref for LineBoxFragmentData {
+    type Target = inline_content::FragmentRecord;
+    fn deref(&self) -> &Self::Target {
+        &self.record
+    }
+}
+
+impl std::ops::DerefMut for LineBoxFragmentData {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.record
+    }
 }
 
 impl LineBoxFragmentData {
@@ -90,7 +86,7 @@ impl LineBoxFragmentData {
         glyphs: Option<GlyphData>,
         facts: FragmentBuildFacts,
     ) -> Self {
-        let mut fragment = Self {
+        let record = inline_content::FragmentRecord {
             layout_node,
             style_source: facts.style_source,
             start,
@@ -105,20 +101,36 @@ impl LineBoxFragmentData {
             accumulated_vertical_shift: CssPixels::default(),
             direction,
             writing_mode,
+            is_block_ellipsis: false,
+            is_atomic_inline: facts.is_atomic_inline,
+            white_space_collapse: facts.white_space_collapse,
+            content_baselines: None,
+            line_index: 0,
+            dom_start_offset_in_node: 0,
+            dom_end_offset_in_node: 0,
+            dom_end_offset_with_trailing_whitespace: 0,
+            trailing_whitespace_length_in_code_units: 0,
+            glyph_run: None,
+        };
+        let mut fragment = Self::with_record(record, glyphs);
+        fragment.text_utf16 = facts.text_utf16;
+        fragment.text_length_in_code_units = facts.text_length_in_code_units;
+        fragment
+    }
+
+    pub(crate) fn with_record(record: inline_content::FragmentRecord, glyphs: Option<GlyphData>) -> Self {
+        let mut fragment = Self {
+            record,
             glyphs,
             insert_position: 0.0,
             current_insert_direction: direction::LTR,
             has_trailing_whitespace: false,
             has_text_overflow_ellipsis: false,
             has_soft_wrap_opportunity_after: false,
-            is_block_ellipsis: false,
             is_fully_truncated: false,
-            is_atomic_inline: facts.is_atomic_inline,
-            white_space_collapse: facts.white_space_collapse,
             trailing_whitespace: TrailingWhitespace::default(),
-            text_utf16: facts.text_utf16,
-            text_length_in_code_units: facts.text_length_in_code_units,
-            content_baselines: None,
+            text_utf16: std::ptr::null(),
+            text_length_in_code_units: 0,
         };
         if let Some(glyphs) = &fragment.glyphs {
             fragment.current_insert_direction = fragment.resolve_glyph_run_direction(glyphs.text_type);
@@ -127,22 +139,6 @@ impl LineBoxFragmentData {
             }
         }
         fragment
-    }
-
-    pub(crate) fn offset(&self) -> (CssPixels, CssPixels) {
-        geometry::to_physical(self.writing_mode, self.inline_offset, self.block_offset)
-    }
-
-    pub(crate) fn size(&self) -> (CssPixels, CssPixels) {
-        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length)
-    }
-
-    pub(crate) fn physical_horizontal_extent(&self) -> CssPixels {
-        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).0
-    }
-
-    pub(crate) fn physical_vertical_extent(&self) -> CssPixels {
-        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).1
     }
 
     pub(crate) fn text(&self) -> &[u16] {

--- a/Libraries/LibWeb/Rust/src/layout/line_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_builder.rs
@@ -1060,7 +1060,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
                 let font_box_size = normal_line_height(style);
                 let font_baseline = Self::baseline_for_style(style, font_box_size);
                 let fragment_mut = &mut self.line_mut(line_index).fragments[fragment_index];
-                fragment_mut.block_offset += fragment_mut.baseline - font_baseline;
+                fragment_mut.record.block_offset += fragment_mut.baseline - font_baseline;
                 fragment_mut.baseline = font_baseline;
                 fragment_mut.block_length = font_box_size;
             }

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -21,6 +21,7 @@ pub mod formatting_context;
 pub(crate) mod fragment_tree;
 pub mod geometry;
 pub mod grid_formatting_context;
+pub mod inline_content;
 pub(crate) mod inline_formatting_context;
 pub mod inline_level_iterator;
 mod intrinsic_sizing;

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -293,6 +293,48 @@ pub(crate) struct LineData {
     pub(crate) inline_box_pieces: Vec<inline_formatting_context::InlineBoxPieceData>,
 }
 
+pub(crate) enum LineDataState {
+    Building(LineData),
+    Finished(std::rc::Rc<inline_content::InlineContent>),
+}
+
+impl Default for LineDataState {
+    fn default() -> Self {
+        Self::Building(LineData::default())
+    }
+}
+
+impl LineDataState {
+    pub(crate) fn building(&self) -> &LineData {
+        let Self::Building(data) = self else {
+            panic!("line building accessed finalized inline content")
+        };
+        data
+    }
+
+    pub(crate) fn building_mut(&mut self) -> &mut LineData {
+        let Self::Building(data) = self else {
+            panic!("line building mutated finalized inline content")
+        };
+        data
+    }
+
+    pub(crate) fn lines(&self) -> impl DoubleEndedIterator<Item = inline_content::LineRecord> + '_ {
+        let (building, finished) = match self {
+            Self::Building(data) => (data.line_boxes.as_slice(), &[][..]),
+            Self::Finished(data) => (&[][..], data.lines.as_slice()),
+        };
+        building
+            .iter()
+            .map(line_box::LineBoxData::retained_metrics)
+            .chain(finished.iter().copied())
+    }
+
+    pub(crate) fn last_line(&self) -> Option<inline_content::LineRecord> {
+        self.lines().next_back()
+    }
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct UsedValuesRareData {
     pub(crate) computed_svg_path: Option<std::rc::Rc<libgfx_rust::path::OwnedPath>>,
@@ -417,7 +459,7 @@ pub(crate) struct UsedValues {
     pub depends_on_percentage_block_size: Cell<bool>,
     pub has_descendant_that_depends_on_percentage_block_size: Cell<bool>,
 
-    pub(crate) line_data: LazyRefCell<std::rc::Rc<LineData>>,
+    pub(crate) line_data: LazyRefCell<LineDataState>,
     pub(crate) rare_data: LazyRefCell<UsedValuesRareData>,
 }
 
@@ -469,14 +511,29 @@ impl UsedValues {
         self.rare_data.get_or_init(UsedValuesRareData::default).borrow_mut()
     }
 
-    pub(crate) fn line_data_ref(&self) -> Option<Ref<'_, LineData>> {
-        self.line_data
-            .get()
-            .map(|cell| Ref::map(cell.borrow(), |shared| &**shared))
+    pub(crate) fn line_data_ref(&self) -> Option<Ref<'_, LineDataState>> {
+        self.line_data.get().map(RefCell::borrow)
     }
 
-    pub(crate) fn line_data_cell(&self) -> &RefCell<std::rc::Rc<LineData>> {
-        self.line_data.get_or_init(std::rc::Rc::default)
+    pub(crate) fn line_data_cell(&self) -> &RefCell<LineDataState> {
+        self.line_data.get_or_init(LineDataState::default)
+    }
+
+    pub(crate) fn finish_line_data(
+        &self,
+        callbacks: &FfiLayoutFcCallbacks,
+    ) -> Option<std::rc::Rc<inline_content::InlineContent>> {
+        let mut state = self.line_data.get()?.borrow_mut();
+        let content = match &mut *state {
+            LineDataState::Finished(content) => return Some(content.clone()),
+            LineDataState::Building(data) => std::rc::Rc::new(inline_content::InlineContent::finish(
+                std::mem::take(data),
+                callbacks.arena(),
+                self.content_inline_size.get(),
+            )),
+        };
+        *state = LineDataState::Finished(content.clone());
+        Some(content)
     }
 
     pub(crate) fn content_baselines_from_cells(&self) -> DerivedBaselines {

--- a/Libraries/LibWeb/Rust/src/painting/caret.rs
+++ b/Libraries/LibWeb/Rust/src/painting/caret.rs
@@ -55,7 +55,8 @@ pub(crate) fn caret_rect_for_position(
         }
     });
     let (block, index) = direct.or(fallback)?;
-    let fragment = &layout_arena.paintable_side_data(block).fragments[index as usize];
+    let side = layout_arena.paintable_side_data(block);
+    let fragment = &side.fragments()[index as usize];
     Some(caret_rect_in_fragment(layout_arena, block, fragment, offset))
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/dump.rs
@@ -116,7 +116,7 @@ fn dump_fragment(
     out.extend_from_slice(b" from ");
     push_class_name(out, kind);
     out.extend_from_slice(b" start: ");
-    push_usize(out, fragment.start_offset);
+    push_usize(out, fragment.start);
     out.extend_from_slice(b", length: ");
     push_usize(out, fragment.length_in_code_units);
     out.extend_from_slice(b", rect: ");
@@ -131,10 +131,10 @@ fn dump_fragment(
             && let Some(content) = layout_arena.text_content(fragment.layout_node)
         {
             let end = fragment
-                .start_offset
+                .start
                 .saturating_add(fragment.length_in_code_units)
                 .min(content.text.len());
-            let start = fragment.start_offset.min(end);
+            let start = fragment.start.min(end);
             push_text_wtf8(out, &content.text[start..end]);
         }
         out.extend_from_slice(b"\"\n");
@@ -149,7 +149,7 @@ pub(crate) fn dump_block_fragments(
     interactive: bool,
 ) {
     let mut fragment_index = 0usize;
-    for fragment in &layout_arena.paintable_side_data(block).fragments {
+    for fragment in layout_arena.paintable_side_data(block).fragments() {
         if layout_arena.node_kind_if_live(fragment.layout_node).is_some()
             && fragment_ownership::nearest_fragmented_inline_ancestor(layout_arena, fragment.layout_node).is_some()
         {
@@ -172,10 +172,10 @@ pub(crate) fn dump_inline_piece_fragments(
     };
     let root_side = layout_arena.paintable_side_data(root);
     for piece_index in &layout_arena.paintable_side_data(inline_paintable).piece_indices {
-        let piece = &root_side.inline_box_pieces[*piece_index as usize];
+        let piece = &root_side.inline_box_pieces()[*piece_index as usize];
         let mut fragment_index_within_piece = 0usize;
         for fragment_index in piece.first_fragment_index..piece.first_fragment_index + piece.fragment_count {
-            let fragment = &root_side.fragments[fragment_index as usize];
+            let fragment = &root_side.fragments()[fragment_index as usize];
             if layout_arena.node_kind_if_live(fragment.layout_node).is_some()
                 && fragment_ownership::nearest_fragmented_inline_ancestor(layout_arena, fragment.layout_node)
                     != Some(piece.node)

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -686,10 +686,11 @@ pub unsafe extern "C" fn layout_arena_selection_apply(
     }
     // SAFETY: The caller guarantees the entry span is valid for this synchronous call.
     let entries = unsafe { ffi_slice(entries, entry_count) };
-    crate::painting::selection::apply(&mut arena.paintable_rows_mut(), viewport, entries);
+    let text_states = crate::painting::selection::apply(&mut arena.paintable_rows_mut(), viewport, entries);
     arena.paint_state().borrow_mut().selection = Some(crate::painting::selection::SelectionRange {
         start_offset: range_start_offset,
         end_offset: range_end_offset,
+        text_states,
     });
 }
 
@@ -703,7 +704,6 @@ pub unsafe extern "C" fn layout_arena_selection_clear(arena: *mut c_void, viewpo
         return;
     }
     crate::painting::selection::clear(&mut arena.paintable_rows_mut(), viewport);
-    arena.paint_state().borrow_mut().selection = None;
 }
 
 /// # Safety
@@ -2297,7 +2297,7 @@ pub unsafe extern "C" fn layout_arena_paintable_empty_line_caret_rect(
     // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
     let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
     let side = arena.paintable_side_data(block);
-    let Some(first_fragment) = side.fragments.first() else {
+    let Some(first_fragment) = side.fragments().first() else {
         return result;
     };
     if !node_slots.contains(&first_fragment.layout_node) {
@@ -2789,7 +2789,7 @@ pub unsafe extern "C" fn layout_arena_paintable_first_fragment_rect_for_node(
     if !paintable_rows.paintable_row_is_populated(block) {
         return result;
     }
-    for fragment in &arena.paintable_side_data(block).fragments {
+    for fragment in arena.paintable_side_data(block).fragments() {
         if fragment.layout_node != node {
             continue;
         }
@@ -2816,7 +2816,7 @@ pub unsafe extern "C" fn layout_arena_for_each_subtree_fragment_rect(
         return;
     }
     crate::painting::paint_order::for_each_in_paint_subtree(&paintable_rows, root, |current| {
-        for fragment in &arena.paintable_side_data(current).fragments {
+        for fragment in arena.paintable_side_data(current).fragments() {
             let shell = arena.shell_if_live(fragment.layout_node);
             let rect = crate::painting::text_fragment::absolute_rect(&paintable_rows, fragment).into();
             // SAFETY: The consumer copies its plain-data arguments synchronously.

--- a/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
+++ b/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
@@ -109,7 +109,7 @@ pub(crate) fn assign_fragment_ownership(layout_arena: &impl PaintableRowsRead, v
             stack.push(first_child);
         }
         if node_painting::has_lines(layout_arena, current)
-            && !layout_arena.paintable_side_data(current).inline_box_pieces.is_empty()
+            && !layout_arena.paintable_side_data(current).inline_box_pieces().is_empty()
         {
             assign_for_block(layout_arena, current);
         }
@@ -124,7 +124,10 @@ pub(crate) fn assign_fragment_ownership_for_pending_line_roots(layout_arena: &La
     for line_root in line_roots {
         if paintable_rows.paintable_row_is_populated(line_root)
             && node_painting::has_lines(&paintable_rows, line_root)
-            && !layout_arena.paintable_side_data(line_root).inline_box_pieces.is_empty()
+            && !layout_arena
+                .paintable_side_data(line_root)
+                .inline_box_pieces()
+                .is_empty()
         {
             assign_for_block(&paintable_rows, line_root);
         }
@@ -142,7 +145,7 @@ pub(crate) fn compute_fragment_ownership_for_block(
     layout_arena: &impl PaintableRowsRead,
     block: NodeSlotId,
 ) -> Vec<(NodeSlotId, FragmentOwnershipFilter)> {
-    let pieces = layout_arena.paintable_side_data(block).inline_box_pieces.clone();
+    let pieces = layout_arena.paintable_side_data(block).inline_box_pieces().to_vec();
     let mut block_filter = FragmentOwnershipFilter::everything();
 
     let mut owners: Vec<NodeSlotId> = Vec::new();
@@ -195,7 +198,7 @@ pub(crate) fn compute_fragment_ownership_for_block(
 fn assign_for_block(layout_arena: &impl PaintableRowsRead, block: NodeSlotId) {
     let owners_with_filters = compute_fragment_ownership_for_block(layout_arena, block);
     // Start every piece's box from a clean slate.
-    let pieces = layout_arena.paintable_side_data(block).inline_box_pieces.clone();
+    let pieces = layout_arena.paintable_side_data(block).inline_box_pieces().to_vec();
     for piece in &pieces {
         if let Some(paintable) = piece_paintable_of(layout_arena, piece.node) {
             layout_arena.paintable_side_data_mut(paintable).fragment_ownership = None;

--- a/Libraries/LibWeb/Rust/src/painting/hit_test/resolve.rs
+++ b/Libraries/LibWeb/Rust/src/painting/hit_test/resolve.rs
@@ -149,7 +149,7 @@ pub(crate) fn with_item_fragment<R>(
     let fragment_index = item.text_fragment_index? as usize;
     arena
         .paintable_side_data(item.paintable)
-        .fragments
+        .fragments()
         .get(fragment_index)
         .map(f)
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -5,12 +5,10 @@
  */
 
 use crate::css::css_pixels::CssPixelRect;
-use crate::css::css_pixels::CssPixels;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeKind, NodeSlotId};
-use crate::layout::{formatting_context, fragment_tree, inline_formatting_context, node_facts, used_values};
+use crate::layout::{formatting_context, fragment_tree, node_facts, used_values};
 use crate::painting::node_painting;
-use crate::painting::paintable_data::*;
 use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
 
 #[derive(Clone, Copy, Debug)]
@@ -226,171 +224,19 @@ impl<'a> PaintableCommit<'a> {
     pub(crate) fn set_line_data(
         &self,
         slot: NodeSlotId,
-        line_data: &used_values::LineData,
-        content_inline_size: CssPixels,
+        line_data: &std::rc::Rc<crate::layout::inline_content::InlineContent>,
     ) -> bool {
         if !node_painting::has_lines(self.arena(), slot) {
             return false;
         }
-        let (lines, fragments, pieces) = self.build_line_records(line_data, content_inline_size);
-        let has_pieces = !pieces.is_empty();
+        let has_pieces = !line_data.inline_box_pieces.is_empty();
         let mut side = self.arena().paintable_side_data_mut(slot);
-        side.lines = lines;
-        side.fragments = fragments;
-        side.inline_box_pieces = pieces;
-        for piece in &side.inline_box_pieces {
-            assert!(
-                (piece.first_fragment_index + piece.fragment_count) as usize <= side.fragments.len(),
-                "inline box piece fragment range exceeds the committed fragments"
-            );
-        }
+        side.inline_content = Some(line_data.clone());
         drop(side);
         if has_pieces {
             self.arena().note_line_root_needs_fragment_ownership(slot);
         }
         has_pieces
-    }
-
-    fn build_line_records(
-        &self,
-        data: &used_values::LineData,
-        content_inline_size: CssPixels,
-    ) -> (Vec<LineRecord>, Vec<FragmentRecord>, Vec<InlineBoxPieceRecord>) {
-        let mut lines = Vec::with_capacity(data.line_boxes.len());
-        let mut fragments = Vec::new();
-        for line in &data.line_boxes {
-            let committed_fragment_count = line.visible_fragments().count() as u32;
-            lines.push(LineRecord {
-                rect: inline_formatting_context::line_rect(line, content_inline_size),
-                baseline: line.block_start + line.baseline,
-                fragment_count: committed_fragment_count,
-            });
-            let line_index = (lines.len() - 1) as u32;
-            for fragment in &line.fragments {
-                if fragment.is_fully_truncated {
-                    continue;
-                }
-                let (x, y) = fragment.offset();
-                let (x, y) = (x + fragment.relpos_delta.x, y + fragment.relpos_delta.y);
-                let (width, height) = fragment.size();
-                let glyph_run = fragment.glyphs.as_ref().map(|glyph_data| GlyphRunRecord {
-                    glyphs: glyph_data.glyphs.clone(),
-                    // SAFETY: The layout pass borrowed the font from a live cascade list; retaining
-                    // it here keeps it alive for as long as the fragment record.
-                    font: unsafe { libgfx_rust::font::RetainedFont::retain(glyph_data.font) },
-                });
-                let (
-                    dom_start_offset_in_node,
-                    dom_end_offset_in_node,
-                    dom_end_offset_with_trailing_whitespace,
-                    trailing_whitespace_length_in_code_units,
-                ) = self.fragment_dom_offsets(
-                    fragment.layout_node,
-                    fragment.start,
-                    fragment.length_in_code_units,
-                    fragment.has_trailing_whitespace,
-                );
-                fragments.push(FragmentRecord {
-                    layout_node: fragment.layout_node,
-                    style_source: fragment.style_source,
-                    offset: used_values::FfiCssPixelPoint { x, y },
-                    size: used_values::FfiCssPixelSize { width, height },
-                    line_index,
-                    start_offset: fragment.start,
-                    length_in_code_units: fragment.length_in_code_units,
-                    dom_start_offset_in_node,
-                    dom_end_offset_in_node,
-                    dom_end_offset_with_trailing_whitespace,
-                    trailing_whitespace_length_in_code_units,
-                    baseline: fragment.baseline,
-                    accumulated_vertical_shift: fragment.accumulated_vertical_shift,
-                    writing_mode: fragment.writing_mode,
-                    is_block_ellipsis: fragment.is_block_ellipsis,
-                    selection_state: 0,
-                    glyph_run,
-                });
-            }
-        }
-        let pieces = data
-            .inline_box_pieces
-            .iter()
-            .map(|piece| InlineBoxPieceRecord {
-                node: piece.node,
-                first_fragment_index: piece.first_fragment_index,
-                fragment_count: piece.fragment_count,
-                line_index: piece.line_index,
-                border_box_rect: used_values::FfiCssPixelRect {
-                    x: piece.border_box_rect.x + piece.relpos_delta.x,
-                    y: piece.border_box_rect.y + piece.relpos_delta.y,
-                    width: piece.border_box_rect.width,
-                    height: piece.border_box_rect.height,
-                },
-                baseline: piece.baseline + piece.relpos_delta.y,
-                accumulated_vertical_shift: piece.accumulated_vertical_shift,
-                present_edges: piece.present_edges,
-                is_geometry_only_placeholder: piece.is_geometry_only_placeholder,
-            })
-            .collect();
-        (lines, fragments, pieces)
-    }
-
-    fn fragment_dom_offsets(
-        &self,
-        layout_node: NodeSlotId,
-        start_offset: usize,
-        length_in_code_units: usize,
-        has_trailing_whitespace: bool,
-    ) -> (usize, usize, usize, usize) {
-        let data = self.callbacks.node_data(layout_node);
-        if !node_facts::kind_is_text(data.kind.get()) {
-            return (
-                start_offset,
-                start_offset + length_in_code_units,
-                start_offset + length_in_code_units,
-                0,
-            );
-        }
-        let content = self.callbacks.text_content(layout_node);
-        let mut trailing_whitespace_length = 0;
-        if has_trailing_whitespace {
-            let position = start_offset + length_in_code_units;
-            while let Some(code_unit) = content.text.get(position + trailing_whitespace_length) {
-                if *code_unit != u16::from(b' ') && *code_unit != u16::from(b'\t') {
-                    break;
-                }
-                trailing_whitespace_length += 1;
-            }
-        }
-        let arena = self.callbacks.arena();
-        let dom_start_offset_in_node = arena.dom_offset_for_rendered_text_offset(
-            layout_node,
-            start_offset,
-            crate::layout::RenderedTextBoundary::Start,
-        );
-        let dom_end_offset_in_node = if length_in_code_units == 0 {
-            dom_start_offset_in_node
-        } else {
-            arena.dom_offset_for_rendered_text_offset(
-                layout_node,
-                start_offset + length_in_code_units,
-                crate::layout::RenderedTextBoundary::End,
-            )
-        };
-        let dom_end_offset_with_trailing_whitespace = if trailing_whitespace_length == 0 {
-            dom_end_offset_in_node
-        } else {
-            arena.dom_offset_for_rendered_text_offset(
-                layout_node,
-                start_offset + length_in_code_units + trailing_whitespace_length,
-                crate::layout::RenderedTextBoundary::End,
-            )
-        };
-        (
-            dom_start_offset_in_node,
-            dom_end_offset_in_node,
-            dom_end_offset_with_trailing_whitespace,
-            trailing_whitespace_length,
-        )
     }
 
     pub(crate) fn stamp_containing_block(&mut self, node: formatting_context::Node) {
@@ -419,7 +265,7 @@ impl<'a> PaintableCommit<'a> {
         let mut piece_indices_by_node: Vec<(NodeSlotId, Vec<u32>)> = Vec::new();
         for (piece_index, piece) in paintable_rows
             .paintable_side_data(slot)
-            .inline_box_pieces
+            .inline_box_pieces()
             .iter()
             .enumerate()
         {
@@ -457,7 +303,7 @@ impl<'a> PaintableCommit<'a> {
                 }
             };
             for piece_index in &piece_indices {
-                let piece = paintable_rows.paintable_side_data(slot).inline_box_pieces[*piece_index as usize];
+                let piece = paintable_rows.paintable_side_data(slot).inline_box_pieces()[*piece_index as usize];
                 let border_rect = CssPixelRect::from(piece.border_box_rect);
                 if piece.is_geometry_only_placeholder {
                     let content_rect = border_rect;

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -126,66 +126,7 @@ pub enum PaintableRowResetKind {
     Freed = 2,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct LineRecord {
-    pub rect: used_values::FfiCssPixelRect,
-    pub baseline: CssPixels,
-    pub fragment_count: u32,
-}
-
-pub struct GlyphRunRecord {
-    pub glyphs: Vec<libgfx_rust::text_layout::DrawGlyph>,
-    pub font: libgfx_rust::font::RetainedFont,
-}
-
-impl GlyphRunRecord {
-    fn font_ref(&self) -> libgfx_rust::font::FontRef<'_> {
-        // SAFETY: The record's RetainedFont keeps the font live for the
-        // lifetime of the returned borrow.
-        unsafe { libgfx_rust::font::FontRef::from_raw(self.font.as_raw()) }
-    }
-
-    pub fn bounding_box(&self, scale: f32) -> [f32; 4] {
-        libgfx_rust::text_layout::glyph_run_bounding_box(self.font_ref(), &self.glyphs, scale)
-    }
-
-    pub fn glyph_intercepts(&self, scale: f32, y_top: f32, y_bottom: f32) -> Vec<f32> {
-        libgfx_rust::text_layout::glyph_run_glyph_intercepts(self.font_ref(), &self.glyphs, scale, y_top, y_bottom)
-    }
-}
-
-pub struct FragmentRecord {
-    pub layout_node: NodeSlotId,
-    pub style_source: NodeSlotId,
-    pub offset: used_values::FfiCssPixelPoint,
-    pub size: used_values::FfiCssPixelSize,
-    pub line_index: u32,
-    pub start_offset: usize,
-    pub length_in_code_units: usize,
-    pub dom_start_offset_in_node: usize,
-    pub dom_end_offset_in_node: usize,
-    pub dom_end_offset_with_trailing_whitespace: usize,
-    pub trailing_whitespace_length_in_code_units: usize,
-    pub baseline: CssPixels,
-    pub accumulated_vertical_shift: CssPixels,
-    pub writing_mode: u8,
-    pub is_block_ellipsis: bool,
-    pub selection_state: u8,
-    pub glyph_run: Option<GlyphRunRecord>,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct InlineBoxPieceRecord {
-    pub node: NodeSlotId,
-    pub first_fragment_index: u32,
-    pub fragment_count: u32,
-    pub line_index: u32,
-    pub border_box_rect: used_values::FfiCssPixelRect,
-    pub baseline: CssPixels,
-    pub accumulated_vertical_shift: CssPixels,
-    pub present_edges: u8,
-    pub is_geometry_only_placeholder: bool,
-}
+pub use crate::layout::inline_content::{FragmentRecord, GlyphRunRecord, InlineBoxPieceRecord};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum BorderEdge {
@@ -227,9 +168,7 @@ impl InlineBoxPieceRecord {
 
 #[derive(Default)]
 pub struct PaintableSideData {
-    pub(crate) lines: Vec<LineRecord>,
-    pub(crate) fragments: Vec<FragmentRecord>,
-    pub(crate) inline_box_pieces: Vec<InlineBoxPieceRecord>,
+    pub(crate) inline_content: Option<std::rc::Rc<crate::layout::inline_content::InlineContent>>,
     pub(crate) piece_indices: Vec<u32>,
     pub(crate) svg_filter_bounds: Cell<Option<used_values::FfiCssPixelRect>>,
     // Only meaningful while is_self_painting(); assigned by the containing block's
@@ -239,10 +178,20 @@ pub struct PaintableSideData {
 
 impl PaintableSideData {
     pub(crate) fn clear_committed_records(&mut self) {
-        self.lines.clear();
-        self.fragments.clear();
-        self.inline_box_pieces.clear();
+        self.inline_content = None;
         self.piece_indices.clear();
         self.fragment_ownership = None;
+    }
+
+    pub(crate) fn lines(&self) -> &[crate::layout::inline_content::LineRecord] {
+        self.inline_content.as_ref().map_or(&[], |content| &content.lines)
+    }
+    pub(crate) fn fragments(&self) -> &[FragmentRecord] {
+        self.inline_content.as_ref().map_or(&[], |content| &content.fragments)
+    }
+    pub(crate) fn inline_box_pieces(&self) -> &[InlineBoxPieceRecord] {
+        self.inline_content
+            .as_ref()
+            .map_or(&[], |content| &content.inline_box_pieces)
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -884,12 +884,18 @@ impl LayoutNodeArena {
             return;
         }
         let mut side = self.paintable_side_data_mut(containing_block);
-        for fragment in &mut side.fragments {
+        let Some(content) = side.inline_content.as_mut() else {
+            return;
+        };
+        // Replacement preserves current paint geometry until the next layout commit. Give that
+        // version new node identities without modifying retained run outputs or copying glyphs.
+        let content = std::rc::Rc::make_mut(content);
+        for fragment in &mut content.fragments {
             if fragment.layout_node == old_node {
                 fragment.layout_node = new_node;
             }
         }
-        for piece in &mut side.inline_box_pieces {
+        for piece in &mut content.inline_box_pieces {
             if piece.node == old_node {
                 piece.node = new_node;
             }
@@ -939,7 +945,7 @@ pub(crate) fn with_inline_pieces(
     let data = arena.paintable_data(inline_paintable);
     let root_side = arena.paintable_side_data(root);
     for piece_index in &arena.paintable_side_data(inline_paintable).piece_indices {
-        let piece = &root_side.inline_box_pieces[*piece_index as usize];
+        let piece = &root_side.inline_box_pieces()[*piece_index as usize];
         if !callback(piece, data) {
             return;
         }

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -170,7 +170,7 @@ impl<'a> PaintRecorder<'a> {
         if phase != PaintPhase::Foreground {
             return;
         }
-        let fragment_count = self.layout_arena.paintable_side_data(paintable).fragments.len();
+        let fragment_count = self.layout_arena.paintable_side_data(paintable).fragments().len();
         if fragment_count == 0
             && crate::painting::paint_order::first_paint_child(self.layout_arena, paintable).is_none()
         {
@@ -196,7 +196,7 @@ impl<'a> PaintRecorder<'a> {
         for target in targets {
             self.append_empty_line_for_fragment(paintable, 0, target.offset, target.line_index, target.rect, context);
         }
-        if !self.layout_arena.paintable_side_data(paintable).fragments.is_empty() {
+        if !self.layout_arena.paintable_side_data(paintable).fragments().is_empty() {
             for target in self.host.line_break_caret_targets(self.layout_node_shell(paintable)) {
                 let rect = CssPixelRect::from(target.rect);
                 let caret_node = paintable;
@@ -229,7 +229,7 @@ impl<'a> PaintRecorder<'a> {
                 return;
             };
             let context = self.data(paintable).accumulated_visual_context_for_descendants;
-            let fragment_count = self.layout_arena.paintable_side_data(root).fragments.len();
+            let fragment_count = self.layout_arena.paintable_side_data(root).fragments().len();
             let filter = fragment_ownership::effective_filter(self.layout_arena, paintable);
             // Hit-test precedence follows paint order: this box's own text loses to the box itself
             // (re-recorded so its z-order matches this box's paint order), while nested content
@@ -240,7 +240,7 @@ impl<'a> PaintRecorder<'a> {
                 if self.fragment_is_block_level_box(root, index) {
                     return;
                 }
-                let fragment_node = self.layout_arena.paintable_side_data(root).fragments[index].layout_node;
+                let fragment_node = self.layout_arena.paintable_side_data(root).fragments()[index].layout_node;
                 if fragment_ownership::nearest_fragmented_inline_ancestor(self.layout_arena, fragment_node)
                     == Some(own_layout_node)
                 {
@@ -273,7 +273,7 @@ impl<'a> PaintRecorder<'a> {
     }
 
     fn piece_of(&self, root: NodeSlotId, piece_index: u32) -> InlineBoxPieceRecord {
-        self.layout_arena.paintable_side_data(root).inline_box_pieces[piece_index as usize]
+        self.layout_arena.paintable_side_data(root).inline_box_pieces()[piece_index as usize]
     }
 
     fn inline_has_content(&self, paintable: NodeSlotId) -> bool {
@@ -295,7 +295,8 @@ impl<'a> PaintRecorder<'a> {
         let layout_arena = self.layout_arena;
         let context = self.data(paintable).accumulated_visual_context;
         for piece_index in &layout_arena.paintable_side_data(paintable).piece_indices {
-            let piece = &layout_arena.paintable_side_data(root).inline_box_pieces[*piece_index as usize];
+            let side = layout_arena.paintable_side_data(root);
+            let piece = &side.inline_box_pieces()[*piece_index as usize];
             if piece.is_geometry_only_placeholder {
                 continue;
             }
@@ -350,7 +351,7 @@ impl<'a> PaintRecorder<'a> {
 
     fn fragment(&self, owner: NodeSlotId, index: usize) -> std::cell::Ref<'a, FragmentRecord> {
         std::cell::Ref::map(self.layout_arena.paintable_side_data(owner), |side_data| {
-            &side_data.fragments[index]
+            &side_data.fragments()[index]
         })
     }
 
@@ -458,7 +459,7 @@ impl<'a> PaintRecorder<'a> {
             return None;
         }
         let side_data = self.layout_arena.paintable_side_data(block);
-        let line = side_data.lines.get(containing_line_box_index)?;
+        let line = side_data.lines().get(containing_line_box_index)?;
         Some(
             CssPixelRect::from(line.rect)
                 .translated_by(paintable_geometry::absolute_position(self.layout_arena, block)),

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
@@ -973,7 +973,8 @@ fn append_text_clip_paths(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotI
     let scale = recorder.inputs.device_pixels_per_css_pixel;
 
     let append_fragment = |recorder: &mut PaintRecorder<'_>, owner: NodeSlotId, fragment_index: usize| {
-        let fragment = &recorder.layout_arena.paintable_side_data(owner).fragments[fragment_index];
+        let side = recorder.layout_arena.paintable_side_data(owner);
+        let fragment = &side.fragments()[fragment_index];
         let is_text = recorder
             .layout_arena
             .node_kind_if_live(fragment.layout_node)
@@ -1016,7 +1017,8 @@ fn append_text_clip_paths(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotI
         {
             let layout_arena = recorder.layout_arena;
             for piece_index in &layout_arena.paintable_side_data(paintable).piece_indices {
-                let piece = &layout_arena.paintable_side_data(root).inline_box_pieces[*piece_index as usize];
+                let side = layout_arena.paintable_side_data(root);
+                let piece = &side.inline_box_pieces()[*piece_index as usize];
                 for fragment_index in piece.first_fragment_index..piece.first_fragment_index + piece.fragment_count {
                     append_fragment(recorder, root, fragment_index as usize);
                 }
@@ -1043,7 +1045,7 @@ fn append_text_clip_paths(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotI
             stack.push(first_child);
         }
         if node_painting::has_lines(recorder.layout_arena, current) {
-            let count = recorder.layout_arena.paintable_side_data(current).fragments.len();
+            let count = recorder.layout_arena.paintable_side_data(current).fragments().len();
             for fragment_index in 0..count {
                 append_fragment(recorder, current, fragment_index);
             }

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
@@ -28,7 +28,8 @@ pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, pha
     let root_position = paintable_geometry::absolute_position(recorder.layout_arena, root);
     let layout_arena = recorder.layout_arena;
     let piece_indices = &layout_arena.paintable_side_data(paintable).piece_indices;
-    let root_pieces = &layout_arena.paintable_side_data(root).inline_box_pieces;
+    let side = layout_arena.paintable_side_data(root);
+    let root_pieces = &side.inline_box_pieces();
     let facts = recorder.base_paint_facts(paintable);
     let self_painting_inline = crate::painting::fragment_ownership::is_self_painting_inline(layout_arena, paintable);
 

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
@@ -9,7 +9,7 @@ use crate::layout::node_data::{NodeFlag, NodeSlotId};
 use crate::painting::display_list::commands::{DisplayListGlyph, FontResourceId};
 use crate::painting::display_list::recorder::GlyphRunForRecording;
 use crate::painting::force_dark::ForceDarkRole;
-use crate::painting::paintable_data::{FragmentRecord, SELECTION_STATE_NONE, SELECTION_STATE_START_AND_END};
+use crate::painting::paintable_data::{FragmentRecord, SELECTION_STATE_START_AND_END};
 use crate::painting::record::PaintRecorder;
 use crate::painting::text_fragment::{self, SelectionOffsets};
 use libgfx_rust::{Color, FloatPoint, IntRect, Orientation};
@@ -60,14 +60,12 @@ fn selection_offsets_for_fragment(
             control.end,
         ));
     }
-    if fragment.selection_state == SELECTION_STATE_NONE {
-        return None;
-    }
-    let range = recorder.paint_state.selection?;
+    let range = recorder.paint_state.selection.as_ref()?;
+    let selection_state = *range.text_states.get(&fragment.layout_node)?;
     drop_degenerate(text_fragment::compute_selection_offsets(
         recorder.layout_arena,
         fragment,
-        fragment.selection_state,
+        selection_state,
         range.start_offset,
         range.end_offset,
     ))
@@ -82,7 +80,8 @@ fn compute_render_spans(
     let layout_arena = recorder.layout_arena;
     let mut spans: Vec<RenderSpan> = Vec::new();
     for &fragment_index in owned_fragment_indices {
-        let fragment = &layout_arena.paintable_side_data(block).fragments[fragment_index as usize];
+        let side = layout_arena.paintable_side_data(block);
+        let fragment = &side.fragments()[fragment_index as usize];
         if fragment.glyph_run.is_none() {
             continue;
         }
@@ -242,7 +241,7 @@ pub(crate) fn paint_fragments_foreground(
     owner: Option<NodeSlotId>,
 ) {
     let filter = crate::painting::fragment_ownership::effective_filter(recorder.layout_arena, owner.unwrap_or(block));
-    let fragment_count = recorder.layout_arena.paintable_side_data(block).fragments.len();
+    let fragment_count = recorder.layout_arena.paintable_side_data(block).fragments().len();
     let mut owned_fragment_indices = Vec::with_capacity(fragment_count);
     filter.for_each_owned_fragment_index(fragment_count, |index| owned_fragment_indices.push(index as u32));
     let spans = compute_render_spans(recorder, block, &owned_fragment_indices);
@@ -278,7 +277,8 @@ fn selection_rect(recorder: &PaintRecorder<'_>, block: NodeSlotId, span: &Render
     let Some(offsets) = span.selection_offsets else {
         return CssPixelRect::default();
     };
-    let fragment = &recorder.layout_arena.paintable_side_data(block).fragments[span.fragment_index as usize];
+    let side = recorder.layout_arena.paintable_side_data(block);
+    let fragment = &side.fragments()[span.fragment_index as usize];
     text_fragment::rect_for_selection_offsets(recorder.layout_arena, fragment, offsets, || {
         text_fragment::first_available_font(recorder.layout_arena, fragment)
     })
@@ -288,7 +288,8 @@ fn paint_text_shadow(recorder: &mut PaintRecorder<'_>, block: NodeSlotId, span: 
     if span.shadow_layers.is_empty() {
         return;
     }
-    let fragment = &recorder.layout_arena.paintable_side_data(block).fragments[span.fragment_index as usize];
+    let side = recorder.layout_arena.paintable_side_data(block);
+    let fragment = &side.fragments()[span.fragment_index as usize];
     let Some(run) = &fragment.glyph_run else {
         return;
     };
@@ -320,8 +321,8 @@ fn paint_text_shadow(recorder: &mut PaintRecorder<'_>, block: NodeSlotId, span: 
 
     let converter = recorder.converter;
     let scale = recorder.inputs.device_pixels_per_css_pixel;
-    let fragment_width = converter.enclosing_device_pixels(fragment.size.width);
-    let fragment_height = converter.enclosing_device_pixels(fragment.size.height);
+    let fragment_width = converter.enclosing_device_pixels(fragment.physical_horizontal_extent());
+    let fragment_height = converter.enclosing_device_pixels(fragment.physical_vertical_extent());
     let fragment_baseline = converter.rounded_device_pixels(fragment.baseline);
     let fragment_absolute_rect = text_fragment::absolute_rect(recorder.layout_arena, fragment);
     let font_id = recorder.register_font(run.font.as_raw());
@@ -375,7 +376,8 @@ fn paint_text_fragment(
     if span.start_code_unit == span.end_code_unit {
         return;
     }
-    let fragment = &recorder.layout_arena.paintable_side_data(block).fragments[span.fragment_index as usize];
+    let side = recorder.layout_arena.paintable_side_data(block);
+    let fragment = &side.fragments()[span.fragment_index as usize];
     if recorder.inputs.should_show_line_box_borders {
         let converter = recorder.converter;
         let fragment_absolute_rect = text_fragment::absolute_rect(recorder.layout_arena, fragment);

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text_decoration.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text_decoration.rs
@@ -101,17 +101,18 @@ fn anchor_for_decorating_box(
         return (fragment.baseline, true);
     }
     let side = recorder.layout_arena.paintable_side_data(block);
-    for piece in &side.inline_box_pieces {
+    for piece in side.inline_box_pieces() {
         if piece.node == decorating_node && piece.line_index == fragment.line_index {
             return (
-                piece.baseline - CssPixels::from_raw(fragment.offset.y.raw_value()),
+                piece.baseline - (fragment.offset().1 + fragment.relpos_delta.y),
                 fragment.accumulated_vertical_shift == piece.accumulated_vertical_shift,
             );
         }
     }
-    let line_baseline = side.lines[fragment.line_index as usize].baseline;
+    let line = &side.lines()[fragment.line_index as usize];
+    let line_baseline = line.block_start + line.baseline;
     (
-        line_baseline - CssPixels::from_raw(fragment.offset.y.raw_value()),
+        line_baseline - (fragment.offset().1 + fragment.relpos_delta.y),
         fragment.accumulated_vertical_shift == CssPixels::from_raw(0),
     )
 }
@@ -126,7 +127,8 @@ pub(crate) fn decoration_sets_for_span(
         return sets;
     }
     let arena = recorder.layout_arena;
-    let fragment = &recorder.layout_arena.paintable_side_data(block).fragments[span.fragment_index as usize];
+    let side = recorder.layout_arena.paintable_side_data(block);
+    let fragment = &side.fragments()[span.fragment_index as usize];
     let text_parent = fragment.style_source;
 
     let mut push_set = |decorating_node: crate::layout::node_data::NodeSlotId,
@@ -280,7 +282,8 @@ fn compute_skip_ink_segments(
     line_thickness: i32,
     font_size: f32,
 ) -> Vec<DecorationSegment> {
-    let fragment = &recorder.layout_arena.paintable_side_data(block).fragments[fragment_index as usize];
+    let side = recorder.layout_arena.paintable_side_data(block);
+    let fragment = &side.fragments()[fragment_index as usize];
     let Some(run) = &fragment.glyph_run else {
         return vec![DecorationSegment {
             start_x: span_start_x,

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -415,12 +415,12 @@ fn measure_scrollable_overflow_impl(
     if crate::painting::node_painting::has_lines(layout_arena, box_paintable) {
         let side_data = layout_arena.paintable_side_data(box_paintable);
         let absolute_position = paintable_geometry::absolute_position(layout_arena, box_paintable);
-        for line in &side_data.lines {
+        for line in side_data.lines() {
             let line_rect = CssPixelRect::from(line.rect).translated_by(absolute_position);
             scrollable_overflow_rect.unite(line_rect);
             in_flow_and_floated_content_bounds.unite(line_rect);
         }
-        for fragment in &side_data.fragments {
+        for fragment in side_data.fragments() {
             let mut fragment_rect = text_fragment::absolute_rect(layout_arena, fragment);
             if fragment_node_is_in_focused_text_control(layout_arena, overflow_callbacks, fragment.layout_node)
                 && let Some(style_source_style) =

--- a/Libraries/LibWeb/Rust/src/painting/selection.rs
+++ b/Libraries/LibWeb/Rust/src/painting/selection.rs
@@ -10,27 +10,31 @@ use crate::painting::paintable_data::{FfiSelectionEntry, SELECTION_STATE_NONE};
 use crate::painting::paintable_rows::PaintableRowsMut;
 use crate::painting::text_fragment;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub(crate) struct SelectionRange {
     pub start_offset: usize,
     pub end_offset: usize,
+    pub text_states: std::collections::HashMap<NodeSlotId, u8>,
 }
 
-fn invalidate_block_and_ancestors(layout_arena: &PaintableRowsMut<'_>, block: NodeSlotId) {
-    let mut current = Some(block);
+fn invalidate_text_node(layout_arena: &PaintableRowsMut<'_>, node: NodeSlotId) {
+    let mut current = text_fragment::containing_block_paintable_of_node(layout_arena, node);
     while let Some(slot) = current {
         layout_arena.invalidate_paint_cache(slot);
         current = crate::painting::paint_order::paint_parent(layout_arena, slot);
     }
-}
-
-fn invalidate_self_painting_inline_box(layout_arena: &PaintableRowsMut<'_>, node: NodeSlotId) {
     if let Some(inline_box) = fragment_ownership::nearest_self_painting_inline_box(layout_arena, node) {
         layout_arena.invalidate_paint_cache(inline_box);
     }
 }
 
-fn reset_states(layout_arena: &mut PaintableRowsMut<'_>, viewport: NodeSlotId) {
+pub(crate) fn clear(layout_arena: &mut PaintableRowsMut<'_>, viewport: NodeSlotId) {
+    let previous = layout_arena.paint_state().borrow_mut().selection.take();
+    if let Some(previous) = previous {
+        for node in previous.text_states.keys() {
+            invalidate_text_node(layout_arena, *node);
+        }
+    }
     let mut slots = Vec::new();
     crate::painting::paint_order::for_each_in_paint_subtree(layout_arena, viewport, |slot| {
         slots.push(slot);
@@ -40,40 +44,20 @@ fn reset_states(layout_arena: &mut PaintableRowsMut<'_>, viewport: NodeSlotId) {
             layout_arena.paintable_data_mut(current).selection_state = SELECTION_STATE_NONE;
             layout_arena.invalidate_paint_cache(current);
         }
-        let mut changed_fragment_nodes: Vec<NodeSlotId> = Vec::new();
-        for fragment in &mut layout_arena.paintable_side_data_mut(current).fragments {
-            if fragment.selection_state != SELECTION_STATE_NONE {
-                fragment.selection_state = SELECTION_STATE_NONE;
-                changed_fragment_nodes.push(fragment.layout_node);
-            }
-        }
-        if !changed_fragment_nodes.is_empty() {
-            invalidate_block_and_ancestors(layout_arena, current);
-            for node in changed_fragment_nodes {
-                invalidate_self_painting_inline_box(layout_arena, node);
-            }
-        }
     }
 }
 
-pub(crate) fn apply(layout_arena: &mut PaintableRowsMut<'_>, viewport: NodeSlotId, entries: &[FfiSelectionEntry]) {
-    reset_states(layout_arena, viewport);
+pub(crate) fn apply(
+    layout_arena: &mut PaintableRowsMut<'_>,
+    viewport: NodeSlotId,
+    entries: &[FfiSelectionEntry],
+) -> std::collections::HashMap<NodeSlotId, u8> {
+    clear(layout_arena, viewport);
+    let mut text_states = std::collections::HashMap::new();
     for entry in entries {
         if entry.is_text_node_entry {
-            let Some(block) = text_fragment::containing_block_paintable_of_node(layout_arena, entry.layout_node) else {
-                continue;
-            };
-            let mut changed = false;
-            for fragment in &mut layout_arena.paintable_side_data_mut(block).fragments {
-                if fragment.layout_node == entry.layout_node && fragment.selection_state != entry.state {
-                    fragment.selection_state = entry.state;
-                    changed = true;
-                }
-            }
-            if changed {
-                invalidate_block_and_ancestors(layout_arena, block);
-                invalidate_self_painting_inline_box(layout_arena, entry.layout_node);
-            }
+            text_states.insert(entry.layout_node, entry.state);
+            invalidate_text_node(layout_arena, entry.layout_node);
         } else {
             if !layout_arena.paintable_row_is_populated(entry.layout_node) {
                 continue;
@@ -84,8 +68,5 @@ pub(crate) fn apply(layout_arena: &mut PaintableRowsMut<'_>, viewport: NodeSlotI
             }
         }
     }
-}
-
-pub(crate) fn clear(layout_arena: &mut PaintableRowsMut<'_>, viewport: NodeSlotId) {
-    reset_states(layout_arena, viewport);
+    text_states
 }

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/verify.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/verify.rs
@@ -123,7 +123,7 @@ impl Verifier<'_> {
 
         let paintable_rows = self.arena.paintable_rows();
         if node_painting::has_lines(&paintable_rows, slot)
-            && !self.arena.paintable_side_data(slot).inline_box_pieces.is_empty()
+            && !self.arena.paintable_side_data(slot).inline_box_pieces().is_empty()
         {
             for (owner, recomputed_filter) in
                 crate::painting::fragment_ownership::compute_fragment_ownership_for_block(&paintable_rows, slot)

--- a/Libraries/LibWeb/Rust/src/painting/text_fragment.rs
+++ b/Libraries/LibWeb/Rust/src/painting/text_fragment.rs
@@ -32,7 +32,14 @@ pub(crate) fn containing_block_paintable(
 }
 
 pub(crate) fn absolute_rect(layout_arena: &impl PaintableRowsRead, fragment: &FragmentRecord) -> CssPixelRect {
-    let mut rect = CssPixelRect::from_location_and_size(fragment.offset.into(), fragment.size.into());
+    let (x, y) = fragment.offset();
+    let (width, height) = fragment.size();
+    let mut rect = CssPixelRect {
+        x: x + fragment.relpos_delta.x,
+        y: y + fragment.relpos_delta.y,
+        width,
+        height,
+    };
     if let Some(block) = containing_block_paintable(layout_arena, fragment) {
         rect = rect.translated_by(paintable_geometry::absolute_position(layout_arena, block));
     }
@@ -44,7 +51,8 @@ pub(crate) fn absolute_line_box_rect(
     owner: NodeSlotId,
     fragment: &FragmentRecord,
 ) -> CssPixelRect {
-    let lines = &layout_arena.paintable_side_data(owner).lines;
+    let side = layout_arena.paintable_side_data(owner);
+    let lines = &side.lines();
     let Some(line) = lines.get(fragment.line_index as usize) else {
         return CssPixelRect::default();
     };
@@ -112,10 +120,7 @@ pub(crate) fn compute_selection_offsets(
     let rendered_offset_for_dom_offset = |dom_offset, boundary| {
         let rendered_offset =
             layout_arena.rendered_text_offset_for_dom_offset(fragment.layout_node, dom_offset, boundary);
-        rendered_offset.clamp(
-            fragment.start_offset,
-            fragment.start_offset + length_with_trailing_whitespace,
-        ) - fragment.start_offset
+        rendered_offset.clamp(fragment.start, fragment.start + length_with_trailing_whitespace) - fragment.start
     };
     match selection_state {
         crate::painting::paintable_data::SELECTION_STATE_NONE => None,
@@ -163,7 +168,7 @@ pub(crate) fn for_each_fragment_of_nodes(
         let Some(block) = containing_block_paintable_of_node(layout_arena, node) else {
             continue;
         };
-        for (index, fragment) in layout_arena.paintable_side_data(block).fragments.iter().enumerate() {
+        for (index, fragment) in layout_arena.paintable_side_data(block).fragments().iter().enumerate() {
             if fragment.layout_node != node {
                 continue;
             }
@@ -217,14 +222,8 @@ pub(crate) fn selection_offsets_for_dom_range(
         crate::layout::RenderedTextBoundary::End,
     );
     Some(SelectionOffsets {
-        start: rendered_start.clamp(
-            fragment.start_offset,
-            fragment.start_offset + length_with_trailing_whitespace,
-        ) - fragment.start_offset,
-        end: rendered_end.clamp(
-            fragment.start_offset,
-            fragment.start_offset + length_with_trailing_whitespace,
-        ) - fragment.start_offset,
+        start: rendered_start.clamp(fragment.start, fragment.start + length_with_trailing_whitespace) - fragment.start,
+        end: rendered_end.clamp(fragment.start, fragment.start + length_with_trailing_whitespace) - fragment.start,
     })
 }
 
@@ -453,8 +452,8 @@ pub(crate) fn index_in_node_for_point(
             fragment.length_in_code_units,
             |cluster_start, cluster_end, cluster_width| {
                 let per_unit_advance = cluster_width / (cluster_end - cluster_start) as f32;
-                let mut grapheme_start = fragment.start_offset + cluster_start;
-                let cluster_absolute_end = fragment.start_offset + cluster_end;
+                let mut grapheme_start = fragment.start + cluster_start;
+                let cluster_absolute_end = fragment.start + cluster_end;
                 while grapheme_start < cluster_absolute_end {
                     let grapheme_end = segmenter
                         .next_boundary(grapheme_start, false)
@@ -494,7 +493,7 @@ pub(crate) fn index_in_node_for_point(
 
     layout_arena.dom_offset_for_rendered_text_offset(
         fragment.layout_node,
-        fragment.start_offset + tracker.resolve(),
+        fragment.start + tracker.resolve(),
         crate::layout::RenderedTextBoundary::End,
     )
 }

--- a/Libraries/LibWeb/Rust/src/painting/visual_lines.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_lines.rs
@@ -138,10 +138,10 @@ pub(crate) fn empty_line_caret_targets(
     block: NodeSlotId,
 ) -> Vec<EmptyLineCaretTarget> {
     let side = layout_arena.paintable_side_data(block);
-    if side.fragments.is_empty() || side.lines.is_empty() {
+    if side.fragments().is_empty() || side.lines().is_empty() {
         return Vec::new();
     }
-    let text_layout_node = side.fragments[0].layout_node;
+    let text_layout_node = side.fragments()[0].layout_node;
     if layout_arena.node_kind_if_live(text_layout_node) != Some(NodeKind::TextNode) {
         return Vec::new();
     }
@@ -160,7 +160,7 @@ pub(crate) fn empty_line_caret_targets(
         return Vec::new();
     }
     if side
-        .fragments
+        .fragments()
         .iter()
         .any(|fragment| fragment.layout_node != text_layout_node)
     {
@@ -169,17 +169,17 @@ pub(crate) fn empty_line_caret_targets(
 
     let lines = collect_visual_lines(layout_arena, &node_slots);
 
-    if lines.len() < side.lines.len() {
+    if lines.len() < side.lines().len() {
         return Vec::new();
     }
     for (i, line) in lines.iter().enumerate() {
-        if i >= side.lines.len() {
+        if i >= side.lines().len() {
             if line.has_fragments {
                 return Vec::new();
             }
             continue;
         }
-        if line.has_fragments != (side.lines[i].fragment_count != 0) {
+        if line.has_fragments != (side.lines()[i].fragment_count != 0) {
             return Vec::new();
         }
         if line.has_fragments && line.line_index as usize != i {
@@ -194,11 +194,11 @@ pub(crate) fn empty_line_caret_targets(
         if line.has_fragments {
             continue;
         }
-        let rect = if i < side.lines.len() {
-            CssPixelRect::from(side.lines[i].rect).translated_by(content_position)
+        let rect = if i < side.lines().len() {
+            CssPixelRect::from(side.lines()[i].rect).translated_by(content_position)
         } else {
-            let last = CssPixelRect::from(side.lines.last().unwrap().rect).translated_by(content_position);
-            let steps = (i - (side.lines.len() - 1)) as i32;
+            let last = CssPixelRect::from(side.lines().last().unwrap().rect).translated_by(content_position);
+            let steps = (i - (side.lines().len() - 1)) as i32;
             CssPixelRect {
                 x: content_position.x,
                 y: last.y + last.height + CssPixels::from_raw(last.height.raw_value() * (steps - 1)),
@@ -241,7 +241,8 @@ pub(crate) fn caret_inline_coordinate(
     let fragments = fragments_of_line(layout_arena, owner_paintable, line_index, node_slots);
     let mut chosen = *fragments.first()?;
     for &(block, index) in &fragments {
-        let fragment = &layout_arena.paintable_side_data(block).fragments[index as usize];
+        let side = layout_arena.paintable_side_data(block);
+        let fragment = &side.fragments()[index as usize];
         let dom_start = fragment.dom_start_offset_in_node;
         let dom_end_with_trailing_whitespace = fragment.dom_end_offset_with_trailing_whitespace;
         if offset >= dom_start && offset <= dom_end_with_trailing_whitespace {
@@ -253,7 +254,8 @@ pub(crate) fn caret_inline_coordinate(
         }
     }
     let (block, index) = chosen;
-    let fragment = &layout_arena.paintable_side_data(block).fragments[index as usize];
+    let side = layout_arena.paintable_side_data(block);
+    let fragment = &side.fragments()[index as usize];
     let dom_start = fragment.dom_start_offset_in_node;
     let dom_end_with_trailing_whitespace = fragment.dom_end_offset_with_trailing_whitespace;
     let clamped_offset = offset.clamp(dom_start, dom_end_with_trailing_whitespace);
@@ -281,7 +283,8 @@ pub(crate) fn offset_closest_to_inline_coordinate(
     let fragments = fragments_of_line(layout_arena, owner_paintable, line_index, node_slots);
     let mut chosen = *fragments.first()?;
     for &(block, index) in &fragments {
-        let fragment = &layout_arena.paintable_side_data(block).fragments[index as usize];
+        let side = layout_arena.paintable_side_data(block);
+        let fragment = &side.fragments()[index as usize];
         let rect = text_fragment::absolute_rect(layout_arena, fragment);
         let inline_start = if text_fragment::fragment_is_horizontal(fragment) {
             rect.x
@@ -293,7 +296,8 @@ pub(crate) fn offset_closest_to_inline_coordinate(
         }
     }
     let (block, index) = chosen;
-    let fragment = &layout_arena.paintable_side_data(block).fragments[index as usize];
+    let side = layout_arena.paintable_side_data(block);
+    let fragment = &side.fragments()[index as usize];
     let rect = text_fragment::absolute_rect(layout_arena, fragment);
     let mut point = crate::css::css_pixels::CssPixelPoint {
         x: rect.x + CssPixels::from_raw(rect.width.raw_value() / 2),

--- a/Tests/LibWeb/Text/expected/layout-run-cache-background-change-preserved.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-background-change-preserved.txt
@@ -1,1 +1,4 @@
 hit delta after paint-only change: 1
+clearing selection changes paint: true
+restoring selection restores paint: true
+cached selection matches fresh layout: true

--- a/Tests/LibWeb/Text/input/abspos-relayout-selection-preserved.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-selection-preserved.html
@@ -31,9 +31,9 @@
         window.getSelection().addRange(range);
         document.body.offsetHeight;
 
-        // Mutate a sibling inside the boundary to trigger a partial relayout. The
-        // partial commit rebuilds paintable fragments for the whole subtree, which
-        // resets fragment-level selection state.
+        // Mutate a sibling inside the boundary to trigger a partial relayout.
+        // Selection must survive the changed fragment output and any replaced
+        // layout nodes in that subtree.
         const partialBefore = internals.partialLayoutCount();
         document.getElementById("child").style.height = "40px";
         document.body.offsetHeight;

--- a/Tests/LibWeb/Text/input/layout-run-cache-background-change-preserved.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-background-change-preserved.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <script src="include.js"></script>
 <style>
     body { margin: 0; }
@@ -8,15 +9,20 @@
         overflow: hidden;
         background-color: yellow;
     }
-    #inner { width: 120px; height: 40px; }
+    #inner { width: 120px; height: 40px; position: relative; left: 3px; text-transform: uppercase; }
 </style>
 <div id="spacer"></div>
 <div id="cached">
-    <div id="inner"></div>
+    <div id="inner">straße אבג café words that wrap</div>
 </div>
 <script>
     asyncTest(async (done) => {
-        document.body.offsetHeight;
+        const range = document.createRange();
+        range.setStart(inner.firstChild, 1);
+        range.setEnd(inner.firstChild, inner.firstChild.length - 2);
+        const selection = window.getSelection();
+        selection.addRange(range);
+        internals.dumpDisplayList();
 
         // A paint-only background change must not invalidate the subtree's cached
         // run; the relayout forced by the growing sibling must replay it.
@@ -26,7 +32,21 @@
         document.body.offsetHeight;
 
         const hitDelta = internals.layoutRunCacheHitCount() - hitsBefore;
+        const selected = internals.dumpDisplayList();
+        selection.removeAllRanges();
+        const unselected = internals.dumpDisplayList();
+        selection.addRange(range);
+        const reselected = internals.dumpDisplayList();
+        // Rebuild the lines at a different width, then compare with the cached paint.
+        cached.style.width = "301px";
+        document.body.offsetHeight;
+        cached.style.width = "300px";
+        document.body.offsetHeight;
+        const fresh = internals.dumpDisplayList();
         println(`hit delta after paint-only change: ${hitDelta}`);
+        println(`clearing selection changes paint: ${unselected !== selected}`);
+        println(`restoring selection restores paint: ${reselected === selected}`);
+        println(`cached selection matches fresh layout: ${fresh === selected}`);
         done();
     });
 </script>


### PR DESCRIPTION
Layout retained line-building structures while painting kept a separate copy of their geometry and glyph buffers. Cached runs also walked the fragment tree to keep borrowed font pointers alive.

Share finalized inline content between committed fragments, run caches and painting. Line builders use the same geometry records and move glyph buffers into records that own their fonts, leaving borrowed text and builder worklists behind. Preserve atomic line-prefix reuse and store text selection once per layout node in the document paint state.

Extend the cache replay regression to cover selection in wrapped, transformed, bidirectional text. Check that clearing and restoring selection updates painting, and compare cached paint with fresh layout.