### PR TITLE
LibJS: Cache property reads whose name is only known at run time

### DIFF
--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/BinarySearch.h>
+#include <AK/HashFunctions.h>
 #include <AK/NeverDestroyed.h>
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtras.h>
@@ -643,6 +644,25 @@ void StaticPropertyLookupCache::sweep_all()
 {
     for (auto* cache : static_property_lookup_caches())
         cache->remove_dead_entries();
+}
+
+KeyedPropertyLookupCache::Entry& KeyedPropertyLookupCache::entry_for(Shape const& shape, Utf16FlyString const& property_name)
+{
+    auto hash = pair_int_hash(ptr_hash(&shape), property_name.hash());
+    return m_entries[hash & (number_of_entries - 1)];
+}
+
+void KeyedPropertyLookupCache::remove_dead_entries()
+{
+    for (auto& entry : m_entries) {
+        if (entry.type == PropertyLookupCache::Entry::Type::Empty)
+            continue;
+        if ((entry.shape && cell_is_dead(entry.shape.ptr()))
+            || (entry.prototype && cell_is_dead(entry.prototype.ptr()))
+            || (entry.prototype_chain_validity && cell_is_dead(entry.prototype_chain_validity.ptr()))) {
+            entry = {};
+        }
+    }
 }
 
 void Executable::remove_dead_cells(Badge<GC::Heap>)

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -233,6 +233,26 @@ struct StaticPropertyLookupCache : public PropertyLookupCache {
     static void sweep_all();
 };
 
+struct KeyedPropertyLookupCache {
+    static constexpr size_t number_of_entries = 2048;
+
+    struct Entry {
+        PropertyLookupCache::Entry::Type type { PropertyLookupCache::Entry::Type::Empty };
+        u32 property_offset { 0 };
+        u32 shape_dictionary_generation { 0 };
+        GC::RawPtr<Shape> shape;
+        GC::RawPtr<Object> prototype;
+        GC::RawPtr<PrototypeChainValidity> prototype_chain_validity;
+        Utf16FlyString property_name;
+    };
+
+    [[nodiscard]] Entry& entry_for(Shape const&, Utf16FlyString const& property_name);
+    void remove_dead_entries();
+
+private:
+    AK::Array<Entry, number_of_entries> m_entries;
+};
+
 struct GlobalVariableCache {
     PropertyLookupCache::Entry* first_entry()
     {

--- a/Libraries/LibJS/Bytecode/PropertyAccess.h
+++ b/Libraries/LibJS/Bytecode/PropertyAccess.h
@@ -215,14 +215,16 @@ ALWAYS_INLINE ThrowCompletionOr<Value> get_by_id(VM& vm, GetBaseIdentifier get_b
     if (shape.prototype())
         prototype_chain_validity = shape.prototype()->shape().prototype_chain_validity();
 
+    auto dictionary_generation = shape.dictionary_generation();
     CacheableGetPropertyMetadata cacheable_metadata;
     cacheable_metadata.property_absence_is_cacheable = base_obj->is_cacheable_for_property_absence();
     auto value = TRY(base_obj->internal_get(property_name, this_value, &cacheable_metadata));
 
     // If internal_get() caused object's shape change, we can no longer be sure
     // that collected metadata is valid, e.g. if getter in prototype chain added
-    // property with the same name into the object itself.
-    if (&shape == &base_obj->shape()) {
+    // property with the same name into the object itself. The same applies when
+    // a getter changed the property storage of a dictionary shape.
+    if (&shape == &base_obj->shape() && shape.dictionary_generation() == dictionary_generation) {
         if (cacheable_metadata.type == CacheableGetPropertyMetadata::Type::GetOwnProperty) {
             cache.update(PropertyLookupCache::Entry::Type::GetOwnProperty, [&](auto& entry) {
                 entry.shape = shape;
@@ -314,6 +316,7 @@ inline ThrowCompletionOr<void> put_by_property_key(VM& vm, Value base, Value thi
     case PutKind::Normal: {
         auto this_value_object = MUST(this_value.to_object(vm));
         auto& from_shape = this_value_object->shape();
+        auto from_shape_dictionary_generation = from_shape.dictionary_generation();
         if (caches) [[likely]] {
             for (auto& cache : caches->entries_for_shape(object->shape())) {
                 switch (cache.type) {
@@ -429,8 +432,9 @@ inline ThrowCompletionOr<void> put_by_property_key(VM& vm, Value base, Value thi
 
         // If internal_set() caused object's shape change, we can no longer be sure
         // that collected metadata is valid, e.g. if setter in prototype chain added
-        // property with the same name into the object itself.
-        if (succeeded && caches && &from_shape == &object->shape()) {
+        // property with the same name into the object itself. The same applies when
+        // a setter changed the property storage of a dictionary shape.
+        if (succeeded && caches && &from_shape == &object->shape() && from_shape.dictionary_generation() == from_shape_dictionary_generation) {
             switch (cacheable_metadata.type) {
             case CacheableSetPropertyMetadata::Type::AddOwnProperty:
                 // Something went wrong if we ended up here, because cacheable addition of a new property should've changed the shape.

--- a/Libraries/LibJS/Bytecode/PropertyAccess.h
+++ b/Libraries/LibJS/Bytecode/PropertyAccess.h
@@ -46,6 +46,77 @@ ALWAYS_INLINE ThrowCompletionOr<Value> get_cached_property_value(VM& vm, Value v
     return TRY(call(vm, *getter, this_value));
 }
 
+ALWAYS_INLINE ThrowCompletionOr<Value> get_by_value_with_keyed_cache(VM& vm, Object& base_object, Value this_value, PropertyKey const& property_key)
+{
+    if (!property_key.is_string())
+        return base_object.internal_get(property_key, this_value);
+
+    auto const& property_name = property_key.as_string();
+    auto& shape = base_object.shape();
+    auto& entry = vm.keyed_property_lookup_cache().entry_for(shape, property_name);
+    if (entry.shape.ptr() == &shape && entry.property_name == property_name
+        && (!shape.is_dictionary() || shape.dictionary_generation() == entry.shape_dictionary_generation)) {
+        switch (entry.type) {
+        case PropertyLookupCache::Entry::Type::GetOwnProperty:
+            return get_cached_property_value(vm, base_object.get_direct(entry.property_offset), this_value);
+        case PropertyLookupCache::Entry::Type::GetPropertyInPrototypeChain:
+            if (auto* prototype_chain_validity = entry.prototype_chain_validity.ptr(); prototype_chain_validity && prototype_chain_validity->is_valid())
+                return get_cached_property_value(vm, entry.prototype->get_direct(entry.property_offset), this_value);
+            break;
+        case PropertyLookupCache::Entry::Type::GetMissingProperty:
+            if (base_object.is_cacheable_for_property_absence()) {
+                if (!shape.prototype())
+                    return js_undefined();
+                if (auto* prototype_chain_validity = entry.prototype_chain_validity.ptr(); prototype_chain_validity && prototype_chain_validity->is_valid())
+                    return js_undefined();
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    GC::Ptr<PrototypeChainValidity> prototype_chain_validity;
+    if (shape.prototype())
+        prototype_chain_validity = shape.prototype()->shape().prototype_chain_validity();
+
+    auto dictionary_generation = shape.dictionary_generation();
+    CacheableGetPropertyMetadata cacheable_metadata;
+    cacheable_metadata.property_absence_is_cacheable = base_object.is_cacheable_for_property_absence();
+    auto value = TRY(base_object.internal_get(property_key, this_value, &cacheable_metadata));
+
+    // A getter may have changed the object's shape or the property storage of a dictionary shape, which
+    // leaves the metadata describing a lookup that no longer applies.
+    if (&shape != &base_object.shape() || shape.dictionary_generation() != dictionary_generation
+        || cacheable_metadata.type == CacheableGetPropertyMetadata::Type::NotCacheable)
+        return value;
+
+    entry = {};
+    entry.shape = &shape;
+    entry.property_name = property_name;
+    if (shape.is_dictionary())
+        entry.shape_dictionary_generation = shape.dictionary_generation();
+    switch (cacheable_metadata.type) {
+    case CacheableGetPropertyMetadata::Type::GetOwnProperty:
+        entry.type = PropertyLookupCache::Entry::Type::GetOwnProperty;
+        entry.property_offset = cacheable_metadata.property_offset.value();
+        break;
+    case CacheableGetPropertyMetadata::Type::GetPropertyInPrototypeChain:
+        entry.type = PropertyLookupCache::Entry::Type::GetPropertyInPrototypeChain;
+        entry.property_offset = cacheable_metadata.property_offset.value();
+        entry.prototype = const_cast<Object*>(cacheable_metadata.prototype.ptr());
+        entry.prototype_chain_validity = prototype_chain_validity;
+        break;
+    case CacheableGetPropertyMetadata::Type::GetMissingProperty:
+        entry.type = PropertyLookupCache::Entry::Type::GetMissingProperty;
+        entry.prototype_chain_validity = prototype_chain_validity;
+        break;
+    case CacheableGetPropertyMetadata::Type::NotCacheable:
+        VERIFY_NOT_REACHED();
+    }
+    return value;
+}
+
 // Non-standard
 ALWAYS_INLINE Value get_own_property_without_side_effects(Object& object, PropertyKey const& property_key, StaticPropertyLookupCache& cache)
 {

--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -321,6 +321,7 @@ class Executable;
 class Generator;
 class Instruction;
 class Operand;
+struct KeyedPropertyLookupCache;
 struct PropertyLookupCache;
 struct StaticPropertyLookupCache;
 class RegexTable;

--- a/Libraries/LibJS/Interpreter/SlowPaths.cpp
+++ b/Libraries/LibJS/Interpreter/SlowPaths.cpp
@@ -1200,9 +1200,11 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
     }
 
     if (ASM_TRY(*vm, pc, binding_object.has_property(identifier))) [[likely]] {
+        auto dictionary_generation = shape.dictionary_generation();
         CacheableGetPropertyMetadata cacheable_metadata;
         auto value = ASM_TRY(*vm, pc, binding_object.internal_get(identifier, &binding_object, &cacheable_metadata));
-        if (cacheable_metadata.type == CacheableGetPropertyMetadata::Type::GetOwnProperty) {
+        if (cacheable_metadata.type == CacheableGetPropertyMetadata::Type::GetOwnProperty
+            && &shape == &binding_object.shape() && shape.dictionary_generation() == dictionary_generation) {
             cache.update(PropertyLookupCache::Entry::Type::GetOwnProperty, [&](auto& entry) {
                 entry.shape = shape;
                 entry.property_offset = cacheable_metadata.property_offset.value();
@@ -1303,6 +1305,7 @@ i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
     }
 
     if (ASM_TRY(*vm, pc, binding_object.has_property(identifier))) {
+        auto dictionary_generation = shape.dictionary_generation();
         CacheableSetPropertyMetadata cacheable_metadata;
         auto success = ASM_TRY(*vm, pc, binding_object.internal_set(identifier, src, &binding_object, &cacheable_metadata));
         if (!success && instruction->strict() == Strict::Yes) [[unlikely]] {
@@ -1317,7 +1320,8 @@ i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
             auto completion = vm->throw_completion<TypeError>(ErrorType::ObjectSetReturnedFalse);
             return handle_asm_exception(*vm, pc, completion.value());
         }
-        if (cacheable_metadata.type == CacheableSetPropertyMetadata::Type::ChangeOwnProperty) {
+        if (cacheable_metadata.type == CacheableSetPropertyMetadata::Type::ChangeOwnProperty
+            && &shape == &binding_object.shape() && shape.dictionary_generation() == dictionary_generation) {
             cache.update(PropertyLookupCache::Entry::Type::ChangeOwnProperty, [&](auto& entry) {
                 entry.shape = shape;
                 entry.property_offset = cacheable_metadata.property_offset.value();

--- a/Libraries/LibJS/Interpreter/SlowPaths.cpp
+++ b/Libraries/LibJS/Interpreter/SlowPaths.cpp
@@ -1047,7 +1047,7 @@ i64 asm_slow_path_get_by_value(VM* vm, u32 pc, Op::GetByValue const* instruction
             return static_cast<i64>(pc + sizeof(Op::GetByValue));
         }
     }
-    vm->set(instruction->dst(), ASM_TRY(*vm, pc, object->internal_get(property_key, base_value)));
+    vm->set(instruction->dst(), ASM_TRY(*vm, pc, get_by_value_with_keyed_cache(*vm, *object, base_value, property_key)));
     return static_cast<i64>(pc + sizeof(Op::GetByValue));
 }
 
@@ -1056,7 +1056,7 @@ i64 asm_slow_path_get_by_value_with_this(VM* vm, u32 pc, Op::GetByValueWithThis 
     auto property_key_value = vm->get(instruction->property());
     auto object = ASM_TRY(*vm, pc, vm->get(instruction->base()).to_object(*vm));
     auto property_key = ASM_TRY(*vm, pc, property_key_value.to_property_key(*vm));
-    auto value = ASM_TRY(*vm, pc, object->internal_get(property_key, vm->get(instruction->this_value())));
+    auto value = ASM_TRY(*vm, pc, get_by_value_with_keyed_cache(*vm, *object, vm->get(instruction->this_value()), property_key));
     vm->set(instruction->dst(), value);
     return static_cast<i64>(pc + sizeof(Op::GetByValueWithThis));
 }

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -1122,6 +1122,10 @@ ThrowCompletionOr<Value> Object::internal_get(PropertyKey const& property_key, V
             return vm.throw_completion<InternalError>(ErrorType::CallStackSizeExceeded);
         if (cacheable_metadata && !parent->is_cacheable_for_property_absence())
             cacheable_metadata->property_absence_is_cacheable = false;
+        // NB: An object whose own lookup can start answering for a name at any time cannot vouch for a
+        //     result found further up the prototype chain.
+        if (cacheable_metadata && !is_cacheable_for_inherited_property())
+            cacheable_metadata = nullptr;
         return parent->internal_get(property_key, receiver, cacheable_metadata, PropertyLookupPhase::PrototypeChain);
     }
 

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -175,6 +175,7 @@ public:
     };
     virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheableGetPropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) const;
     virtual bool is_cacheable_for_property_absence() const { return true; }
+    virtual bool is_cacheable_for_inherited_property() const { return true; }
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheableSetPropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty);
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&);
     virtual ThrowCompletionOr<GC::RootVector<Value>> internal_own_property_keys() const;

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -92,8 +92,10 @@ VM::VM(ErrorMessages error_messages)
     m_heap_region_base = GC::BlockAllocator::heap_region_start();
     VERIFY(m_heap_region_base != 0);
 
-    m_heap.register_sweep_callback([] {
+    m_keyed_property_lookup_cache = make<Bytecode::KeyedPropertyLookupCache>();
+    m_heap.register_sweep_callback([this] {
         Bytecode::StaticPropertyLookupCache::sweep_all();
+        m_keyed_property_lookup_cache->remove_dead_entries();
     });
 
     m_empty_string = m_heap.allocate<PrimitiveString>(Utf16String {});

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -188,6 +188,8 @@ public:
         return m_utf16_string_cache;
     }
 
+    Bytecode::KeyedPropertyLookupCache& keyed_property_lookup_cache() { return *m_keyed_property_lookup_cache; }
+
     auto& numeric_string_cache() { return m_numeric_string_cache; }
 
     PrimitiveString& empty_string() { return *m_empty_string; }
@@ -588,6 +590,7 @@ private:
     static VM* s_the;
 
     HashMap<Utf16String, GC::Ptr<PrimitiveString>> m_utf16_string_cache;
+    OwnPtr<Bytecode::KeyedPropertyLookupCache> m_keyed_property_lookup_cache;
 
     static constexpr size_t numeric_string_cache_size = 1000;
     AK::Array<GC::Ptr<PrimitiveString>, numeric_string_cache_size> m_numeric_string_cache;

--- a/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -296,6 +296,14 @@ WebIDL::ExceptionOr<void> PlatformObject::invoke_named_property_setter(Utf16FlyS
     return set_value_of_named_property(realm(), property_name, value);
 }
 
+bool PlatformObject::is_cacheable_for_inherited_property() const
+{
+    if (!is_legacy_platform_object())
+        return true;
+    return !(m_legacy_platform_object_flags->supports_named_properties
+        && m_legacy_platform_object_flags->has_legacy_override_built_ins_interface_extended_attribute);
+}
+
 // https://webidl.spec.whatwg.org/#legacy-platform-object-getownproperty
 JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> PlatformObject::internal_get_own_property(JS::PropertyKey const& property_name) const
 {

--- a/Libraries/LibWeb/Bindings/PlatformObject.h
+++ b/Libraries/LibWeb/Bindings/PlatformObject.h
@@ -53,7 +53,7 @@ public:
 
     // ^JS::Object
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
-    virtual bool is_cacheable_for_property_absence() const override { return false; }
+    virtual bool is_cacheable_for_property_absence() const override { return !is_legacy_platform_object(); }
     virtual bool is_cacheable_for_inherited_property() const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value, JS::Value, JS::CacheableSetPropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;

--- a/Libraries/LibWeb/Bindings/PlatformObject.h
+++ b/Libraries/LibWeb/Bindings/PlatformObject.h
@@ -54,6 +54,7 @@ public:
     // ^JS::Object
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual bool is_cacheable_for_property_absence() const override { return false; }
+    virtual bool is_cacheable_for_inherited_property() const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value, JS::Value, JS::CacheableSetPropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;

--- a/Meta/Generators/libweb_bindings/interface_declaration.py
+++ b/Meta/Generators/libweb_bindings/interface_declaration.py
@@ -131,6 +131,7 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_is_extensible() const override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
+    virtual bool is_cacheable_for_property_absence() const override { return false; }
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheableGetPropertyMetadata*, PropertyLookupPhase) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value, JS::Value receiver, JS::CacheableSetPropertyMetadata*, PropertyLookupPhase) override;

--- a/Meta/Generators/libweb_bindings/named_and_indexed_properties.py
+++ b/Meta/Generators/libweb_bindings/named_and_indexed_properties.py
@@ -497,6 +497,7 @@ public:
 
 private:
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
+    virtual bool is_cacheable_for_property_absence() const override {{ return false; }}
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;

--- a/Tests/LibJS/Runtime/inline-cache-edge-cases.js
+++ b/Tests/LibJS/Runtime/inline-cache-edge-cases.js
@@ -16,3 +16,92 @@ test("Inline cache invalidated by deleting property from unique shape", () => {
     expect(first).toBe(2);
     expect(second).toBeUndefined();
 });
+
+function createObjectWithUniqueShape() {
+    let o = {};
+    for (let x = 0; x < 1000; ++x) {
+        o["prop" + x] = x;
+    }
+    for (let x = 0; x < 1000; ++x) {
+        delete o["prop" + x];
+    }
+    return o;
+}
+
+test("Getter that deletes itself from a unique shape", () => {
+    let o = createObjectWithUniqueShape();
+    Object.defineProperty(o, "accessor", {
+        get() {
+            delete o.accessor;
+            return "getter";
+        },
+        configurable: true,
+    });
+    o.neighbor = "neighbor";
+
+    function ic(o) {
+        return o.accessor;
+    }
+
+    expect(ic(o)).toBe("getter");
+    expect(ic(o)).toBeUndefined();
+    expect(o.neighbor).toBe("neighbor");
+});
+
+test("Setter that deletes itself from a unique shape", () => {
+    let o = createObjectWithUniqueShape();
+    Object.defineProperty(o, "accessor", {
+        set(value) {
+            delete o.accessor;
+        },
+        configurable: true,
+    });
+    o.neighbor = "neighbor";
+
+    function ic(o, value) {
+        o.accessor = value;
+    }
+
+    ic(o, 1);
+    ic(o, 2);
+    expect(o.neighbor).toBe("neighbor");
+    expect(o.accessor).toBe(2);
+});
+
+test("Global getter that deletes itself", () => {
+    Object.defineProperty(globalThis, "selfDeletingGlobalGetter", {
+        get() {
+            delete globalThis.selfDeletingGlobalGetter;
+            return "getter";
+        },
+        configurable: true,
+    });
+    globalThis.globalNeighbor = "neighbor";
+
+    function ic() {
+        return selfDeletingGlobalGetter;
+    }
+
+    expect(ic()).toBe("getter");
+    expect(ic).toThrowWithMessage(ReferenceError, "'selfDeletingGlobalGetter' is not defined");
+    expect(globalThis.globalNeighbor).toBe("neighbor");
+});
+
+test("Global setter that deletes itself", () => {
+    Object.defineProperty(globalThis, "selfDeletingGlobalSetter", {
+        set(value) {
+            delete globalThis.selfDeletingGlobalSetter;
+        },
+        configurable: true,
+    });
+    globalThis.globalSetterNeighbor = "neighbor";
+
+    function ic(value) {
+        selfDeletingGlobalSetter = value;
+    }
+
+    ic(1);
+    ic(2);
+    expect(globalThis.globalSetterNeighbor).toBe("neighbor");
+    expect(globalThis.selfDeletingGlobalSetter).toBe(2);
+});

--- a/Tests/LibJS/Runtime/keyed-property-lookup-cache.js
+++ b/Tests/LibJS/Runtime/keyed-property-lookup-cache.js
@@ -1,0 +1,170 @@
+describe("keyed property lookup cache", () => {
+    function read(object, key) {
+        return object[key];
+    }
+
+    test("own properties on objects of the same shape", () => {
+        const objects = [];
+        for (let i = 0; i < 20; ++i) objects.push({ a: i, b: i * 2, c: i * 3 });
+        for (let round = 0; round < 3; ++round) {
+            for (let i = 0; i < objects.length; ++i) {
+                expect(read(objects[i], "a")).toBe(i);
+                expect(read(objects[i], "b")).toBe(i * 2);
+                expect(read(objects[i], "c")).toBe(i * 3);
+            }
+        }
+    });
+
+    test("properties found on the prototype chain", () => {
+        class Base {
+            base() {
+                return "base";
+            }
+        }
+        class Derived extends Base {
+            derived() {
+                return "derived";
+            }
+        }
+        const instance = new Derived();
+        for (let i = 0; i < 5; ++i) {
+            expect(read(instance, "base")()).toBe("base");
+            expect(read(instance, "derived")()).toBe("derived");
+        }
+        Base.prototype.base = function () {
+            return "replaced";
+        };
+        expect(read(instance, "base")()).toBe("replaced");
+        instance.base = function () {
+            return "shadowed";
+        };
+        expect(read(instance, "base")()).toBe("shadowed");
+        delete instance.base;
+        expect(read(instance, "base")()).toBe("replaced");
+        Object.setPrototypeOf(Derived.prototype, { base: () => "swapped" });
+        expect(read(instance, "base")()).toBe("swapped");
+    });
+
+    test("missing properties become present", () => {
+        const object = {};
+        for (let i = 0; i < 5; ++i) expect(read(object, "later")).toBeUndefined();
+        object.later = 1;
+        expect(read(object, "later")).toBe(1);
+        const prototype = {};
+        const child = Object.create(prototype);
+        for (let i = 0; i < 5; ++i) expect(read(child, "inherited")).toBeUndefined();
+        prototype.inherited = 2;
+        expect(read(child, "inherited")).toBe(2);
+        Object.setPrototypeOf(child, null);
+        expect(read(child, "inherited")).toBeUndefined();
+    });
+
+    test("accessors receive the receiver as this", () => {
+        const prototype = {
+            get self() {
+                return this;
+            },
+        };
+        const first = Object.create(prototype);
+        const second = Object.create(prototype);
+        for (let i = 0; i < 5; ++i) {
+            expect(read(first, "self")).toBe(first);
+            expect(read(second, "self")).toBe(second);
+        }
+        expect(read(3, "toFixed")).toBe(Number.prototype.toFixed);
+        expect(read("abc", "length")).toBe(3);
+        expect(read("abc", "toUpperCase")).toBe(String.prototype.toUpperCase);
+    });
+
+    test("shape changes after the first read", () => {
+        const object = { a: 1 };
+        for (let i = 0; i < 5; ++i) expect(read(object, "a")).toBe(1);
+        object.b = 2;
+        expect(read(object, "a")).toBe(1);
+        expect(read(object, "b")).toBe(2);
+        delete object.a;
+        expect(read(object, "a")).toBeUndefined();
+        expect(read(object, "b")).toBe(2);
+        object.a = 3;
+        expect(read(object, "a")).toBe(3);
+        Object.defineProperty(object, "b", {
+            get() {
+                return 4;
+            },
+        });
+        expect(read(object, "b")).toBe(4);
+    });
+
+    test("dictionary shapes track later changes", () => {
+        const object = {};
+        for (let i = 0; i < 200; ++i) object["p" + i] = i;
+        for (let i = 0; i < 200; ++i) expect(read(object, "p" + i)).toBe(i);
+        delete object.p7;
+        expect(read(object, "p7")).toBeUndefined();
+        object.p7 = "back";
+        expect(read(object, "p7")).toBe("back");
+        for (let i = 0; i < 200; ++i) {
+            if (i !== 7) expect(read(object, "p" + i)).toBe(i);
+        }
+    });
+
+    test("numeric and symbol keys", () => {
+        const array = [10, 20, 30];
+        expect(read(array, "1")).toBe(20);
+        expect(read(array, "length")).toBe(3);
+        array.push(40);
+        expect(read(array, "length")).toBe(4);
+        const symbol = Symbol("s");
+        const object = { [symbol]: "symbol" };
+        for (let i = 0; i < 3; ++i) expect(read(object, symbol)).toBe("symbol");
+    });
+
+    test("proxies are never served from the cache", () => {
+        let reads = 0;
+        const proxy = new Proxy(
+            { a: 1 },
+            {
+                get(target, key) {
+                    ++reads;
+                    return target[key];
+                },
+            }
+        );
+        for (let i = 0; i < 5; ++i) expect(read(proxy, "a")).toBe(1);
+        expect(reads).toBe(5);
+    });
+
+    test("entries survive garbage collection", () => {
+        const prototype = { inherited: "yes" };
+        const object = Object.create(prototype);
+        object.own = "own";
+        expect(read(object, "inherited")).toBe("yes");
+        expect(read(object, "own")).toBe("own");
+        gc();
+        expect(read(object, "inherited")).toBe("yes");
+        expect(read(object, "own")).toBe("own");
+        for (let i = 0; i < 50; ++i) {
+            const short_lived = { ["k" + i]: i };
+            expect(read(short_lived, "k" + i)).toBe(i);
+        }
+        gc();
+        expect(read(object, "inherited")).toBe("yes");
+    });
+
+    test("getter that deletes itself from a unique shape", () => {
+        const object = {};
+        for (let i = 0; i < 1000; ++i) object["prop" + i] = i;
+        for (let i = 0; i < 1000; ++i) delete object["prop" + i];
+        Object.defineProperty(object, "accessor", {
+            get() {
+                delete object.accessor;
+                return "getter";
+            },
+            configurable: true,
+        });
+        object.neighbor = "neighbor";
+        expect(read(object, "accessor")).toBe("getter");
+        expect(read(object, "accessor")).toBeUndefined();
+        expect(read(object, "neighbor")).toBe("neighbor");
+    });
+});

--- a/Tests/LibWeb/Text/expected/DOM/keyed-property-absence-cache.txt
+++ b/Tests/LibWeb/Text/expected/DOM/keyed-property-absence-cache.txt
@@ -1,0 +1,11 @@
+absent: undefined
+own: own
+deleted: undefined
+prototype: prototype
+prototype deleted: undefined
+form before: undefined
+form after: true
+window before: undefined
+window after: true
+document collection: 0
+style: red

--- a/Tests/LibWeb/Text/expected/WebIDL/named-property-shadows-cached-prototype-property.txt
+++ b/Tests/LibWeb/Text/expected/WebIDL/named-property-shadows-cached-prototype-property.txt
@@ -1,0 +1,4 @@
+form: true
+document: true
+dataset: shadow
+form with a fixed name: true

--- a/Tests/LibWeb/Text/input/DOM/keyed-property-absence-cache.html
+++ b/Tests/LibWeb/Text/input/DOM/keyed-property-absence-cache.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<div id="container"></div>
+<form id="form"></form>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function read(object, key) {
+            return object[key];
+        }
+
+        const element = document.createElement("div");
+        for (let i = 0; i < 5; ++i)
+            read(element, "expando");
+        println(`absent: ${read(element, "expando")}`);
+        element.expando = "own";
+        println(`own: ${read(element, "expando")}`);
+        delete element.expando;
+        println(`deleted: ${read(element, "expando")}`);
+        HTMLDivElement.prototype.expando = "prototype";
+        println(`prototype: ${read(element, "expando")}`);
+        delete HTMLDivElement.prototype.expando;
+        println(`prototype deleted: ${read(element, "expando")}`);
+
+        for (let i = 0; i < 5; ++i)
+            read(form, "field");
+        println(`form before: ${read(form, "field")}`);
+        const input = document.createElement("input");
+        input.name = "field";
+        form.append(input);
+        println(`form after: ${read(form, "field") === input}`);
+
+        for (let i = 0; i < 5; ++i)
+            read(window, "named");
+        println(`window before: ${read(window, "named")}`);
+        const named = document.createElement("span");
+        named.id = "named";
+        container.append(named);
+        println(`window after: ${read(window, "named") === named}`);
+
+        for (let i = 0; i < 5; ++i)
+            read(document, "images");
+        println(`document collection: ${read(document, "images").length}`);
+        for (let i = 0; i < 5; ++i)
+            read(element.style, "color");
+        element.style.color = "red";
+        println(`style: ${read(element.style, "color")}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/WebIDL/named-property-shadows-cached-prototype-property.html
+++ b/Tests/LibWeb/Text/input/WebIDL/named-property-shadows-cached-prototype-property.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<div id="host"></div>
+<form id="form"></form>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function read(object, key) {
+            return object[key];
+        }
+
+        for (let i = 0; i < 5; ++i)
+            read(form, "action");
+        const input = document.createElement("input");
+        input.name = "action";
+        form.append(input);
+        println(`form: ${read(form, "action") === input}`);
+
+        for (let i = 0; i < 5; ++i)
+            read(document, "images");
+        const namedForm = document.createElement("form");
+        namedForm.name = "images";
+        document.body.append(namedForm);
+        println(`document: ${read(document, "images") === namedForm}`);
+
+        const map = host.dataset;
+        for (let i = 0; i < 5; ++i)
+            read(map, "toString");
+        host.setAttribute("data-to-string", "shadow");
+        println(`dataset: ${read(map, "toString")}`);
+
+        function readAction(object) {
+            return object.action;
+        }
+        const otherForm = document.createElement("form");
+        document.body.append(otherForm);
+        for (let i = 0; i < 5; ++i)
+            readAction(otherForm);
+        println(`form with a fixed name: ${readAction(form) === input}`);
+    });
+</script>


### PR DESCRIPTION
A property read with a computed key, went through a full lookup every time - the descriptor search on the receiver, then the same search on each object of the prototype chain. Code that reads many different names from objects of a few shapes, paid that cost on every read. The engine now keeps a cache keyed by the receiver's shape and the property name, shared by every read site, and serves repeated pairs from it under the same validity rules as the per-site caches for reads with a fixed name.

This speeds up the `TodoMVC-jQuery` Speedometer3 tests:
```
Benchmark     Suite                                       Test                   Speedup  Old (Mean ± Range)    New (Mean ± Range)
------------  ------------------------------------------  -------------------  ---------  --------------------  --------------------
Speedometer3  Charts-chartjs                              Draw opaque scatter      1.031  0.10 ± 0.01           0.10 ± 0.00
Speedometer3  Charts-chartjs                              Draw scatter             1.154  0.18 ± 0.05           0.15 ± 0.03
Speedometer3  Charts-chartjs                              Show tooltip             0.658  0.00 ± 0.00           0.00 ± 0.00
Speedometer3  Charts-observable-plot                      Dotted                   0.977  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 20            1.037  0.12 ± 0.01           0.12 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 6             0.978  0.08 ± 0.00           0.08 ± 0.00
Speedometer3  Editor-CodeMirror                           Highlight                1.002  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  Editor-CodeMirror                           Long                     1.108  0.04 ± 0.01           0.04 ± 0.00
Speedometer3  Editor-TipTap                               Highlight                1.043  0.19 ± 0.01           0.18 ± 0.01
Speedometer3  Editor-TipTap                               Long                     0.961  0.13 ± 0.01           0.13 ± 0.02
Speedometer3  NewsSite-Next                               NavigateToPolitics       1.044  0.18 ± 0.02           0.17 ± 0.01
Speedometer3  NewsSite-Next                               NavigateToUS             1.017  0.17 ± 0.01           0.16 ± 0.01
Speedometer3  NewsSite-Next                               NavigateToWorld          1.069  0.19 ± 0.03           0.18 ± 0.01
Speedometer3  NewsSite-Nuxt                               NavigateToPolitics       0.922  0.15 ± 0.00           0.16 ± 0.02
Speedometer3  NewsSite-Nuxt                               NavigateToUS             1.028  0.14 ± 0.00           0.14 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToWorld          0.969  0.15 ± 0.02           0.15 ± 0.02
Speedometer3  Perf-Dashboard                              Render                   1.018  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingPoints          0.989  0.12 ± 0.00           0.12 ± 0.01
Speedometer3  Perf-Dashboard                              SelectingRange           1.016  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  React-Stockcharts-SVG                       PanTheChart              1.002  0.12 ± 0.01           0.12 ± 0.01
Speedometer3  React-Stockcharts-SVG                       Render                   0.991  0.12 ± 0.01           0.12 ± 0.01
Speedometer3  React-Stockcharts-SVG                       ZoomTheChart             0.955  0.44 ± 0.01           0.46 ± 0.04
Speedometer3  TodoMVC-Angular-Complex-DOM                 Adding100Items           1.005  0.12 ± 0.01           0.12 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 CompletingAllItems       1.143  0.08 ± 0.02           0.07 ± 0.00
Speedometer3  TodoMVC-Angular-Complex-DOM                 DeletingAllItems         1.01   0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Backbone                            Adding100Items           1.03   0.07 ± 0.01           0.07 ± 0.00
Speedometer3  TodoMVC-Backbone                            CompletingAllItems       1.006  0.05 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Backbone                            DeletingAllItems         1.01   0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      Adding100Items           1.011  0.13 ± 0.01           0.12 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES5                      CompletingAllItems       0.881  0.04 ± 0.00           0.05 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES5                      DeletingAllItems         1.022  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  Adding100Items           1.046  0.13 ± 0.01           0.12 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  CompletingAllItems       1.004  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  DeletingAllItems         0.994  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     Adding100Items           0.951  0.05 ± 0.00           0.05 ± 0.01
Speedometer3  TodoMVC-Lit-Complex-DOM                     CompletingAllItems       0.996  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     DeletingAllItems         0.955  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  Adding100Items           0.944  0.03 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  CompletingAllItems       1.005  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  DeletingAllItems         0.901  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   Adding100Items           1.03   0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   CompletingAllItems       1.024  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   DeletingAllItems         0.965  0.05 ± 0.01           0.05 ± 0.01
Speedometer3  TodoMVC-React-Redux                         Adding100Items           0.953  0.09 ± 0.00           0.09 ± 0.01
Speedometer3  TodoMVC-React-Redux                         CompletingAllItems       0.995  0.11 ± 0.00           0.11 ± 0.00
Speedometer3  TodoMVC-React-Redux                         DeletingAllItems         1.008  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  Adding100Items           0.97   0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  CompletingAllItems       1.033  0.03 ± 0.01           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  DeletingAllItems         0.985  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Vue                                 Adding100Items           0.915  0.05 ± 0.00           0.05 ± 0.01
Speedometer3  TodoMVC-Vue                                 CompletingAllItems       1.006  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Vue                                 DeletingAllItems         1.047  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       Adding100Items           0.923  0.06 ± 0.00           0.06 ± 0.01
Speedometer3  TodoMVC-WebComponents                       CompletingAllItems       0.942  0.03 ± 0.00           0.03 ± 0.01
Speedometer3  TodoMVC-WebComponents                       DeletingAllItems         1.047  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-jQuery                              Adding100Items           0.997  0.19 ± 0.03           0.19 ± 0.03
Speedometer3  TodoMVC-jQuery                              CompletingAllItems       1.104  0.43 ± 0.05           0.39 ± 0.03
Speedometer3  TodoMVC-jQuery                              DeletingAllItems         1.151  0.17 ± 0.04           0.14 ± 0.03

Benchmark     Old Score    New Score      Score Improvement  Old Total Time (s)    New Total Time (s)      Speedup
------------  -----------  -----------  -------------------  --------------------  --------------------  ---------
Speedometer3  4.92 ± 0.12  4.95 ± 0.12                1.006  5.32 ± 0.16           5.24 ± 0.15               1.016
```

The effect on `js-bechmarks` was below the noise floor of the benchmark suite.