### PR TITLE
LibWeb: Allow a Page to host any local navigable

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -10268,14 +10268,14 @@ Optional<CSSPixelRect> Document::current_caret_rect()
         return {};
 
     // The caret rects computed here are document-relative (absolute). Platform IME overlays are positioned relative to
-    // the viewport — so translate by scroll offset and map through any containing navigables to the top-level viewport.
+    // the viewport — so translate by scroll offset and map through any containing navigables to the local page viewport.
     auto to_viewport_rect = [this](CSSPixelRect rect) -> CSSPixelRect {
         auto navigable = this->navigable();
         if (!navigable)
             return rect;
         auto scroll = navigable->viewport_scroll_offset();
         CSSPixelRect viewport_rect { rect.x() - scroll.x(), rect.y() - scroll.y(), rect.width(), rect.height() };
-        return navigable->to_top_level_rect(viewport_rect);
+        return navigable->to_page_rect(viewport_rect);
     };
 
     if (is<DOM::Text>(dom_node)) {

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -692,10 +692,8 @@ void EventLoop::update_the_rendering()
             document->update_layout(DOM::UpdateLayoutReason::HTMLEventLoopRenderingUpdate);
         navigable->paint_next_frame();
         ++m_rendering_scheduler_counters.paints;
-        if (navigable->is_traversable()) {
-            auto traversable = navigable->traversable_navigable();
-            traversable->process_screenshot_requests();
-        }
+        if (navigable->is_traversable())
+            navigable->page().process_screenshot_requests();
     }
 
     // 23. For each doc of docs, process top layer removals given doc.

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -692,7 +692,7 @@ void EventLoop::update_the_rendering()
             document->update_layout(DOM::UpdateLayoutReason::HTMLEventLoopRenderingUpdate);
         navigable->paint_next_frame();
         ++m_rendering_scheduler_counters.paints;
-        if (navigable->is_traversable())
+        if (navigable->is_local_root())
             navigable->page().process_screenshot_requests();
     }
 

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -278,7 +278,7 @@ bool EventLoop::rendering_opportunity(HighResolutionTime::DOMHighResTimeStamp fr
     // 3. For each navigable that has a rendering opportunity, queue a global task on the rendering task source given navigable's active window to update the rendering:
     bool has_eligible_navigable = false;
     for (auto& navigable : all_local_navigables()) {
-        if (!navigable->is_traversable())
+        if (!navigable->is_local_root())
             continue;
         if (!navigable->has_a_rendering_opportunity())
             continue;
@@ -297,7 +297,7 @@ bool EventLoop::rendering_opportunity(HighResolutionTime::DOMHighResTimeStamp fr
         return false;
 
     // AD-HOC: One rendering update services every document in this event loop, so queue one event-loop task for the
-    //         opportunity instead of one global task per traversable.
+    //         opportunity instead of one global task per page local root.
     VERIFY(!m_rendering_task_queued);
     m_rendering_task_queued = true;
     queue_a_task(Task::Source::Rendering, this, nullptr, *m_rendering_task_function);
@@ -394,7 +394,7 @@ void EventLoop::update_the_rendering()
     VERIFY(!m_running_rendering_task);
     m_running_rendering_task = true;
     for (auto& navigable : all_local_navigables()) {
-        if (navigable->is_traversable())
+        if (navigable->is_local_root())
             navigable->page().client().will_begin_rendering_update();
     }
     auto update_start_time = HighResolutionTime::unsafe_shared_current_time();
@@ -405,7 +405,7 @@ void EventLoop::update_the_rendering()
         m_running_rendering_task = false;
 
         for (auto& navigable : all_local_navigables()) {
-            if (navigable->is_traversable())
+            if (navigable->is_local_root())
                 navigable->page().client().did_finish_rendering_update();
         }
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -582,7 +582,7 @@ void HTMLSelectElement::show_the_picker_if_applicable()
     // Request select dropdown
     auto weak_element = GC::Weak<HTMLSelectElement> { *this };
     auto rect = get_bounding_client_rect();
-    auto position = document().navigable()->to_top_level_position(Web::CSSPixelPoint { rect.x(), rect.bottom() });
+    auto position = document().navigable()->to_page_position(Web::CSSPixelPoint { rect.x(), rect.bottom() });
     document().page().did_request_select_dropdown(weak_element, position, rect.width(), m_select_items);
     set_is_open(true);
 }

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -2703,7 +2703,7 @@ void LocalNavigable::continue_navigation_after_population_dispatch(PreparedNavig
         return;
     }
 
-    if (!is_top_level_traversable()) {
+    if (!is_local_root()) {
         if (auto parent = this->parent(); parent && has_compositor_context()) {
             auto& local_parent = as<LocalNavigable>(*parent);
             if (local_parent.has_compositor_context())
@@ -4728,8 +4728,8 @@ bool LocalNavigable::is_focused() const
     if (!m_page->client().has_focus())
         return false;
 
-    // A top-level traversable retains system focus while the focus chain descends into a child navigable.
-    if (is_traversable())
+    // The local root retains the page's system focus while the focus chain descends into a child navigable.
+    if (is_local_root())
         return true;
     return &m_page->focused_navigable() == this;
 }
@@ -5330,9 +5330,9 @@ void LocalNavigable::set_force_dark_enabled(bool value)
     m_force_dark_enabled = value;
     set_needs_repaint();
 
-    // The page presents a dark preferred color scheme while the top-level traversable has force-dark on, so flipping
+    // The page presents a dark preferred color scheme while its local root has force-dark on, so flipping
     // it here changes what every media query and system color in the page resolves to.
-    if (is_top_level_traversable())
+    if (is_local_root())
         page().invalidate_style_for_preference_change();
 
     for (auto const& child_navigable : child_navigables())
@@ -5537,7 +5537,7 @@ void LocalNavigable::paint_next_frame()
 
     auto viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
     PaintConfig paint_config { .paint_overlay = true, .should_show_caret_hit_test_debug_overlay = m_should_show_caret_hit_test_debug_overlay };
-    if (is_top_level_traversable()) {
+    if (is_local_root()) {
         paint_config.canvas_fill_rect = Gfx::IntRect { {}, viewport_rect.size() };
     } else {
         // Nested navigables paint transparent bitmaps for their parent compositor context.

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3661,18 +3661,18 @@ bool LocalNavigable::is_local_root() const
     return &local_root == this;
 }
 
-CSSPixelRect LocalNavigable::to_top_level_rect(CSSPixelRect const& a_rect)
+CSSPixelRect LocalNavigable::to_page_rect(CSSPixelRect const& a_rect)
 {
     auto rect = a_rect;
-    rect.set_location(to_top_level_position(a_rect.location()));
+    rect.set_location(to_page_position(a_rect.location()));
     return rect;
 }
 
-CSSPixelPoint LocalNavigable::to_top_level_position(CSSPixelPoint a_position)
+CSSPixelPoint LocalNavigable::to_page_position(CSSPixelPoint a_position)
 {
     auto position = a_position;
     for (GC::Ptr<LocalNavigable> ancestor = this; ancestor;) {
-        if (is<LocalTraversableNavigable>(*ancestor))
+        if (ancestor->is_local_root())
             break;
         if (!ancestor->container())
             return {};

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3655,6 +3655,12 @@ void LocalNavigable::scroll_offset_did_change()
     doc->append_pending_scroll_event({ *doc, EventNames::scroll });
 }
 
+bool LocalNavigable::is_local_root() const
+{
+    HTML::LocalNavigable& local_root = page().local_root_navigable();
+    return &local_root == this;
+}
+
 CSSPixelRect LocalNavigable::to_top_level_rect(CSSPixelRect const& a_rect)
 {
     auto rect = a_rect;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1339,7 +1339,7 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
 
             auto create_new_traversable = [&](GC::Ptr<BrowsingContext> opener) -> GC::Ref<LocalTraversableNavigable> {
                 auto traversable = LocalTraversableNavigable::create_a_new_top_level_traversable(*new_web_view.page, opener, target_name, {}, new_web_view.system_visibility_state);
-                new_web_view.page->set_top_level_traversable(traversable);
+                new_web_view.page->set_local_root_navigable(traversable);
                 traversable->set_window_handle(Utf16String::from_ascii_without_validation(new_web_view.window_handle.bytes()));
                 return traversable;
             };

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -901,6 +901,37 @@ void LocalNavigable::activate_history_entry(RefPtr<SessionHistoryEntry> entry, G
     notify_navigation_observers_navigation_complete();
 }
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step
+// The steps queued for one navigable of nonchangingNavigablesThatStillNeedUpdates.
+void LocalNavigable::update_nonchanging_navigable_history_step_state(HistoryObjectLengthAndIndex history_object_length_and_index, GC::Ref<GC::Function<void()>> on_complete)
+{
+    // AD-HOC: The navigable may have been destroyed while the UI process dispatched this job.
+    if (has_been_destroyed() || !active_document()) {
+        on_complete->function()();
+        return;
+    }
+
+    // AD-HOC: Queue with null document instead of using queue_global_task. A document-associated task can become
+    //         unrunnable while the UI process waits for completion, so validate the document when the task runs.
+    queue_a_task(Task::Source::NavigationAndTraversal, nullptr, nullptr, GC::create_function(heap(), [navigable = GC::Ref { *this }, history_object_length_and_index, on_complete] {
+        // 1. Let document be navigable's active document.
+        auto document = navigable->active_document();
+        if (navigable->has_been_destroyed() || !document || !document->is_fully_active()) {
+            on_complete->function()();
+            return;
+        }
+
+        // 2. Set document's history object's index to scriptHistoryIndex.
+        document->history()->m_index = history_object_length_and_index.script_history_index;
+
+        // 3. Set document's history object's length to scriptHistoryLength.
+        document->history()->m_length = history_object_length_and_index.script_history_length;
+
+        // 4. Increment completedNonchangingJobs.
+        on_complete->function()();
+    }));
+}
+
 void LocalNavigable::notify_navigation_observers_navigation_complete()
 {
     if (!m_ongoing_navigation.has<Empty>())

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -79,6 +79,8 @@ public:
 
     virtual bool is_traversable() const { return false; }
 
+    bool is_local_root() const;
+
     bool is_closing() const { return m_closing; }
     void set_closing(bool value) { m_closing = value; }
     bool is_script_closable();

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -206,8 +206,8 @@ public:
     void report_child_frame_destroyed();
     void remove_from_all_local_navigables();
 
-    CSSPixelPoint to_top_level_position(CSSPixelPoint);
-    CSSPixelRect to_top_level_rect(CSSPixelRect const&);
+    CSSPixelPoint to_page_position(CSSPixelPoint);
+    CSSPixelRect to_page_rect(CSSPixelRect const&);
 
     CSSPixelPoint viewport_scroll_offset() const { return m_viewport_scroll_offset; }
     CSSPixelRect viewport_rect() const { return { m_viewport_scroll_offset, m_viewport_size }; }

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -106,6 +106,7 @@ public:
     void consume_child_navigable_history_reconstruction_id(size_t index);
 
     void activate_history_entry(RefPtr<SessionHistoryEntry>, GC::Ref<DOM::Document>, VisibilityState system_visibility_state);
+    void update_nonchanging_navigable_history_step_state(HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete);
     void notify_navigation_observers_navigation_complete();
 
     GC::Ptr<DOM::Document> active_document() const;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -10,9 +10,6 @@
 #include <AK/NeverDestroyed.h>
 #include <AK/NumericLimits.h>
 #include <LibGC/RootVector.h>
-#include <LibGfx/Bitmap.h>
-#include <LibGfx/PaintingSurface.h>
-#include <LibGfx/SkiaBackendContext.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Geolocation/GeolocationCoordinates.h>
@@ -35,7 +32,6 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/Timer.h>
 
@@ -2060,53 +2056,6 @@ void LocalTraversableNavigable::unregister_emulated_position_data_observer(u64 o
 {
     VERIFY(is_top_level_traversable());
     m_emulated_position_data_observers.remove(observer_id);
-}
-
-void LocalTraversableNavigable::process_screenshot_requests()
-{
-    auto& client = page().client();
-    while (!m_screenshot_tasks.is_empty()) {
-        auto task = m_screenshot_tasks.dequeue();
-        if (task.node_id.has_value()) {
-            auto* dom_node = DOM::Node::from_unique_id(*task.node_id);
-            if (dom_node)
-                dom_node->document().update_layout(DOM::UpdateLayoutReason::ProcessScreenshot);
-            auto const* layout_node = dom_node ? dom_node->layout_node() : nullptr;
-            if (!layout_node || !Painting::has_committed_box(*layout_node)) {
-                client.page_did_take_screenshot({});
-                continue;
-            }
-            auto rect = page().enclosing_device_rect(Painting::absolute_border_box_rect(*layout_node));
-            auto bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>());
-            if (bitmap_or_error.is_error()) {
-                client.page_did_take_screenshot({});
-                continue;
-            }
-            auto bitmap = bitmap_or_error.release_value();
-            auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*bitmap);
-            PaintConfig paint_config { .canvas_fill_rect = rect.to_type<int>() };
-            render_screenshot(painting_surface, paint_config, [bitmap, &client] {
-                client.page_did_take_screenshot(bitmap->to_shareable_bitmap());
-            });
-        } else {
-            active_document()->update_layout(DOM::UpdateLayoutReason::ProcessScreenshot);
-            auto const* layout_node = active_document()->layout_node();
-            VERIFY(layout_node && Painting::has_committed_box(*layout_node));
-            auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(*layout_node);
-            auto rect = page().enclosing_device_rect(scrollable_overflow_rect.value());
-            auto bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>());
-            if (bitmap_or_error.is_error()) {
-                client.page_did_take_screenshot({});
-                continue;
-            }
-            auto bitmap = bitmap_or_error.release_value();
-            auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*bitmap);
-            PaintConfig paint_config { .paint_overlay = true, .canvas_fill_rect = rect.to_type<int>() };
-            render_screenshot(painting_surface, paint_config, [bitmap, &client] {
-                client.page_did_take_screenshot(bitmap->to_shareable_bitmap());
-            });
-        }
-    }
 }
 
 }

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1126,42 +1126,6 @@ void LocalTraversableNavigable::apply_changing_navigable_history_step_continuati
     }
 }
 
-void LocalTraversableNavigable::update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex history_object_length_and_index, GC::Ref<GC::Function<void()>> on_complete)
-{
-    auto navigable = local_navigable_with_id(navigable_id);
-
-    // AD-HOC: This check is not in the spec but we should not continue navigation if navigable has been destroyed,
-    //         or if there's no active window.
-    if (!navigable || navigable->has_been_destroyed() || !navigable->active_window()) {
-        on_complete->function()();
-        return;
-    }
-
-    // AD-HOC: Queue with null document instead of using queue_global_task.
-    //         Tasks associated with a document are only runnable when fully active.
-    //         In the async state machine, documents can become non-fully-active between
-    //         queue time and execution, causing the task to be permanently stuck.
-    //         A null-document task is always runnable; we check validity inside.
-    queue_a_task(Task::Source::NavigationAndTraversal, nullptr, nullptr, GC::create_function(heap(), [navigable = GC::Ref { *navigable }, history_object_length_and_index, on_complete] {
-        if (navigable->has_been_destroyed() || !navigable->active_window() || !navigable->active_document()->is_fully_active()) {
-            on_complete->function()();
-            return;
-        }
-
-        // 1. Let document be navigable's active document.
-        auto document = navigable->active_document();
-
-        // 2. Set document's history object's index to scriptHistoryIndex.
-        document->history()->m_index = history_object_length_and_index.script_history_index;
-
-        // 3. Set document's history object's length to scriptHistoryLength.
-        document->history()->m_length = history_object_length_and_index.script_history_length;
-
-        // 4. Increment completedNonchangingJobs.
-        on_complete->function()();
-    }));
-}
-
 class CheckUnloadingCanceledState : public GC::Cell {
     GC_CELL(CheckUnloadingCanceledState, GC::Cell);
     GC_DECLARE_ALLOCATOR(CheckUnloadingCanceledState);

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -165,7 +165,7 @@ GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_fresh_top
 {
     // 1. Let traversable be the result of creating a new top-level traversable given null and the empty string.
     auto traversable = create_a_new_top_level_traversable(page, nullptr, {}, initial_document_state_id, system_visibility_state);
-    page->set_top_level_traversable(traversable);
+    page->set_local_root_navigable(traversable);
 
     // AD-HOC: Deny geolocation until the UI process sends the browser-wide setting via IPC. This prevents a request
     //         from observing the test position during the short window before the initial settings IPC arrives.

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -22,14 +22,6 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/StorageAPI/StorageShed.h>
 
-#ifdef AK_OS_MACOS
-#    include <LibGfx/MetalContext.h>
-#endif
-
-#ifdef USE_VULKAN
-#    include <LibGfx/VulkanContext.h>
-#endif
-
 namespace Web::HTML {
 
 struct ChangingNavigableContinuationState;
@@ -126,14 +118,6 @@ public:
     u64 register_emulated_position_data_observer(GC::Ref<GC::Function<void()>>);
     void unregister_emulated_position_data_observer(u64 observer_id);
 
-    void process_screenshot_requests();
-    void queue_screenshot_task(Optional<UniqueNodeID> node_id)
-    {
-        m_screenshot_tasks.enqueue({ node_id });
-        set_needs_repaint();
-        page().client().request_frame();
-    }
-
 private:
     LocalTraversableNavigable(GC::Ref<Page>);
 
@@ -195,11 +179,6 @@ private:
     Geolocation::EmulatedPositionData m_emulated_position_data;
     HashMap<u64, GC::Ref<GC::Function<void()>>> m_emulated_position_data_observers;
     u64 m_next_emulated_position_data_observer_id { 0 };
-
-    struct ScreenshotTask {
-        Optional<Web::UniqueNodeID> node_id;
-    };
-    Queue<ScreenshotTask> m_screenshot_tasks;
 };
 
 struct BrowsingContextAndDocument {

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -76,7 +76,6 @@ public:
     void run_ui_descendant_unload_task(CrossProcessId navigable_id, GC::Ref<GC::Function<void()>> on_complete);
     void unload_child_navigable_before_destruction(GC::Ref<LocalNavigable>, GC::Ref<GC::Function<void()>> after_all_unloads);
     void continue_child_navigable_destruction(CrossProcessId navigable_id, UnloadDisplayedDocument);
-    void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete);
     void complete_ui_history_operation(CrossProcessId operation_id, HistoryStepResult, Optional<i32> committed_step, u64 session_history_entry_count);
 
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement, Optional<SessionHistoryEntryPersistedState> previous_entry_persisted_state);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -623,7 +623,7 @@ void Internals::pinch(double x, double y, double scale_delta, WebIDL::UnsignedSh
 
 void Internals::reset_zoom()
 {
-    page().top_level_traversable()->reset_zoom();
+    page().local_root_navigable()->reset_zoom();
 }
 
 Utf16String Internals::current_cursor()
@@ -709,7 +709,7 @@ void Internals::load_url(Utf16String const& url_string)
     Core::deferred_invoke([page = GC::make_root(page()), url = url.release_value()] {
         // This navigation originates inside WebContent, so it has no UI-recorded navigation id;
         // the navigate algorithm generates one.
-        (void)page->top_level_traversable()->navigate({ .url = url,
+        (void)page->local_root_navigable()->navigate({ .url = url,
             .history_handling = Web::Bindings::NavigationHistoryBehavior::Auto,
             .user_involvement = HTML::UserNavigationInvolvement::BrowserUI });
     });
@@ -992,12 +992,12 @@ bool Internals::headless()
 
 bool Internals::needs_repaint()
 {
-    return page().top_level_traversable()->needs_repaint();
+    return page().local_root_navigable()->needs_repaint();
 }
 
 bool Internals::needs_display_list_record()
 {
-    return page().top_level_traversable()->needs_to_record_display_list();
+    return page().local_root_navigable()->needs_to_record_display_list();
 }
 
 bool Internals::screen_wake_lock_active()
@@ -1274,7 +1274,7 @@ void Internals::perform_per_test_cleanup()
     m_gamepads.clear();
 
     // Clear any input state
-    page().top_level_traversable()->event_handler().clear_per_test_input_state({});
+    page().local_root_navigable()->event_handler().clear_per_test_input_state({});
 
     // Restore the page to the visible state.
     page().client().page_did_request_set_system_visibility_state(HTML::VisibilityState::Visible);

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -2604,13 +2604,13 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, MouseEventCo
             node_of_box_under_pointer = *parent_element;
     }
 
-    auto top_level_viewport_position = m_navigable->to_top_level_position(viewport_position);
+    auto page_viewport_position = m_navigable->to_page_position(viewport_position);
     if (auto const* link = node_under_pointer->enclosing_link_element()) {
         auto href = link->href();
         auto url = document->encoding_parse_url(href);
         if (url.has_value()) {
             m_navigable->page().record_context_menu_request({}, { .kind = Page::ContextMenuRequest::Kind::Link, .target = const_cast<DOM::Element&>(link->hyperlink_element_utils_element()) });
-            m_navigable->page().client().page_did_request_link_context_menu(top_level_viewport_position, *url, link->target().to_byte_string(), modifiers);
+            m_navigable->page().client().page_did_request_link_context_menu(page_viewport_position, *url, link->target().to_byte_string(), modifiers);
         }
     } else {
         // AD-HOC: Skip up the tree to the first ancestor that is not a UA shadow DOM node, and use its context menu.
@@ -2633,7 +2633,7 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, MouseEventCo
                     bitmap = &frame->bitmap();
 
                 m_navigable->page().record_context_menu_request({}, { .kind = Page::ContextMenuRequest::Kind::Image, .target = image_element });
-                m_navigable->page().client().page_did_request_image_context_menu(top_level_viewport_position, *image_url, "", modifiers, bitmap);
+                m_navigable->page().client().page_did_request_image_context_menu(page_viewport_position, *image_url, "", modifiers, bitmap);
             }
         } else if (is<HTML::HTMLMediaElement>(*context_menu_node)) {
             auto& media_element = as<HTML::HTMLMediaElement>(*context_menu_node);
@@ -2650,13 +2650,13 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, MouseEventCo
             };
 
             m_navigable->page().record_context_menu_request({}, { .kind = Page::ContextMenuRequest::Kind::Media, .target = media_element });
-            m_navigable->page().did_request_media_context_menu(media_element.unique_id(), top_level_viewport_position, "", modifiers, menu);
+            m_navigable->page().did_request_media_context_menu(media_element.unique_id(), page_viewport_position, "", modifiers, menu);
         } else {
             select_context_menu_text(document, coordinates.visual_viewport_position);
 
             auto for_input_events_target = document->active_input_events_target() ? ContextMenuForInputEventsTarget::Yes : ContextMenuForInputEventsTarget::No;
             m_navigable->page().record_context_menu_request({}, { .kind = Page::ContextMenuRequest::Kind::Page, .target = context_menu_node });
-            m_navigable->page().client().page_did_request_context_menu(top_level_viewport_position, for_input_events_target);
+            m_navigable->page().client().page_did_request_context_menu(page_viewport_position, for_input_events_target);
         }
     }
 }

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -101,7 +101,7 @@ void Page::visit_edges(JS::Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     if (m_context_menu_request.has_value())
         visitor.visit(m_context_menu_request->target);
-    visitor.visit(m_top_level_traversable);
+    visitor.visit(m_local_root_navigable);
     visitor.visit(m_client);
     visitor.visit(m_window_rect_observer);
     visitor.visit(m_on_pending_dialog_closed);
@@ -485,42 +485,37 @@ void Page::update_needs_beforeunload_check()
     client().page_did_change_needs_beforeunload_check(m_needs_beforeunload_check);
 }
 
-GC::Ref<HTML::LocalNavigable> Page::local_root_navigable() const
+void Page::set_local_root_navigable(GC::Ref<HTML::LocalNavigable> navigable)
 {
-    return *m_top_level_traversable;
+    VERIFY(!m_local_root_navigable); // Replacement is not allowed!
+    VERIFY(&navigable->page() == this);
+    m_local_root_navigable = navigable;
+    update_needs_beforeunload_check();
 }
 
 bool Page::has_local_root_navigable() const
 {
-    return !!m_top_level_traversable;
-}
-
-void Page::set_top_level_traversable(GC::Ref<HTML::LocalTraversableNavigable> navigable)
-{
-    VERIFY(!m_top_level_traversable); // Replacement is not allowed!
-    VERIFY(&navigable->page() == this);
-    m_top_level_traversable = navigable;
-    update_needs_beforeunload_check();
-}
-
-bool Page::top_level_traversable_is_initialized() const
-{
-    return !!m_top_level_traversable;
+    return m_local_root_navigable != nullptr;
 }
 
 HTML::BrowsingContext& Page::top_level_browsing_context()
 {
-    return *m_top_level_traversable->active_browsing_context();
+    return *as<HTML::LocalNavigable>(*top_level_traversable()).active_browsing_context();
 }
 
 HTML::BrowsingContext const& Page::top_level_browsing_context() const
 {
-    return *m_top_level_traversable->active_browsing_context();
+    return *as<HTML::LocalNavigable>(*top_level_traversable()).active_browsing_context();
 }
 
-GC::Ref<HTML::LocalTraversableNavigable> Page::top_level_traversable() const
+GC::Ref<HTML::LocalNavigable> Page::local_root_navigable() const
 {
-    return *m_top_level_traversable;
+    return *m_local_root_navigable;
+}
+
+GC::Ref<HTML::Navigable> Page::top_level_traversable() const
+{
+    return local_root_navigable()->top_level_traversable();
 }
 
 void Page::did_complete_window_rect_request(u64 completion_id)

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -485,6 +485,16 @@ void Page::update_needs_beforeunload_check()
     client().page_did_change_needs_beforeunload_check(m_needs_beforeunload_check);
 }
 
+GC::Ref<HTML::LocalNavigable> Page::local_root_navigable() const
+{
+    return *m_top_level_traversable;
+}
+
+bool Page::has_local_root_navigable() const
+{
+    return !!m_top_level_traversable;
+}
+
 void Page::set_top_level_traversable(GC::Ref<HTML::LocalTraversableNavigable> navigable)
 {
     VERIFY(!m_top_level_traversable); // Replacement is not allowed!

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -1459,7 +1459,7 @@ void Page::set_viewport_is_fullscreen(ViewportIsFullscreen is_fullscreen)
 
 void PageClient::history_navigation_params_creation_finished(HTML::CrossProcessId operation_id, HTML::HistoryNavigationPopulation population)
 {
-    page().top_level_traversable()->resume_history_navigation_population(operation_id, move(population));
+    as<HTML::LocalTraversableNavigable>(*page().local_root_navigable()).resume_history_navigation_population(operation_id, move(population));
 }
 
 void PageClient::request_navigation_start(HTML::LocalNavigable& navigable, NavigationTarget target, URL::URL const&, Utf16String navigation_id, Optional<HTML::NavigationStartRequest> start_request)

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -124,7 +124,7 @@ HTML::LocalNavigable& Page::focused_navigable()
 {
     if (m_focused_navigable)
         return *m_focused_navigable;
-    return top_level_traversable();
+    return local_root_navigable();
 }
 
 void Page::set_focused_navigable(HTML::LocalNavigable& navigable)
@@ -142,7 +142,7 @@ void Page::navigable_document_destroyed(Badge<DOM::Document>, HTML::LocalNavigab
 
 void Page::load(URL::URL const& url, Bindings::NavigationHistoryBehavior history_handling, Utf16String navigation_id)
 {
-    (void)top_level_traversable()->navigate({ .url = url, .history_handling = history_handling, .user_involvement = HTML::UserNavigationInvolvement::BrowserUI, .navigation_id = move(navigation_id) });
+    (void)local_root_navigable()->navigate({ .url = url, .history_handling = history_handling, .user_involvement = HTML::UserNavigationInvolvement::BrowserUI, .navigation_id = move(navigation_id) });
 }
 
 void Page::load_html(StringView html, Utf16String navigation_id)
@@ -150,7 +150,7 @@ void Page::load_html(StringView html, Utf16String navigation_id)
     // FIXME: #23909 Figure out why GC threshold does not stay low when repeatedly loading html from the WebView
     heap().collect_garbage();
 
-    (void)top_level_traversable()->navigate({ .url = URL::about_srcdoc(),
+    (void)local_root_navigable()->navigate({ .url = URL::about_srcdoc(),
         .document_resource = Utf16String::from_utf8(html),
         .user_involvement = HTML::UserNavigationInvolvement::BrowserUI,
         .navigation_id = move(navigation_id) });
@@ -158,20 +158,20 @@ void Page::load_html(StringView html, Utf16String navigation_id)
 
 void Page::reload()
 {
-    top_level_traversable()->reload();
+    local_root_navigable()->reload();
 }
 
 void Page::queue_screenshot_task(Optional<UniqueNodeID> node_id)
 {
     m_screenshot_tasks.enqueue({ node_id });
-    top_level_traversable()->set_needs_repaint();
+    local_root_navigable()->set_needs_repaint();
     client().request_frame();
 }
 
 void Page::process_screenshot_requests()
 {
     auto& client = this->client();
-    auto navigable = top_level_traversable();
+    auto navigable = local_root_navigable();
     while (!m_screenshot_tasks.is_empty()) {
         auto task = m_screenshot_tasks.dequeue();
         if (task.node_id.has_value()) {
@@ -271,7 +271,7 @@ CSS::PreferredColorScheme Page::preferred_color_scheme() const
     // Force-dark presents a dark preference, the way Android WebView's force-dark does (Chrome itself leaves the
     // preference alone and darkens per element): a page that can style itself dark does, the color-scheme opt-out keeps
     // the filter away from it, and only pages with no dark support get filtered.
-    if (top_level_traversable_is_initialized() && top_level_traversable()->force_dark_enabled())
+    if (has_local_root_navigable() && local_root_navigable()->force_dark_enabled())
         return CSS::PreferredColorScheme::Dark;
 
     auto preferred_color_scheme = m_client->preferred_color_scheme();
@@ -372,7 +372,7 @@ EventResult Page::handle_mouseup(DevicePixelPoint position, DevicePixelPoint scr
             navigable->event_handler().reset_mouse_input_tracking({});
         }
     };
-    return top_level_traversable()->event_handler().handle_mouseup(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers);
+    return local_root_navigable()->event_handler().handle_mouseup(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers);
 }
 
 EventResult Page::handle_mousedown(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int click_count)
@@ -382,7 +382,7 @@ EventResult Page::handle_mousedown(DevicePixelPoint position, DevicePixelPoint s
             navigable->event_handler().reset_mouse_input_tracking({});
         m_mouse_event_tracking_navigable = nullptr;
     }
-    return top_level_traversable()->event_handler().handle_mousedown(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, click_count);
+    return local_root_navigable()->event_handler().handle_mousedown(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, click_count);
 }
 
 void Page::set_mouse_event_tracking_navigable(Badge<EventHandler>, HTML::LocalNavigable& navigable)
@@ -392,24 +392,24 @@ void Page::set_mouse_event_tracking_navigable(Badge<EventHandler>, HTML::LocalNa
 
 EventResult Page::handle_mousemove(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned buttons, unsigned modifiers)
 {
-    return top_level_traversable()->event_handler().handle_mousemove(device_to_css_point(position), device_to_css_point(screen_position), buttons, modifiers);
+    return local_root_navigable()->event_handler().handle_mousemove(device_to_css_point(position), device_to_css_point(screen_position), buttons, modifiers);
 }
 
 EventResult Page::handle_mouseleave()
 {
-    return top_level_traversable()->event_handler().handle_mouseleave();
+    return local_root_navigable()->event_handler().handle_mouseleave();
 }
 
 #if defined(AK_OS_MACOS)
 bool Page::select_word_for_dictionary_lookup(DevicePixelPoint position)
 {
-    return top_level_traversable()->event_handler().select_word_for_dictionary_lookup(device_to_css_point(position));
+    return local_root_navigable()->event_handler().select_word_for_dictionary_lookup(device_to_css_point(position));
 }
 #endif
 
 UniqueNodeID Page::node_id_at_position(DevicePixelPoint position)
 {
-    auto node = top_level_traversable()->event_handler().target_node_for_mouse_position(device_to_css_point(position));
+    auto node = local_root_navigable()->event_handler().target_node_for_mouse_position(device_to_css_point(position));
     if (!node)
         return 0;
 
@@ -418,17 +418,17 @@ UniqueNodeID Page::node_id_at_position(DevicePixelPoint position)
 
 EventResult Page::handle_mousewheel(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, WheelDeltaPrecision wheel_delta_precision, ScrollGesturePhase scroll_gesture_phase, bool async_scroll_performed_default_action, Optional<AsyncScrollOperation>* async_scroll_operation)
 {
-    return top_level_traversable()->event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y, wheel_delta_precision, scroll_gesture_phase, async_scroll_performed_default_action, async_scroll_operation);
+    return local_root_navigable()->event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y, wheel_delta_precision, scroll_gesture_phase, async_scroll_performed_default_action, async_scroll_operation);
 }
 
 EventResult Page::handle_drag_and_drop_event(DragEvent::Type type, DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files)
 {
-    return top_level_traversable()->event_handler().handle_drag_and_drop_event(type, device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, move(files));
+    return local_root_navigable()->event_handler().handle_drag_and_drop_event(type, device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, move(files));
 }
 
 EventResult Page::handle_pinch_event(DevicePixelPoint position, unsigned modifiers, double scale)
 {
-    return top_level_traversable()->event_handler().handle_pinch_event(device_to_css_point(position), modifiers, scale);
+    return local_root_navigable()->event_handler().handle_pinch_event(device_to_css_point(position), modifiers, scale);
 }
 
 EventResult Page::handle_keydown(UIEvents::KeyCode key, unsigned modifiers, u32 code_point, bool repeat, bool should_insert_text)
@@ -443,30 +443,30 @@ EventResult Page::handle_keyup(UIEvents::KeyCode key, unsigned modifiers, u32 co
 
 void Page::handle_sdl_input_events()
 {
-    top_level_traversable()->event_handler().handle_sdl_input_events();
+    local_root_navigable()->event_handler().handle_sdl_input_events();
 }
 
 void Page::invalidate_compositor_wheel_event_listener_state()
 {
     ++m_wheel_event_listener_state_generation;
 
-    if (!m_async_scrolling_enabled || !top_level_traversable_is_initialized() || !top_level_traversable()->has_compositor_context())
+    if (!m_async_scrolling_enabled || !has_local_root_navigable() || !local_root_navigable()->has_compositor_context())
         return;
 
-    top_level_traversable()->compositor_context().invalidate_wheel_event_listener_state(m_wheel_event_listener_state_generation);
+    local_root_navigable()->compositor_context().invalidate_wheel_event_listener_state(m_wheel_event_listener_state_generation);
 }
 
 void Page::update_needs_beforeunload_check()
 {
     auto needs_beforeunload_check = [&] {
-        if (!top_level_traversable_is_initialized())
+        if (!has_local_root_navigable())
             return true;
 
-        auto top_level_traversable = this->top_level_traversable();
-        auto active_document = top_level_traversable->active_document();
+        auto local_root_navigable = this->local_root_navigable();
+        auto active_document = local_root_navigable->active_document();
         if (!active_document)
             return true;
-        if (active_document->navigable() != top_level_traversable)
+        if (active_document->navigable() != local_root_navigable)
             return true;
 
         for (auto const& navigable : active_document->inclusive_descendant_navigables()) {
@@ -1036,7 +1036,7 @@ void Page::set_content_blocking_enabled(bool enabled)
 
 void Page::invalidate_user_style()
 {
-    if (!top_level_traversable_is_initialized() || !top_level_traversable()->active_document())
+    if (!has_local_root_navigable() || !local_root_navigable()->active_document())
         return;
 
     auto invalidate_document = [](DOM::Document& document) {
@@ -1048,7 +1048,7 @@ void Page::invalidate_user_style()
         document.record_style_environment_change();
     };
 
-    auto& active_document = *top_level_traversable()->active_document();
+    auto& active_document = *local_root_navigable()->active_document();
     invalidate_document(active_document);
 
     for (auto& navigable : active_document.descendant_navigables()) {
@@ -1059,7 +1059,7 @@ void Page::invalidate_user_style()
 
 void Page::invalidate_style_for_preference_change()
 {
-    if (!top_level_traversable_is_initialized() || !top_level_traversable()->active_document())
+    if (!has_local_root_navigable() || !local_root_navigable()->active_document())
         return;
 
     auto invalidate_document = [](DOM::Document& document) {
@@ -1067,7 +1067,7 @@ void Page::invalidate_style_for_preference_change()
         document.set_needs_media_query_evaluation();
     };
 
-    auto& active_document = *top_level_traversable()->active_document();
+    auto& active_document = *local_root_navigable()->active_document();
     invalidate_document(active_document);
 
     for (auto& navigable : active_document.descendant_navigables()) {
@@ -1078,11 +1078,11 @@ void Page::invalidate_style_for_preference_change()
 
 Vector<GC::Root<DOM::Document>> Page::documents_in_active_window() const
 {
-    if (!top_level_traversable_is_initialized())
+    if (!has_local_root_navigable())
         return {};
 
     auto documents = HTML::main_thread_event_loop().documents_in_this_event_loop_matching([&](auto& document) {
-        return document.window() == top_level_traversable()->active_window();
+        return document.window() == local_root_navigable()->active_window();
     });
 
     return documents;
@@ -1101,7 +1101,7 @@ void Page::clear_selection()
 
 Page::FindInPageResult Page::perform_find_in_page_query(FindInPageQuery const& query, Optional<SearchDirection> direction)
 {
-    VERIFY(top_level_traversable_is_initialized());
+    VERIFY(has_local_root_navigable());
 
     Vector<GC::Root<DOM::Range>> all_matches;
 
@@ -1130,7 +1130,7 @@ Page::FindInPageResult Page::perform_find_in_page_query(FindInPageQuery const& q
     auto should_update_match_index = false;
     for (auto const& document : documents_in_active_window()) {
         auto matches = document->find_matching_text(query.string, query.case_sensitivity);
-        if (GC::Ptr { document.ptr() } == top_level_traversable()->active_document()) {
+        if (GC::Ptr { document.ptr() } == local_root_navigable()->active_document()) {
             if (auto range = active_range(*document)) {
                 auto new_match_index = find_current_match_index(*range, matches);
                 should_update_match_index = true;
@@ -1143,9 +1143,9 @@ Page::FindInPageResult Page::perform_find_in_page_query(FindInPageQuery const& q
         all_matches.extend(move(matches));
     }
 
-    if (auto active_document = top_level_traversable()->active_document()) {
+    if (auto active_document = local_root_navigable()->active_document()) {
         if (m_last_find_in_page_url.serialize(URL::ExcludeFragment::Yes) != active_document->url().serialize(URL::ExcludeFragment::Yes)) {
-            m_last_find_in_page_url = top_level_traversable()->active_document()->url();
+            m_last_find_in_page_url = local_root_navigable()->active_document()->url();
             m_find_in_page_match_index = 0;
         }
     }
@@ -1180,7 +1180,7 @@ Page::FindInPageResult Page::perform_find_in_page_query(FindInPageQuery const& q
 
 Page::FindInPageResult Page::find_in_page(FindInPageQuery const& query)
 {
-    if (!top_level_traversable_is_initialized())
+    if (!has_local_root_navigable())
         return {};
 
     if (query.string.is_empty()) {
@@ -1192,14 +1192,14 @@ Page::FindInPageResult Page::find_in_page(FindInPageQuery const& query)
     auto result = perform_find_in_page_query(query);
 
     m_last_find_in_page_query = query;
-    m_last_find_in_page_url = top_level_traversable()->active_document()->url();
+    m_last_find_in_page_url = local_root_navigable()->active_document()->url();
 
     return result;
 }
 
 Page::FindInPageResult Page::find_in_page_next_match()
 {
-    if (!(m_last_find_in_page_query.has_value() && top_level_traversable_is_initialized()))
+    if (!(m_last_find_in_page_query.has_value() && has_local_root_navigable()))
         return {};
 
     auto result = perform_find_in_page_query(*m_last_find_in_page_query, SearchDirection::Forward);
@@ -1208,7 +1208,7 @@ Page::FindInPageResult Page::find_in_page_next_match()
 
 Page::FindInPageResult Page::find_in_page_previous_match()
 {
-    if (!(m_last_find_in_page_query.has_value() && top_level_traversable_is_initialized()))
+    if (!(m_last_find_in_page_query.has_value() && has_local_root_navigable()))
         return {};
 
     auto result = perform_find_in_page_query(*m_last_find_in_page_query, SearchDirection::Backward);

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -9,6 +9,8 @@
 #include <AK/SourceLocation.h>
 #include <LibGC/Heap.h>
 #include <LibGC/HeapVector.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/PaintingSurface.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 #include <LibWeb/Bindings/CSS.h>
@@ -31,8 +33,10 @@
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/ContentBlocker.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Selection/Selection.h>
 
@@ -155,6 +159,61 @@ void Page::load_html(StringView html, Utf16String navigation_id)
 void Page::reload()
 {
     top_level_traversable()->reload();
+}
+
+void Page::queue_screenshot_task(Optional<UniqueNodeID> node_id)
+{
+    m_screenshot_tasks.enqueue({ node_id });
+    top_level_traversable()->set_needs_repaint();
+    client().request_frame();
+}
+
+void Page::process_screenshot_requests()
+{
+    auto& client = this->client();
+    auto navigable = top_level_traversable();
+    while (!m_screenshot_tasks.is_empty()) {
+        auto task = m_screenshot_tasks.dequeue();
+        if (task.node_id.has_value()) {
+            auto* dom_node = DOM::Node::from_unique_id(*task.node_id);
+            if (dom_node)
+                dom_node->document().update_layout(DOM::UpdateLayoutReason::ProcessScreenshot);
+            auto const* layout_node = dom_node ? dom_node->layout_node() : nullptr;
+            if (!layout_node || !Painting::has_committed_box(*layout_node)) {
+                client.page_did_take_screenshot({});
+                continue;
+            }
+            auto rect = enclosing_device_rect(Painting::absolute_border_box_rect(*layout_node));
+            auto bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>());
+            if (bitmap_or_error.is_error()) {
+                client.page_did_take_screenshot({});
+                continue;
+            }
+            auto bitmap = bitmap_or_error.release_value();
+            auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*bitmap);
+            HTML::PaintConfig paint_config { .canvas_fill_rect = rect.to_type<int>() };
+            navigable->render_screenshot(painting_surface, paint_config, [bitmap, &client] {
+                client.page_did_take_screenshot(bitmap->to_shareable_bitmap());
+            });
+        } else {
+            navigable->active_document()->update_layout(DOM::UpdateLayoutReason::ProcessScreenshot);
+            auto const* layout_node = navigable->active_document()->layout_node();
+            VERIFY(layout_node && Painting::has_committed_box(*layout_node));
+            auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(*layout_node);
+            auto rect = enclosing_device_rect(scrollable_overflow_rect.value());
+            auto bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>());
+            if (bitmap_or_error.is_error()) {
+                client.page_did_take_screenshot({});
+                continue;
+            }
+            auto bitmap = bitmap_or_error.release_value();
+            auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*bitmap);
+            HTML::PaintConfig paint_config { .paint_overlay = true, .canvas_fill_rect = rect.to_type<int>() };
+            navigable->render_screenshot(painting_surface, paint_config, [bitmap, &client] {
+                client.page_did_take_screenshot(bitmap->to_shareable_bitmap());
+            });
+        }
+    }
 }
 
 Gfx::Palette Page::palette() const

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -107,18 +107,15 @@ public:
     Compositor::CompositorHost const& compositor_host() const;
 
     // The root navigable hosted by this Page. Its logical ancestors may belong to other pages or processes.
+    void set_local_root_navigable(GC::Ref<HTML::LocalNavigable>);
     GC::Ref<HTML::LocalNavigable> local_root_navigable() const;
+
     bool has_local_root_navigable() const;
-
-    void set_top_level_traversable(GC::Ref<HTML::LocalTraversableNavigable>);
-
-    // FIXME: This is a hack.
-    bool top_level_traversable_is_initialized() const;
 
     HTML::BrowsingContext& top_level_browsing_context();
     HTML::BrowsingContext const& top_level_browsing_context() const;
 
-    GC::Ref<HTML::LocalTraversableNavigable> top_level_traversable() const;
+    GC::Ref<HTML::Navigable> top_level_traversable() const;
 
     HTML::LocalNavigable& focused_navigable();
     HTML::LocalNavigable const& focused_navigable() const { return const_cast<Page*>(this)->focused_navigable(); }
@@ -381,7 +378,7 @@ private:
     // a child navigable. Retain the interaction owner separately from focus to clear its non-DOM input state.
     GC::Weak<HTML::LocalNavigable> m_mouse_event_tracking_navigable;
 
-    GC::Ptr<HTML::LocalTraversableNavigable> m_top_level_traversable;
+    GC::Ptr<HTML::LocalNavigable> m_local_root_navigable;
 
     struct ScreenshotTask {
         Optional<UniqueNodeID> node_id;

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -127,6 +127,9 @@ public:
 
     void reload();
 
+    void queue_screenshot_task(Optional<UniqueNodeID> node_id);
+    void process_screenshot_requests();
+
     CSSPixelPoint device_to_css_point(DevicePixelPoint) const;
     DevicePixelPoint css_to_device_point(CSSPixelPoint) const;
     DevicePixelRect css_to_device_rect(CSSPixelRect) const;
@@ -375,6 +378,11 @@ private:
     GC::Weak<HTML::LocalNavigable> m_mouse_event_tracking_navigable;
 
     GC::Ptr<HTML::LocalTraversableNavigable> m_top_level_traversable;
+
+    struct ScreenshotTask {
+        Optional<UniqueNodeID> node_id;
+    };
+    Queue<ScreenshotTask> m_screenshot_tasks;
 
     bool m_is_scripting_enabled { true };
     bool m_should_block_pop_ups { true };

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -106,6 +106,10 @@ public:
     Compositor::CompositorHost& compositor_host();
     Compositor::CompositorHost const& compositor_host() const;
 
+    // The root navigable hosted by this Page. Its logical ancestors may belong to other pages or processes.
+    GC::Ref<HTML::LocalNavigable> local_root_navigable() const;
+    bool has_local_root_navigable() const;
+
     void set_top_level_traversable(GC::Ref<HTML::LocalTraversableNavigable>);
 
     // FIXME: This is a hack.

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -93,7 +93,7 @@ ErrorOr<GC::Ref<SVGDecodedImageData>> SVGDecodedImageData::create(GC::Ref<Page> 
     auto page = Page::create(*page_client);
     page->set_is_scripting_enabled(false);
     page_client->m_svg_page = page.ptr();
-    page->set_top_level_traversable(HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {}));
+    page->set_local_root_navigable(HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {}));
     auto navigable = page->local_root_navigable();
     auto response = Fetch::Infrastructure::Response::create();
     response->url_list().append(url);

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -52,7 +52,7 @@ public:
 
     ScopedSVGImageDocument(SVGDecodedImageData::SVGPageClient& page_client, DOM::Document& document, FrameRequests frame_requests, GC::Ptr<SVGDecodedImageData> current_image_data = nullptr)
         : m_page_client(page_client)
-        , m_navigable(page_client.page().top_level_traversable())
+        , m_navigable(page_client.page().local_root_navigable())
         , m_window(page_client.window())
         , m_previous_document(*m_navigable->active_document())
         , m_previous_current_image_data(page_client.current_svg_image_data())
@@ -80,7 +80,7 @@ public:
 
 private:
     GC::Ref<SVGDecodedImageData::SVGPageClient> m_page_client;
-    GC::Ref<HTML::LocalTraversableNavigable> m_navigable;
+    GC::Ref<HTML::LocalNavigable> m_navigable;
     GC::Ref<HTML::Window> m_window;
     GC::Ref<DOM::Document> m_previous_document;
     GC::Weak<SVGDecodedImageData> m_previous_current_image_data;
@@ -94,7 +94,7 @@ ErrorOr<GC::Ref<SVGDecodedImageData>> SVGDecodedImageData::create(GC::Ref<Page> 
     page->set_is_scripting_enabled(false);
     page_client->m_svg_page = page.ptr();
     page->set_top_level_traversable(HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {}));
-    auto navigable = page->top_level_traversable();
+    auto navigable = page->local_root_navigable();
     auto response = Fetch::Infrastructure::Response::create();
     response->url_list().append(url);
     auto origin = URL::Origin::create_opaque();
@@ -439,7 +439,7 @@ void SVGDecodedImageData::SVGPageClient::prune_cached_display_list_resources_now
         svg_image_data.append_paint_command_cache_source_resources(retained_resources);
     }
 
-    m_svg_page->top_level_traversable()->display_list_resource_storage().retain_only(retained_resources);
+    m_svg_page->local_root_navigable()->display_list_resource_storage().retain_only(retained_resources);
 }
 
 void SVGDecodedImageData::SVGPageClient::end_recording_display_list()
@@ -456,7 +456,7 @@ void SVGDecodedImageData::SVGPageClient::end_recording_display_list()
 
 HTML::Window& SVGDecodedImageData::SVGPageClient::window() const
 {
-    auto window = m_svg_page->top_level_traversable()->active_window();
+    auto window = m_svg_page->local_root_navigable()->active_window();
     VERIFY(window);
     return *window;
 }

--- a/Libraries/LibWeb/WebDriver/Actions.cpp
+++ b/Libraries/LibWeb/WebDriver/Actions.cpp
@@ -1260,7 +1260,7 @@ static ErrorOr<void, WebDriver::Error> perform_pointer_move(ActionObject::Pointe
 // https://w3c.github.io/webdriver/#dfn-dispatch-a-pointermove-action
 static ErrorOr<void, WebDriver::Error> dispatch_pointer_move_action(ActionObject::PointerMoveFields const& action_object, PointerInputSource& source, GlobalKeyState const& global_key_state, AK::Duration tick_duration, HTML::BrowsingContext& browsing_context, ActionsOptions const& actions_options)
 {
-    auto viewport = browsing_context.page().top_level_traversable()->viewport_rect();
+    auto viewport = as<HTML::LocalNavigable>(*browsing_context.page().top_level_traversable()).viewport_rect();
 
     // 1. Let x offset be equal to the x property of action object.
     // 2. Let y offset be equal to the y property of action object.
@@ -1304,7 +1304,7 @@ static ErrorOr<void, WebDriver::Error> dispatch_pointer_move_action(ActionObject
 // https://w3c.github.io/webdriver/#dfn-dispatch-a-scroll-action
 static ErrorOr<void, WebDriver::Error> dispatch_scroll_action(ActionObject::ScrollFields const& action_object, GlobalKeyState const& global_key_state, AK::Duration tick_duration, HTML::BrowsingContext& browsing_context, ActionsOptions const& actions_options)
 {
-    auto viewport = browsing_context.page().top_level_traversable()->viewport_rect();
+    auto viewport = as<HTML::LocalNavigable>(*browsing_context.page().top_level_traversable()).viewport_rect();
 
     // 1. Let x offset be equal to the x property of action object.
     // 2. Let y offset be equal to the y property of action object.

--- a/Libraries/LibWeb/WebDriver/ElementReference.cpp
+++ b/Libraries/LibWeb/WebDriver/ElementReference.cpp
@@ -272,7 +272,7 @@ bool is_element_pointer_interactable(Web::HTML::BrowsingContext const& browsing_
     if (!layout_root || !Painting::has_committed_box(*layout_root))
         return false;
 
-    auto viewport = browsing_context.page().top_level_traversable()->viewport_rect();
+    auto viewport = as<HTML::LocalNavigable>(*browsing_context.page().top_level_traversable()).viewport_rect();
     auto center_point_or_error = in_view_center_point(element, viewport);
     if (center_point_or_error.is_error())
         return false;
@@ -412,7 +412,7 @@ GC::RootVector<GC::Ref<Web::DOM::Element>> pointer_interactable_tree(Web::HTML::
         return GC::RootVector<GC::Ref<Web::DOM::Element>> {};
 
     // 4. Let center point be the in-view center point of the first indexed element in rectangles.
-    auto viewport = browsing_context.page().top_level_traversable()->viewport_rect();
+    auto viewport = as<HTML::LocalNavigable>(*browsing_context.page().top_level_traversable()).viewport_rect();
     auto center_point_or_error = Web::WebDriver::in_view_center_point(element, viewport);
     if (center_point_or_error.is_error())
         return GC::RootVector<GC::Ref<Web::DOM::Element>> {};

--- a/Libraries/LibWebView/WebDriverBrowserConnection.cpp
+++ b/Libraries/LibWebView/WebDriverBrowserConnection.cpp
@@ -152,8 +152,7 @@ void WebDriverBrowserConnection::load_url(u64 command_id, String window_handle, 
         return;
     }
 
-    if (url.scheme() != "javascript"sv)
-        view->did_start_webdriver_navigation();
+    view->did_start_webdriver_navigation();
 
     auto strong_this = NonnullRefPtr { *this };
     Core::deferred_invoke([strong_this, command_id, view_id = view->view_id(), url = move(url)]() {

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -211,7 +211,7 @@ void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Co
     if (!page.has_value())
         return;
 
-    auto& compositor_context = page->page().top_level_traversable()->compositor_context();
+    auto& compositor_context = page->page().local_root_navigable()->compositor_context();
     if (parent_context_id.has_value())
         compositor_context.stop_presenting_to_client();
     compositor_context.set_parent_context(parent_context_id);
@@ -428,7 +428,7 @@ void ConnectionFromClient::reload(u64 page_id)
 void ConnectionFromClient::stop_loading(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().top_level_traversable()->stop_loading();
+        page->page().local_root_navigable()->stop_loading();
 }
 
 void ConnectionFromClient::cancel_download(u64 page_id, u64 download_id)
@@ -445,10 +445,9 @@ void ConnectionFromClient::history_operation_started(u64 page_id, Web::HTML::Cro
         return;
     }
 
-    page->page().top_level_traversable()->handle_ui_history_operation_started(operation_id, move(reconstructed_child_navigation),
-        GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id](Web::HistoryOperationReadyResult result) {
-            async_history_operation_ready(page_id, operation_id, move(result));
-        }));
+    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).handle_ui_history_operation_started(operation_id, move(reconstructed_child_navigation), GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id](Web::HistoryOperationReadyResult result) {
+        async_history_operation_ready(page_id, operation_id, move(result));
+    }));
 }
 
 void ConnectionFromClient::run_history_step_unload_cancelation_job(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Vector<Web::HTML::CrossProcessId> navigables_crossing_documents, Web::HTML::UserNavigationInvolvement user_involvement)
@@ -459,10 +458,9 @@ void ConnectionFromClient::run_history_step_unload_cancelation_job(u64 page_id, 
         return;
     }
 
-    page->page().top_level_traversable()->run_ui_history_step_unload_cancelation_job(operation_id, move(target_entry), move(navigables_crossing_documents), user_involvement,
-        GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id](Web::HTML::HistoryStepResult result, Web::HTML::UnloadPromptShown unload_prompt_shown) {
-            async_history_step_unload_cancelation_result(page_id, operation_id, result, unload_prompt_shown);
-        }));
+    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).run_ui_history_step_unload_cancelation_job(operation_id, move(target_entry), move(navigables_crossing_documents), user_involvement, GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id](Web::HTML::HistoryStepResult result, Web::HTML::UnloadPromptShown unload_prompt_shown) {
+        async_history_step_unload_cancelation_result(page_id, operation_id, result, unload_prompt_shown);
+    }));
 }
 
 void ConnectionFromClient::run_history_step_beforeunload_check(u64 page_id, Web::HTML::CrossProcessId operation_id, Vector<Web::HTML::CrossProcessId> navigable_ids, Web::HTML::UnloadPromptShown unload_prompt_shown)
@@ -473,10 +471,9 @@ void ConnectionFromClient::run_history_step_beforeunload_check(u64 page_id, Web:
         return;
     }
 
-    page->page().top_level_traversable()->run_ui_history_step_beforeunload_check(move(navigable_ids), unload_prompt_shown,
-        GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id](Web::HTML::HistoryStepResult result, Web::HTML::UnloadPromptShown unload_prompt_shown) {
-            async_history_step_beforeunload_check_result(page_id, operation_id, result, unload_prompt_shown);
-        }));
+    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).run_ui_history_step_beforeunload_check(move(navigable_ids), unload_prompt_shown, GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id](Web::HTML::HistoryStepResult result, Web::HTML::UnloadPromptShown unload_prompt_shown) {
+        async_history_step_beforeunload_check_result(page_id, operation_id, result, unload_prompt_shown);
+    }));
 }
 
 void ConnectionFromClient::discard_embedded_page(u64 page_id)
@@ -487,13 +484,13 @@ void ConnectionFromClient::discard_embedded_page(u64 page_id)
 
     // The UI process has already coordinated the embedded subtree's unload. This local traversable is the page
     // coordinator for an iframe, not a browser top-level traversable, so discard it without running close steps.
-    page->page().top_level_traversable()->destroy_local_traversable();
+    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).destroy_local_traversable();
 }
 
 void ConnectionFromClient::queue_navigation_api_state_clear_task(u64 page_id, Web::HTML::CrossProcessId, Web::HTML::CrossProcessId navigable_id)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().top_level_traversable()->queue_navigation_api_state_clear_task(navigable_id);
+        as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).queue_navigation_api_state_clear_task(navigable_id);
 }
 
 void ConnectionFromClient::continue_history_navigation_population(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Web::Bindings::NavigationType> navigation_type, Web::HTML::HistoryNavigationPopulation population)
@@ -504,11 +501,11 @@ void ConnectionFromClient::continue_history_navigation_population(u64 page_id, W
         async_changing_navigable_history_job_ready(page_id, operation_id, navigable_id, Web::HTML::ChangingNavigableHistoryStepJobDisposition::Skipped, Web::HTML::UnloadDisplayedDocument::No);
         return;
     }
-    auto traversable = page->page().top_level_traversable();
-    if (traversable->resume_history_navigation_population(operation_id, move(population)))
+    auto& traversable = as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable());
+    if (traversable.resume_history_navigation_population(operation_id, move(population)))
         return;
     auto user_involvement = population.request.user_involvement;
-    traversable->run_ui_changing_navigable_history_job(operation_id, navigable_id, move(target_entry), user_involvement, navigation_type, false,
+    traversable.run_ui_changing_navigable_history_job(operation_id, navigable_id, move(target_entry), user_involvement, navigation_type, false,
         GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id](Web::HTML::ChangingNavigableHistoryStepJobDisposition disposition, Web::HTML::UnloadDisplayedDocument unload_displayed_document) {
             async_changing_navigable_history_job_ready(page_id, operation_id, navigable_id, disposition, unload_displayed_document);
         }),
@@ -523,10 +520,9 @@ void ConnectionFromClient::run_changing_navigable_history_job(u64 page_id, Web::
         return;
     }
 
-    page->page().top_level_traversable()->run_ui_changing_navigable_history_job(operation_id, navigable_id, move(target_entry), user_involvement, navigation_type, superseded_by_newer_navigation,
-        GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id](Web::HTML::ChangingNavigableHistoryStepJobDisposition disposition, Web::HTML::UnloadDisplayedDocument unload_displayed_document) {
-            async_changing_navigable_history_job_ready(page_id, operation_id, navigable_id, disposition, unload_displayed_document);
-        }));
+    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).run_ui_changing_navigable_history_job(operation_id, navigable_id, move(target_entry), user_involvement, navigation_type, superseded_by_newer_navigation, GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id](Web::HTML::ChangingNavigableHistoryStepJobDisposition disposition, Web::HTML::UnloadDisplayedDocument unload_displayed_document) {
+        async_changing_navigable_history_job_ready(page_id, operation_id, navigable_id, disposition, unload_displayed_document);
+    }));
 }
 
 void ConnectionFromClient::prepare_changing_navigable_for_unload(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id)
@@ -537,10 +533,9 @@ void ConnectionFromClient::prepare_changing_navigable_for_unload(u64 page_id, We
         return;
     }
 
-    page->page().top_level_traversable()->prepare_ui_changing_navigable_for_unload(operation_id, navigable_id,
-        GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id] {
-            async_changing_navigable_unload_preparation_complete(page_id, operation_id, navigable_id);
-        }));
+    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).prepare_ui_changing_navigable_for_unload(operation_id, navigable_id, GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id] {
+        async_changing_navigable_unload_preparation_complete(page_id, operation_id, navigable_id);
+    }));
 }
 
 void ConnectionFromClient::apply_changing_navigable_continuation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries_for_navigation_api, Web::HTML::VisibilityState system_visibility_state, Web::HTML::UnloadDisplayedDocument unload_displayed_document)
@@ -551,10 +546,9 @@ void ConnectionFromClient::apply_changing_navigable_continuation(u64 page_id, We
         return;
     }
 
-    page->page().top_level_traversable()->apply_ui_changing_navigable_continuation(operation_id, navigable_id, { script_history_length, script_history_index }, move(entries_for_navigation_api), system_visibility_state, unload_displayed_document,
-        GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id](Optional<Web::HTML::ReplicatedNavigableState> activated_navigable_state, Optional<Web::HTML::SessionHistoryEntryPersistedState> previous_entry_persisted_state) {
-            async_changing_navigable_continuation_applied(page_id, operation_id, navigable_id, move(activated_navigable_state), move(previous_entry_persisted_state));
-        }));
+    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).apply_ui_changing_navigable_continuation(operation_id, navigable_id, { script_history_length, script_history_index }, move(entries_for_navigation_api), system_visibility_state, unload_displayed_document, GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id](Optional<Web::HTML::ReplicatedNavigableState> activated_navigable_state, Optional<Web::HTML::SessionHistoryEntryPersistedState> previous_entry_persisted_state) {
+        async_changing_navigable_continuation_applied(page_id, operation_id, navigable_id, move(activated_navigable_state), move(previous_entry_persisted_state));
+    }));
 }
 
 void ConnectionFromClient::run_descendant_unload_task(u64 page_id, Web::HTML::CrossProcessId unload_id, Web::HTML::CrossProcessId navigable_id)
@@ -565,22 +559,21 @@ void ConnectionFromClient::run_descendant_unload_task(u64 page_id, Web::HTML::Cr
         return;
     }
 
-    page->page().top_level_traversable()->run_ui_descendant_unload_task(navigable_id,
-        GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, unload_id, navigable_id] {
-            async_descendant_unload_task_complete(page_id, unload_id, navigable_id);
-        }));
+    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).run_ui_descendant_unload_task(navigable_id, GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, unload_id, navigable_id] {
+        async_descendant_unload_task_complete(page_id, unload_id, navigable_id);
+    }));
 }
 
 void ConnectionFromClient::continue_child_navigable_destruction(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::UnloadDisplayedDocument unload_displayed_document)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().top_level_traversable()->continue_child_navigable_destruction(navigable_id, unload_displayed_document);
+        as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).continue_child_navigable_destruction(navigable_id, unload_displayed_document);
 }
 
 void ConnectionFromClient::run_traversable_close_unload_task(u64 page_id, Web::HTML::CrossProcessId)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().top_level_traversable()->run_ui_traversable_close_unload_task();
+        as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).run_ui_traversable_close_unload_task();
 }
 
 void ConnectionFromClient::update_nonchanging_navigable_history_state(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index)
@@ -591,23 +584,22 @@ void ConnectionFromClient::update_nonchanging_navigable_history_state(u64 page_i
         return;
     }
 
-    page->page().top_level_traversable()->update_nonchanging_navigable_history_step_state(navigable_id, { script_history_length, script_history_index },
-        GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id] {
-            async_nonchanging_navigable_history_state_updated(page_id, operation_id, navigable_id);
-        }));
+    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).update_nonchanging_navigable_history_step_state(navigable_id, { script_history_length, script_history_index }, GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id] {
+        async_nonchanging_navigable_history_state_updated(page_id, operation_id, navigable_id);
+    }));
 }
 
 void ConnectionFromClient::complete_history_operation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult result, Optional<i32> committed_step, u64 session_history_entry_count)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().top_level_traversable()->complete_ui_history_operation(operation_id, result, committed_step, session_history_entry_count);
+        as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).complete_ui_history_operation(operation_id, result, committed_step, session_history_entry_count);
 }
 
 void ConnectionFromClient::reset_session_history_for_testing(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value()) {
-        page->page().top_level_traversable()->reset_session_history_for_testing();
-        auto active_entry = page->page().top_level_traversable()->active_session_history_entry();
+        as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).reset_session_history_for_testing();
+        auto active_entry = page->page().local_root_navigable()->active_session_history_entry();
         VERIFY(active_entry);
         async_did_reset_session_history_for_testing(page_id, Web::HTML::create_session_history_entry_descriptor(*active_entry));
     }
@@ -727,13 +719,12 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
         return;
 
     if (request == "dump-session-history") {
-        auto const& traversable = page->page().top_level_traversable();
-        Web::dump_tree(*traversable);
+        Web::dump_tree(as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()));
         return;
     }
 
     if (request == "dump-display-list") {
-        if (auto* doc = page->page().top_level_browsing_context().active_document()) {
+        if (auto doc = page->page().local_root_navigable()->active_document()) {
             auto display_list_dump = doc->dump_display_list();
             dbgln("{}", display_list_dump.to_utf8());
         }
@@ -741,13 +732,13 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
     }
 
     if (request == "dump-dom-tree") {
-        if (auto* doc = page->page().top_level_browsing_context().active_document())
+        if (auto doc = page->page().local_root_navigable()->active_document())
             Web::dump_tree(*doc);
         return;
     }
 
     if (request == "dump-layout-tree") {
-        if (auto* doc = page->page().top_level_browsing_context().active_document()) {
+        if (auto doc = page->page().local_root_navigable()->active_document()) {
             if (auto* viewport = doc->layout_node())
                 Web::dump_tree(*viewport);
         }
@@ -755,7 +746,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
     }
 
     if (request == "dump-stacking-context-tree") {
-        if (auto* doc = page->page().top_level_browsing_context().active_document()) {
+        if (auto doc = page->page().local_root_navigable()->active_document()) {
             if (doc->layout_node()) {
                 VERIFY(doc->has_committed_viewport_box());
                 doc->update_paint_and_hit_testing_properties_if_needed();
@@ -768,7 +759,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
     }
 
     if (request == "dump-style-sheets") {
-        if (auto* doc = page->page().top_level_browsing_context().active_document()) {
+        if (auto doc = page->page().local_root_navigable()->active_document()) {
             dbgln("=== In document: ===");
             for (auto& sheet : doc->style_sheets().sheets()) {
                 Web::dump_sheet(sheet);
@@ -799,7 +790,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
             dbgln("---");
         };
 
-        if (auto* doc = page->page().top_level_browsing_context().active_document()) {
+        if (auto doc = page->page().local_root_navigable()->active_document()) {
             Queue<Web::DOM::Node*> nodes_to_visit;
             nodes_to_visit.enqueue(doc->document_element());
             while (!nodes_to_visit.is_empty()) {
@@ -850,25 +841,25 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
 
     if (request == "set-force-dark") {
         bool state = argument == "on";
-        auto traversable = page->page().top_level_traversable();
-        traversable->set_force_dark_enabled(state);
+        auto local_root_navigable = page->page().local_root_navigable();
+        local_root_navigable->set_force_dark_enabled(state);
         // This request means the whole default force-dark state, thresholds included: only tests move them (through
         // internals), and one test's thresholds must not leak into the next test sharing the view.
-        traversable->set_force_dark_thresholds(Web::HTML::default_force_dark_foreground_threshold, Web::HTML::default_force_dark_background_threshold);
+        local_root_navigable->set_force_dark_thresholds(Web::HTML::default_force_dark_foreground_threshold, Web::HTML::default_force_dark_background_threshold);
         return;
     }
 
     if (request == "set-line-box-borders") {
         bool state = argument == "on";
-        auto traversable = page->page().top_level_traversable();
-        traversable->set_should_show_line_box_borders(state);
+        auto local_root_navigable = page->page().local_root_navigable();
+        local_root_navigable->set_should_show_line_box_borders(state);
         return;
     }
 
     if (request == "set-caret-hit-test-debug-overlay") {
         bool state = argument == "on";
-        auto traversable = page->page().top_level_traversable();
-        traversable->set_should_show_caret_hit_test_debug_overlay(state);
+        auto local_root_navigable = page->page().local_root_navigable();
+        local_root_navigable->set_should_show_caret_hit_test_debug_overlay(state);
         return;
     }
 
@@ -893,7 +884,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
     }
 
     if (request == "dump-local-storage") {
-        if (auto* document = page->page().top_level_browsing_context().active_document()) {
+        if (auto document = page->page().local_root_navigable()->active_document()) {
             auto storage_or_error = document->window()->local_storage();
             if (storage_or_error.is_error())
                 dbgln("Failed to retrieve local storage: {}", storage_or_error.release_error());
@@ -904,7 +895,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
     }
 
     if (request == "dump-session-storage") {
-        if (auto* document = page->page().top_level_browsing_context().active_document()) {
+        if (auto document = page->page().local_root_navigable()->active_document()) {
             auto storage_or_error = document->window()->session_storage();
             if (storage_or_error.is_error())
                 dbgln("Failed to retrieve session storage: {}", storage_or_error.release_error());
@@ -940,7 +931,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
 void ConnectionFromClient::get_source(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value()) {
-        if (auto* doc = page->page().top_level_browsing_context().active_document())
+        if (auto doc = page->page().local_root_navigable()->active_document())
             async_did_get_source(page_id, doc->url(), doc->base_url(), doc->source());
     }
 }
@@ -948,7 +939,7 @@ void ConnectionFromClient::get_source(u64 page_id)
 void ConnectionFromClient::inspect_dom_tree(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value()) {
-        if (auto* doc = page->page().top_level_browsing_context().active_document())
+        if (auto doc = page->page().local_root_navigable()->active_document())
             async_did_inspect_dom_tree(page_id, doc->dump_dom_tree_as_json().to_utf8());
     }
 }
@@ -961,7 +952,7 @@ void ConnectionFromClient::inspect_storage(u64 page_id, Web::StorageAPI::Storage
         return;
     }
 
-    auto* document = page->page().top_level_browsing_context().active_document();
+    auto document = page->page().local_root_navigable()->active_document();
     if (!document || !document->window()) {
         async_did_inspect_storage(page_id, request_id, "[]"_string);
         return;
@@ -1001,7 +992,7 @@ void ConnectionFromClient::inspect_storage(u64 page_id, Web::StorageAPI::Storage
 
 static Optional<GC::Ref<Web::HTML::Storage>> active_session_storage_for_page(PageClient& page)
 {
-    auto* document = page.page().top_level_browsing_context().active_document();
+    auto document = page.page().local_root_navigable()->active_document();
     if (!document || !document->window())
         return {};
 
@@ -1332,7 +1323,7 @@ void ConnectionFromClient::inspect_indexed_database_storage(u64 page_id, u64 req
     if (!page.has_value())
         return;
 
-    auto* document = page->page().top_level_browsing_context().active_document();
+    auto document = page->page().local_root_navigable()->active_document();
     if (!document) {
         async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
         return;
@@ -1347,7 +1338,7 @@ void ConnectionFromClient::inspect_indexed_database_objects(u64 page_id, u64 req
     if (!page.has_value())
         return;
 
-    auto* document = page->page().top_level_browsing_context().active_document();
+    auto document = page->page().local_root_navigable()->active_document();
     if (!document) {
         async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
         return;
@@ -1374,7 +1365,7 @@ void ConnectionFromClient::delete_indexed_database(u64 page_id, u64 request_id, 
     if (!page.has_value())
         return;
 
-    auto* document = page->page().top_level_browsing_context().active_document();
+    auto document = page->page().local_root_navigable()->active_document();
     if (!document) {
         async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
         return;
@@ -1389,7 +1380,7 @@ void ConnectionFromClient::clear_indexed_database_object_store(u64 page_id, u64 
     if (!page.has_value())
         return;
 
-    auto* document = page->page().top_level_browsing_context().active_document();
+    auto document = page->page().local_root_navigable()->active_document();
     if (!document) {
         async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
         return;
@@ -1404,7 +1395,7 @@ void ConnectionFromClient::delete_indexed_database_record(u64 page_id, u64 reque
     if (!page.has_value())
         return;
 
-    auto* document = page->page().top_level_browsing_context().active_document();
+    auto document = page->page().local_root_navigable()->active_document();
     if (!document) {
         async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
         return;
@@ -1569,7 +1560,7 @@ void ConnectionFromClient::clear_grid_highlight(u64 page_id, Web::UniqueNodeID n
 void ConnectionFromClient::inspect_accessibility_tree(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value()) {
-        if (auto* doc = page->page().top_level_browsing_context().active_document())
+        if (auto doc = page->page().local_root_navigable()->active_document())
             async_did_inspect_accessibility_tree(page_id, doc->dump_accessibility_tree_as_json().to_utf8());
     }
 }
@@ -1582,7 +1573,7 @@ void ConnectionFromClient::get_hovered_node_id(u64 page_id)
 
     Web::UniqueNodeID node_id = 0;
 
-    if (auto* document = page->page().top_level_browsing_context().active_document()) {
+    if (auto document = page->page().local_root_navigable()->active_document()) {
         if (auto* hovered_node = document->hovered_node())
             node_id = hovered_node->unique_id();
     }
@@ -1616,7 +1607,7 @@ void ConnectionFromClient::request_style_sheet_source(u64 page_id, Web::CSS::Sty
     if (!page.has_value())
         return;
 
-    if (auto* document = page->page().top_level_browsing_context().active_document()) {
+    if (auto document = page->page().local_root_navigable()->active_document()) {
         if (auto stylesheet = document->get_style_sheet_source(identifier); stylesheet.has_value())
             async_did_get_style_sheet_source(page_id, identifier, document->base_url(), stylesheet.value());
     }
@@ -1807,7 +1798,7 @@ void ConnectionFromClient::resolve_dom_node_url(u64 page_id, u64 request_id, Opt
             return nullptr;
         }
 
-        return page->page().top_level_browsing_context().active_document();
+        return page->page().local_root_navigable()->active_document().ptr();
     }();
 
     auto resolved_url = document
@@ -2064,7 +2055,7 @@ void ConnectionFromClient::remove_dom_node(u64 page_id, Web::UniqueNodeID node_i
     if (!page.has_value())
         return;
 
-    auto* active_document = page->page().top_level_browsing_context().active_document();
+    auto active_document = page->page().local_root_navigable()->active_document();
     if (!active_document) {
         async_did_finish_editing_dom_node(page_id, {});
         return;
@@ -2105,7 +2096,7 @@ void ConnectionFromClient::take_dom_node_screenshot(u64 page_id, Web::UniqueNode
 
 static void append_page_text(Web::Page& page, StringBuilder& builder)
 {
-    auto* document = page.top_level_browsing_context().active_document();
+    auto document = page.local_root_navigable()->active_document();
     if (!document) {
         builder.append("(no DOM tree)"sv);
         return;
@@ -2122,7 +2113,7 @@ static void append_page_text(Web::Page& page, StringBuilder& builder)
 
 static void append_layout_tree(Web::Page& page, StringBuilder& builder)
 {
-    auto* document = page.top_level_browsing_context().active_document();
+    auto document = page.local_root_navigable()->active_document();
     if (!document) {
         builder.append("(no DOM tree)"sv);
         return;
@@ -2141,7 +2132,7 @@ static void append_layout_tree(Web::Page& page, StringBuilder& builder)
 
 static void append_stacking_context_tree(Web::Page& page, StringBuilder& builder)
 {
-    auto* document = page.top_level_browsing_context().active_document();
+    auto document = page.local_root_navigable()->active_document();
     if (!document) {
         builder.append("(no DOM tree)"sv);
         return;
@@ -2654,7 +2645,7 @@ void ConnectionFromClient::update_visibility_state(u64 page_id, Web::HTML::Cross
 void ConnectionFromClient::reset_zoom(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().top_level_traversable()->reset_zoom();
+        page->page().local_root_navigable()->reset_zoom();
 }
 
 void ConnectionFromClient::js_console_input(u64 page_id, String js_source)
@@ -2788,7 +2779,7 @@ void ConnectionFromClient::set_document_cookie_version_index(u64 page_id, i64 do
 void ConnectionFromClient::cookies_changed(u64 page_id, Vector<HTTP::Cookie::Cookie> cookies)
 {
     if (auto page = this->page(page_id); page.has_value()) {
-        auto window = page->page().top_level_traversable()->active_window();
+        auto window = page->page().local_root_navigable()->active_window();
         if (!window)
             return;
 
@@ -2839,8 +2830,8 @@ void ConnectionFromClient::force_close(u64 page_id)
 void ConnectionFromClient::exit_fullscreen(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value()) {
-        Web::HTML::TemporaryExecutionContext context(page->page().top_level_browsing_context().active_document()->relevant_settings_object(), Web::HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
-        page->page().top_level_browsing_context().active_document()->fully_exit_fullscreen();
+        Web::HTML::TemporaryExecutionContext context(page->page().local_root_navigable()->active_document()->relevant_settings_object(), Web::HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        page->page().local_root_navigable()->active_document()->fully_exit_fullscreen();
     }
 }
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -579,12 +579,13 @@ void ConnectionFromClient::run_traversable_close_unload_task(u64 page_id, Web::H
 void ConnectionFromClient::update_nonchanging_navigable_history_state(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index)
 {
     auto page = this->page(page_id);
-    if (!page.has_value()) {
+    auto navigable = Web::HTML::local_navigable_with_id(navigable_id);
+    if (!page.has_value() || !navigable) {
         async_nonchanging_navigable_history_state_updated(page_id, operation_id, navigable_id);
         return;
     }
 
-    as<Web::HTML::LocalTraversableNavigable>(*page->page().local_root_navigable()).update_nonchanging_navigable_history_step_state(navigable_id, { script_history_length, script_history_index }, GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id] {
+    navigable->update_nonchanging_navigable_history_step_state({ script_history_length, script_history_index }, GC::create_function(navigable->heap(), [this, page_id, operation_id, navigable_id] {
         async_nonchanging_navigable_history_state_updated(page_id, operation_id, navigable_id);
     }));
 }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -279,7 +279,7 @@ void ConnectionFromClient::close_server()
 Messages::WebContentServer::GetWindowHandleResponse ConnectionFromClient::get_window_handle(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())
-        return page->page().top_level_traversable()->window_handle().to_utf8();
+        return as<Web::HTML::LocalTraversableNavigable>(*page->page().top_level_traversable()).window_handle().to_utf8();
     return String {};
 }
 
@@ -2818,13 +2818,13 @@ void ConnectionFromClient::request_close(u64 page_id)
     // Browser user agents should offer users the ability to arbitrarily close any top-level traversable in their top-level traversable set.
     // For example, by clicking a "close tab" button.
     if (auto page = this->page(page_id); page.has_value())
-        page->page().top_level_traversable()->close_top_level_traversable();
+        as<Web::HTML::LocalTraversableNavigable>(*page->page().top_level_traversable()).close_top_level_traversable();
 }
 
 void ConnectionFromClient::force_close(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().top_level_traversable()->close_top_level_traversable(Web::HTML::LocalTraversableNavigable::PromptToUnload::No);
+        as<Web::HTML::LocalTraversableNavigable>(*page->page().top_level_traversable()).close_top_level_traversable(Web::HTML::LocalTraversableNavigable::PromptToUnload::No);
 }
 
 void ConnectionFromClient::exit_fullscreen(u64 page_id)

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2235,10 +2235,10 @@ static Optional<Gfx::IntPoint> dictionary_lookup_baseline_origin_for_range(Web::
     if (!navigable)
         return {};
 
-    auto to_top_level_viewport_point = [&](Web::CSSPixelPoint point) {
+    auto to_page_viewport_point = [&](Web::CSSPixelPoint point) {
         auto scroll_offset = navigable->viewport_scroll_offset();
         Web::CSSPixelPoint viewport_point { point.x() - scroll_offset.x(), point.y() - scroll_offset.y() };
-        return navigable->to_top_level_position(viewport_point);
+        return navigable->to_page_position(viewport_point);
     };
 
     auto rect = range.get_bounding_client_rect();
@@ -2250,7 +2250,7 @@ static Optional<Gfx::IntPoint> dictionary_lookup_baseline_origin_for_range(Web::
         Web::CSSPixels::nearest_value_for(rect->x()),
         Web::CSSPixels::nearest_value_for(rect->y() + font.pixel_metrics().ascent),
     };
-    return page.css_to_device_point(to_top_level_viewport_point(baseline_origin)).to_type<int>();
+    return page.css_to_device_point(to_page_viewport_point(baseline_origin)).to_type<int>();
 }
 
 void ConnectionFromClient::get_selected_text_for_lookup(u64 page_id, u64 request_id)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1978,7 +1978,7 @@ Web::Compositor::CompositorHost const* PageClient::compositor_host() const
 
 void PageClient::queue_screenshot_task(Optional<Web::UniqueNodeID> node_id)
 {
-    page().top_level_traversable()->queue_screenshot_task(node_id);
+    page().queue_screenshot_task(node_id);
 }
 
 }

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -202,7 +202,7 @@ void PageClient::set_has_focus(bool has_focus)
 
 void PageClient::set_window_handle(Utf16String window_handle)
 {
-    page().top_level_traversable()->set_window_handle(move(window_handle));
+    as<Web::HTML::LocalTraversableNavigable>(*page().top_level_traversable()).set_window_handle(move(window_handle));
 }
 
 void PageClient::setup_palette()
@@ -1006,19 +1006,19 @@ void PageClient::set_geolocation_emulated_position(WebView::GeolocationPositionD
 
 void PageClient::apply_pending_geolocation_emulated_position()
 {
-    if (!m_pending_geolocation_emulated_position.has_value() || !page().top_level_traversable_is_initialized())
+    if (!m_pending_geolocation_emulated_position.has_value() || !page().has_local_root_navigable())
         return;
 
     auto const& pending = *m_pending_geolocation_emulated_position;
     auto const& position = pending.position;
-    auto traversable = page().top_level_traversable();
+    auto& traversable = as<Web::HTML::LocalTraversableNavigable>(*page().top_level_traversable());
 
     if (pending.error_code.has_value())
-        traversable->set_emulated_position_data(geolocation_position_error_code_from_ipc(*pending.error_code));
+        traversable.set_emulated_position_data(geolocation_position_error_code_from_ipc(*pending.error_code));
     else if (auto coordinates = geolocation_coordinates_from_ipc(position); coordinates.has_value())
-        traversable->set_emulated_position_data(*coordinates);
+        traversable.set_emulated_position_data(*coordinates);
     else
-        traversable->set_emulated_position_data(Empty {});
+        traversable.set_emulated_position_data(Empty {});
 }
 
 void PageClient::geolocation_position_response(u64 request_id, WebView::GeolocationPositionData const& position, Optional<u16> error_code)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -182,7 +182,7 @@ void PageClient::set_has_focus(bool has_focus)
 
     m_has_focus = has_focus;
 
-    if (auto document = page().top_level_traversable()->active_document(); document && has_focus)
+    if (auto document = page().local_root_navigable()->active_document(); document && has_focus)
         document->reset_cursor_blink_cycle();
 
     // The focus ring, the text caret, and selection highlight colors all depend on the window focus state, so
@@ -197,7 +197,7 @@ void PageClient::set_has_focus(bool has_focus)
         for (auto& child_navigable : navigable.child_navigables())
             invalidate_cached_paint_recursively(*child_navigable);
     };
-    invalidate_cached_paint_recursively(page().top_level_traversable());
+    invalidate_cached_paint_recursively(page().local_root_navigable());
 }
 
 void PageClient::set_window_handle(Utf16String window_handle)
@@ -446,7 +446,7 @@ void PageClient::compositor_process_reconnected()
     if (auto* compositor_host = m_owner.compositor_host())
         compositor_host->discard_canvas_2d_stream();
 
-    page().top_level_traversable()->repaint_after_compositor_process_reconnect();
+    page().local_root_navigable()->repaint_after_compositor_process_reconnect();
     page().notify_all_canvas_elements_of_lost_backing_storage();
     page().prepare_canvas_contexts_for_compositing();
     page().restore_all_media_element_video_sinks();
@@ -508,13 +508,13 @@ void PageClient::set_viewport(Web::DevicePixelSize const& size, double device_pi
     m_viewport_size = size;
     m_device_pixel_ratio = device_pixel_ratio;
 
-    page().top_level_traversable()->set_viewport_size(page().device_to_css_size(size), invalidate);
+    page().local_root_navigable()->set_viewport_size(page().device_to_css_size(size), invalidate);
 }
 
 void PageClient::set_zoom_level(double zoom_level)
 {
     m_zoom_level = zoom_level;
-    page().top_level_traversable()->set_viewport_size(page().device_to_css_size(m_viewport_size), Web::InvalidateDisplayList::Yes);
+    page().local_root_navigable()->set_viewport_size(page().device_to_css_size(m_viewport_size), Web::InvalidateDisplayList::Yes);
 }
 
 void PageClient::request_frame()
@@ -544,9 +544,9 @@ void PageClient::request_rendering_opportunity_if_needed()
     if (Web::HTML::main_thread_event_loop().rendering_task_queued_or_running())
         return;
 
-    if (page().top_level_traversable_is_initialized()) {
-        auto& traversable = *page().top_level_traversable();
-        if (traversable.has_compositor_context() && traversable.compositor_context().request_rendering_opportunity(m_maximum_frames_per_second)) {
+    if (page().has_local_root_navigable()) {
+        auto& local_root_navigable = *page().local_root_navigable();
+        if (local_root_navigable.has_compositor_context() && local_root_navigable.compositor_context().request_rendering_opportunity(m_maximum_frames_per_second)) {
             m_compositor_rendering_opportunity_outstanding = true;
             schedule_compositor_watchdog();
             return;
@@ -589,7 +589,7 @@ void PageClient::frame_timer_fired()
     auto purpose = m_frame_timer_purpose;
     m_frame_timer_purpose = FrameTimerPurpose::Inactive;
 
-    auto document = page().top_level_traversable_is_initialized() ? page().top_level_traversable()->active_document() : nullptr;
+    auto document = page().has_local_root_navigable() ? page().local_root_navigable()->active_document() : nullptr;
     // NB: The Compositor keeps its pending request while the context is hidden. Forget our copy once its watchdog
     //     fires so becoming visible can arm a new watchdog for the retained request.
     if (document && document->hidden()) {
@@ -620,7 +620,7 @@ void PageClient::frame_timer_fired()
                 return;
             if (page_client->m_compositor_watchdog_deadline != watchdog_deadline)
                 return;
-            auto document = page_client->page().top_level_traversable_is_initialized() ? page_client->page().top_level_traversable()->active_document() : nullptr;
+            auto document = page_client->page().has_local_root_navigable() ? page_client->page().local_root_navigable()->active_document() : nullptr;
             if (document && document->hidden()) {
                 page_client->m_compositor_rendering_opportunity_outstanding = false;
                 page_client->m_compositor_watchdog_deadline = 0;
@@ -721,7 +721,7 @@ void PageClient::inject_rendering_opportunity(double frame_time)
     if (!m_rendering_update_requested || m_rendering_opportunity_granted)
         return;
 
-    auto document = page().top_level_traversable_is_initialized() ? page().top_level_traversable()->active_document() : nullptr;
+    auto document = page().has_local_root_navigable() ? page().local_root_navigable()->active_document() : nullptr;
     if (document && document->hidden())
         return;
 
@@ -957,12 +957,12 @@ void PageClient::page_did_receive_reference_test_metadata(JsonValue metadata)
 
 void PageClient::page_did_set_browser_zoom(double factor)
 {
-    auto traversable = page().top_level_traversable();
-    traversable->set_pending_set_browser_zoom_request(true);
+    auto local_root_navigable = page().local_root_navigable();
+    local_root_navigable->set_pending_set_browser_zoom_request(true);
     client().async_did_set_browser_zoom(m_id, factor);
     auto& event_loop = Web::HTML::main_thread_event_loop();
-    event_loop.spin_until(GC::create_function(GC::Heap::the(), [this, traversable]() {
-        return !traversable->pending_set_browser_zoom_request() || !is_connection_open();
+    event_loop.spin_until(GC::create_function(GC::Heap::the(), [this, local_root_navigable]() {
+        return !local_root_navigable->pending_set_browser_zoom_request() || !is_connection_open();
     }));
 }
 
@@ -1391,7 +1391,7 @@ void PageClient::page_did_request_activate_tab()
 
 void PageClient::page_did_close_top_level_traversable()
 {
-    page().top_level_traversable()->compositor_context().stop_presenting_to_client();
+    page().local_root_navigable()->compositor_context().stop_presenting_to_client();
 
     // FIXME: Rename this IPC call
     client().async_did_close_browsing_context(m_id);

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -265,14 +265,14 @@ void PageClient::navigation_population_failed(Web::HTML::CrossProcessId navigabl
 
 void PageClient::populate_navigation(Web::HTML::NavigationPopulationRequest request, Web::HTML::NavigationPopulationResult result)
 {
-    page().top_level_traversable()->continue_navigation_at_population(move(request), move(result));
+    as<Web::HTML::LocalTraversableNavigable>(*page().local_root_navigable()).continue_navigation_at_population(move(request), move(result));
 }
 
 void PageClient::create_navigation_params(Web::HTML::NavigationPopulationRequest request)
 {
     auto navigable_id = request.navigable_id;
     auto navigation_id = request.navigation_id;
-    auto active_document = page().top_level_traversable()->active_document();
+    auto active_document = page().local_root_navigable()->active_document();
     if (!active_document) {
         client().async_did_finish_navigation_params_creation(m_id, navigable_id, navigation_id, {});
         return;
@@ -291,7 +291,7 @@ void PageClient::create_navigation_params(Web::HTML::NavigationPopulationRequest
 
 void PageClient::cancel_navigation_params_creation(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_id)
 {
-    auto active_document = page().top_level_traversable()->active_document();
+    auto active_document = page().local_root_navigable()->active_document();
     if (!active_document)
         return;
 
@@ -305,7 +305,7 @@ void PageClient::cancel_navigation_params_creation(Web::HTML::CrossProcessId nav
 
 void PageClient::run_navigation_unload_check(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_id)
 {
-    auto active_document = page().top_level_traversable()->active_document();
+    auto active_document = page().local_root_navigable()->active_document();
     if (!active_document) {
         client().async_did_fail_navigation_population(m_id, navigable_id, navigation_id);
         return;
@@ -361,7 +361,7 @@ Optional<Web::Compositor::CompositorContextId> PageClient::compositor_context_id
 
 void PageClient::run_iframe_load_event_steps(Web::HTML::CrossProcessId frame_id)
 {
-    auto active_document = page().top_level_traversable()->active_document();
+    auto active_document = page().local_root_navigable()->active_document();
     if (!active_document)
         return;
 
@@ -1206,7 +1206,7 @@ void PageClient::page_did_update_cookie(HTTP::Cookie::Cookie const& cookie)
     client().async_did_update_cookie(cookie);
 
     // Since the above (test-only) IPC is async, we reset the document cookie version now to avoid a stale cache.
-    if (auto* document = page().top_level_browsing_context().active_document())
+    if (auto document = page().local_root_navigable()->active_document())
         document->reset_cookie_version();
 }
 
@@ -1215,7 +1215,7 @@ void PageClient::page_did_expire_cookies_with_time_offset(AK::Duration offset)
     client().async_did_expire_cookies_with_time_offset(offset);
 
     // Since the above (test-only) IPC is async, we reset the document cookie version now to avoid a stale cache.
-    if (auto* document = page().top_level_browsing_context().active_document())
+    if (auto document = page().local_root_navigable()->active_document())
         document->reset_cookie_version();
 }
 
@@ -1225,7 +1225,7 @@ void PageClient::page_did_delete_all_cookies(URL::URL const& url, GC::Ref<Web::W
     m_pending_delete_all_cookies_promises.set(request_id, promise);
     client().async_did_request_delete_all_cookies(m_id, request_id, url);
 
-    if (auto* document = page().top_level_browsing_context().active_document())
+    if (auto document = page().local_root_navigable()->active_document())
         document->reset_cookie_version();
 }
 
@@ -1676,7 +1676,7 @@ void PageClient::set_webdriver_session_config(Web::WebDriver::UserPromptHandler 
 
 ErrorOr<void> PageClient::connect_to_web_ui(IPC::TransportHandle handle)
 {
-    auto* active_document = page().top_level_browsing_context().active_document();
+    auto active_document = page().local_root_navigable()->active_document();
     if (!active_document || !active_document->window())
         return {};
 
@@ -1771,7 +1771,7 @@ void PageClient::js_console_input(StringView js_source)
 
 void PageClient::run_javascript(StringView js_source)
 {
-    auto* active_document = page().top_level_browsing_context().active_document();
+    auto active_document = page().local_root_navigable()->active_document();
 
     if (!active_document)
         return;
@@ -1829,7 +1829,7 @@ Vector<Web::CSS::StyleSheetIdentifier> PageClient::list_style_sheets() const
 {
     Vector<Web::CSS::StyleSheetIdentifier> results;
 
-    auto const* document = page().top_level_browsing_context().active_document();
+    auto document = page().local_root_navigable()->active_document();
     if (document) {
         for (auto& sheet : document->style_sheets().sheets()) {
             gather_style_sheets(results, sheet);
@@ -1875,7 +1875,7 @@ Vector<Web::HTML::ScriptRegistry::Description> PageClient::list_devtools_sources
 {
     Vector<Web::HTML::ScriptRegistry::Description> results;
 
-    auto const* document = page().top_level_browsing_context().active_document();
+    auto document = page().local_root_navigable()->active_document();
     if (document)
         append_devtools_sources_for_document(results, *document);
 
@@ -1899,7 +1899,7 @@ static Optional<Web::HTML::ScriptRegistry::Description> find_devtools_source_des
 
 Optional<Web::HTML::ScriptRegistry::Description> PageClient::devtools_source_description(JS::SourceCode const& source_code) const
 {
-    auto const* document = page().top_level_browsing_context().active_document();
+    auto document = page().local_root_navigable()->active_document();
     if (!document)
         return {};
     return find_devtools_source_description(*document, source_code);

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -229,7 +229,7 @@ NonnullRefPtr<WebDriverConnection> WebDriverConnection::create(PageClient& page_
 WebDriverConnection::WebDriverConnection(PageClient& page_client)
     : m_page_client(page_client)
 {
-    set_current_top_level_browsing_context(*page_client.page().top_level_traversable()->active_browsing_context());
+    set_current_top_level_browsing_context(*as<Web::HTML::LocalNavigable>(*page_client.page().top_level_traversable()).active_browsing_context());
     page_client.page().set_is_webdriver_active(true);
 }
 

--- a/Tests/LibWeb/TestDownloadReader.cpp
+++ b/Tests/LibWeb/TestDownloadReader.cpp
@@ -81,7 +81,7 @@ TEST_CASE(download_reader_is_registered_with_page_client)
     client->m_page = page.ptr();
 
     auto traversable = Web::HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {});
-    page->set_top_level_traversable(traversable);
+    page->set_local_root_navigable(traversable);
 
     auto response = Web::Fetch::Infrastructure::Response::create(vm);
     response->set_body(Web::Fetch::Infrastructure::byte_sequence_as_body(*realm, "download contents"sv.bytes()));

--- a/Tests/LibWeb/TestWindowProxyWorld.cpp
+++ b/Tests/LibWeb/TestWindowProxyWorld.cpp
@@ -81,7 +81,7 @@ TEST_CASE(per_world_windowproxy_and_window_wrapper)
     client->m_page = page.ptr();
 
     auto traversable = Web::HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {});
-    page->set_top_level_traversable(traversable);
+    page->set_local_root_navigable(traversable);
     auto document = GC::Ref { *traversable->active_document() };
     auto browsing_context = GC::Ref { *document->browsing_context() };
     auto window = document->window();

--- a/Tests/LibWeb/TestWrapperWorld.cpp
+++ b/Tests/LibWeb/TestWrapperWorld.cpp
@@ -991,7 +991,7 @@ TEST_CASE(relevant_global_main_world_wrapper_ignores_preferred_realm)
     client->m_page = page.ptr();
 
     auto traversable = Web::HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {});
-    page->set_top_level_traversable(traversable);
+    page->set_local_root_navigable(traversable);
     auto window = GC::Ref { *traversable->active_document()->window() };
 
     auto preferred_execution_context = MUST(JS::Realm::initialize_host_defined_realm(vm, nullptr, nullptr));
@@ -1030,7 +1030,7 @@ TEST_CASE(resize_observer_releases_activity_root_when_registration_document_is_c
         auto page = Web::Page::create(client);
         client->m_page = page.ptr();
         auto traversable = Web::HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {});
-        page->set_top_level_traversable(traversable);
+        page->set_local_root_navigable(traversable);
         return GC::Ref { *traversable->active_document() };
     };
 

--- a/Utilities/dump-html-tree.cpp
+++ b/Utilities/dump-html-tree.cpp
@@ -339,7 +339,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     page->set_is_scripting_enabled(false);
     page_client->set_page(page);
     page->set_top_level_traversable(Web::HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {}));
-    auto& origin_document = *page->top_level_traversable()->active_document();
+    auto& origin_document = *page->local_root_navigable()->active_document();
 
     auto timer = Core::ElapsedTimer::start_new();
 

--- a/Utilities/dump-html-tree.cpp
+++ b/Utilities/dump-html-tree.cpp
@@ -338,7 +338,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto page = Web::Page::create(page_client);
     page->set_is_scripting_enabled(false);
     page_client->set_page(page);
-    page->set_top_level_traversable(Web::HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {}));
+    page->set_local_root_navigable(Web::HTML::LocalTraversableNavigable::create_a_new_top_level_traversable(page, nullptr, {}));
     auto& origin_document = *page->local_root_navigable()->active_document();
 
     auto timer = Core::ElapsedTimer::start_new();


### PR DESCRIPTION
Every Page was previously assuming its root navigable is a LocalTraversableNavigable. That works for a tab, but forces the WebContent process hosting an OOP iframe to hackily fake a top-level traversable.

This MR separates the two concepts. A Page is responsible for local rendering and input surface rooted at local_root_navigable() (which may be any LocalNavigable) and the top-level traversable is derived from the normal navigable tree. This structure holds even in the case of OOP frames.

Rendering, viewport updates, input, focus, coordinate conversion and WebContent's page operations now use that local root. Screenshot requests also move from LocalTraversableNavigable to Page. Nonchanging history-state updates run on the navigable they target.

This is one further step towards trying to remove the (many) local navigable assumptions that block the introduction of a RemoteNavigable into the navigable tree for iframe site isolation.