### PR TITLE
LibWeb: Restore image style sharing while preserving resource context

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3779,17 +3779,21 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
     // The monospace font-size recascade reads the whole ancestor chain rather than the inherited
     // context, and unfixed random values read the element's random cache. Image URLs also need their
     // declaration's resource context, which retained winner value identities do not distinguish.
+    // The full declaration key retains source identities for resource-dependent values, so it
+    // can still share their computed styles without enabling winner-only reuse.
     // `var()` is not among them: what it resolves against is the cascaded custom properties, which
     // the blocks in the record decide, and the inherited environment, which the
     // parent in the record decides. Neither is an animation or transition: it carries state on the
     // element itself, and its values are published by the animation refresh rather than derived here.
-    bool const computation_read_only_the_record = !element.style_uses_attr_css_function()
+    bool const computation_read_only_the_declaration_key = !element.style_uses_attr_css_function()
         && !element.style_uses_if_css_function()
         && !element.style_uses_custom_function()
         && !element.style_uses_tree_counting_function()
         && !element.style_depends_on_viewport_metrics()
         && !element.style_depends_on_size_container_query()
         && !element.style_depends_on_style_container_query()
+        && !sharing.computation_reads_element_context;
+    bool const computation_read_only_the_record = computation_read_only_the_declaration_key
         && !sharing.computation_reads_unkeyed_context;
     // The flags are cleared for the next computation, so the record is what has to answer whether
     // that computation can be skipped.
@@ -3804,7 +3808,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
     if (sharing.is_candidate && sharing.may_reuse_or_publish_shared_style) {
         // The result answers for another element only if it also holds no animated values: an
         // animation or transition is state of this element that the other element does not have.
-        bool const computation_read_only_the_key = computation_read_only_the_record
+        bool const computation_read_only_the_key = computation_read_only_the_declaration_key
             && !computed_values->animated_properties()
             && !computed_values->has_animated_values();
         if (computation_read_only_the_key) {
@@ -3837,6 +3841,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
                 .style_record_identity = {},
                 .style_input_declaration_words = move(style_input_declaration_words),
                 .pinned_style_input_values = move(pinned_style_input_values),
+                .read_beyond_the_record = !computation_read_only_the_record,
                 .style_uses_var_css_function = element.style_uses_var_css_function(),
                 .style_uses_inherit_css_function = element.style_uses_inherit_css_function(),
             });
@@ -4636,12 +4641,12 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
                     parent->add_children_explicitly_inherited_non_inherited_style_groups(entry.explicitly_inherited_non_inherited_style_groups);
             }
             compute_transitioned_properties(*sharing->shared_values, abstract_element);
-            // An entry is only published by a computation that read nothing beyond the key, so an
-            // element answered from one is one whose own next computation can be skipped.
+            // The declaration key can distinguish resource contexts that retained cascade winners
+            // cannot. Preserve that restriction for subsequent partial computation.
             if (!abstract_element.pseudo_element().has_value()) {
                 auto* record = abstract_element.element().style_input_record();
                 VERIFY(record);
-                record->read_beyond_the_record = false;
+                record->read_beyond_the_record = entry.read_beyond_the_record;
                 record->style_uses_var_css_function = entry.style_uses_var_css_function;
                 record->style_uses_inherit_css_function = entry.style_uses_inherit_css_function;
                 record->explicitly_inherited_non_inherited_style_groups = entry.explicitly_inherited_non_inherited_style_groups;
@@ -4785,7 +4790,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
             if (!bucket.has_value())
                 continue;
             for (auto const& entry : *bucket) {
-                if (!entry.style_record_identity.has_value() || !entry.style_node_id)
+                if (entry.read_beyond_the_record || !entry.style_record_identity.has_value() || !entry.style_node_id)
                     continue;
                 if (!entry.key.equals_without_values(sharing->key))
                     continue;
@@ -4933,7 +4938,8 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
         sharing ? &sharing->explicitly_inherited_non_inherited_style_groups : nullptr, previous_computed_style_record,
         sharing && sharing->is_candidate ? sharing->computed_groups_to_rebuild.value_or(ComputedValues::all_style_groups) : ComputedValues::all_style_groups,
         use_retained_style_computation_selection, false, &computed_group_mask,
-        sharing ? &sharing->computation_reads_unkeyed_context : nullptr);
+        sharing ? &sharing->computation_reads_unkeyed_context : nullptr,
+        sharing ? &sharing->computation_reads_element_context : nullptr);
     if (new_style_input_record)
         new_style_input_record->bind_next_published_style = true;
     static bool const verify_computed_closure = getenv("LIBWEB_VERIFY_COMPUTED_CLOSURE") != nullptr;
@@ -5096,7 +5102,7 @@ void StyleComputer::ensure_style_metadata_tables_installed()
     (void)installed;
 }
 
-NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::AbstractElement abstract_element, CascadedProperties& cascaded_properties, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups, StyleRecordID previous_style_record, u32 initial_computed_group_mask, bool use_retained_style_computation_selection, bool stop_after_longhand_drive, u32* selected_computed_group_mask, bool* computation_reads_unkeyed_context) const
+NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::AbstractElement abstract_element, CascadedProperties& cascaded_properties, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups, StyleRecordID previous_style_record, u32 initial_computed_group_mask, bool use_retained_style_computation_selection, bool stop_after_longhand_drive, u32* selected_computed_group_mask, bool* computation_reads_unkeyed_context, bool* computation_reads_element_context) const
 {
     begin_style_update();
     ScopeGuard end_style_update = [&] { this->end_style_update(); };
@@ -5170,6 +5176,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         bool stop_after_longhand_drive;
         u32* selected_computed_group_mask;
         bool* computation_reads_unkeyed_context;
+        bool* computation_reads_element_context;
         PreparePhaseContext prepare_phase_context;
         OwnPtr<NativeLonghandState> state;
     };
@@ -5240,6 +5247,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         .stop_after_longhand_drive = stop_after_longhand_drive,
         .selected_computed_group_mask = selected_computed_group_mask,
         .computation_reads_unkeyed_context = computation_reads_unkeyed_context,
+        .computation_reads_element_context = computation_reads_element_context,
         .prepare_phase_context = prepare_phase_context,
         .state = nullptr,
     };
@@ -5268,6 +5276,11 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
                 *context.selected_computed_group_mask = computed_group_mask;
             if (context.computation_reads_unkeyed_context)
                 *context.computation_reads_unkeyed_context = computation_requirements->computation_reads_unkeyed_context;
+            if (context.computation_reads_element_context) {
+                auto random_sharings = ReadonlySpan<ComputedValuesFFI::FfiUnfixedRandomSharing> { computation_requirements->unfixed_random_sharings, computation_requirements->unfixed_random_sharing_count };
+                *context.computation_reads_element_context = computation_requirements->has_monospace_font_family
+                    || any_of(random_sharings, [](auto const& sharing) { return !sharing.element_shared; });
+            }
             auto const* computed_properties_to_evaluate = computation_requirements->has_computed_property_selection
                 ? computation_requirements->computed_property_words
                 : nullptr;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -178,7 +178,7 @@ public:
     // `explicitly_inherited_non_inherited_style_groups` reports the style groups whose values the
     // computation read from the half of the style it inherits from that a child normally cannot
     // see, which decides whether its answer can be offered to another element.
-    [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> compute_properties(DOM::AbstractElement, CascadedProperties&, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups = nullptr, StyleRecordID previous_style_record = {}, u32 initial_computed_group_mask = ComputedValues::all_style_groups, bool use_retained_style_computation_selection = false, bool stop_after_longhand_drive = false, u32* selected_computed_group_mask = nullptr, bool* computation_reads_unkeyed_context = nullptr) const;
+    [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> compute_properties(DOM::AbstractElement, CascadedProperties&, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups = nullptr, StyleRecordID previous_style_record = {}, u32 initial_computed_group_mask = ComputedValues::all_style_groups, bool use_retained_style_computation_selection = false, bool stop_after_longhand_drive = false, u32* selected_computed_group_mask = nullptr, bool* computation_reads_unkeyed_context = nullptr, bool* computation_reads_element_context = nullptr) const;
 
     void process_animation_definitions(ComputedStyleWorkingSet const& computed_properties, CascadedProperties const&, DOM::AbstractElement& abstract_element, ReadonlySpan<AnimationProperties> animation_definitions) const;
 
@@ -281,6 +281,7 @@ public:
         // mint afresh whenever any of them recomputes.
         bool cascade_reads_custom_properties { false };
         bool computation_reads_unkeyed_context { true };
+        bool computation_reads_element_context { true };
         RefPtr<CustomPropertyData const> pinned_parent_custom_property_data;
         // The style groups whose values the computation read from the inherited style's
         // non-inherited half, which the key does not name.
@@ -399,6 +400,7 @@ private:
         Optional<StyleRecordID> style_record_identity;
         Vector<u64> style_input_declaration_words;
         Vector<NonnullRefPtr<StyleValue const>> pinned_style_input_values;
+        bool read_beyond_the_record { false };
         bool style_uses_var_css_function { false };
         bool style_uses_inherit_css_function { false };
     };

--- a/Libraries/LibWeb/Rust/src/css/style/program.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/program.rs
@@ -1192,6 +1192,15 @@ impl StyleSheetProgram {
         if self.rules[rule_index].semantic_declaration != SemanticDeclarationID::default() {
             return self.rules[rule_index].semantic_declaration;
         }
+        // Image value identities omit the declaration's resource context. Keep the native
+        // declaration identity in sharing keys for these blocks instead of merging them.
+        if self.rules[rule_index].written_values.iter().any(|value| {
+            crate::css::style_compute::value_is_computationally_independent(value.data()).is_none()
+                || crate::css::style_compute::external_value_dependencies(value.data())
+                    .may_need_style_sheet_resource_context
+        }) {
+            return SemanticDeclarationID::default();
+        }
         let hash = super::intern_table::content_hash(&self.rules[rule.0 as usize].declared_properties);
         let previous_map_capacity = self.semantic_declarations.shallow_capacity_bytes();
         let previous_bucket_capacity = self

--- a/Libraries/LibWeb/Rust/src/css/style/specified_value.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/specified_value.rs
@@ -77,9 +77,14 @@ impl SpecifiedValues {
         if let Some(id) = self.entries_by_pointer.get(&(probe.pointer as usize)) {
             return Lookup::Known(*id);
         }
-        if let Some(index) = self.entries.find(probe.value.content_hash(), |_index, entry| {
-            entry.value.data() == probe.value
-        }) {
+        // Equal URL text can refer to different resources in different declarations. The native
+        // image keeps its stylesheet context outside StyleValueData, so only an existing pointer
+        // identity can prove equality for values containing resource-dependent images.
+        if !crate::css::style_compute::value_may_need_style_sheet_resource_context(probe.value)
+            && let Some(index) = self.entries.find(probe.value.content_hash(), |_index, entry| {
+                entry.value.data() == probe.value
+            })
+        {
             return Lookup::Known(self.entries[index].id);
         }
         match self.coverage() {

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -1377,7 +1377,7 @@ fn container_relative_length_unit_bit(unit: u8) -> u8 {
     }
 }
 
-pub(crate) fn external_value_dependencies(value: &StyleValueData) -> ExternalValueDependencies {
+fn collect_external_value_dependencies(value: &StyleValueData) -> ExternalValueDependencies {
     fn collect_optional(value: &RetainedStyleValueData, dependencies: &mut ExternalValueDependencies) {
         if let Some(value) = value.optional_data() {
             collect(value, dependencies);
@@ -1656,6 +1656,15 @@ pub(crate) fn external_value_dependencies(value: &StyleValueData) -> ExternalVal
 
     let mut dependencies = ExternalValueDependencies::default();
     collect(value, &mut dependencies);
+    dependencies
+}
+
+pub(crate) fn value_may_need_style_sheet_resource_context(value: &StyleValueData) -> bool {
+    collect_external_value_dependencies(value).may_need_style_sheet_resource_context
+}
+
+pub(crate) fn external_value_dependencies(value: &StyleValueData) -> ExternalValueDependencies {
+    let mut dependencies = collect_external_value_dependencies(value);
     dependencies.inheritance_dependent = crate::css::style_value::value_depends_on_current_color(value)
         || !value_is_computationally_independent(value)
             .expect("computational independence requested for an unsupported value");

--- a/Tests/LibWeb/Text/expected/css/style-engine/shared-image-declaration-context.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/shared-image-declaration-context.txt
@@ -1,4 +1,6 @@
 image styles share within each declaration context: true
 distinct stylesheet base URLs: true
+changed declaration contexts: true
+restored declaration contexts: true
 image contexts survive winner changes: true
 other winners update: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/shared-image-declaration-context.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/shared-image-declaration-context.txt
@@ -1,0 +1,4 @@
+image styles share within each declaration context: true
+distinct stylesheet base URLs: true
+image contexts survive winner changes: true
+other winners update: true

--- a/Tests/LibWeb/Text/input/css/style-engine/shared-image-declaration-context.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/shared-image-declaration-context.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<link rel="stylesheet" href="support/shared-image-style.css">
+<style>
+    .local { background-image: url("image.svg"); }
+    .changed { color: rgb(1, 2, 3); }
+</style>
+<div id="container"></div>
+<script>
+    test(() => {
+        internals.updateStyle();
+        const before = internals.getStyleInvalidationCounters().elementStyleSharedComputations;
+        const nodes = [];
+        for (const className of ["local", "imported"]) {
+            for (let index = 0; index < 8; ++index) {
+                const node = document.createElement("div");
+                node.className = className;
+                container.append(node);
+                nodes.push(node);
+            }
+        }
+        internals.updateStyle();
+        const after = internals.getStyleInvalidationCounters().elementStyleSharedComputations;
+        println(`image styles share within each declaration context: ${after - before >= 14}`);
+
+        function checkImages(label) {
+            const correct = nodes.every(node => {
+                const path = node.classList.contains("imported") ? "support/image.svg" : "image.svg";
+                return getComputedStyle(node).backgroundImage === `url("${new URL(path, location.href)}")`;
+            });
+            println(`${label}: ${correct}`);
+        }
+        checkImages("distinct stylesheet base URLs");
+        for (const node of nodes) {
+            node.classList.toggle("local");
+            node.classList.toggle("imported");
+            node.classList.add("changed");
+        }
+        checkImages("image contexts survive winner changes");
+        println(`other winners update: ${nodes.every(node => getComputedStyle(node).color === "rgb(1, 2, 3)")}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/shared-image-declaration-context.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/shared-image-declaration-context.html
@@ -34,8 +34,15 @@
         for (const node of nodes) {
             node.classList.toggle("local");
             node.classList.toggle("imported");
-            node.classList.add("changed");
         }
+        checkImages("changed declaration contexts");
+        for (const node of nodes) {
+            node.classList.toggle("local");
+            node.classList.toggle("imported");
+        }
+        checkImages("restored declaration contexts");
+        for (const node of nodes)
+            node.classList.add("changed");
         checkImages("image contexts survive winner changes");
         println(`other winners update: ${nodes.every(node => getComputedStyle(node).color === "rgb(1, 2, 3)")}`);
     });

--- a/Tests/LibWeb/Text/input/css/style-engine/support/shared-image-style.css
+++ b/Tests/LibWeb/Text/input/css/style-engine/support/shared-image-style.css
@@ -1,0 +1,1 @@
+.imported { background-image: url("image.svg"); }


### PR DESCRIPTION
#11592 disabled native style sharing for image values, causing repeated style computation in Speedometer’s TodoMVC workloads. Restore sharing when full declaration keys match, while retaining stricter guards for other reuse paths.

Also fix invalidation when switching between identical image URL text from stylesheets with different base URLs, in a separate commit.

Single-iteration scores before → after:

- Speedometer 2: 89.92 → 91.70 (+2.0%)
- Speedometer 3: 5.53 → 5.80 (+4.9%)
