### PR TITLE
LibJS: Speed up remainder for integer-valued doubles

### DIFF
--- a/Libraries/LibJS/Flap/src/hir/intrinsic.rs
+++ b/Libraries/LibJS/Flap/src/hir/intrinsic.rs
@@ -116,6 +116,7 @@ fn intrinsic_value_type(ty: IntrinsicValueType) -> Type {
         IntrinsicValueType::F64 => Type::F64,
         IntrinsicValueType::FunctionSymbol => Type::FunctionSymbol,
         IntrinsicValueType::I32 => Type::I32,
+        IntrinsicValueType::I64 => Type::I64,
         IntrinsicValueType::Label => Type::label(),
         IntrinsicValueType::Memory => Type::Memory,
         IntrinsicValueType::Operand => Type::Operand,

--- a/Libraries/LibJS/Flap/src/intrinsic.rs
+++ b/Libraries/LibJS/Flap/src/intrinsic.rs
@@ -561,6 +561,7 @@ pub(crate) enum ValueOperation {
     UnboxBoolean,
     ExtractTag { rematerialized: bool },
     ToInt32,
+    Int32ToInt64,
     ToUint32,
     LogicalNot,
     UnboxObject,
@@ -592,6 +593,7 @@ intrinsic_names!(ValueOperation {
     Self::UnboxBoolean => "unbox_bool";
     Self::ExtractTag { rematerialized: false } => "extract_tag" signatures [signature!([In Value] -> ValueTag), signature!([Out ValueTag, In Value])];
     Self::ExtractTag { rematerialized: true } => "rematerialize_extract_tag" from [];
+    Self::Int32ToInt64 => "i64" signatures [signature!([In I32] -> I64)];
     Self::ToInt32 => "i32" signatures [signature!([In AnyGpr] -> I32)];
     Self::ToUint32 => "u32" signatures [signature!([In AnyGpr] -> U32)];
     Self::LogicalNot => "not_bool";
@@ -602,6 +604,7 @@ define_named_intrinsic_enum! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub(crate) enum LowLevelOperation {
         LoadLabel => "load_label" signatures [signature!([Out BytecodeOffset, In BytecodeOffset])];
+        Modulo64 => "mod_i64" signatures [signature!([In I64, In I64] -> I64)];
         DivideModulo => "divmod" signatures [signature!([In I32, In I32] -> (I32, I32)), signature!([Out I32, Out I32, In I32, In I32])];
         Move => "mov" signatures [signature!([Out AnyGpr, In AnyGpr])];
         LoadEffectiveAddress => "lea" signatures [signature!([Out AnyGpr, In Memory])];
@@ -724,10 +727,12 @@ pub(crate) enum FloatUnaryOperation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum FloatConversion {
     Int32ToFloat64,
+    Int64ToFloat64,
     Uint32ToFloat64,
     Float32ToFloat64,
     Float64ToFloat32,
     Float64ToInt32,
+    Float64ToInt64,
     JavaScriptToInt32,
 }
 
@@ -743,7 +748,9 @@ impl FloatingPointOperation {
     pub(crate) fn is_fallible(self) -> bool {
         matches!(
             self,
-            Self::Convert(FloatConversion::Float64ToInt32 | FloatConversion::JavaScriptToInt32)
+            Self::Convert(
+                FloatConversion::Float64ToInt32 | FloatConversion::Float64ToInt64 | FloatConversion::JavaScriptToInt32
+            )
         )
     }
 }
@@ -756,6 +763,8 @@ intrinsic_names!(FloatingPointOperation {
     Self::Unary(FloatUnaryOperation::Floor) => "fp_floor" signatures [signature!([In F64] -> F64), signature!([Out F64, In F64])];
     Self::Unary(FloatUnaryOperation::Ceil) => "fp_ceil" signatures [signature!([In F64] -> F64), signature!([Out F64, In F64])];
     Self::Unary(FloatUnaryOperation::SquareRoot) => "fp_sqrt" signatures [signature!([In F64] -> F64), signature!([Out F64, In F64])];
+    Self::Convert(FloatConversion::Int64ToFloat64) => "i64_to_f64" signatures [signature!([In I64] -> F64)];
+    Self::Convert(FloatConversion::Float64ToInt64) => "double_to_int64" signatures [signature!(fallible [In F64] -> I64)];
     Self::Convert(FloatConversion::Int32ToFloat64) => "to_f64" signatures [signature!([In I32] -> F64)];
     Self::Convert(FloatConversion::Uint32ToFloat64) => "u32_to_f64" signatures [signature!([In U32] -> F64), signature!([Out F64, In U32])];
     Self::Convert(FloatConversion::Float32ToFloat64) => "float_to_double" signatures [signature!([In F32] -> F64), signature!([Out F64, In F32])];
@@ -990,6 +999,7 @@ pub(crate) enum IntrinsicValueType {
     F64,
     FunctionSymbol,
     I32,
+    I64,
     Label,
     Memory,
     Operand,

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -679,6 +679,59 @@ handler Nop() { dispatch_next; }
     }
 
     #[test]
+    fn compiles_checked_int64_conversion_and_remainder_for_each_target() {
+        let source = r#"
+handler Mod(dst: out Operand, lhs: in Operand, rhs: in Operand) {
+    let failure = || @cold { dispatch_next; };
+    guard let Value<f64>(lhs_number) = load(lhs) else failure;
+    guard let Value<f64>(rhs_number) = load(rhs) else failure;
+    guard let lhs_integer = double_to_int64(lhs_number) else failure;
+    guard let rhs_integer = double_to_int64(rhs_number) else failure;
+    guard rhs_integer != 0 else failure;
+    let zero: i64 = 0;
+    let negative_one = zero - 1;
+    guard rhs_integer != negative_one else failure;
+    let remainder = mod_i64(lhs_integer, rhs_integer);
+    store(dst, box_f64(i64_to_f64(remainder)));
+    dispatch_next;
+}
+handler Widen(dst: out Operand, src: in Operand) {
+    let failure = || @cold { dispatch_next; };
+    guard let Value<f64>(number) = load(src) else failure;
+    guard let integer = double_to_int64(number) else failure;
+    store(dst, box_f64(i64_to_f64(i64(i32(integer)))));
+    dispatch_next;
+}
+
+"#;
+        for architecture in [Architecture::X86_64, Architecture::Aarch64] {
+            let assembly = compiler(architecture).compile(unit(source)).unwrap();
+            let assembly = assembly.as_str();
+            match architecture {
+                Architecture::X86_64 => {
+                    assert!(assembly.contains("cvttsd2si r"));
+                    assert!(assembly.contains("cvtsi2sd xmm"));
+                    assert!(assembly.contains("ucomisd"));
+                    assert!(assembly.contains("jp "));
+                    assert!(assembly.contains("movsxd"));
+                    assert!(assembly.contains("cqo"));
+                    assert!(assembly.contains("idiv r"));
+                }
+                Architecture::Aarch64 => {
+                    assert!(assembly.contains("fcvtzs x"));
+                    assert!(assembly.contains("scvtf d"));
+                    assert!(assembly.contains("cmn x"));
+                    assert!(assembly.contains("b.vs "));
+                    assert!(assembly.contains("fcmp d"));
+                    assert!(assembly.contains("sxtw x"));
+                    assert!(assembly.contains("sdiv x"));
+                    assert!(assembly.contains("msub x"));
+                }
+            }
+        }
+    }
+
+    #[test]
     fn compiles_from_in_memory_sources_for_each_target() {
         for architecture in [Architecture::X86_64, Architecture::Aarch64] {
             let assembly = compiler(architecture)

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -2502,7 +2502,7 @@ fn lower_instruction(
                     .map(|(_, source)| value_operand(function, source))
                     .unwrap_or_else(|| value_operand(function, *rhs))?;
                 output.push(machine_instruction(
-                    MachineOperation::Modulo,
+                    MachineOperation::Modulo(IntegerWidth::U32),
                     vec![remainder.clone(), lhs, rhs],
                 ));
             } else {
@@ -3353,7 +3353,9 @@ fn value_machine_operation(operation: ValueOperation) -> Option<MachineOperation
         | ValueOperation::ReinterpretUint64AsValue => MachineOperation::Move(IntegerWidth::U64),
         ValueOperation::BoxInt32 { clean } => MachineOperation::BoxInt32 { clean },
         ValueOperation::BoxFloat64 | ValueOperation::ValueToFloat64 => MachineOperation::FloatMove,
-        ValueOperation::UnboxInt32 { .. } | ValueOperation::UnboxBoolean => MachineOperation::UnboxInt32,
+        ValueOperation::UnboxInt32 { .. } | ValueOperation::UnboxBoolean | ValueOperation::Int32ToInt64 => {
+            MachineOperation::UnboxInt32
+        }
         ValueOperation::ExtractTag { .. } => MachineOperation::ExtractTag,
         ValueOperation::ToInt32 | ValueOperation::ToUint32 => MachineOperation::Move(IntegerWidth::U32),
         ValueOperation::UnboxObject => MachineOperation::UnboxObject,
@@ -3364,7 +3366,8 @@ fn value_machine_operation(operation: ValueOperation) -> Option<MachineOperation
 fn low_level_machine_operation(operation: LowLevelOperation) -> MachineOperation {
     match operation {
         LowLevelOperation::LoadLabel => MachineOperation::LoadLabel,
-        LowLevelOperation::DivideModulo => MachineOperation::Modulo,
+        LowLevelOperation::DivideModulo => MachineOperation::Modulo(IntegerWidth::U32),
+        LowLevelOperation::Modulo64 => MachineOperation::Modulo(IntegerWidth::U64),
         LowLevelOperation::Move => MachineOperation::Move(IntegerWidth::U64),
         LowLevelOperation::LoadEffectiveAddress => MachineOperation::LoadEffectiveAddress,
         LowLevelOperation::LoadVm => MachineOperation::LoadVm,

--- a/Libraries/LibJS/Flap/src/target/aarch64.rs
+++ b/Libraries/LibJS/Flap/src/target/aarch64.rs
@@ -136,6 +136,7 @@ pub(crate) enum FloatConversion {
     FloatToDouble,
     DoubleToFloat,
     DoubleToSigned32Truncate,
+    DoubleToSigned64Truncate,
     JavaScriptToSigned32,
 }
 
@@ -331,13 +332,14 @@ define_machine_opcodes! {
         match conversion {
             FloatConversion::Signed64ToDouble | FloatConversion::Signed32ToDouble => operands_match(operands, &[FR, R]),
             FloatConversion::FloatToDouble | FloatConversion::DoubleToFloat => operands_match(operands, &[FR, FR]),
-            FloatConversion::DoubleToSigned32Truncate | FloatConversion::JavaScriptToSigned32 => operands_match(operands, &[R, FR]),
+            FloatConversion::DoubleToSigned32Truncate | FloatConversion::DoubleToSigned64Truncate | FloatConversion::JavaScriptToSigned32 => operands_match(operands, &[R, FR]),
         }
     } printing match conversion {
         FloatConversion::Signed64ToDouble => simple!("scvtf"; native(0), native(1)),
         FloatConversion::Signed32ToDouble => simple!("scvtf"; native(0), word(1)),
         FloatConversion::FloatToDouble => simple!("fcvt"; native(0), single(1)),
         FloatConversion::DoubleToFloat => simple!("fcvt"; single(0), native(1)),
+        FloatConversion::DoubleToSigned64Truncate => simple!("fcvtzs"; native(0), native(1)),
         FloatConversion::DoubleToSigned32Truncate => simple!("fcvtzs"; word(0), native(1)),
         FloatConversion::JavaScriptToSigned32 => simple!("fjcvtzs"; word(0), native(1)),
     };
@@ -397,6 +399,8 @@ define_machine_opcodes! {
     [BitClear64Immediate] => Self::BitClear64Immediate => [[R, I]] encoding {
         immediate(1).is_some_and(|value| is_logical_immediate(IntegerWidth::U64, value as u64))
     } printing simple!("bic"; native(0), native(0), SimpleOperand::HashImmediate(1, true));
+    [SignedDivide64] => Self::SignedDivide64 => [[R, R, R]] printing simple!("sdiv"; native(0), native(1), native(2));
+    [MultiplySubtract64] => Self::MultiplySubtract64 => [[R, R, R, R]] printing simple!("msub"; native(0), native(1), native(2), native(3));
     [SignedDivide32] => Self::SignedDivide32 => [[R, R, R]] printing simple!("sdiv"; word(0), word(1), word(2));
     [MultiplySubtract32] => Self::MultiplySubtract32 => [[R, R, R, R]] printing simple!("msub"; word(0), word(1), word(2), word(3));
 }
@@ -631,9 +635,9 @@ impl Opcode {
                 FloatingPointOperation::Convert(IntrinsicFloatConversion::Int32ToFloat64) => {
                     Self::FloatConversion(FloatConversion::Signed32ToDouble)
                 }
-                FloatingPointOperation::Convert(IntrinsicFloatConversion::Uint32ToFloat64) => {
-                    Self::FloatConversion(FloatConversion::Signed64ToDouble)
-                }
+                FloatingPointOperation::Convert(
+                    IntrinsicFloatConversion::Uint32ToFloat64 | IntrinsicFloatConversion::Int64ToFloat64,
+                ) => Self::FloatConversion(FloatConversion::Signed64ToDouble),
                 FloatingPointOperation::Convert(IntrinsicFloatConversion::Float32ToFloat64) => {
                     Self::FloatConversion(FloatConversion::FloatToDouble)
                 }
@@ -641,7 +645,9 @@ impl Opcode {
                     Self::FloatConversion(FloatConversion::DoubleToFloat)
                 }
                 FloatingPointOperation::Convert(
-                    IntrinsicFloatConversion::Float64ToInt32 | IntrinsicFloatConversion::JavaScriptToInt32,
+                    IntrinsicFloatConversion::Float64ToInt32
+                    | IntrinsicFloatConversion::Float64ToInt64
+                    | IntrinsicFloatConversion::JavaScriptToInt32,
                 )
                 | FloatingPointOperation::CanonicalizeNan => Self::Pseudo,
             },

--- a/Libraries/LibJS/Flap/src/target/aarch64/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/aarch64/finalize.rs
@@ -1156,6 +1156,18 @@ impl Backend for Aarch64Backend {
             emit!(emit.output, Aarch64; Opcode::FloatConversion(FloatConversion::JavaScriptToSigned32) => [register destination, register source];);
             return;
         }
+        if operation == FloatingPointOperation::Convert(IntrinsicFloatConversion::Float64ToInt64) {
+            emit!(emit.output, Aarch64;
+                Opcode::FloatConversion(FloatConversion::DoubleToSigned64Truncate) => [register destination, register source];
+                // Reject saturation to i64::MAX, which rounds back to +2^63 as a double.
+                Opcode::CompareNegativeImmediate(IntegerWidth::U64) => [register destination, immediate 1];
+                Opcode::BranchOverflow => [label failure.clone()];
+                Opcode::FloatConversion(FloatConversion::Signed64ToDouble) => [register fpr_scratch, register destination];
+                Opcode::CompareDouble => [register source, register fpr_scratch];
+                Opcode::BranchCondition(Condition::NotEqual) => [label failure];
+            );
+            return;
+        }
         emit!(emit.output, Aarch64;
             Opcode::FloatConversion(FloatConversion::DoubleToSigned32Truncate) => [register destination, register source];
             Opcode::FloatConversion(FloatConversion::Signed32ToDouble) => [register fpr_scratch, register destination];
@@ -2156,9 +2168,14 @@ impl Backend for Aarch64Backend {
         }
     }
 
-    fn finalize_divide(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
+    fn finalize_divide(&self, emit: &mut Emit<'_>, width: IntegerWidth, operands: &[AllocatedOperand]) {
         let [remainder, dividend, divisor, scratch] = operands.physical_registers();
-        emit!(emit.output, Aarch64; Opcode::SignedDivide32 => [register scratch, register dividend, register divisor];);
-        emit!(emit.output, Aarch64; Opcode::MultiplySubtract32 => [register remainder, register scratch, register divisor, register dividend];);
+        let (divide, multiply_subtract) = match width {
+            IntegerWidth::U32 => (Opcode::SignedDivide32, Opcode::MultiplySubtract32),
+            IntegerWidth::U64 => (Opcode::SignedDivide64, Opcode::MultiplySubtract64),
+            _ => unreachable!("remainder requires a 32-bit or 64-bit width"),
+        };
+        emit!(emit.output, Aarch64; divide => [register scratch, register dividend, register divisor];);
+        emit!(emit.output, Aarch64; multiply_subtract => [register remainder, register scratch, register divisor, register dividend];);
     }
 }

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -2658,7 +2658,7 @@ mod tests {
                 instruction!(Operation::Move(IntegerWidth::U64), register("dividend"), immediate(1)),
                 instruction!(Operation::Move(IntegerWidth::U64), register("divisor"), immediate(2)),
                 instruction!(
-                    Operation::Modulo,
+                    Operation::Modulo(IntegerWidth::U32),
                     register("rem"),
                     register("dividend"),
                     register("divisor")
@@ -2669,7 +2669,7 @@ mod tests {
             ],
             Architecture::X86_64,
         );
-        let names = find_operation(&out, Operation::Modulo)
+        let names = find_operation(&out, Operation::Modulo(IntegerWidth::U32))
             .operands
             .iter()
             .map(|operand| operand.register_name().unwrap_or("<non-reg>"))

--- a/Libraries/LibJS/Flap/src/target/backend.rs
+++ b/Libraries/LibJS/Flap/src/target/backend.rs
@@ -268,7 +268,7 @@ pub(crate) trait Backend: Sync {
         operands: &[AllocatedOperand],
     );
 
-    fn finalize_divide(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]);
+    fn finalize_divide(&self, emit: &mut Emit<'_>, width: IntegerWidth, operands: &[AllocatedOperand]);
 }
 
 pub(crate) struct X86_64Backend;

--- a/Libraries/LibJS/Flap/src/target/description.rs
+++ b/Libraries/LibJS/Flap/src/target/description.rs
@@ -163,7 +163,7 @@ pub(crate) enum Operation {
     Or32Branch(SignCondition),
     Negate,
     Not(IntegerWidth),
-    Modulo,
+    Modulo(IntegerWidth),
     Overflow(OverflowOperation),
     ExtractTag,
     UnboxInt32,
@@ -948,7 +948,7 @@ fn lookup_operation(operation: Operation) -> &'static InstructionDescription {
                     .coalesces(&[(0, 1)])
             }
         }
-        Operation::Modulo => {
+        Operation::Modulo(_) => {
             &const {
                 plain(&[GprOut, GprIn, GprIn])
                     .x86_64(spec().outputs(&[RDX]).fixed(&[(0, RDX)]).scratches(&[RAX]))
@@ -992,8 +992,11 @@ fn lookup_operation(operation: Operation) -> &'static InstructionDescription {
             }
         }
         Operation::Float(FloatingPointOperation::Convert(
-            FloatConversion::Int32ToFloat64 | FloatConversion::Uint32ToFloat64,
+            FloatConversion::Int32ToFloat64 | FloatConversion::Int64ToFloat64 | FloatConversion::Uint32ToFloat64,
         )) => &const { plain(&[FprOut, GprIn]) },
+        Operation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt64)) => {
+            &const { plain(&[GprOut, FprIn, Label]).scratches(&[XMM3], &[D16]) }
+        }
         Operation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt32)) => {
             &const { plain(&[GprOut, FprIn, Label]).scratches(&[RCX, XMM3], &[D16]) }
         }

--- a/Libraries/LibJS/Flap/src/target/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/finalize.rs
@@ -206,7 +206,9 @@ fn finalize_float_operation(
 ) {
     if !matches!(
         operation,
-        FloatingPointOperation::Convert(FloatConversion::Float64ToInt32 | FloatConversion::JavaScriptToInt32)
+        FloatingPointOperation::Convert(
+            FloatConversion::Float64ToInt32 | FloatConversion::Float64ToInt64 | FloatConversion::JavaScriptToInt32
+        )
     ) {
         backend.float_operation(emit, opcode, operation, operands);
         return;
@@ -404,7 +406,7 @@ fn finalize_instruction(
         Operation::Cold => {
             return emit.error("operation Cold was not expanded into legal machine instructions");
         }
-        Operation::Modulo => backend.finalize_divide(emit, operands),
+        Operation::Modulo(width) => backend.finalize_divide(emit, width, operands),
         _ => emit.output.push(MachineInstruction {
             opcode,
             operands: instruction.operands,

--- a/Libraries/LibJS/Flap/src/target/verify.rs
+++ b/Libraries/LibJS/Flap/src/target/verify.rs
@@ -325,7 +325,7 @@ mod tests {
     fn rejects_explicit_scratch_aliases() {
         let error = verify_instruction_for_architecture(
             Instruction {
-                opcode: Operation::Modulo,
+                opcode: Operation::Modulo(IntegerWidth::U32),
                 operands: vec![
                     Operand::PhysicalRegister(aarch64::X1),
                     Operand::PhysicalRegister(aarch64::X2),
@@ -439,14 +439,14 @@ mod tests {
         );
         assert_invalid_arity(
             Architecture::Aarch64,
-            Operation::Modulo,
+            Operation::Modulo(IntegerWidth::U32),
             [aarch64::X1, aarch64::X2, aarch64::X3]
                 .map(Operand::PhysicalRegister)
                 .into(),
         );
         assert_invalid_arity(
             Architecture::X86_64,
-            Operation::Modulo,
+            Operation::Modulo(IntegerWidth::U32),
             vec![
                 Operand::PhysicalRegister(x86_64::RAX),
                 Operand::PhysicalRegister(x86_64::RDX),

--- a/Libraries/LibJS/Flap/src/target/x86_64.rs
+++ b/Libraries/LibJS/Flap/src/target/x86_64.rs
@@ -305,6 +305,8 @@ define_machine_opcodes! {
         immediate(1).is_some_and(|value| (0..64).contains(&value))
     } printing simple!("btr"; native(0), SimpleOperand::Immediate(1));
     [SignExtendEaxToEdx] => Self::SignExtendEaxToEdx => [[]] printing simple!("cdq");
+    [SignExtendRaxToRdx] => Self::SignExtendRaxToRdx => [[]] printing simple!("cqo");
+    [SignedDivide64Register] => Self::SignedDivide64Register => [[R]] printing simple!("idiv"; native(0));
     [SignedDivide32Register] => Self::SignedDivide32Register => [[R]] printing simple!("idiv"; integer(0, IntegerWidth::U32));
 }
 
@@ -399,9 +401,9 @@ impl Opcode {
                 FloatingPointOperation::Convert(IntrinsicFloatConversion::Int32ToFloat64) => {
                     Self::FloatConversion(FloatConversion::Signed32ToDouble)
                 }
-                FloatingPointOperation::Convert(IntrinsicFloatConversion::Uint32ToFloat64) => {
-                    Self::FloatConversion(FloatConversion::Signed64ToDouble)
-                }
+                FloatingPointOperation::Convert(
+                    IntrinsicFloatConversion::Uint32ToFloat64 | IntrinsicFloatConversion::Int64ToFloat64,
+                ) => Self::FloatConversion(FloatConversion::Signed64ToDouble),
                 FloatingPointOperation::Convert(IntrinsicFloatConversion::Float32ToFloat64) => {
                     Self::FloatConversion(FloatConversion::FloatToDouble)
                 }
@@ -409,7 +411,9 @@ impl Opcode {
                     Self::FloatConversion(FloatConversion::DoubleToFloat)
                 }
                 FloatingPointOperation::Convert(
-                    IntrinsicFloatConversion::Float64ToInt32 | IntrinsicFloatConversion::JavaScriptToInt32,
+                    IntrinsicFloatConversion::Float64ToInt32
+                    | IntrinsicFloatConversion::Float64ToInt64
+                    | IntrinsicFloatConversion::JavaScriptToInt32,
                 )
                 | FloatingPointOperation::CanonicalizeNan => Self::Pseudo,
             },

--- a/Libraries/LibJS/Flap/src/target/x86_64/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/x86_64/finalize.rs
@@ -850,6 +850,16 @@ impl Backend for X86_64Backend {
         failure: &Label,
     ) {
         match (operation, scratches) {
+            (FloatingPointOperation::Convert(FloatConversion::Float64ToInt64), [fpr_scratch]) => {
+                use super::{Condition, FloatConversion};
+                emit!(emit.output, X86_64;
+                    Opcode::FloatConversion(FloatConversion::DoubleToSigned64Truncate) => [register destination, register source];
+                    Opcode::FloatConversion(FloatConversion::Signed64ToDouble) => [register verified_register(fpr_scratch), register destination];
+                    Opcode::CompareDouble => [register source, register verified_register(fpr_scratch)];
+                    Opcode::JumpParity => [label failure.clone()];
+                    Opcode::JumpCondition(Condition::NotEqual) => [label failure.clone()];
+                );
+            }
             (FloatingPointOperation::Convert(FloatConversion::Float64ToInt32), [gpr_scratch, fpr_scratch]) => {
                 double_to_int32(
                     emit,
@@ -1768,13 +1778,26 @@ impl Backend for X86_64Backend {
         }
     }
 
-    fn finalize_divide(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
+    fn finalize_divide(&self, emit: &mut Emit<'_>, width: IntegerWidth, operands: &[AllocatedOperand]) {
         let [_, dividend, divisor, accumulator] = operands.physical_registers();
 
+        let (move_dividend, sign_extend, divide) = match width {
+            IntegerWidth::U32 => (
+                Opcode::Move32Register,
+                Opcode::SignExtendEaxToEdx,
+                Opcode::SignedDivide32Register,
+            ),
+            IntegerWidth::U64 => (
+                Opcode::Move64Register,
+                Opcode::SignExtendRaxToRdx,
+                Opcode::SignedDivide64Register,
+            ),
+            _ => unreachable!("remainder requires a 32-bit or 64-bit width"),
+        };
         emit!(emit.output, X86_64;
-            Opcode::Move32Register => [register accumulator, register dividend];
-            Opcode::SignExtendEaxToEdx => [];
-            Opcode::SignedDivide32Register => [register divisor];
+            move_dividend => [register accumulator, register dividend];
+            sign_extend => [];
+            divide => [register divisor];
         );
     }
 }

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
@@ -3427,17 +3427,18 @@ asm_handler_UnsignedRightShift_hot_end:
 
 .p2align 4
 asm_handler_Mod:
-    ldp w0, w1, [x21, #8]
+    ldr w0, [x21, #8]
     ldr x0, [x27, x0, lsl #3]
-    ldr x1, [x27, x1, lsl #3]
     lsr x9, x0, #48
     cmp x9, x22
-    b.ne .Lasm_Mod.ssa_block_1
+    b.ne .Lasm_Mod.ssa_block_2
+    ldr w1, [x21, #12]
+    ldr x1, [x27, x1, lsl #3]
     lsr x9, x1, #48
     cmp x9, x22
-    b.ne .Lasm_Mod.ssa_block_1
+    b.ne .Lasm_Mod.ssa_block_2
     cbz w1, .Lasm_Mod.ssa_block_1
-    tbnz w0, #31, .Lasm_Mod.ssa_block_1
+    tbnz w0, #31, .Lasm_Mod.ssa_block_2
     sdiv w9, w0, w1
     msub w0, w9, w1, w0
     movk x0, #0x7ffa, lsl #48
@@ -5962,12 +5963,12 @@ asm_handler_UnsignedRightShiftRhsInt32_hot_end:
 asm_handler_ModRhsInt32:
     ldr w0, [x21, #8]
     ldr x0, [x27, x0, lsl #3]
-    ldr w1, [x21, #12]
     lsr x9, x0, #48
     cmp x9, x22
-    b.ne .Lasm_ModRhsInt32.ssa_block_1
+    b.ne .Lasm_ModRhsInt32.ssa_block_2
+    ldr w1, [x21, #12]
     cbz w1, .Lasm_ModRhsInt32.ssa_block_1
-    tbnz w0, #31, .Lasm_ModRhsInt32.ssa_block_1
+    tbnz w0, #31, .Lasm_ModRhsInt32.ssa_block_2
     sdiv w9, w0, w1
     msub w0, w9, w1, w0
     movk x0, #0x7ffa, lsl #48
@@ -8965,7 +8966,96 @@ asm_handler_UnsignedRightShift_cold:
 asm_handler_UnsignedRightShift_cold_end:
 asm_handler_Mod_cold:
 // Cold paths for Mod
+.Lasm_Mod.ssa_block_2:
+    lsr x1, x0, #48
+    cmp w1, w22
+    b.eq .Lasm_Mod.ssa_block_15
+    and w1, w1, #0x7ff8
+    mov w9, #32760
+    cmp w1, w9
+    b.eq .Lasm_Mod.ssa_block_1
+    fmov d0, x0
+    fcvtzs x2, d0
+    cmn x2, #1
+    b.vs .Lasm_Mod.ssa_block_1
+    scvtf d16, x2
+    fcmp d0, d16
+    b.ne .Lasm_Mod.ssa_block_1
+    b .Lasm_Mod.ssa_block_18
+.Lasm_Mod.ssa_block_15:
+    sxtw x1, w0
+    sxtw x2, w1
+.Lasm_Mod.ssa_block_18:
+    ldr w1, [x21, #12]
+    ldr x1, [x27, x1, lsl #3]
+    lsr x3, x1, #48
+    cmp w3, w22
+    b.eq .Lasm_Mod.ssa_block_20
+    and w3, w3, #0x7ff8
+    mov w9, #32760
+    cmp w3, w9
+    b.eq .Lasm_Mod.ssa_block_1
+    fmov d0, x1
+    fcvtzs x1, d0
+    cmn x1, #1
+    b.vs .Lasm_Mod.ssa_block_1
+    scvtf d16, x1
+    fcmp d0, d16
+    b.ne .Lasm_Mod.ssa_block_1
+    b .Lasm_Mod.ssa_block_23
+.Lasm_Mod.ssa_block_20:
+    sxtw x1, w1
+    sxtw x1, w1
+.Lasm_Mod.ssa_block_23:
+    cbz x1, .Lasm_Mod.ssa_block_1
+    mov x3, #0
+    subs x3, x3, #1
+    cmp x1, x3
+    b.eq .Lasm_Mod.ssa_block_3
+    sdiv x9, x2, x1
+    msub x1, x9, x1, x2
+    cbz x1, .Lasm_Mod.ssa_block_3
+    mov w0, w1
+    sxtw x2, w0
+    cmp x2, x1
+    b.ne .Lasm_Mod.ssa_block_5
+    movk x0, #0x7ffa, lsl #48
+    ldr w9, [x21, #4]
+    str x0, [x27, x9, lsl #3]
+    ldrb w9, [x21, #16]
+    add x21, x21, #16
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Mod.ssa_block_5:
+    scvtf d0, x1
+    fmov x0, d0
+    ldr w9, [x21, #4]
+    str x0, [x27, x9, lsl #3]
+    ldrb w9, [x21, #16]
+    add x21, x21, #16
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Mod.ssa_block_3:
+    tbnz x2, #63, .Lasm_Mod.ssa_block_4
+    tbnz x0, #63, .Lasm_Mod.ssa_block_4
+    movz x0, #0x7ffa, lsl #48
+    ldr w9, [x21, #4]
+    str x0, [x27, x9, lsl #3]
+    ldrb w9, [x21, #16]
+    add x21, x21, #16
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Mod.ssa_block_4:
+    ldr w9, [x21, #4]
+    movz x10, #0x8000, lsl #48
+    str x10, [x27, x9, lsl #3]
+    ldrb w9, [x21, #16]
+    add x21, x21, #16
+    ldr x10, [x19, x9, lsl #3]
+    br x10
 .Lasm_Mod.ssa_block_1:
+    ldr w1, [x21, #12]
+    ldr x1, [x27, x1, lsl #3]
     ldr w2, [x21, #4]
     mov x3, x0
     mov x4, x1
@@ -11754,6 +11844,74 @@ asm_handler_UnsignedRightShiftRhsInt32_cold:
 asm_handler_UnsignedRightShiftRhsInt32_cold_end:
 asm_handler_ModRhsInt32_cold:
 // Cold paths for ModRhsInt32
+.Lasm_ModRhsInt32.ssa_block_2:
+    lsr x1, x0, #48
+    cmp w1, w22
+    b.eq .Lasm_ModRhsInt32.ssa_block_15
+    and w1, w1, #0x7ff8
+    mov w9, #32760
+    cmp w1, w9
+    b.eq .Lasm_ModRhsInt32.ssa_block_1
+    fmov d0, x0
+    fcvtzs x2, d0
+    cmn x2, #1
+    b.vs .Lasm_ModRhsInt32.ssa_block_1
+    scvtf d16, x2
+    fcmp d0, d16
+    b.ne .Lasm_ModRhsInt32.ssa_block_1
+    b .Lasm_ModRhsInt32.ssa_block_18
+.Lasm_ModRhsInt32.ssa_block_15:
+    sxtw x1, w0
+    sxtw x2, w1
+.Lasm_ModRhsInt32.ssa_block_18:
+    ldr w1, [x21, #12]
+    sxtw x1, w1
+    cbz x1, .Lasm_ModRhsInt32.ssa_block_1
+    mov x3, #0
+    subs x3, x3, #1
+    cmp x1, x3
+    b.eq .Lasm_ModRhsInt32.ssa_block_3
+    sdiv x9, x2, x1
+    msub x1, x9, x1, x2
+    cbz x1, .Lasm_ModRhsInt32.ssa_block_3
+    mov w0, w1
+    sxtw x2, w0
+    cmp x2, x1
+    b.ne .Lasm_ModRhsInt32.ssa_block_5
+    movk x0, #0x7ffa, lsl #48
+    ldr w9, [x21, #4]
+    str x0, [x27, x9, lsl #3]
+    ldrb w9, [x21, #16]
+    add x21, x21, #16
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ModRhsInt32.ssa_block_5:
+    scvtf d0, x1
+    fmov x0, d0
+    ldr w9, [x21, #4]
+    str x0, [x27, x9, lsl #3]
+    ldrb w9, [x21, #16]
+    add x21, x21, #16
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ModRhsInt32.ssa_block_3:
+    tbnz x2, #63, .Lasm_ModRhsInt32.ssa_block_4
+    tbnz x0, #63, .Lasm_ModRhsInt32.ssa_block_4
+    movz x0, #0x7ffa, lsl #48
+    ldr w9, [x21, #4]
+    str x0, [x27, x9, lsl #3]
+    ldrb w9, [x21, #16]
+    add x21, x21, #16
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ModRhsInt32.ssa_block_4:
+    ldr w9, [x21, #4]
+    movz x10, #0x8000, lsl #48
+    str x10, [x27, x9, lsl #3]
+    ldrb w9, [x21, #16]
+    add x21, x21, #16
+    ldr x10, [x19, x9, lsl #3]
+    br x10
 .Lasm_ModRhsInt32.ssa_block_1:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
@@ -3434,22 +3434,22 @@ asm_handler_UnsignedRightShift_hot_end:
 
 .p2align 6
 asm_handler_Mod:
-    mov ecx, DWORD PTR [r14 + r13 + 8]
-    mov eax, DWORD PTR [r14 + r13 + 12]
-    mov rcx, QWORD PTR [rbx + rcx * 8]
-    mov rsi, QWORD PTR [rbx + rax * 8]
+    mov eax, DWORD PTR [r14 + r13 + 8]
+    mov rcx, QWORD PTR [rbx + rax * 8]
     mov r11, rcx
     shr r11, 48
     cmp r11w, 32762
-    jne .Lasm_Mod.ssa_block_1
+    jne .Lasm_Mod.ssa_block_2
+    mov eax, DWORD PTR [r14 + r13 + 12]
+    mov rsi, QWORD PTR [rbx + rax * 8]
     mov r11, rsi
     shr r11, 48
     cmp r11w, 32762
-    jne .Lasm_Mod.ssa_block_1
+    jne .Lasm_Mod.ssa_block_2
     test esi, esi
     jz .Lasm_Mod.ssa_block_1
     test ecx, ecx
-    js .Lasm_Mod.ssa_block_1
+    js .Lasm_Mod.ssa_block_2
     mov eax, ecx
     cdq
     idiv esi
@@ -6090,15 +6090,15 @@ asm_handler_UnsignedRightShiftRhsInt32_hot_end:
 asm_handler_ModRhsInt32:
     mov eax, DWORD PTR [r14 + r13 + 8]
     mov rcx, QWORD PTR [rbx + rax * 8]
-    mov esi, DWORD PTR [r14 + r13 + 12]
     mov r11, rcx
     shr r11, 48
     cmp r11w, 32762
-    jne .Lasm_ModRhsInt32.ssa_block_1
+    jne .Lasm_ModRhsInt32.ssa_block_2
+    mov esi, DWORD PTR [r14 + r13 + 12]
     test esi, esi
     jz .Lasm_ModRhsInt32.ssa_block_1
     test ecx, ecx
-    js .Lasm_ModRhsInt32.ssa_block_1
+    js .Lasm_ModRhsInt32.ssa_block_2
     mov eax, ecx
     cdq
     idiv esi
@@ -9100,10 +9100,100 @@ asm_handler_UnsignedRightShift_cold:
 asm_handler_UnsignedRightShift_cold_end:
 asm_handler_Mod_cold:
 # Cold paths for Mod
+.Lasm_Mod.ssa_block_2:
+    mov rax, rcx
+    shr rax, 48
+    cmp ax, 32762
+    je .Lasm_Mod.ssa_block_15
+    and ax, 32760
+    cmp ax, 32760
+    je .Lasm_Mod.ssa_block_1
+    movq xmm0, rcx
+    cvttsd2si rdi, xmm0
+    cvtsi2sd xmm3, rdi
+    ucomisd xmm0, xmm3
+    jp .Lasm_Mod.ssa_block_1
+    jne .Lasm_Mod.ssa_block_1
+    jmp .Lasm_Mod.ssa_block_18
+.Lasm_Mod.ssa_block_15:
+    movsxd rax, ecx
+    movsxd rdi, eax
+.Lasm_Mod.ssa_block_18:
+    mov eax, DWORD PTR [r14 + r13 + 12]
+    mov rax, QWORD PTR [rbx + rax * 8]
+    mov rdx, rax
+    shr rdx, 48
+    cmp dx, 32762
+    je .Lasm_Mod.ssa_block_20
+    and dx, 32760
+    cmp dx, 32760
+    je .Lasm_Mod.ssa_block_1
+    movq xmm0, rax
+    cvttsd2si rsi, xmm0
+    cvtsi2sd xmm3, rsi
+    ucomisd xmm0, xmm3
+    jp .Lasm_Mod.ssa_block_1
+    jne .Lasm_Mod.ssa_block_1
+    jmp .Lasm_Mod.ssa_block_23
+.Lasm_Mod.ssa_block_20:
+    movsxd rax, eax
+    movsxd rsi, eax
+.Lasm_Mod.ssa_block_23:
+    test rsi, rsi
+    jz .Lasm_Mod.ssa_block_1
+    xor rax, rax
+    sub rax, 1
+    cmp rsi, rax
+    je .Lasm_Mod.ssa_block_3
+    mov rax, rdi
+    cqo
+    idiv rsi
+    test rdx, rdx
+    jz .Lasm_Mod.ssa_block_3
+    mov eax, edx
+    movsxd rcx, eax
+    cmp rcx, rdx
+    jne .Lasm_Mod.ssa_block_5
+    movabs r11, 9221683186994511872
+    or rax, r11
+    mov r11d, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + r11 * 8], rax
+    add r13d, 16
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Mod.ssa_block_5:
+    cvtsi2sd xmm0, rdx
+    movq rax, xmm0
+    mov r11d, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + r11 * 8], rax
+    add r13d, 16
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Mod.ssa_block_3:
+    test rdi, rdi
+    js .Lasm_Mod.ssa_block_4
+    test rcx, rcx
+    js .Lasm_Mod.ssa_block_4
+    movabs rax, 9221683186994511872
+    mov r11d, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + r11 * 8], rax
+    add r13d, 16
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Mod.ssa_block_4:
+    movabs r11, -9223372036854775808
+    mov eax, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + rax * 8], r11
+    add r13d, 16
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
 .Lasm_Mod.ssa_block_1:
-    mov edx, DWORD PTR [r14 + r13 + 4]
+    mov eax, DWORD PTR [r14 + r13 + 12]
+    mov rdx, QWORD PTR [rbx + rax * 8]
+    mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
-    mov r8, rsi
+    mov r8, rdx
+    mov rdx, rsi
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_mod_values)
@@ -12030,6 +12120,75 @@ asm_handler_UnsignedRightShiftRhsInt32_cold:
 asm_handler_UnsignedRightShiftRhsInt32_cold_end:
 asm_handler_ModRhsInt32_cold:
 # Cold paths for ModRhsInt32
+.Lasm_ModRhsInt32.ssa_block_2:
+    mov rax, rcx
+    shr rax, 48
+    cmp ax, 32762
+    je .Lasm_ModRhsInt32.ssa_block_15
+    and ax, 32760
+    cmp ax, 32760
+    je .Lasm_ModRhsInt32.ssa_block_1
+    movq xmm0, rcx
+    cvttsd2si rsi, xmm0
+    cvtsi2sd xmm3, rsi
+    ucomisd xmm0, xmm3
+    jp .Lasm_ModRhsInt32.ssa_block_1
+    jne .Lasm_ModRhsInt32.ssa_block_1
+    jmp .Lasm_ModRhsInt32.ssa_block_18
+.Lasm_ModRhsInt32.ssa_block_15:
+    movsxd rax, ecx
+    movsxd rsi, eax
+.Lasm_ModRhsInt32.ssa_block_18:
+    mov eax, DWORD PTR [r14 + r13 + 12]
+    movsxd rdi, eax
+    test rdi, rdi
+    jz .Lasm_ModRhsInt32.ssa_block_1
+    xor rax, rax
+    sub rax, 1
+    cmp rdi, rax
+    je .Lasm_ModRhsInt32.ssa_block_3
+    mov rax, rsi
+    cqo
+    idiv rdi
+    test rdx, rdx
+    jz .Lasm_ModRhsInt32.ssa_block_3
+    mov eax, edx
+    movsxd rcx, eax
+    cmp rcx, rdx
+    jne .Lasm_ModRhsInt32.ssa_block_5
+    movabs r11, 9221683186994511872
+    or rax, r11
+    mov r11d, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + r11 * 8], rax
+    add r13d, 16
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ModRhsInt32.ssa_block_5:
+    cvtsi2sd xmm0, rdx
+    movq rax, xmm0
+    mov r11d, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + r11 * 8], rax
+    add r13d, 16
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ModRhsInt32.ssa_block_3:
+    test rsi, rsi
+    js .Lasm_ModRhsInt32.ssa_block_4
+    test rcx, rcx
+    js .Lasm_ModRhsInt32.ssa_block_4
+    movabs rax, 9221683186994511872
+    mov r11d, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + r11 * 8], rax
+    add r13d, 16
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ModRhsInt32.ssa_block_4:
+    movabs r11, -9223372036854775808
+    mov eax, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + rax * 8], r11
+    add r13d, 16
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
 .Lasm_ModRhsInt32.ssa_block_1:
     mov edx, DWORD PTR [r14 + r13 + 12]
     movabs r11, 9221683186994511872

--- a/Libraries/LibJS/Interpreter/interpreter.flap
+++ b/Libraries/LibJS/Interpreter/interpreter.flap
@@ -120,6 +120,19 @@ inline fn numeric_pair_to_f64(
     (lhs_result, rhs_result)
 }
 
+inline fn integer_value_to_i64(value: Value, else failure: Label) -> i64 {
+    match value {
+        Value<i32>(integer) => {
+            i64(integer)
+        },
+        Value<f64>(number) => {
+            guard let integer = double_to_int64(number) else failure;
+            integer
+        },
+        _ => failure,
+    }
+}
+
 inline fn load_property_lookup_cache(
     cache: PropertyLookupCacheIndex,
     else fail: Label
@@ -1931,16 +1944,49 @@ handler Mod(
     rhs: in Operand
 ) {
     let lhs = load(lhs);
-    let rhs = load(rhs);
 
     let slow = || @cold {
-        call_binary_slow_path(mod_values, dst, lhs, rhs);
+        let rhs_value = load(rhs);
+        call_binary_slow_path(mod_values, dst, lhs, rhs_value);
     };
 
-    guard let Value<i32>(lhs_int) = lhs else slow;
-    guard let Value<i32>(rhs_int) = rhs else slow;
+    let try_int64 = || @cold {
+        guard let lhs_integer = integer_value_to_i64(lhs) else slow;
+        guard let rhs_integer = integer_value_to_i64(load(rhs)) else slow;
+        guard rhs_integer != 0 else slow;
+
+        let zero = || @cold {
+            let negative_zero = || @cold {
+                store(dst, Value<NegativeZero>);
+                dispatch_next;
+            };
+            guard lhs_integer >= 0 else negative_zero;
+            branch_value_bits_negative(lhs, negative_zero);
+            let zero_value: Value = INT32_TAG_SHIFTED;
+            store(dst, zero_value);
+            dispatch_next;
+        };
+
+        # NB: Avoid signed division overflow for INT64_MIN % -1.
+        let zero_integer: i64 = 0;
+        let negative_one = zero_integer - 1;
+        guard rhs_integer != negative_one else zero;
+        let remainder = mod_i64(lhs_integer, rhs_integer);
+        guard remainder != 0 else zero;
+        let remainder_int32 = i32(remainder);
+        let widened_remainder = i64(remainder_int32);
+        guard widened_remainder == remainder else @cold {
+            store(dst, box_f64(i64_to_f64(remainder)));
+            dispatch_next;
+        };
+        store(dst, box_i32(remainder_int32));
+        dispatch_next;
+    };
+
+    guard let Value<i32>(lhs_int) = lhs else try_int64;
+    guard let Value<i32>(rhs_int) = load(rhs) else try_int64;
     guard rhs_int != 0 else slow;
-    guard lhs_int >= 0 else slow;
+    guard lhs_int >= 0 else try_int64;
     let [_, remainder] = divmod(lhs_int, rhs_int);
     store(dst, box_i32(remainder));
     dispatch_next;

--- a/Tests/LibJS/Runtime/operators/modulo-basic.js
+++ b/Tests/LibJS/Runtime/operators/modulo-basic.js
@@ -80,3 +80,64 @@ test("Int32 fast path edge cases", () => {
     expect(3 % -7).toBe(3);
     expect(-3 % -7).toBe(-3);
 });
+
+test("integer-valued double operands", () => {
+    const cases = [
+        [2147483648, 3],
+        [2147483647 * 16807, 2147483647],
+        [2147483646 * 16807, 2147483647],
+        [2 ** 40 + 1, 2 ** 32 + 1],
+        [Number.MAX_SAFE_INTEGER, 3],
+        [2 ** 53, 3],
+        [2 ** 63 - 1024, 3],
+        [2 ** 63 - 1024, 2 ** 62],
+        [2 ** 63 - 1024, 2 ** 63 - 1024],
+        [1, 2 ** 63 - 1024],
+        [0, 2 ** 32],
+        // Exercise the fallback at and beyond the conversion boundary too.
+        [2 ** 63, 1],
+        [2 ** 63, 3],
+        [2 ** 63, 2 ** 63],
+        [2 ** 64, 3],
+        [2 ** 64, 2 ** 63],
+        [1, 2 ** 63],
+        [Number.MAX_VALUE, 3],
+    ];
+
+    for (const [dividend, divisor] of cases) {
+        const remainder = Number(BigInt(dividend) % BigInt(divisor));
+        expect(dividend % divisor).toBe(remainder);
+        expect(dividend % -divisor).toBe(remainder);
+        expect(-dividend % divisor).toBe(-remainder);
+        expect(-dividend % -divisor).toBe(-remainder);
+    }
+});
+
+test("non-integral double operands and special values", () => {
+    const cases = [
+        [2147483648.5, 3, 2.5],
+        [2147483648, 2.5, 0.5],
+        [2147483648.5, 2.5, 1],
+        [2147483648.5, 0.5, 0],
+        [0.5, 2147483648, 0.5],
+        [Number.MIN_VALUE, 2147483648, Number.MIN_VALUE],
+        [2147483648, Number.MIN_VALUE, 0],
+        [2147483648, Infinity, 2147483648],
+    ];
+
+    for (const [dividend, divisor, remainder] of cases) {
+        expect(dividend % divisor).toBe(remainder);
+        expect(dividend % -divisor).toBe(remainder);
+        expect(-dividend % divisor).toBe(-remainder);
+        expect(-dividend % -divisor).toBe(-remainder);
+    }
+
+    for (const dividend of [2147483648, -2147483648, 2 ** 63, -(2 ** 63)]) {
+        expect(dividend % 0).toBeNaN();
+        expect(dividend % -0).toBeNaN();
+        expect(dividend % NaN).toBeNaN();
+        expect(NaN % dividend).toBeNaN();
+        expect(Infinity % dividend).toBeNaN();
+        expect(-Infinity % dividend).toBeNaN();
+    }
+});


### PR DESCRIPTION
Keep `%` in the interpreter when integral Number operands fit in int64, avoiding the C++ slow path and `fmod`. Add the necessary Flap primitives for AArch64 and x86-64, preserving negative zero and guarding against signed division overflow.
