### PR TITLE
LibWeb: Share local predicate results when building prefix relations

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
@@ -884,37 +884,62 @@ impl PrefixAutomaton {
             .iter()
             .map(|&node| evaluation.positional_bits(node, counters).unwrap())
             .collect();
+        // Local predicates read the same facts for every member of a fact cohort. Reuse their
+        // answers while building memberships, as scalar prefix transitions already do. Keep
+        // document-root identity in the key and check positional truth separately per node.
+        let mut local_facts = super::LocalFactInterner::new();
+        let local_fact_keys: Vec<_> = rows
+            .iter()
+            .enumerate()
+            .map(|(position, row)| {
+                let identity = if evaluation.facts_are_composite() {
+                    local_facts.mint_identity()
+                } else {
+                    local_facts.intern(row.facts, row.row, counters)
+                };
+                identity as usize * 2 + usize::from(parents[position] == usize::MAX)
+            })
+            .collect();
+        let mut local_matches = vec![None; local_facts.next_identity as usize * 2];
         let mut compound_matches = Vec::with_capacity(self.compounds.len());
         for compound in &self.compounds {
+            local_matches.fill(None);
             let matched: Vec<_> = candidates[&compound.dispatch_key]
                 .iter()
                 .copied()
                 .filter(|&position| {
-                    counters.bump(Counter::PrefixCompoundsEvaluated);
-                    let row = rows[position];
-                    match &compound.predicate {
-                        PrefixPredicate::Features {
-                            feature_start,
-                            feature_len,
-                            required_positional_bits,
-                        } => {
-                            positional[position] & required_positional_bits == *required_positional_bits
-                                && self
-                                    .features_for(*feature_start, *feature_len)
-                                    .iter()
-                                    .all(|&feature| matches_feature(row.facts, row.row, feature))
-                        }
-                        PrefixPredicate::Program { program, local } => evaluation
-                            .evaluator
-                            .matches_prefix_local(
-                                *program,
-                                evaluation.programs.get(*program),
-                                *local,
-                                nodes[position],
-                                counters,
-                            )
-                            .unwrap(),
+                    if let PrefixPredicate::Features {
+                        required_positional_bits,
+                        ..
+                    } = &compound.predicate
+                        && positional[position] & required_positional_bits != *required_positional_bits
+                    {
+                        return false;
                     }
+                    *local_matches[local_fact_keys[position]].get_or_insert_with(|| {
+                        counters.bump(Counter::PrefixCompoundsEvaluated);
+                        let row = rows[position];
+                        match &compound.predicate {
+                            PrefixPredicate::Features {
+                                feature_start,
+                                feature_len,
+                                ..
+                            } => self
+                                .features_for(*feature_start, *feature_len)
+                                .iter()
+                                .all(|&feature| matches_feature(row.facts, row.row, feature)),
+                            PrefixPredicate::Program { program, local } => evaluation
+                                .evaluator
+                                .matches_prefix_local(
+                                    *program,
+                                    evaluation.programs.get(*program),
+                                    *local,
+                                    nodes[position],
+                                    counters,
+                                )
+                                .unwrap(),
+                        }
+                    })
                 })
                 .collect();
             compound_matches.push(matched);

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5087,6 +5087,172 @@ fn update_test_prefix_relation(
 }
 
 #[test]
+fn prefix_relation_construction_reuses_local_facts_without_sharing_position() {
+    let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
+    let mut raw = [0; 65];
+    engine.allocate_style_nodes(&mut raw);
+    let nodes: Vec<_> = raw.into_iter().map(|raw| StyleNodeID::from_raw(raw).unwrap()).collect();
+    let class = StyleAtomID(200);
+    engine.record_tree_delta(nodes[0], None, Some(relations(None, None, None)));
+    for index in 1..nodes.len() {
+        engine.record_tree_delta(
+            nodes[index],
+            None,
+            Some(relations(
+                Some(nodes[0].raw()),
+                (index > 1).then(|| nodes[index - 1].raw()),
+                None,
+            )),
+        );
+    }
+    for &node in &nodes {
+        add_feature(&mut engine, node, LocalFeatureKey::Class(class));
+    }
+
+    // The root has the same local facts as its children, but :root and nth-child
+    // still distinguish their positions. :not(:root) uses a program predicate.
+    let mut builder = selector::SelectorProgramBuilder::new();
+    let feature = builder.push_feature(selector::FeatureTest::Class(class));
+    let root = builder.push(selector::SelectorOp::Root);
+    let not_root = builder.push(selector::SelectorOp::Not(root));
+    let compound = builder.push_compound(&[feature, not_root]);
+    builder.push_entry_for_pseudo(compound, None);
+    let sheet = engine.add_sheet(StyleSheetObjectID(1), CascadeOrigin::Author);
+    engine.attach_sheet(sheet, TreeScopeID::DOCUMENT);
+    for selector in [
+        builder.finish(),
+        test_selector_program(".same:nth-child(2n)", &[("same", class)]),
+    ] {
+        let program = engine.programs.add(selector);
+        let rule = engine.append_rule(sheet, None, RuleKind::Style);
+        engine.add_routing_rule(rule, program);
+        let mut version = engine.program.rule_version(rule);
+        version.selector_program = Some(program);
+        version.declaration_block = Some(DeclarationBlockID(1));
+        engine.replace_rule_version(rule, version);
+    }
+    discard_transaction(&mut engine);
+    let before = engine.counters.get(Counter::PrefixCompoundsEvaluated);
+    let (_, relation) = test_prefix_relation(&mut engine, nodes[0]);
+    let evaluations = engine.counters.get(Counter::PrefixCompoundsEvaluated) - before;
+    assert!(
+        evaluations < 16,
+        "repeated local facts required {evaluations} evaluations"
+    );
+    let mut states = PrefixStates::new(0);
+    relation.install_answers(&mut states);
+    assert!(states.retained_matches_for(nodes[0]).unwrap().is_empty());
+    for (index, &node) in nodes.iter().enumerate().skip(1) {
+        assert_eq!(
+            states.retained_matches_for(node).unwrap().len(),
+            1 + usize::from(index % 2 == 0)
+        );
+    }
+}
+
+#[test]
+fn prefix_relation_local_fact_cache_separates_predicates_and_tracks_changes() {
+    for negate in [false, true] {
+        let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
+        let mut raw = [0; 65];
+        engine.allocate_style_nodes(&mut raw);
+        let nodes: Vec<_> = raw.into_iter().map(|raw| StyleNodeID::from_raw(raw).unwrap()).collect();
+        let same = StyleAtomID(200);
+        let selected = StyleAtomID(201);
+        engine.record_tree_delta(nodes[0], None, Some(relations(None, None, None)));
+        for index in 1..nodes.len() {
+            engine.record_tree_delta(
+                nodes[index],
+                None,
+                Some(relations(
+                    Some(nodes[0].raw()),
+                    (index > 1).then(|| nodes[index - 1].raw()),
+                    None,
+                )),
+            );
+        }
+        for (index, &node) in nodes.iter().enumerate() {
+            add_feature(&mut engine, node, LocalFeatureKey::Class(same));
+            if index % 2 == 0 {
+                add_feature(&mut engine, node, LocalFeatureKey::Class(selected));
+            }
+        }
+        let sheet = engine.add_sheet(StyleSheetObjectID(1), CascadeOrigin::Author);
+        engine.attach_sheet(sheet, TreeScopeID::DOCUMENT);
+        // Both compounds dispatch on .same, but have different answers. Negation
+        // exercises program predicates, including shared false results.
+        for require_selected in [false, true] {
+            let mut builder = selector::SelectorProgramBuilder::new();
+            let same = builder.push_feature(selector::FeatureTest::Class(same));
+            let mut operands = vec![same];
+            if require_selected {
+                let selected = builder.push_feature(selector::FeatureTest::Class(selected));
+                operands.push(if negate {
+                    builder.push(selector::SelectorOp::Not(selected))
+                } else {
+                    selected
+                });
+            }
+            let compound = builder.push_compound(&operands);
+            builder.push_entry_for_pseudo(compound, None);
+            let program = engine.programs.add(builder.finish());
+            let rule = engine.append_rule(sheet, None, RuleKind::Style);
+            engine.add_routing_rule(rule, program);
+            let mut version = engine.program.rule_version(rule);
+            version.selector_program = Some(program);
+            version.declaration_block = Some(DeclarationBlockID(1));
+            engine.replace_rule_version(rule, version);
+        }
+        discard_transaction(&mut engine);
+        let before = engine.counters.get(Counter::PrefixCompoundsEvaluated);
+        let (dispatch, mut relation) = test_prefix_relation(&mut engine, nodes[0]);
+        let evaluations = engine.counters.get(Counter::PrefixCompoundsEvaluated) - before;
+        assert!(
+            evaluations < 16,
+            "repeated local facts required {evaluations} evaluations"
+        );
+        let mut states = PrefixStates::new(0);
+        relation.install_answers(&mut states);
+        for (index, &node) in nodes.iter().enumerate() {
+            assert_eq!(
+                states.retained_matches_for(node).unwrap().len(),
+                1 + usize::from((index % 2 == 0) != negate)
+            );
+        }
+
+        // Move one element between fact groups in each direction. Other members
+        // must keep their answers, and rebuilding must agree with the update.
+        let old_facts = engine.facts.primary().clone();
+        add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(selected));
+        remove_feature(&mut engine, nodes[2], LocalFeatureKey::Class(selected));
+        discard_transaction(&mut engine);
+        update_test_prefix_relation(
+            &engine,
+            &dispatch,
+            &mut relation,
+            &old_facts,
+            &[nodes[1], nodes[2]],
+            None,
+        );
+        assert_eq!(relation.changed_answers.len(), 2);
+        relation.install_answers(&mut states);
+        let (_, rebuilt) = test_prefix_relation(&mut engine, nodes[0]);
+        let mut rebuilt_states = PrefixStates::new(0);
+        rebuilt.install_answers(&mut rebuilt_states);
+        for (index, &node) in nodes.iter().enumerate() {
+            let selected = match index {
+                1 => true,
+                2 => false,
+                _ => index % 2 == 0,
+            };
+            let matches = states.retained_matches_for(node).unwrap();
+            assert_eq!(matches.len(), 1 + usize::from(selected != negate));
+            assert_eq!(matches, rebuilt_states.retained_matches_for(node).unwrap());
+        }
+    }
+}
+
+#[test]
 fn prefix_relations_propagate_local_changes_over_every_axis() {
     for (selector, nested, guard_index, target_index) in [
         (".guard > .target", true, 2, 3),


### PR DESCRIPTION
Avoid evaluating the same selector compound independently for every element when constructing prefix memberships. Intern local facts and reuse each compound result for equivalent elements, while keeping document roots and positional truth distinct.

Restore the local-fact sharing already used by scalar prefix matching, reducing redundant selector work in Speedometer TodoMVC workloads without discarding maintained memberships between style updates.

Bound compound evaluations for repeated local facts and verify that :root and :nth-child still distinguish otherwise identical nodes.