### PR TITLE
LibWeb: Stop rebuilding the selector prefix relation on every style update

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -342,30 +342,46 @@ impl StyleEngine {
             let _ = self.install_before_sibling_geometry(&mut transaction_fact_view);
         }
         let has_before_sibling_relations = transaction_fact_view.before_sibling_relations_available;
-        self.prefix_caches.borrow_mut().states.mark_previous();
         self.transaction_fact_view = Some(transaction_fact_view);
+        let mut caches = self.prefix_caches.borrow_mut();
+        caches.states.mark_previous();
         // The relation maintains document-scoped prefixes. Incomplete transitions and
         // tag changes, whose of-type effects extend to siblings, require cold reconstruction.
-        if self.prefix_caches.borrow().states.has_relation()
-            && (self
+        if caches.states.has_relation() {
+            let mut reconstruct = self
                 .transaction_fact_view
                 .as_ref()
-                .is_none_or(|view| view.prefix.is_none())
-                || !transaction.inputs.iter().all(|input| {
-                    input
-                        .key
-                        .style_node()
-                        .is_some_and(|node| self.tree.tree_scope(node) == TreeScopeID::DOCUMENT)
-                        && !matches!(
-                            input.key,
-                            InputKey::LocalFeature(_, LocalFeatureKey::TagName | LocalFeatureKey::FoldedTagName)
-                        )
-                }))
-        {
-            let mut caches = self.prefix_caches.borrow_mut();
-            caches.states.release();
-            caches.answers.release(&mut self.match_answers);
+                .is_none_or(|view| view.prefix.is_none());
+            let mut confined_elsewhere = false;
+            for input in &transaction.inputs {
+                if reconstruct {
+                    break;
+                }
+                let (tree_scope, maintained) = match input.key {
+                    InputKey::LocalFeature(node, LocalFeatureKey::TagName | LocalFeatureKey::FoldedTagName) => {
+                        (self.tree.tree_scope(node), false)
+                    }
+                    key => match key.style_node() {
+                        Some(node) => (self.tree.tree_scope(node), true),
+                        None => (key.program_tree_scope().unwrap_or(TreeScopeID::DOCUMENT), false),
+                    },
+                };
+                if tree_scope != TreeScopeID::DOCUMENT {
+                    confined_elsewhere = true;
+                } else if !maintained {
+                    reconstruct = true;
+                }
+            }
+            if reconstruct {
+                caches.states.release();
+                caches.answers.release(&mut self.match_answers);
+            } else if confined_elsewhere {
+                // The other scope's own retained transitions are not maintained.
+                caches.states.release_transition_states();
+                caches.answers.release(&mut self.match_answers);
+            }
         }
+        drop(caches);
         let fact_view_bytes = self
             .transaction_fact_view
             .as_ref()

--- a/Libraries/LibWeb/Rust/src/css/style/impact.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/impact.rs
@@ -83,6 +83,27 @@ pub enum ImpactRegion {
 }
 
 impl ImpactRegion {
+    /// Whether the region lies outside the document tree scope.
+    #[must_use]
+    pub(super) fn lies_outside_document_scope(self, tree: &StyleNodeTree) -> bool {
+        match self {
+            Self::Empty | Self::Document => false,
+            Self::TreeScope(scope) => scope != TreeScopeID::DOCUMENT,
+            Self::HostedSubtrees(_) => true,
+            Self::Node(node)
+            | Self::Children(node)
+            | Self::Subtree(node)
+            | Self::StrictSubtree(node)
+            | Self::NextSibling(node)
+            | Self::FollowingSiblings(node)
+            | Self::FollowingSiblingSubtrees(node)
+            | Self::SiblingSequence(node)
+            | Self::Ancestors(node)
+            | Self::PreviousSibling(node)
+            | Self::PrecedingSiblings(node) => tree.tree_scope(node) != TreeScopeID::DOCUMENT,
+        }
+    }
+
     /// Widen a region by one inverse relation step.
     ///
     /// Each case answers "where can this relation reach, starting from everything already in the

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -2084,11 +2084,21 @@ impl StyleEngine {
         let matches = retained
             .iter()
             .copied()
+            .filter(|entry| {
+                !self.program.declarations_are_complete_for(entry.rule)
+                    || self
+                        .program
+                        .declared_properties_of(entry.rule)
+                        .iter()
+                        .any(|declared| properties.binary_search(&declared.property).is_ok())
+            })
             .map(|entry| entry.materialize(node, &self.programs, 0))
             .collect::<Option<Vec<_>>>();
         let Some(matches) = matches else {
             return;
         };
+        self.counters
+            .add(Counter::ElementDeclarationRepairMatches, matches.len() as u64);
         let Some(updates) = self.exact_cascade_winner_updates_for_properties(node, &matches, None, properties) else {
             return;
         };

--- a/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
@@ -99,6 +99,7 @@ define_counters! {
     PrefixRelationUpdates => "prefixRelationUpdates",
     PrefixRelationStops => "prefixRelationStops",
     PrefixRelationCascadeStops => "prefixRelationCascadeStops",
+    PrefixRelationBuilds => "prefixRelationBuilds",
     PrefixConvergencePasses => "prefixConvergencePasses",
     PrefixConvergenceNodes => "prefixConvergenceNodes",
     PrefixConvergenceStops => "prefixConvergenceStops",

--- a/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
@@ -42,6 +42,7 @@ define_counters! {
     LocalFeatureDeltas => "localFeatureDeltas",
     StateDeltas => "stateDeltas",
     ElementDeclarationDeltas => "elementDeclarationDeltas",
+    ElementDeclarationRepairMatches => "elementDeclarationRepairMatches",
     ProgramDeltas => "programDeltas",
     CascadeTopologyDeltas => "cascadeTopologyDeltas",
     EnvironmentDeltas => "environmentDeltas",

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -2118,13 +2118,11 @@ impl StyleEngine {
             }
             let join_deltas = transaction.program_joins_for(input.key);
             if !join_deltas.is_empty() {
-                if matches!(
-                    input.key,
-                    InputKey::SheetAttachment(_, tree_scope)
-                        | InputKey::CascadeTopology(
-                            TopologyAxis::LayerOrder(tree_scope) | TopologyAxis::SheetOrder(tree_scope)
-                        ) if tree_scope != TreeScopeID::DOCUMENT
-                ) {
+                if input
+                    .key
+                    .program_tree_scope()
+                    .is_some_and(|scope| scope != TreeScopeID::DOCUMENT)
+                {
                     return None;
                 }
                 for delta in join_deltas {

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -556,7 +556,7 @@ impl StyleEngine {
 
     pub(super) fn retain_prefix_states(&mut self) {
         if !self.prefix_caches.borrow_mut().states.retain(&mut self.memory) {
-            self.prefix_caches.borrow_mut().states.release();
+            self.prefix_caches.borrow_mut().states.release_transition_states();
         }
     }
 
@@ -683,7 +683,7 @@ impl StyleEngine {
                     caches.answers.release(&mut self.match_answers);
                 }
             } else {
-                caches.states.release();
+                caches.states.release_transition_states();
                 caches.answers.release(&mut self.match_answers);
             }
         }
@@ -2009,7 +2009,7 @@ impl StyleEngine {
             MemoryCategory::RetainedSelectorIncidence => self.retained_selector_incidences.clear(),
             MemoryCategory::RetainedMatchAnswer => self.retained_match_answers.evict(&mut self.match_answers),
             MemoryCategory::PrefixTransitionCache => {
-                self.prefix_caches.borrow_mut().states.release();
+                self.prefix_caches.borrow_mut().states.release_transition_states();
             }
             MemoryCategory::PrefixAnswerCache => {
                 self.prefix_caches.borrow_mut().answers.release(&mut self.match_answers);

--- a/Libraries/LibWeb/Rust/src/css/style/memory.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/memory.rs
@@ -117,6 +117,7 @@ define_memory_categories! {
     // Appended to preserve record-replay category ordinals.
     ParsedSubstitutionCache => (Acceleration, "parsedSubstitutionCache"),
     SelectorQuery => (Scratch, "selectorQuery"),
+    PrefixRelation => (Acceleration, "prefixRelation"),
 }
 
 impl MemoryCategory {

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -4433,6 +4433,12 @@ impl PrefixStateCache {
             PrefixStateCacheLifecycle::CurrentRetained(coverage) => PrefixStateCacheLifecycle::Retained(coverage),
             previous @ (PrefixStateCacheLifecycle::Scratch(_) | PrefixStateCacheLifecycle::Retained(_)) => previous,
         };
+        for states in self.by_program.iter_mut().flatten() {
+            if let Some(relation) = states.relation.as_mut() {
+                // A key's routes change with the program.
+                relation.handled_routing_keys.clear();
+            }
+        }
     }
 
     pub(super) fn make_scratch(&mut self, memory: &mut MemoryController) {

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -3886,12 +3886,10 @@ impl PrefixStates {
                 self.ancestor_chain,
             ];
             cached [];
-            nested [
-                self.states_by_hash_collision_bytes,
-                self.relation.as_ref().map_or(0, |relation| size_of::<PrefixRelation>() as u64 + relation.capacity_bytes()),
-            ];
+            nested [self.states_by_hash_collision_bytes];
             skip [
                 self.local_fact_interner,
+                self.relation,
                 self.comparison_epoch,
                 self.states_by_hash_collision_bytes,
                 self.new_descendant_hash,
@@ -3916,6 +3914,13 @@ impl PrefixStates {
             nested [self.top_level_capacity_bytes()];
             skip [];
         }
+    }
+
+    #[must_use]
+    pub(super) fn relation_capacity_bytes(&self) -> u64 {
+        self.relation.as_ref().map_or(0, |relation| {
+            size_of::<PrefixRelation>() as u64 + relation.capacity_bytes()
+        })
     }
 }
 
@@ -4190,6 +4195,7 @@ pub(super) struct PrefixStateCache {
     by_program: Column<Option<Box<PrefixStates>>>,
     scratch_memory: MemoryLease,
     residency: MemoryLease,
+    relation_residency: MemoryLease,
     lifecycle: PrefixStateCacheLifecycle,
 }
 
@@ -4232,6 +4238,7 @@ impl Default for PrefixStateCache {
             by_program: Column::default(),
             scratch_memory: MemoryLease::new(MemoryCategory::BatchScratch),
             residency: MemoryLease::new(MemoryCategory::PrefixTransitionCache),
+            relation_residency: MemoryLease::new(MemoryCategory::PrefixRelation),
             lifecycle: PrefixStateCacheLifecycle::Scratch(PrefixStateCacheCoverage::Full),
         }
     }
@@ -4278,17 +4285,25 @@ impl PrefixStateCache {
     }
 
     pub(super) fn settle_memory(&mut self, memory: &mut MemoryController) {
+        let (transition_bytes, relation_bytes) =
+            self.by_program
+                .iter()
+                .flatten()
+                .fold((0, 0), |(transitions, relations), states| {
+                    (
+                        transitions + size_of::<PrefixStates>() as u64 + states.capacity_bytes(),
+                        relations + states.relation_capacity_bytes(),
+                    )
+                });
         let bytes = capacity_bytes! {
             shallow [self.by_program];
             cached [];
-            nested [self
-                .by_program
-                .iter()
-                .flatten()
-                .map(|states| size_of::<PrefixStates>() as u64 + states.capacity_bytes())
-                .sum::<u64>()];
-            skip [self.scratch_memory, self.residency, self.lifecycle];
+            nested [transition_bytes];
+            skip [self.scratch_memory, self.residency, self.relation_residency, self.lifecycle];
         };
+        if relation_bytes != 0 || self.relation_residency.bytes() != 0 {
+            self.relation_residency.reconcile_committed(memory, relation_bytes);
+        }
         if self.lifecycle.is_retained() {
             self.residency.reconcile_committed(memory, bytes);
             memory.finish_committed_acceleration_growth(MemoryCategory::PrefixTransitionCache);
@@ -4303,8 +4318,35 @@ impl PrefixStateCache {
         } else {
             self.scratch_memory.release();
         }
+        self.relation_residency.release();
         self.by_program = Column::default();
         self.lifecycle = PrefixStateCacheLifecycle::Scratch(self.lifecycle.coverage());
+    }
+
+    pub(super) fn release_transition_states(&mut self) {
+        if !self.has_relation() {
+            self.release();
+            return;
+        }
+        for slot in self.by_program.iter_mut() {
+            // The next installation restores the relation answers from the relation.
+            *slot = slot.as_mut().and_then(|states| states.relation.take()).map(|relation| {
+                let mut states = PrefixStates::new(0);
+                states.relation = Some(relation);
+                Box::new(states)
+            });
+        }
+        if self.lifecycle.is_retained() {
+            self.residency.release();
+        } else {
+            self.scratch_memory.release();
+        }
+        let coverage = self.lifecycle.coverage();
+        self.lifecycle = if self.lifecycle.is_current() {
+            PrefixStateCacheLifecycle::CurrentScratch(coverage)
+        } else {
+            PrefixStateCacheLifecycle::Scratch(coverage)
+        };
     }
 
     pub(super) fn retain(&mut self, memory: &mut MemoryController) -> bool {
@@ -4423,12 +4465,12 @@ impl PrefixStateCache {
         if self.by_program.get(index).is_none_or(Option::is_none) {
             return;
         }
-        let released = size_of::<PrefixStates>() as u64
-            + self.by_program[index]
-                .as_ref()
-                .expect("program entry is live")
-                .capacity_bytes();
+        let states = self.by_program[index].as_ref().expect("program entry is live");
+        let relation_released = states.relation_capacity_bytes();
+        let released = size_of::<PrefixStates>() as u64 + states.capacity_bytes();
         self.by_program[index] = None;
+        self.relation_residency
+            .shrink_committed(relation_released.min(self.relation_residency.bytes()));
         let held = if self.lifecycle.is_retained() {
             self.residency.bytes()
         } else {

--- a/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
@@ -13,6 +13,7 @@
 use super::super::capacity::ShallowCapacityBytes;
 use super::super::fast_hash::FastSet as HashSet;
 use super::super::selector::RoutingKey;
+use super::super::tree::TreeScopeID;
 use super::{
     Column, Counter, Counters, DispatchKey, EntryID, HashMap, PrefixAutomaton, PrefixEvaluation, PrefixOutputKind,
     PrefixPredicate, PrefixStates, PrefixStepID, PrefixTransitionLookup, StyleNodeID, StyleNodeTree, matches_feature,
@@ -183,7 +184,10 @@ impl PrefixRelation {
         self.old_previous.clear();
         self.sibling_order_is_preserved = self.has_following_steps;
         for &node in changed {
-            if !tree.is_live(node) || self.position_of(Some(node)) != usize::MAX {
+            if !tree.is_live(node)
+                || self.position_of(Some(node)) != usize::MAX
+                || tree.tree_scope(node) != TreeScopeID::DOCUMENT
+            {
                 continue;
             }
             for node in tree.preorder(node) {
@@ -833,7 +837,7 @@ impl PrefixAutomaton {
             && tree.parent(root).is_none()
             && tree
                 .preorder(root)
-                .all(|node| tree.tree_scope(node) == super::super::tree::TreeScopeID::DOCUMENT)
+                .all(|node| tree.tree_scope(node) == TreeScopeID::DOCUMENT)
     }
 
     pub(in crate::css::style) fn build_relation(

--- a/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
@@ -842,6 +842,7 @@ impl PrefixAutomaton {
         root: StyleNodeID,
         counters: &mut Counters,
     ) -> PrefixRelation {
+        counters.bump(Counter::PrefixRelationBuilds);
         let tree = evaluation.tree;
         let nodes: Vec<_> = tree.preorder(root).collect();
         let count = nodes.len();

--- a/Libraries/LibWeb/Rust/src/css/style/program_updates.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/program_updates.rs
@@ -1087,6 +1087,10 @@ impl StyleEngine {
                         _,
                         _,
                     ) => {}
+                    (key, _, _)
+                        if key
+                            .program_tree_scope()
+                            .is_some_and(|scope| scope != TreeScopeID::DOCUMENT) => {}
                     (
                         InputKey::LocalFeature(node, key),
                         InputValue::Feature(old_value),

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -2831,14 +2831,19 @@ impl StyleEngine {
             caches.states.mark_full();
             caches.states.mark_current();
             caches.states.settle_memory(&mut self.memory);
+            // The relation answers for the document tree alone. A route reaching into another tree
+            // scope keeps those regions for its own program to route.
             let mut released_route_bytes = 0;
             pending.retain(|key, routed_regions| {
-                if eligible.binary_search(&key).is_ok() {
-                    released_route_bytes += (routed_regions.capacity() * size_of::<ImpactRegion>()) as u64;
-                    false
-                } else {
-                    true
+                if eligible.binary_search(&key).is_err() {
+                    return true;
                 }
+                routed_regions.retain(|region| region.lies_outside_document_scope(&self.tree));
+                if !routed_regions.is_empty() {
+                    return true;
+                }
+                released_route_bytes += (routed_regions.capacity() * size_of::<ImpactRegion>()) as u64;
+                false
             });
             self.memory.release(MemoryCategory::BatchScratch, released_route_bytes);
             return PrefixConvergenceOutcome {

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -4385,6 +4385,64 @@ fn element_declaration_edits_repair_only_their_property_inventory() {
 }
 
 #[test]
+fn element_declaration_repairs_materialize_only_rules_declaring_their_properties() {
+    let (mut engine, nodes) = linear_document();
+    let deciding = add_target_rule(&mut engine, StyleSheetObjectID(1), StyleAtomID(200));
+    engine.set_rule_declared_properties_with_values(deciding, &[(1, false, SpecifiedValueID(101))], true);
+    let unrelated = add_target_rule(&mut engine, StyleSheetObjectID(2), StyleAtomID(200));
+    engine.set_rule_declared_properties_with_values(unrelated, &[(5, false, SpecifiedValueID(105))], true);
+    for kind in ElementDeclarationKind::ALL {
+        engine.set_element_declared_properties(nodes[0], kind, &[], Vec::new(), Vec::new(), Vec::new(), true);
+    }
+    commit_test_setup(&mut engine);
+    let matches = vec![
+        concrete_rule_match(&engine, nodes[0], deciding, 0, None),
+        concrete_rule_match(&engine, nodes[0], unrelated, 1, None),
+    ];
+    engine.matches_for_cascade(matches.clone(), false, Some(nodes[0]));
+    engine.remember_retained_match_answer(nodes[0], &matches);
+
+    let materialized_before = engine.counters().get(Counter::ElementDeclarationRepairMatches);
+    engine.set_element_declared_properties(
+        nodes[0],
+        ElementDeclarationKind::PresentationalHint,
+        &[
+            DeclaredProperty {
+                property: 1,
+                important: false,
+                operator: CascadeOperator::Declared,
+                value: SpecifiedValueID(301),
+            },
+            DeclaredProperty {
+                property: 3,
+                important: false,
+                operator: CascadeOperator::Declared,
+                value: SpecifiedValueID(303),
+            },
+        ],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        true,
+    );
+    assert_eq!(
+        engine.counters().get(Counter::ElementDeclarationRepairMatches) - materialized_before,
+        1
+    );
+
+    let key = WinnerGroupKey::current(nodes[0], engine.program.version());
+    assert!(
+        matches!(engine.winner_groups.winner(key, 1), Lookup::Known(winner) if winner.source == WinnerSource::Rule(deciding) && winner.key.value == SpecifiedValueID(101))
+    );
+    assert!(
+        matches!(engine.winner_groups.winner(key, 3), Lookup::Known(winner) if winner.source == WinnerSource::Element(ElementDeclarationKind::PresentationalHint) && winner.key.value == SpecifiedValueID(303))
+    );
+    assert!(
+        matches!(engine.winner_groups.winner(key, 5), Lookup::Known(winner) if winner.source == WinnerSource::Rule(unrelated) && winner.key.value == SpecifiedValueID(105))
+    );
+}
+
+#[test]
 fn rule_declaration_edits_repair_only_their_property_inventory() {
     let (mut engine, nodes) = linear_document();
     let target = StyleAtomID(200);

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5640,6 +5640,46 @@ fn retained_prefix_transitions_supply_invalidation_and_matching() {
 }
 
 #[test]
+fn a_refused_prefix_transition_cache_keeps_the_maintained_relation() {
+    let (mut engine, nodes) = nested_document();
+    let guard = StyleAtomID(200);
+    let target = StyleAtomID(201);
+    add_guard_target_rule(&mut engine, guard, target);
+    for (node, class) in [(nodes[1], guard), (nodes[3], target)] {
+        add_feature(&mut engine, node, LocalFeatureKey::Class(class));
+    }
+    discard_transaction(&mut engine);
+
+    engine.begin_published_match_answer_completion_batch(nodes[0], true);
+    assert_eq!(engine.match_element(nodes[3]).unwrap().len(), 1);
+    engine.end_published_match_answer_completion_batch();
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+    assert!(engine.memory().bytes_in_category(MemoryCategory::PrefixRelation) > 0);
+
+    engine.memory.set_tier3_limit_for_test(0);
+    for present in [false, true] {
+        if present {
+            add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+        } else {
+            remove_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+        }
+        let mut planned = Vec::new();
+        assert!(engine.take_style_transaction_nodes(nodes[0], |nodes| planned.extend_from_slice(nodes)));
+        assert_eq!(planned, vec![nodes[3].raw()]);
+        engine.begin_published_match_answer_completion_batch(nodes[0], true);
+        assert_eq!(engine.match_element(nodes[3]).unwrap().len(), usize::from(present));
+        engine.end_published_match_answer_completion_batch();
+    }
+    assert_eq!(engine.counters().get(Counter::PrefixRelationUpdates), 2);
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+    assert_eq!(
+        engine.memory().bytes_in_category(MemoryCategory::PrefixTransitionCache),
+        0
+    );
+    assert!(engine.memory().bytes_in_category(MemoryCategory::PrefixRelation) > 0);
+}
+
+#[test]
 fn covered_prefix_changes_forget_only_the_covered_subtree() {
     let (mut engine, nodes) = nested_document();
     let guard = StyleAtomID(200);

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -2001,6 +2001,33 @@ fn linear_document() -> (StyleEngine, Vec<StyleNodeID>) {
 }
 
 /// Builds `root -> outer -> inner -> target`.
+fn attach_shadow_tree(
+    engine: &mut StyleEngine,
+    host: StyleNodeID,
+    scope: TreeScopeID,
+    depth: usize,
+) -> Vec<StyleNodeID> {
+    let mut raw = vec![0_u32; depth + 1];
+    engine.allocate_style_nodes(&mut raw);
+    let nodes: Vec<_> = raw.iter().map(|&id| StyleNodeID::from_raw(id).unwrap()).collect();
+    engine.record_tree_delta(nodes[0], None, Some(TreeRelations::detached(scope)));
+    for pair in nodes.windows(2) {
+        engine.record_tree_delta(
+            pair[1],
+            None,
+            Some(TreeRelations {
+                parent: Some(pair[0]),
+                tree_scope: scope,
+                ..TreeRelations::detached(scope)
+            }),
+        );
+        set_atom_feature(engine, pair[1], LocalFeatureKey::TagName, StyleAtomID(100));
+    }
+    engine.set_shadow_root(host, nodes[0]);
+    engine.set_tree_scope_root(scope, nodes[0]);
+    nodes
+}
+
 fn nested_document() -> (StyleEngine, Vec<StyleNodeID>) {
     let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
     let mut raw = [0_u32; 4];
@@ -5637,6 +5664,160 @@ fn retained_prefix_transitions_supply_invalidation_and_matching() {
     assert!(engine.take_style_transaction_nodes(nodes[0], |nodes| planned.extend_from_slice(nodes)));
     assert_eq!(planned, vec![nodes[3].raw()]);
     assert_eq!(engine.memory().bytes_in_category(MemoryCategory::BatchScratch), 0);
+}
+
+#[test]
+fn a_foreign_scope_input_keeps_the_document_prefix_relation() {
+    let (mut engine, nodes) = nested_document();
+    let scope = TreeScopeID(1);
+    let shadow_child = attach_shadow_tree(&mut engine, nodes[3], scope, 1)[1];
+    let guard = StyleAtomID(200);
+    let target = StyleAtomID(201);
+    add_guard_target_rule(&mut engine, guard, target);
+    for (node, class) in [(nodes[1], guard), (nodes[3], target)] {
+        add_feature(&mut engine, node, LocalFeatureKey::Class(class));
+    }
+    let adopted_program = engine
+        .programs
+        .add(test_class_selector_program(".target", &[("target", target)], None));
+    let adopted_sheet = engine.add_sheet(StyleSheetObjectID(2), CascadeOrigin::Author);
+    let adopted_rule = engine.append_rule(adopted_sheet, None, RuleKind::Style);
+    engine.add_routing_rule(adopted_rule, adopted_program);
+    let mut version = engine.program.rule_version(adopted_rule);
+    version.selector_program = Some(adopted_program);
+    version.declaration_block = Some(DeclarationBlockID(1));
+    engine.replace_rule_version(adopted_rule, version);
+    discard_transaction(&mut engine);
+
+    engine.begin_published_match_answer_completion_batch(nodes[0], true);
+    assert_eq!(engine.match_element(nodes[3]).unwrap().len(), 1);
+    engine.end_published_match_answer_completion_batch();
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+
+    add_feature(&mut engine, shadow_child, LocalFeatureKey::Class(guard));
+    remove_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+    let mut planned = Vec::new();
+    assert!(engine.take_style_transaction_nodes(nodes[0], |nodes| planned.extend_from_slice(nodes)));
+    assert_eq!(planned, vec![nodes[3].raw()]);
+    assert_eq!(engine.counters().get(Counter::PrefixRelationUpdates), 1);
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+
+    engine.begin_published_match_answer_completion_batch(nodes[0], true);
+    assert!(engine.match_element(nodes[3]).unwrap().is_empty());
+    engine.end_published_match_answer_completion_batch();
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+
+    engine.attach_sheet(adopted_sheet, scope);
+    add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+    planned.clear();
+    assert!(engine.take_style_transaction_nodes(nodes[0], |nodes| planned.extend_from_slice(nodes)));
+    assert!(planned.contains(&nodes[3].raw()));
+    assert_eq!(engine.counters().get(Counter::PrefixRelationUpdates), 2);
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+
+    engine.begin_published_match_answer_completion_batch(nodes[0], true);
+    assert_eq!(engine.match_element(nodes[3]).unwrap().len(), 1);
+    engine.end_published_match_answer_completion_batch();
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+}
+
+#[test]
+fn a_maintained_relation_leaves_shadow_scope_routes_to_their_own_program() {
+    let (mut engine, nodes) = nested_document();
+    let scope = TreeScopeID(1);
+    let shadow = attach_shadow_tree(&mut engine, nodes[3], scope, 2);
+    let (shadow_outer, shadow_inner) = (shadow[1], shadow[2]);
+    let guard = StyleAtomID(200);
+    let target = StyleAtomID(201);
+    let inner = StyleAtomID(202);
+    add_guard_target_rule(&mut engine, guard, target);
+    let shadow_program = engine.programs.add(test_selector_program_with_metadata(
+        ".guard .inner",
+        &[("guard", guard), ("inner", inner)],
+        Some(Specificity {
+            classes: 2,
+            ..Specificity::default()
+        }),
+        None,
+    ));
+    let shadow_sheet = engine.add_sheet(StyleSheetObjectID(2), CascadeOrigin::Author);
+    engine.attach_sheet(shadow_sheet, scope);
+    let shadow_rule = engine.append_rule(shadow_sheet, None, RuleKind::Style);
+    engine.add_routing_rule(shadow_rule, shadow_program);
+    let mut version = engine.program.rule_version(shadow_rule);
+    version.selector_program = Some(shadow_program);
+    version.declaration_block = Some(DeclarationBlockID(2));
+    engine.replace_rule_version(shadow_rule, version);
+    for (node, class) in [(nodes[1], guard), (nodes[3], target), (shadow_inner, inner)] {
+        add_feature(&mut engine, node, LocalFeatureKey::Class(class));
+    }
+    discard_transaction(&mut engine);
+
+    engine.begin_published_match_answer_completion_batch(nodes[0], true);
+    assert_eq!(engine.match_element(nodes[3]).unwrap().len(), 1);
+    assert!(engine.match_element(shadow_inner).unwrap().is_empty());
+    engine.end_published_match_answer_completion_batch();
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+
+    add_feature(&mut engine, shadow_outer, LocalFeatureKey::Class(guard));
+    let mut planned = Vec::new();
+    assert!(engine.take_style_transaction_nodes(nodes[0], |nodes| planned.extend_from_slice(nodes)));
+    assert_eq!(planned, vec![shadow_inner.raw()]);
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+
+    engine.begin_published_match_answer_completion_batch(nodes[0], true);
+    assert_eq!(engine.match_element(shadow_inner).unwrap().len(), 1);
+    engine.end_published_match_answer_completion_batch();
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+}
+
+#[test]
+fn a_maintained_relation_leaves_shared_selector_shadow_routes_to_their_own_program() {
+    let (mut engine, nodes) = nested_document();
+    let scope = TreeScopeID(1);
+    let shadow = attach_shadow_tree(&mut engine, nodes[3], scope, 2);
+    let (shadow_outer, shadow_inner) = (shadow[1], shadow[2]);
+    let guard = StyleAtomID(200);
+    let target = StyleAtomID(201);
+    add_guard_target_rule(&mut engine, guard, target);
+    let program = engine.programs.add(test_selector_program_with_metadata(
+        ".guard .target",
+        &[("guard", guard), ("target", target)],
+        Some(Specificity {
+            classes: 2,
+            ..Specificity::default()
+        }),
+        None,
+    ));
+    let shadow_sheet = engine.add_sheet(StyleSheetObjectID(2), CascadeOrigin::Author);
+    engine.attach_sheet(shadow_sheet, scope);
+    let shadow_rule = engine.append_rule(shadow_sheet, None, RuleKind::Style);
+    engine.add_routing_rule(shadow_rule, program);
+    let mut version = engine.program.rule_version(shadow_rule);
+    version.selector_program = Some(program);
+    version.declaration_block = Some(DeclarationBlockID(2));
+    engine.replace_rule_version(shadow_rule, version);
+    for (node, class) in [(nodes[1], guard), (nodes[3], target), (shadow_inner, target)] {
+        add_feature(&mut engine, node, LocalFeatureKey::Class(class));
+    }
+    discard_transaction(&mut engine);
+
+    engine.begin_published_match_answer_completion_batch(nodes[0], true);
+    assert_eq!(engine.match_element(nodes[3]).unwrap().len(), 1);
+    assert!(engine.match_element(shadow_inner).unwrap().is_empty());
+    engine.end_published_match_answer_completion_batch();
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+
+    add_feature(&mut engine, shadow_outer, LocalFeatureKey::Class(guard));
+    let mut planned = Vec::new();
+    assert!(engine.take_style_transaction_nodes(nodes[0], |nodes| planned.extend_from_slice(nodes)));
+    assert_eq!(planned, vec![shadow_inner.raw()]);
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
+
+    engine.begin_published_match_answer_completion_batch(nodes[0], true);
+    assert_eq!(engine.match_element(shadow_inner).unwrap().len(), 1);
+    engine.end_published_match_answer_completion_batch();
+    assert_eq!(engine.counters().get(Counter::PrefixRelationBuilds), 1);
 }
 
 #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/transaction.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/transaction.rs
@@ -239,6 +239,18 @@ impl InputKey {
             | Self::CascadeTopology(..) => None,
         }
     }
+
+    /// The tree scope whose program this key changes, for keys that name one.
+    #[must_use]
+    pub fn program_tree_scope(self) -> Option<TreeScopeID> {
+        match self {
+            Self::SheetAttachment(_, tree_scope)
+            | Self::CascadeTopology(TopologyAxis::SheetOrder(tree_scope) | TopologyAxis::LayerOrder(tree_scope)) => {
+                Some(tree_scope)
+            }
+            _ => None,
+        }
+    }
 }
 
 /// The value of a journal key on one side of a mutation.

--- a/Tests/LibWeb/Text/expected/css/style-engine/prefix-relation-survives-foreign-scope-inputs.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/prefix-relation-survives-foreign-scope-inputs.txt
@@ -1,0 +1,7 @@
+a value arrives in the text control as a guard does: settles exactly, relation maintained
+guarded targets recolored: true
+the control is cleared as the guard moves to the child: settles exactly, relation maintained
+a guard arrives inside the shadow tree as the document guard leaves: settles exactly, relation maintained
+shadow guard recolored its inner element: true
+the shadow guard leaves as a sibling guard arrives: settles exactly, relation maintained
+sibling guard reached the later target: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/prefix-relation-survives-tree-scope-moves.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/prefix-relation-survives-tree-scope-moves.txt
@@ -1,0 +1,14 @@
+a guarded target moves into the shadow tree: settles exactly, relation maintained
+the document guard no longer reaches it: true
+a guard arrives around it inside the shadow tree: settles exactly, relation maintained
+it moves back under the document guard: settles exactly, relation maintained
+the document guard reaches it again: true
+the document guard leaves as the shadow guard does: settles exactly, relation maintained
+a guard arrives in the shadow tree sharing the document's selector: settles exactly, relation maintained
+the shadow tree's own guard rule reaches the node born there: true
+that guard leaves: settles exactly, relation maintained
+the other target moves into that shadow tree: settles exactly, relation maintained
+a guard arrives around it there: settles exactly, relation maintained
+the shadow tree's own guard rule reaches both: true
+it moves back as the document guard returns: settles exactly, relation maintained
+the document guard reaches both again: true

--- a/Tests/LibWeb/Text/input/css/style-engine/prefix-relation-survives-foreign-scope-inputs.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/prefix-relation-survives-foreign-scope-inputs.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .guard .target { color: rgb(0, 128, 0) }
+    .guard > .child { outline-color: rgb(0, 0, 255) }
+    .guard ~ .after .target { border-top-color: rgb(255, 0, 0) }
+</style>
+<div id="fixture">
+    <input id="field" placeholder="type here">
+    <div id="outer">
+        <div id="middle" class="child">
+            <span id="target" class="target"></span>
+        </div>
+    </div>
+    <div id="after" class="after"><span id="late" class="target"></span></div>
+    <div id="host"></div>
+</div>
+<script>
+    // The maintained selector prefix relation covers the document tree. Inputs from other tree
+    // scopes, such as the inline style a text control gives its placeholder when its value
+    // changes, or a class change inside a shadow tree, must not make the engine discard it.
+    const shadow = document.getElementById("host").attachShadow({ mode: "open" });
+    shadow.innerHTML = `<style>.guard .inner { color: rgb(9, 9, 9) }</style><div id="shadowOuter"><span id="shadowInner" class="inner"></span></div>`;
+
+    let forced = 0;
+
+    function snapshot() {
+        return Array.from(document.querySelectorAll("#fixture *"))
+            .map(element => {
+                const style = getComputedStyle(element);
+                return `${element.id}=${style.color}/${style.outlineColor}/${style.borderTopColor}`;
+            })
+            .concat(Array.from(shadow.querySelectorAll("*")).map(element => `${element.id}=${getComputedStyle(element).color}`))
+            .join(" ");
+    }
+
+    function settlesExactly(name, mutate) {
+        internals.updateStyle();
+        const before = internals.styleEngineCounters();
+        mutate();
+        internals.updateStyle();
+        const after = internals.styleEngineCounters();
+        const maintained = after.prefixRelationUpdates - before.prefixRelationUpdates === 1
+            && after.prefixRelationBuilds - before.prefixRelationBuilds === 0;
+        const incremental = snapshot();
+        internals.setUserStyle(`/* force complete style ${forced++} */`);
+        internals.updateStyle();
+        const complete = snapshot();
+        internals.setUserStyle("");
+        println(`${name}: ${incremental === complete ? "settles exactly" : "STALE"}, relation ${maintained ? "maintained" : "REBUILT"}`);
+        if (incremental !== complete) {
+            println(`  incremental: ${incremental}`);
+            println(`  complete:    ${complete}`);
+        }
+        return incremental;
+    }
+
+    test(() => {
+        const field = document.getElementById("field");
+        const outer = document.getElementById("outer");
+        const middle = document.getElementById("middle");
+        const shadowOuter = shadow.getElementById("shadowOuter");
+
+        const guarded = settlesExactly("a value arrives in the text control as a guard does", () => {
+            field.value = "typed";
+            outer.classList.add("guard");
+        });
+        println(`guarded targets recolored: ${guarded.includes("target=rgb(0, 128, 0)")}`);
+        settlesExactly("the control is cleared as the guard moves to the child", () => {
+            field.value = "";
+            outer.classList.remove("guard");
+            middle.classList.add("guard");
+        });
+        const shadowGuarded = settlesExactly("a guard arrives inside the shadow tree as the document guard leaves", () => {
+            shadowOuter.classList.add("guard");
+            middle.classList.remove("guard");
+        });
+        println(`shadow guard recolored its inner element: ${shadowGuarded.includes("shadowInner=rgb(9, 9, 9)")}`);
+        const siblingGuarded = settlesExactly("the shadow guard leaves as a sibling guard arrives", () => {
+            shadowOuter.classList.remove("guard");
+            field.value = "again";
+            outer.classList.add("guard");
+        });
+        println(`sibling guard reached the later target: ${siblingGuarded.includes("late=rgb(0, 0, 0)/rgb(0, 0, 0)/rgb(255, 0, 0)")}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/prefix-relation-survives-tree-scope-moves.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/prefix-relation-survives-tree-scope-moves.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .guard .target { color: rgb(0, 128, 0) }
+</style>
+<div id="fixture">
+    <div id="outer" class="guard"><span id="target" class="target"></span><span id="other" class="target"></span></div>
+    <div id="host"></div>
+    <div id="styledHost"></div>
+</div>
+<script>
+    // A node moving between the document and a shadow tree leaves or joins the maintained selector
+    // prefix relation without the engine discarding it, whether or not the shadow tree has its own
+    // style sheet. A shadow sheet repeating a document selector shares its program with the
+    // document rule, so the relation must not claim that rule's routes inside the shadow tree.
+    const shadow = document.getElementById("host").attachShadow({ mode: "open" });
+    shadow.innerHTML = `<div id="shadowOuter"></div>`;
+    const styledShadow = document.getElementById("styledHost").attachShadow({ mode: "open" });
+    styledShadow.innerHTML = `<style>.guard .target { color: rgb(9, 9, 9) }</style><div id="styledOuter"><span id="born" class="target"></span></div>`;
+
+    let forced = 0;
+
+    function snapshot() {
+        return Array.from(document.querySelectorAll("#fixture *"))
+            .concat(Array.from(shadow.querySelectorAll("*")), Array.from(styledShadow.querySelectorAll("*")))
+            .map(element => `${element.id}=${getComputedStyle(element).color}`)
+            .join(" ");
+    }
+
+    function settlesExactly(name, mutate) {
+        internals.updateStyle();
+        const before = internals.styleEngineCounters();
+        mutate();
+        internals.updateStyle();
+        const after = internals.styleEngineCounters();
+        const maintained = after.prefixRelationUpdates - before.prefixRelationUpdates === 1
+            && after.prefixRelationBuilds - before.prefixRelationBuilds === 0;
+        const incremental = snapshot();
+        internals.setUserStyle(`/* force complete style ${forced++} */`);
+        internals.updateStyle();
+        const complete = snapshot();
+        internals.setUserStyle("");
+        println(`${name}: ${incremental === complete ? "settles exactly" : "STALE"}, relation ${maintained ? "maintained" : "REBUILT"}`);
+        if (incremental !== complete) {
+            println(`  incremental: ${incremental}`);
+            println(`  complete:    ${complete}`);
+        }
+        return incremental;
+    }
+
+    test(() => {
+        const outer = document.getElementById("outer");
+        const target = document.getElementById("target");
+        const other = document.getElementById("other");
+        const shadowOuter = shadow.getElementById("shadowOuter");
+        const styledOuter = styledShadow.getElementById("styledOuter");
+
+        const moved = settlesExactly("a guarded target moves into the shadow tree", () => shadowOuter.appendChild(target));
+        println(`the document guard no longer reaches it: ${moved.includes("target=rgb(0, 0, 0)")}`);
+        settlesExactly("a guard arrives around it inside the shadow tree", () => shadowOuter.classList.add("guard"));
+        const returned = settlesExactly("it moves back under the document guard", () => outer.appendChild(target));
+        println(`the document guard reaches it again: ${returned.includes("target=rgb(0, 128, 0)")}`);
+        settlesExactly("the document guard leaves as the shadow guard does", () => {
+            outer.classList.remove("guard");
+            shadowOuter.classList.remove("guard");
+        });
+
+        const bornGuarded = settlesExactly("a guard arrives in the shadow tree sharing the document's selector", () => styledOuter.classList.add("guard"));
+        println(`the shadow tree's own guard rule reaches the node born there: ${bornGuarded.includes("born=rgb(9, 9, 9)")}`);
+        settlesExactly("that guard leaves", () => styledOuter.classList.remove("guard"));
+        settlesExactly("the other target moves into that shadow tree", () => styledOuter.appendChild(other));
+        const styledGuarded = settlesExactly("a guard arrives around it there", () => styledOuter.classList.add("guard"));
+        println(`the shadow tree's own guard rule reaches both: ${styledGuarded.includes("born=rgb(9, 9, 9)") && styledGuarded.includes("other=rgb(9, 9, 9)")}`);
+        const bothReturned = settlesExactly("it moves back as the document guard returns", () => {
+            outer.classList.add("guard");
+            outer.appendChild(other);
+        });
+        println(`the document guard reaches both again: ${bothReturned.includes("target=rgb(0, 128, 0)") && bothReturned.includes("other=rgb(0, 128, 0)")}`);
+    });
+</script>


### PR DESCRIPTION
These commits restore Speedometer2 and 3 performance (particularly the `TodoMVC` suite) to within a ~1% of its high point prior to #11592. Getting back to full parity would mean reversing changes that would regress Stylebench, so I've not done that.

See individual commits for details.

Speedometer3 results:

```
Benchmark     Suite                                       Test                   Speedup  Old (Mean ± Range)    New (Mean ± Range)
------------  ------------------------------------------  -------------------  ---------  --------------------  --------------------
Speedometer3  Charts-chartjs                              Draw opaque scatter      0.982  0.10 ± 0.01           0.10 ± 0.01
Speedometer3  Charts-chartjs                              Draw scatter             1.004  0.14 ± 0.02           0.14 ± 0.02
Speedometer3  Charts-chartjs                              Show tooltip             1.012  0.00 ± 0.00           0.00 ± 0.00
Speedometer3  Charts-observable-plot                      Dotted                   1.005  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 20            1.024  0.13 ± 0.01           0.12 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 6             1.044  0.09 ± 0.01           0.08 ± 0.01
Speedometer3  Editor-CodeMirror                           Highlight                0.914  0.03 ± 0.00           0.03 ± 0.01
Speedometer3  Editor-CodeMirror                           Long                     1.934  0.06 ± 0.06           0.03 ± 0.00
Speedometer3  Editor-TipTap                               Highlight                0.892  0.18 ± 0.01           0.20 ± 0.06
Speedometer3  Editor-TipTap                               Long                     1.023  0.12 ± 0.01           0.11 ± 0.01
Speedometer3  NewsSite-Next                               NavigateToPolitics       1.005  0.17 ± 0.01           0.17 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToUS             1.027  0.17 ± 0.01           0.16 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToWorld          0.98   0.17 ± 0.01           0.18 ± 0.01
Speedometer3  NewsSite-Nuxt                               NavigateToPolitics       0.951  0.15 ± 0.01           0.15 ± 0.02
Speedometer3  NewsSite-Nuxt                               NavigateToUS             1.072  0.15 ± 0.02           0.14 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToWorld          1.021  0.14 ± 0.00           0.14 ± 0.01
Speedometer3  Perf-Dashboard                              Render                   0.983  0.06 ± 0.00           0.06 ± 0.01
Speedometer3  Perf-Dashboard                              SelectingPoints          1.016  0.12 ± 0.01           0.12 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingRange           0.944  0.06 ± 0.00           0.06 ± 0.01
Speedometer3  React-Stockcharts-SVG                       PanTheChart              0.989  0.12 ± 0.02           0.12 ± 0.02
Speedometer3  React-Stockcharts-SVG                       Render                   0.988  0.12 ± 0.01           0.12 ± 0.01
Speedometer3  React-Stockcharts-SVG                       ZoomTheChart             0.983  0.45 ± 0.02           0.46 ± 0.02
Speedometer3  TodoMVC-Angular-Complex-DOM                 Adding100Items           1.013  0.12 ± 0.01           0.12 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 CompletingAllItems       1.011  0.07 ± 0.01           0.07 ± 0.00
Speedometer3  TodoMVC-Angular-Complex-DOM                 DeletingAllItems         0.969  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Backbone                            Adding100Items           1.028  0.07 ± 0.01           0.07 ± 0.01
Speedometer3  TodoMVC-Backbone                            CompletingAllItems       1.042  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Backbone                            DeletingAllItems         0.965  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      Adding100Items           0.954  0.13 ± 0.01           0.13 ± 0.02
Speedometer3  TodoMVC-JavaScript-ES5                      CompletingAllItems       1.389  0.04 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      DeletingAllItems         1.029  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  Adding100Items           1      0.12 ± 0.00           0.12 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  CompletingAllItems       0.931  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  DeletingAllItems         0.84   0.02 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     Adding100Items           1.024  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     CompletingAllItems       1.07   0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     DeletingAllItems         0.902  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  Adding100Items           1.019  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  CompletingAllItems       1      0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  DeletingAllItems         0.968  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   Adding100Items           0.99   0.09 ± 0.00           0.09 ± 0.01
Speedometer3  TodoMVC-React-Complex-DOM                   CompletingAllItems       0.999  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   DeletingAllItems         1.019  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-React-Redux                         Adding100Items           0.994  0.08 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Redux                         CompletingAllItems       1.077  0.13 ± 0.02           0.12 ± 0.00
Speedometer3  TodoMVC-React-Redux                         DeletingAllItems         1.04   0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  Adding100Items           1.025  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  CompletingAllItems       0.979  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  DeletingAllItems         0.895  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Vue                                 Adding100Items           0.974  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Vue                                 CompletingAllItems       0.977  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Vue                                 DeletingAllItems         1.06   0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       Adding100Items           0.999  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-WebComponents                       CompletingAllItems       1.004  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       DeletingAllItems         4.798  0.06 ± 0.11           0.01 ± 0.00
Speedometer3  TodoMVC-jQuery                              Adding100Items           1.143  0.18 ± 0.04           0.16 ± 0.01
Speedometer3  TodoMVC-jQuery                              CompletingAllItems       0.948  0.41 ± 0.04           0.43 ± 0.06
Speedometer3  TodoMVC-jQuery                              DeletingAllItems         0.997  0.14 ± 0.00           0.14 ± 0.00

Benchmark     Old Score    New Score      Score Improvement  Old Total Time (s)    New Total Time (s)      Speedup
------------  -----------  -----------  -------------------  --------------------  --------------------  ---------
Speedometer3  4.82 ± 0.21  4.90 ± 0.10                1.018  5.28 ± 0.23           5.21 ± 0.11               1.013
```