### PR TITLE
LibRegex: Port the relevant optimisations from the old engine back

### DIFF
--- a/Libraries/LibRegex/Rust/Cargo.toml
+++ b/Libraries/LibRegex/Rust/Cargo.toml
@@ -15,5 +15,10 @@ libunicode_rust = { path = "../../LibUnicode/Rust", default-features = false }
 default = []
 allocator = []
 
+# `cargo test` links a plain Rust binary with no LibUnicode C++ behind it, so the
+# unicode_* FFI callbacks the engine calls have to come from somewhere.
+[dev-dependencies]
+libunicode_rust = { path = "../../LibUnicode/Rust", default-features = false, features = ["ffi-stubs"] }
+
 [build-dependencies]
 cbindgen = "0.29"

--- a/Libraries/LibRegex/Rust/src/bytecode.rs
+++ b/Libraries/LibRegex/Rust/src/bytecode.rs
@@ -35,6 +35,10 @@ pub struct NamedGroupEntry {
 /// <https://tc39.es/ecma262/#sec-compilepattern>
 #[derive(Debug, Clone)]
 pub struct Program {
+    /// Compile-time information used to avoid redundant matching and backtracking.
+    pub(crate) optimization: crate::optimizer::Optimization,
+    /// Minimum number of UTF-16 code units consumed by a match.
+    pub minimum_length: usize,
     /// The bytecode instructions.
     pub instructions: Vec<Instruction>,
     /// Number of capture groups (not counting group 0).
@@ -237,6 +241,8 @@ impl Default for Program {
 impl Program {
     pub fn new() -> Self {
         Self {
+            optimization: Default::default(),
+            minimum_length: 0,
             instructions: Vec::new(),
             capture_count: 0,
             register_count: 2, // group 0 always exists

--- a/Libraries/LibRegex/Rust/src/compiler.rs
+++ b/Libraries/LibRegex/Rust/src/compiler.rs
@@ -34,18 +34,29 @@ pub fn resolve_property(name: &str, value: Option<&str>) -> Option<ResolvedPrope
 pub fn compile(pattern: &Pattern) -> Program {
     let mut compiler = Compiler::new(pattern);
     compiler.compile_pattern(pattern);
-    compiler.program.named_groups = pattern
-        .named_groups
-        .iter()
-        .map(|ng| NamedGroupEntry {
-            name: ng.name.clone(),
-            index: ng.index,
-        })
-        .collect();
+    crate::optimizer::normalize_character_classes(&mut compiler.program);
+    compiler.program.minimum_length = crate::optimizer::minimum_length(&pattern.disjunction);
+    compiler.program.optimization = crate::optimizer::analyze(&compiler.program);
+    compiler.program
+}
+
+#[cfg(test)]
+pub(crate) fn compile_unoptimized(pattern: &Pattern) -> Program {
+    let mut compiler = Compiler::new(pattern);
+    compiler.optimize = false;
+    compiler.compile_pattern(pattern);
+    let len = compiler.program.instructions.len();
+    compiler.program.optimization = crate::optimizer::Optimization {
+        leading_match: vec![None; len],
+        atomic_loop: vec![false; len],
+        literal_runs: vec![None; len],
+    };
     compiler.program
 }
 
 struct Compiler {
+    #[cfg(test)]
+    optimize: bool,
     program: Program,
     /// Effective flags (affected by modifier groups).
     effective_ignore_case: bool,
@@ -90,7 +101,11 @@ impl Compiler {
         // Registers: 0-1 for group 0, then 2 per capture group.
         let register_count = 2 + pattern.capture_count * 2;
         Self {
+            #[cfg(test)]
+            optimize: true,
             program: Program {
+                optimization: Default::default(),
+                minimum_length: 0,
                 instructions: Vec::new(),
                 capture_count: pattern.capture_count,
                 register_count,
@@ -445,6 +460,14 @@ impl Compiler {
         // Save end of match (group 0).
         self.emit(Instruction::Save(1));
         self.emit(Instruction::Match);
+        self.program.named_groups = pattern
+            .named_groups
+            .iter()
+            .map(|ng| NamedGroupEntry {
+                name: ng.name.clone(),
+                index: ng.index,
+            })
+            .collect();
     }
 
     /// Lower `Disjunction` to a chain of split/jump choice points.
@@ -454,7 +477,83 @@ impl Compiler {
             self.compile_term(&term);
             return;
         }
-        self.emit_split_chain(&disj.alternatives, |s, alt| s.compile_alternative(alt));
+        #[cfg(test)]
+        if !self.optimize {
+            self.emit_split_chain(&disj.alternatives, |compiler, alt| compiler.compile_alternative(alt));
+            return;
+        }
+        self.compile_alternatives(&disj.alternatives, 0);
+    }
+
+    fn compile_alternatives(&mut self, alternatives: &[Alternative], depth: usize) {
+        fn term_at(alt: &Alternative, offset: usize, backward: bool) -> Option<&Term> {
+            let index = if backward {
+                alt.terms.len().checked_sub(offset + 1)?
+            } else {
+                offset
+            };
+            alt.terms.get(index)
+        }
+        if alternatives.len() == 1 {
+            self.compile_alternative(&alternatives[0]);
+            return;
+        }
+        if depth >= 64 {
+            self.emit_split_chain(alternatives, |compiler, alt| compiler.compile_alternative(alt));
+            return;
+        }
+        let mut groups = Vec::new();
+        let mut start = 0;
+        while start < alternatives.len() {
+            let first = term_at(&alternatives[start], 0, self.backward);
+            let mut end = start + 1;
+            if let Some(Term {
+                atom: Atom::Literal(_),
+                quantifier: None,
+            }) = first
+            {
+                while end < alternatives.len() && term_at(&alternatives[end], 0, self.backward) == first {
+                    end += 1;
+                }
+            }
+            groups.push(&alternatives[start..end]);
+            start = end;
+        }
+        self.emit_split_chain(&groups, |compiler, group| {
+            if group.len() == 1 {
+                compiler.compile_alternative(&group[0]);
+                return;
+            }
+            // Factor the whole common literal run at once.
+            let mut count = 0;
+            while let Some(
+                term @ Term {
+                    atom: Atom::Literal(_),
+                    quantifier: None,
+                },
+            ) = term_at(&group[0], count, compiler.backward)
+            {
+                if !group
+                    .iter()
+                    .all(|alt| term_at(alt, count, compiler.backward) == Some(term))
+                {
+                    break;
+                }
+                compiler.compile_term(term);
+                count += 1;
+            }
+            let tails: Vec<_> = group
+                .iter()
+                .map(|alt| Alternative {
+                    terms: if compiler.backward {
+                        alt.terms[..alt.terms.len() - count].to_vec()
+                    } else {
+                        alt.terms[count..].to_vec()
+                    },
+                })
+                .collect();
+            compiler.compile_alternatives(&tails, depth + 1);
+        });
     }
 
     /// Lower `Alternative` in the current direction.

--- a/Libraries/LibRegex/Rust/src/lib.rs
+++ b/Libraries/LibRegex/Rust/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ast;
 pub mod bytecode;
 pub mod compiler;
 pub mod ffi;
+mod optimizer;
 pub mod parser;
 pub mod regex;
 pub mod vm;

--- a/Libraries/LibRegex/Rust/src/optimizer.rs
+++ b/Libraries/LibRegex/Rust/src/optimizer.rs
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::ast::Atom;
+use crate::ast::CharacterClassBody;
+use crate::ast::Disjunction;
+use crate::bytecode::BuiltinCharacterClass;
+use crate::bytecode::CharRange;
+use crate::bytecode::Instruction;
+use crate::bytecode::Program;
+use crate::bytecode::SimpleMatch;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Optimization {
+    pub leading_match: Vec<Option<usize>>,
+    pub atomic_loop: Vec<bool>,
+    pub literal_runs: Vec<Option<Box<[u16]>>>,
+}
+
+pub(crate) fn normalize_character_classes(program: &mut Program) {
+    fn normalize(ranges: &mut Vec<CharRange>) {
+        ranges.sort_unstable_by_key(|range| range.start);
+        ranges.dedup_by(|next, previous| {
+            if next.start <= previous.end.saturating_add(1) {
+                previous.end = previous.end.max(next.end);
+                true
+            } else {
+                false
+            }
+        });
+    }
+    fn normalize_matcher(matcher: &mut SimpleMatch) {
+        match matcher {
+            SimpleMatch::CharClass { ranges, .. } => normalize(ranges),
+            SimpleMatch::Union(left, right) => {
+                normalize_matcher(left);
+                normalize_matcher(right);
+            }
+            _ => {}
+        }
+    }
+    for instruction in &mut program.instructions {
+        match instruction {
+            Instruction::CharClass { ranges, .. } => normalize(ranges),
+            Instruction::GreedyLoop { matcher, .. } | Instruction::LazyLoop { matcher, .. } => {
+                normalize_matcher(matcher)
+            }
+            _ => {}
+        }
+    }
+}
+
+pub(crate) fn minimum_length(disjunction: &Disjunction) -> usize {
+    disjunction
+        .alternatives
+        .iter()
+        .map(|alternative| {
+            alternative.terms.iter().fold(0usize, |length, term| {
+                let atom_length = match &term.atom {
+                    Atom::Literal(cp) => {
+                        if *cp > 0xFFFF {
+                            2
+                        } else {
+                            1
+                        }
+                    }
+                    Atom::Dot | Atom::BuiltinCharacterClass(_) => 1,
+                    Atom::CharacterClass(class) if matches!(class.body, CharacterClassBody::Ranges(_)) => 1,
+                    Atom::Group(group) => minimum_length(&group.body),
+                    Atom::NonCapturingGroup(group) => minimum_length(&group.body),
+                    Atom::ModifierGroup(group) => minimum_length(&group.body),
+                    // Backreferences can refer to an unmatched capture; /v sets and
+                    // properties can contain strings, including the empty string.
+                    _ => 0,
+                };
+                length
+                    .saturating_add(atom_length.saturating_mul(term.quantifier.as_ref().map_or(1, |q| q.min as usize)))
+            })
+        })
+        .min()
+        .unwrap_or(0)
+}
+
+pub(crate) fn analyze(program: &Program) -> Optimization {
+    let instructions = &program.instructions;
+    let len = instructions.len();
+    let mut result = Optimization {
+        leading_match: vec![None; len],
+        atomic_loop: vec![false; len],
+        literal_runs: vec![None; len],
+    };
+    // Only traverse forward edges and bookkeeping with no effect on matching.
+    for pc in (0..len).rev() {
+        result.leading_match[pc] = match &instructions[pc] {
+            Instruction::Char(_)
+            | Instruction::CharNoCase(..)
+            | Instruction::AnyChar { .. }
+            | Instruction::CharClass { .. }
+            | Instruction::BuiltinClass(_) => Some(pc),
+            Instruction::GreedyLoop { min, .. } | Instruction::LazyLoop { min, .. } if *min > 0 => Some(pc),
+            Instruction::Save(_) | Instruction::ClearRegister(_) | Instruction::Nop => {
+                result.leading_match.get(pc + 1).copied().flatten()
+            }
+            Instruction::Jump(target) if *target as usize > pc => {
+                result.leading_match.get(*target as usize).copied().flatten()
+            }
+            _ => None,
+        };
+    }
+
+    let mut ignore_case = program.ignore_case;
+    let mut modifiers = Vec::new();
+    let mut pc = 0;
+    while pc < len {
+        match &instructions[pc] {
+            Instruction::PushModifiers { ignore_case: value, .. } => {
+                modifiers.push(ignore_case);
+                ignore_case = value.unwrap_or(ignore_case);
+            }
+            Instruction::PopModifiers => ignore_case = modifiers.pop().unwrap_or(program.ignore_case),
+            Instruction::GreedyLoop { matcher, .. } => {
+                let next = result.leading_match.get(pc + 1).copied().flatten();
+                if let Some(next) = next
+                    && let (Some(left), Some(right)) = (
+                        matcher_ranges(matcher, ignore_case, program.unicode),
+                        instruction_ranges(&instructions[next], ignore_case, program.unicode),
+                    )
+                {
+                    result.atomic_loop[pc] = !ranges_overlap(left, right);
+                }
+                // A trailing simple loop has no internal captures or choices.
+                let mut next = pc + 1;
+                while let Some(Instruction::Save(_) | Instruction::ClearRegister(_) | Instruction::Nop) =
+                    instructions.get(next)
+                {
+                    next += 1;
+                }
+                if matches!(instructions.get(next), Some(Instruction::Match)) {
+                    result.atomic_loop[pc] = true;
+                }
+            }
+            Instruction::Char(_) if !ignore_case => {
+                let start = pc;
+                let mut literal = Vec::new();
+                while let Some(Instruction::Char(cp)) = instructions.get(pc) {
+                    // BMP non-surrogates have the same boundaries in both modes.
+                    if *cp > 0xFFFF || (0xD800..=0xDFFF).contains(cp) {
+                        break;
+                    }
+                    literal.push(*cp as u16);
+                    pc += 1;
+                }
+                if literal.len() > 1 {
+                    result.literal_runs[start] = Some(literal.into_boxed_slice());
+                }
+                if pc > start {
+                    continue;
+                }
+            }
+            _ => {}
+        }
+        pc += 1;
+    }
+    result
+}
+
+// Union of the possible first characters without changing alternative order.
+pub(crate) fn first_filter(program: &Program, start: usize) -> Option<SimpleMatch> {
+    let mut pending = vec![start];
+    let mut ranges = Vec::new();
+    let mut budget = 128usize;
+    while let Some(mut pc) = pending.pop() {
+        loop {
+            budget = budget.checked_sub(1)?;
+            let instruction = program.instructions.get(pc)?;
+            match instruction {
+                Instruction::Save(_) | Instruction::ClearRegister(_) | Instruction::Nop => pc += 1,
+                Instruction::Jump(target) if *target as usize > pc => pc = *target as usize,
+                Instruction::Split { prefer, other } if *prefer as usize > pc && *other as usize > pc => {
+                    pending.push(*other as usize);
+                    pc = *prefer as usize;
+                }
+                Instruction::GreedyLoop { min: 0, .. } | Instruction::LazyLoop { min: 0, .. } => return None,
+                _ => {
+                    ranges.extend(instruction_ranges(instruction, false, program.unicode)?);
+                    break;
+                }
+            }
+        }
+    }
+    Some(SimpleMatch::CharClass {
+        ranges: normalize_ranges(ranges)
+            .into_iter()
+            .map(|(start, end)| CharRange { start, end })
+            .collect(),
+        negated: false,
+    })
+}
+
+fn normalize_ranges(mut ranges: Ranges) -> Ranges {
+    ranges.sort_unstable();
+    let mut merged: Ranges = Vec::new();
+    for (start, end) in ranges {
+        if let Some(last) = merged.last_mut()
+            && start <= last.1.saturating_add(1)
+        {
+            last.1 = last.1.max(end);
+        } else {
+            merged.push((start, end));
+        }
+    }
+    merged
+}
+
+fn ranges_overlap(left: Ranges, right: Ranges) -> bool {
+    let left = normalize_ranges(left);
+    let right = normalize_ranges(right);
+    let (mut a, mut b) = (0, 0);
+    while a < left.len() && b < right.len() {
+        if left[a].1 < right[b].0 {
+            a += 1;
+        } else if right[b].1 < left[a].0 {
+            b += 1;
+        } else {
+            return true;
+        }
+    }
+    false
+}
+
+type Ranges = Vec<(u32, u32)>;
+
+fn instruction_ranges(instruction: &Instruction, ignore_case: bool, unicode: bool) -> Option<Ranges> {
+    match instruction {
+        Instruction::Char(cp) => expand_case_ranges(vec![(*cp, *cp)], ignore_case, unicode),
+        Instruction::CharNoCase(cp, _) => expand_case_ranges(vec![(*cp, *cp)], true, unicode),
+        Instruction::AnyChar { dot_all } => {
+            matcher_ranges(&SimpleMatch::AnyChar { dot_all: *dot_all }, ignore_case, unicode)
+        }
+        Instruction::CharClass { ranges, negated } => Some(class_ranges(
+            expand_case_ranges(ranges.iter().map(|r| (r.start, r.end)).collect(), ignore_case, unicode)?,
+            *negated,
+        )),
+        Instruction::BuiltinClass(class) => builtin_ranges(*class, ignore_case, unicode),
+        Instruction::GreedyLoop { matcher, .. } | Instruction::LazyLoop { matcher, .. } => {
+            matcher_ranges(matcher, ignore_case, unicode)
+        }
+        _ => None,
+    }
+}
+
+fn matcher_ranges(matcher: &SimpleMatch, ignore_case: bool, unicode: bool) -> Option<Ranges> {
+    match matcher {
+        SimpleMatch::Char(cp) => expand_case_ranges(vec![(*cp, *cp)], ignore_case, unicode),
+        SimpleMatch::CharNoCase(cp, _) => expand_case_ranges(vec![(*cp, *cp)], true, unicode),
+        SimpleMatch::AnyChar { dot_all: true } => Some(vec![(0, 0x10FFFF)]),
+        SimpleMatch::AnyChar { dot_all: false } => Some(class_ranges(vec![(10, 10), (13, 13), (0x2028, 0x2029)], true)),
+        SimpleMatch::CharClass { ranges, negated } => Some(class_ranges(
+            expand_case_ranges(ranges.iter().map(|r| (r.start, r.end)).collect(), ignore_case, unicode)?,
+            *negated,
+        )),
+        SimpleMatch::BuiltinClass(class) => builtin_ranges(*class, ignore_case, unicode),
+        SimpleMatch::Union(left, right) => {
+            let mut ranges = matcher_ranges(left, ignore_case, unicode)?;
+            ranges.extend(matcher_ranges(right, ignore_case, unicode)?);
+            Some(ranges)
+        }
+        // Unicode properties require more than raw intervals.
+        _ => None,
+    }
+}
+
+fn builtin_ranges(class: BuiltinCharacterClass, ignore_case: bool, unicode: bool) -> Option<Ranges> {
+    use BuiltinCharacterClass::*;
+    let ranges = match class {
+        Digit | NonDigit => vec![(0x30, 0x39)],
+        Word | NonWord => vec![(0x30, 0x39), (0x41, 0x5A), (0x5F, 0x5F), (0x61, 0x7A)],
+        Whitespace | NonWhitespace => vec![
+            (9, 13),
+            (0x20, 0x20),
+            (0xA0, 0xA0),
+            (0x1680, 0x1680),
+            (0x2000, 0x200A),
+            (0x2028, 0x2029),
+            (0x202F, 0x202F),
+            (0x205F, 0x205F),
+            (0x3000, 0x3000),
+            (0xFEFF, 0xFEFF),
+        ],
+    };
+    let ranges = if ignore_case && unicode && matches!(class, Word | NonWord) {
+        expand_case_ranges(ranges, true, true)?
+    } else {
+        ranges
+    };
+    Some(class_ranges(
+        ranges,
+        matches!(class, NonDigit | NonWord | NonWhitespace),
+    ))
+}
+
+fn expand_case_ranges(mut ranges: Ranges, ignore_case: bool, unicode: bool) -> Option<Ranges> {
+    if !ignore_case {
+        return Some(ranges);
+    }
+    if ranges.iter().any(|range| range.1 >= 128) {
+        return None;
+    }
+    let original = normalize_ranges(ranges.clone());
+    for (start, end) in original {
+        for cp in start..=end {
+            if !(cp as u8).is_ascii_alphabetic() {
+                continue;
+            }
+            if unicode {
+                let mut closure = [0u32; 16];
+                let count = libunicode_rust::character_types::get_case_closure(cp, &mut closure);
+                if count > closure.len() {
+                    return None;
+                }
+                ranges.extend(closure[..count].iter().map(|cp| (*cp, *cp)));
+            } else {
+                let other = cp ^ 0x20;
+                ranges.push((other, other));
+            }
+        }
+    }
+    Some(ranges)
+}
+
+fn class_ranges(mut ranges: Ranges, negated: bool) -> Ranges {
+    if !negated {
+        return ranges;
+    }
+    ranges.sort_unstable();
+    let mut complement = Vec::new();
+    let mut start = 0;
+    for (low, high) in ranges {
+        if start < low {
+            complement.push((start, low - 1));
+        }
+        start = start.max(high.saturating_add(1));
+    }
+    if start <= 0x10FFFF {
+        complement.push((start, 0x10FFFF));
+    }
+    complement
+}

--- a/Libraries/LibRegex/Rust/src/vm.rs
+++ b/Libraries/LibRegex/Rust/src/vm.rs
@@ -443,7 +443,10 @@ fn first_filter_matches<I: Input>(program: &Program, input: I, pos: usize, filte
 
 #[inline(always)]
 fn next_candidate_start<I: Input>(program: &Program, input: I, hints: &PatternHints, mut pos: usize) -> Option<usize> {
-    while pos <= input.len() {
+    while pos <= input.len().saturating_sub(program.minimum_length) {
+        if input.len() - pos < program.minimum_length {
+            return None;
+        }
         if program.unicode
             && !hints.can_match_empty
             && pos > 0
@@ -509,6 +512,9 @@ pub fn execute_anchored_into_with_scratch<I: Input>(
     out: &mut [i32],
     scratch: &mut VmScratch,
 ) -> VmResult {
+    if start_pos > input.len() || input.len() - start_pos < program.minimum_length {
+        return VmResult::NoMatch;
+    }
     if fails_trailing_literal_hint(input, hints) {
         return VmResult::NoMatch;
     }
@@ -535,6 +541,9 @@ pub fn find_all_with_scratch<I: Input>(
     result_buf: &mut [i32],
     scratch: &mut VmScratch,
 ) -> i32 {
+    if start_pos > input.len() || input.len() - start_pos < program.minimum_length {
+        return 0;
+    }
     if fails_trailing_literal_hint(input, hints) {
         return 0;
     }
@@ -556,6 +565,9 @@ pub fn find_all_with_scratch<I: Input>(
         && !program.unicode
     {
         while let Some(candidate_pos) = next_literal_start_from_hint(input, pos, start_hint) {
+            if input.len() - candidate_pos < program.minimum_length {
+                break;
+            }
             vm.reset(candidate_pos);
             match vm.run() {
                 VmResult::Match => {
@@ -603,6 +615,9 @@ pub fn find_all_with_scratch<I: Input>(
     {
         let ch16 = ch as u16;
         while let Some(candidate_pos) = input.next_literal_start(pos, ch16) {
+            if input.len() - candidate_pos < program.minimum_length {
+                break;
+            }
             vm.reset(candidate_pos);
             match vm.run() {
                 VmResult::Match => {
@@ -696,6 +711,9 @@ fn execute_into_impl<I: Input>(
     out: &mut [i32],
     scratch: &mut VmScratch,
 ) -> VmResult {
+    if start_pos > input.len() || input.len() - start_pos < program.minimum_length {
+        return VmResult::NoMatch;
+    }
     if fails_trailing_literal_hint(input, hints) {
         return VmResult::NoMatch;
     }
@@ -732,6 +750,9 @@ fn execute_into_impl<I: Input>(
     {
         let mut pos = start_pos;
         while let Some(candidate_pos) = next_literal_start_from_hint(input, pos, start_hint) {
+            if input.len() - candidate_pos < program.minimum_length {
+                break;
+            }
             vm.reset(candidate_pos);
             match vm.run() {
                 VmResult::Match => {
@@ -759,6 +780,9 @@ fn execute_into_impl<I: Input>(
         let ch16 = ch as u16;
         let mut pos = start_pos;
         while let Some(candidate_pos) = input.next_literal_start(pos, ch16) {
+            if input.len() - candidate_pos < program.minimum_length {
+                break;
+            }
             vm.reset(candidate_pos);
             match vm.run() {
                 VmResult::Match => {
@@ -1183,7 +1207,7 @@ pub(crate) fn analyze_pattern(
                 negated: *negated,
             }),
             Some(Instruction::GreedyLoop { matcher, min, .. }) if *min >= 1 => Some(matcher.clone()),
-            _ => None,
+            _ => crate::optimizer::first_filter(program, filter_offset),
         }
     } else {
         None
@@ -1478,6 +1502,12 @@ impl<'a, I: Input> Vm<'a, I> {
             let inst = &instructions[pc];
             match inst {
                 Instruction::Char(c) => {
+                    if let Some(matched) = self.match_literal_run(pc) {
+                        if !matched && !self.backtrack() {
+                            return VmResult::NoMatch;
+                        }
+                        continue;
+                    }
                     let c = *c;
                     if self.pos < input_len {
                         let input_cp = input.code_unit(self.pos) as u32;
@@ -1592,8 +1622,20 @@ impl<'a, I: Input> Vm<'a, I> {
                     let prefer = *prefer;
                     let other = *other;
                     let pos = self.pos;
-                    self.push_backtrack(other, pos);
-                    self.pc = prefer;
+                    if !self.branch_can_match(prefer as usize) {
+                        if !self.branch_can_match(other as usize) {
+                            if !self.backtrack() {
+                                return VmResult::NoMatch;
+                            }
+                        } else {
+                            self.pc = other;
+                        }
+                    } else {
+                        if self.branch_can_match(other as usize) {
+                            self.push_backtrack(other, pos);
+                        }
+                        self.pc = prefer;
+                    }
                 }
 
                 Instruction::Save(reg) => {
@@ -1779,7 +1821,7 @@ impl<'a, I: Input> Vm<'a, I> {
                             return VmResult::NoMatch;
                         }
                     } else {
-                        if count > min {
+                        if count > min && !self.program.optimization.atomic_loop.get(pc).copied().unwrap_or(false) {
                             let greedy_pos = self.pos;
                             self.push_greedy_backtrack(self.pc, start_pos, greedy_pos, min);
                         }
@@ -1842,6 +1884,12 @@ impl<'a, I: Input> Vm<'a, I> {
             let inst = &instructions[pc];
             match inst {
                 Instruction::Char(c) => {
+                    if let Some(matched) = self.match_literal_run(pc) {
+                        if !matched && !self.backtrack() {
+                            return VmResult::NoMatch;
+                        }
+                        continue;
+                    }
                     if !self.match_char(*c) {
                         if !self.backtrack() {
                             return VmResult::NoMatch;
@@ -1955,8 +2003,20 @@ impl<'a, I: Input> Vm<'a, I> {
                     let prefer = *prefer;
                     let other = *other;
                     let pos = self.pos;
-                    self.push_backtrack(other, pos);
-                    self.pc = prefer;
+                    if !self.branch_can_match(prefer as usize) {
+                        if !self.branch_can_match(other as usize) {
+                            if !self.backtrack() {
+                                return VmResult::NoMatch;
+                            }
+                        } else {
+                            self.pc = other;
+                        }
+                    } else {
+                        if self.branch_can_match(other as usize) {
+                            self.push_backtrack(other, pos);
+                        }
+                        self.pc = prefer;
+                    }
                 }
 
                 Instruction::Save(reg) => {
@@ -2129,7 +2189,7 @@ impl<'a, I: Input> Vm<'a, I> {
                         }
                     } else {
                         // Push a greedy backtrack state only if we consumed more than min.
-                        if count > min {
+                        if count > min && !self.program.optimization.atomic_loop.get(pc).copied().unwrap_or(false) {
                             let greedy_pos = self.pos;
                             self.push_greedy_backtrack(self.pc, start_pos, greedy_pos, min);
                         }
@@ -2785,7 +2845,15 @@ impl<'a, I: Input> Vm<'a, I> {
                             start_pos - min as usize
                         };
 
-                        let next_inst = self.program.instructions.get(pc as usize + 1);
+                        let next_inst = self
+                            .program
+                            .optimization
+                            .leading_match
+                            .get(pc as usize + 1)
+                            .copied()
+                            .flatten()
+                            .and_then(|next| self.program.instructions.get(next))
+                            .or_else(|| self.program.instructions.get(pc as usize + 1));
                         let new_pos = if let Some(suffix_deficit) = same_matcher_loop_suffix_deficit {
                             let Some(pos) = self.advance_n_chars(current_pos, suffix_deficit) else {
                                 return self.backtrack();
@@ -2887,7 +2955,15 @@ impl<'a, I: Input> Vm<'a, I> {
                         // Optimization: peek at the next instruction. If it's a
                         // Char, scan backward for that char to skip positions
                         // that can't match.
-                        let next_inst = self.program.instructions.get(pc as usize + 1);
+                        let next_inst = self
+                            .program
+                            .optimization
+                            .leading_match
+                            .get(pc as usize + 1)
+                            .copied()
+                            .flatten()
+                            .and_then(|next| self.program.instructions.get(next))
+                            .or_else(|| self.program.instructions.get(pc as usize + 1));
                         let new_pos = if let Some(suffix_deficit) = same_matcher_loop_suffix_deficit {
                             let Some(pos) = self.retreat_n_chars(current_pos, suffix_deficit) else {
                                 return self.backtrack();
@@ -3014,6 +3090,64 @@ impl<'a, I: Input> Vm<'a, I> {
         } else {
             false
         }
+    }
+
+    fn branch_can_match(&self, pc: usize) -> bool {
+        let Some(next) = self.program.optimization.leading_match.get(pc).copied().flatten() else {
+            return true;
+        };
+        let Some(cp) = self.current_code_point() else {
+            return false;
+        };
+        match &self.program.instructions[next] {
+            Instruction::Char(c) => {
+                !self.modifiers.ignore_case && cp == *c
+                    || self.modifiers.ignore_case && case_fold_eq(cp, *c, self.program.unicode)
+            }
+            Instruction::CharNoCase(c, _) => case_fold_eq(cp, *c, self.program.unicode),
+            Instruction::AnyChar { dot_all } => *dot_all || self.modifiers.dot_all || !is_line_terminator(cp),
+            Instruction::CharClass { ranges, negated } => {
+                match_char_class(
+                    cp,
+                    ranges,
+                    self.modifiers.ignore_case,
+                    self.program.unicode,
+                    self.program.unicode_sets,
+                ) != *negated
+            }
+            Instruction::BuiltinClass(class) => {
+                match_builtin_class(cp, *class, self.modifiers.ignore_case && self.program.unicode)
+            }
+            Instruction::GreedyLoop { matcher, .. } | Instruction::LazyLoop { matcher, .. } => {
+                self.match_simple(cp, matcher)
+            }
+            _ => true,
+        }
+    }
+
+    fn match_literal_run(&mut self, pc: usize) -> Option<bool> {
+        if self.modifiers.ignore_case {
+            return None;
+        }
+        let literal = self.program.optimization.literal_runs.get(pc)?.as_deref()?;
+        let matched = if self.backward {
+            self.pos >= literal.len()
+                && literal
+                    .iter()
+                    .enumerate()
+                    .all(|(offset, expected)| self.input_code_unit(self.pos - offset - 1) == *expected)
+        } else {
+            self.input.matches_u16_at(self.pos, literal)
+        };
+        if matched {
+            if self.backward {
+                self.pos -= literal.len();
+            } else {
+                self.pos += literal.len();
+            }
+            self.pc += literal.len() as u32;
+        }
+        Some(matched)
     }
 
     /// Check if a code point matches a SimpleMatch.
@@ -3602,4 +3736,298 @@ pub(crate) fn match_unicode_property_resolved(
         return libunicode_rust::character_types::resolved_property_matches(cp, *r);
     }
     match_unicode_property(cp, name, value)
+}
+
+#[cfg(test)]
+mod optimizer_tests {
+    use super::*;
+    use crate::ast::Flags;
+    use crate::compiler;
+    use crate::parser;
+
+    fn run(program: &Program, input: &[u16], start: usize) -> (VmResult, Vec<i32>, u64) {
+        let mut scratch = VmScratch::new();
+        let mut vm = Vm::new(program, input, start, &mut scratch);
+        let result = vm.run();
+        (result, vm.registers.to_vec(), vm.steps)
+    }
+
+    fn compare(pattern: &str, flags: Flags, subjects: &[Vec<u16>]) {
+        let parsed = parser::parse(pattern, flags).unwrap();
+        let optimized = compiler::compile(&parsed);
+        let original = compiler::compile_unoptimized(&parsed);
+        let regex = crate::regex::Regex::compile(pattern, flags).unwrap();
+        for input in subjects {
+            let expected = (0..=input.len()).find_map(|start| {
+                let (result, captures, _) = run(&original, input, start);
+                (result == VmResult::Match).then_some(captures)
+            });
+            let mut out = vec![-1; (parsed.capture_count as usize + 1) * 2];
+            let result = regex.exec_into(input, 0, &mut out);
+            assert_eq!(
+                result == VmResult::Match,
+                expected.is_some(),
+                "search {pattern:?} {flags:?}, {input:?}"
+            );
+            if let Some(expected) = expected {
+                assert_eq!(
+                    out,
+                    expected[..out.len()],
+                    "search captures {pattern:?} {flags:?}, {input:?}"
+                );
+            }
+            for start in 0..=input.len() {
+                let (result, captures, _) = run(&optimized, input, start);
+                let (expected, expected_captures, _) = run(&original, input, start);
+                assert_eq!(result, expected, "{pattern:?} {flags:?}, {input:?} at {start}");
+                if result == VmResult::Match {
+                    let count = (parsed.capture_count as usize + 1) * 2;
+                    assert_eq!(
+                        &captures[..count],
+                        &expected_captures[..count],
+                        "{pattern:?} {flags:?}, {input:?} at {start}"
+                    );
+                    assert!(
+                        captures[1] as usize - captures[0] as usize >= optimized.minimum_length,
+                        "{pattern:?}"
+                    );
+                }
+                if input.iter().all(|cp| *cp < 128) {
+                    let ascii: Vec<_> = input.iter().map(|cp| *cp as u8).collect();
+                    let mut scratch = VmScratch::new();
+                    let mut vm = Vm::new(&optimized, ascii.as_slice(), start, &mut scratch);
+                    assert_eq!(vm.run(), expected, "ASCII {pattern:?}, {input:?} at {start}");
+                    if expected == VmResult::Match {
+                        let count = (parsed.capture_count as usize + 1) * 2;
+                        assert_eq!(&vm.registers[..count], &expected_captures[..count]);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn optimizations_preserve_matches_and_captures() {
+        let mut subjects = vec![Vec::new()];
+        for _ in 0..4 {
+            let previous = subjects.clone();
+            for prefix in previous {
+                for cp in *b"aAbc \n" {
+                    let mut subject = prefix.clone();
+                    subject.push(cp as u16);
+                    subjects.push(subject);
+                }
+            }
+        }
+        subjects.sort();
+        subjects.dedup();
+        subjects.extend([
+            vec![0xD800],
+            vec![0xDC00],
+            vec![0xD800, 0xDC00],
+            vec![b'a' as u16, 0xD800, 0xDC00, b'b' as u16],
+            "ab\u{212a}a\u{017f}bc".encode_utf16().collect(),
+        ]);
+        let patterns = [
+            "(?<x>ab|ac)\\k<x>",
+            "([a-cb-da-b]*)([^a-c])a",
+            "(?:[a-b]c|[c-d]a|[x-z]b)",
+            "([a-b]c|[c-d]a|[x-z]b)",
+            "(ab|abc|a)(bc)?",
+            "(ab|a|abc)(b|bc)?",
+            "(ab|ac|a|abc)(.*)",
+            "(abc|b|ab)(c?)",
+            "(ab|ac)+b",
+            "((ab)|(ac))*c",
+            "(ab|ac|ad|b)*c",
+            "(?:ab|a|abc)+bc",
+            "(a*)(b)c",
+            "([a-b]*)(c|b)a",
+            "(a*?)(b|a)c",
+            "(a|b)*ac",
+            "(a)|(b)|(c)",
+            "(?:(a)|(b))+(c)?",
+            "(a*)[bc]+a",
+            "([^b]*)b.a",
+            "(\\w*)\\W.a",
+            "(\\d*)\\D.a",
+            "(\\s*)\\S.a",
+            "(.*)(ab)c",
+            "(.*)(a)b",
+            "(.*)(a*)b",
+            "(.*)(a|b)c",
+            "(.*?)(ab)c",
+            "(?<=abc|ab|ac)c",
+            "(?<=(a)(.*))b",
+            "(?<=(ab|ac))(.*)",
+            "(?=(a|ab))\\1b",
+            "(?!(ab|ac))(.*)",
+            "(a*)(?=a)b|a",
+            "(?i:a*)(?-i:A)b",
+            "(?-i:a*)(?i:A)b",
+            "(?s:.*)(a)b",
+            "(?-s:.*)(a)b",
+            "(a+)(a+)b",
+            "(?:a{2,4})(a)b",
+            "(a|)b",
+            "(?:|ab|ac)b",
+            "(abc)?a",
+            "(?=abc)a",
+            "(a)?\\1b",
+            "(?:abc|a)b",
+            "\\uD800+\\uDC00",
+            "(a*)\\u{212a}b",
+            "(s*)\\u{017f}b",
+            "(ab){0,3}c",
+            "(?:abc){2,4}",
+        ];
+        for flags in [
+            Flags::default(),
+            Flags {
+                ignore_case: true,
+                ..Flags::default()
+            },
+            Flags {
+                unicode: true,
+                ..Flags::default()
+            },
+            Flags {
+                unicode: true,
+                ignore_case: true,
+                ..Flags::default()
+            },
+            Flags {
+                unicode_sets: true,
+                dot_all: true,
+                ..Flags::default()
+            },
+        ] {
+            for pattern in patterns {
+                compare(pattern, flags, &subjects);
+            }
+        }
+    }
+
+    #[test]
+    fn literal_runs_and_prefixes_reduce_vm_work() {
+        for (pattern, subject) in [
+            ("(abcdefghijklmnopqrstuvwxyz)$", "abcdefghijklmnopqrstuvwxyz"),
+            ("(abcdefghijklX|abcdefghijklY|abcdefghijklZ)$", "abcdefghijklZ"),
+            ("^(.*)(a)bc$", "axyzaxyzaxyzaxyzabc"),
+        ] {
+            let parsed = parser::parse(pattern, Flags::default()).unwrap();
+            let input: Vec<_> = subject.encode_utf16().collect();
+            let optimized = run(&compiler::compile(&parsed), &input, 0);
+            let original = run(&compiler::compile_unoptimized(&parsed), &input, 0);
+            assert_eq!(optimized.0, VmResult::Match);
+            assert_eq!(optimized.0, original.0);
+            eprintln!("{pattern}: {} -> {} VM steps", original.2, optimized.2);
+            assert!(optimized.2 < original.2, "{pattern}: {} vs {}", optimized.2, original.2);
+        }
+    }
+
+    #[test]
+    #[ignore = "manual optimizer throughput comparison"]
+    fn optimizer_throughput() {
+        use std::hint::black_box;
+        use std::time::Instant;
+        for (pattern, subject) in [
+            (
+                "(abcdefghijklmnopqrstuvwxyz)$",
+                "abcdefghijklmnopqrstuvwxyz".to_string(),
+            ),
+            (
+                "(abcdefghijklX|abcdefghijklY|abcdefghijklZ)$",
+                "abcdefghijklZ".to_string(),
+            ),
+            ("^([ab]*)cd$", format!("{}cX", "ab".repeat(512))),
+            ("^(.*)(a)bc$", format!("{}abc", "xyz".repeat(512))),
+            ("(a)|(b)", "b".to_string()),
+            ("a.b", "acb".to_string()),
+        ] {
+            let parsed = parser::parse(pattern, Flags::default()).unwrap();
+            let original = compiler::compile_unoptimized(&parsed);
+            let optimized = compiler::compile(&parsed);
+            let input: Vec<_> = subject.encode_utf16().collect();
+            let measure = |program: &Program| {
+                let mut scratch = VmScratch::new();
+                let start = Instant::now();
+                for _ in 0..100_000 {
+                    let mut vm = Vm::new(black_box(program), black_box(input.as_slice()), 0, &mut scratch);
+                    black_box(vm.run());
+                }
+                start.elapsed()
+            };
+            let before = measure(&original);
+            let after = measure(&optimized);
+            eprintln!(
+                "{pattern}: {before:?} -> {after:?} ({:.2}x)",
+                before.as_secs_f64() / after.as_secs_f64()
+            );
+        }
+    }
+
+    #[test]
+    fn disjoint_loops_and_impossible_branches_do_not_save_registers() {
+        for flags in [
+            Flags::default(),
+            Flags {
+                ignore_case: true,
+                unicode: true,
+                ..Flags::default()
+            },
+        ] {
+            for (pattern, subject) in [
+                ("(a*)bc", "aaaaabc"),
+                ("([^b]*)bc", "aaaaabc"),
+                ("(\\w*)\\Wbc", "aaaaa bc"),
+                ("(a)|(b)", "b"),
+            ] {
+                let parsed = parser::parse(pattern, flags).unwrap();
+                let input: Vec<_> = subject.encode_utf16().collect();
+                let optimized = compiler::compile(&parsed);
+                let original = compiler::compile_unoptimized(&parsed);
+                let mut optimized_scratch = VmScratch::new();
+                let mut original_scratch = VmScratch::new();
+                assert_eq!(
+                    Vm::new(&optimized, input.as_slice(), 0, &mut optimized_scratch).run(),
+                    VmResult::Match
+                );
+                assert_eq!(
+                    Vm::new(&original, input.as_slice(), 0, &mut original_scratch).run(),
+                    VmResult::Match
+                );
+                assert_eq!(optimized_scratch.register_pool.capacity(), 0, "{pattern}");
+                assert!(original_scratch.register_pool.capacity() > 0, "{pattern}");
+            }
+        }
+    }
+
+    #[test]
+    fn minimum_length_search_keeps_optional_and_zero_width_matches() {
+        for (pattern, subject, matches) in [
+            ("(?:abc){1000000000}", "abc", false),
+            ("(?=abc)a", "abc", true),
+            ("(abc)?a", "a", true),
+            ("(abc)?\\1a", "a", true),
+            ("(?:abc|a)b", "ab", true),
+            ("[\\q{}]a", "a", true),
+            ("(?<=abc)", "abc", true),
+        ] {
+            let regex = crate::regex::Regex::compile(
+                pattern,
+                Flags {
+                    unicode_sets: true,
+                    ..Flags::default()
+                },
+            )
+            .unwrap();
+            let input: Vec<_> = subject.encode_utf16().collect();
+            assert_eq!(
+                regex.test(&input, 0),
+                if matches { VmResult::Match } else { VmResult::NoMatch },
+                "{pattern}"
+            );
+        }
+    }
 }

--- a/Libraries/LibUnicode/Rust/Cargo.toml
+++ b/Libraries/LibUnicode/Rust/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2024"
 default = []
 allocator = []
 idna = []
+# Standalone Rust implementations of the `unicode_*` callbacks that this crate
+# normally resolves against LibUnicode's C++ implementation. Only for test
+# binaries that link no C++; see src/ffi_stubs.rs.
+ffi-stubs = []
 
 [lib]
 crate-type = ["staticlib", "rlib"]

--- a/Libraries/LibUnicode/Rust/src/ffi_stubs.rs
+++ b/Libraries/LibUnicode/Rust/src/ffi_stubs.rs
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Standalone implementations of the `unicode_*` FFI callbacks that
+//! `character_types` normally resolves against LibUnicode's C++ (and thus ICU)
+//! implementation.
+
+/// Returns the single `char` an iterator yields, or `None` if it yields any other number of them.
+fn single_char(mut chars: impl Iterator<Item = char>) -> Option<u32> {
+    let first = chars.next()?;
+    chars.next().is_none().then_some(first as u32)
+}
+
+/// Simple enough casefolding to make regex happy.
+fn fold(code_point: u32) -> u32 {
+    match code_point {
+        0x017F => 's' as u32, // LATIN SMALL LETTER LONG S
+        0x0345 => 0x03B9,     // COMBINING GREEK YPOGEGRAMMENI
+        0x03C2 => 0x03C3,     // GREEK SMALL LETTER FINAL SIGMA
+        0x1E9E => 0x00DF,     // LATIN CAPITAL LETTER SHARP S
+        _ => char::from_u32(code_point)
+            .and_then(|c| single_char(c.to_lowercase()))
+            .unwrap_or(code_point),
+    }
+}
+
+fn extra_case_equivalents(canonical: u32) -> &'static [u32] {
+    match canonical {
+        0x73 => &[0x017F], // s
+        0x6B => &[0x212A], // k
+        0x00DF => &[0x1E9E],
+        0x03B9 => &[0x0345, 0x1FBE],
+        0x03C3 => &[0x03C2],
+        _ => &[],
+    }
+}
+
+fn case_closure(code_point: u32) -> Vec<u32> {
+    let canonical = fold(code_point);
+
+    let mut closure = vec![code_point, canonical];
+    closure.extend(extra_case_equivalents(canonical));
+    if let Some(uppercased) = char::from_u32(canonical).and_then(|c| single_char(c.to_uppercase())) {
+        closure.push(uppercased);
+    }
+
+    closure.retain(|candidate| fold(*candidate) == canonical);
+    closure.sort_unstable();
+    closure.dedup();
+    closure
+}
+
+// 22.2.2.7.3 Canonicalize ( rer, ch ), https://tc39.es/ecma262/#sec-runtime-semantics-canonicalize-ch
+fn canonicalize(code_point: u32, unicode_mode: bool) -> u32 {
+    if unicode_mode {
+        return fold(code_point);
+    }
+
+    if code_point < 128 {
+        return u32::from((code_point as u8).to_ascii_uppercase());
+    }
+
+    let Some(uppercased) = char::from_u32(code_point).and_then(|c| single_char(c.to_uppercase())) else {
+        return code_point;
+    };
+
+    if uppercased < 128 { code_point } else { uppercased }
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_simple_case_fold(code_point: u32, unicode_mode: bool) -> u32 {
+    canonicalize(code_point, unicode_mode)
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_code_point_matches_range_ignoring_case(
+    code_point: u32,
+    from: u32,
+    to: u32,
+    unicode_mode: bool,
+) -> bool {
+    if code_point >= from && code_point <= to {
+        return true;
+    }
+
+    let canonical = canonicalize(code_point, unicode_mode);
+    case_closure(code_point)
+        .into_iter()
+        .filter(|candidate| *candidate >= from && *candidate <= to)
+        .any(|candidate| canonicalize(candidate, unicode_mode) == canonical)
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn unicode_get_case_closure(code_point: u32, out_buffer: *mut u32, buffer_capacity: u32) -> u32 {
+    let closure = case_closure(code_point);
+    let count = closure.len().min(buffer_capacity as usize);
+
+    for (index, candidate) in closure.into_iter().take(count).enumerate() {
+        // SAFETY: The caller guarantees `out_buffer` is writable for `buffer_capacity` elements.
+        unsafe { out_buffer.add(index).write(candidate) };
+    }
+
+    count as u32
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_code_point_has_space_separator_general_category(code_point: u32) -> bool {
+    // General_Category=Zs.
+    matches!(
+        code_point,
+        0x20 | 0xA0 | 0x1680 | 0x2000..=0x200A | 0x202F | 0x205F | 0x3000
+    )
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_code_point_has_identifier_start_property(code_point: u32) -> bool {
+    char::from_u32(code_point).is_some_and(|c| c.is_alphabetic() || c == '$' || c == '_')
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_code_point_has_identifier_continue_property(code_point: u32) -> bool {
+    char::from_u32(code_point).is_some_and(|c| c.is_alphanumeric() || c == '$' || c == '_')
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_property_matches(_: u32, _: *const u8, _: usize, _: *const u8, _: usize) -> bool {
+    unimplemented!("Unicode property lookups are unavailable in Rust-only test binaries")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_property_matches_case_insensitive(
+    _: u32,
+    _: *const u8,
+    _: usize,
+    _: *const u8,
+    _: usize,
+) -> bool {
+    unimplemented!("Unicode property lookups are unavailable in Rust-only test binaries")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_property_all_case_equivalents_match(
+    _: u32,
+    _: *const u8,
+    _: usize,
+    _: *const u8,
+    _: usize,
+) -> bool {
+    unimplemented!("Unicode property lookups are unavailable in Rust-only test binaries")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_resolve_property(
+    _: *const u8,
+    _: usize,
+    _: *const u8,
+    _: usize,
+    _: *mut u8,
+    _: *mut u32,
+) -> bool {
+    unimplemented!("Unicode property lookups are unavailable in Rust-only test binaries")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_resolved_property_matches(_: u32, _: u8, _: u32) -> bool {
+    unimplemented!("Unicode property lookups are unavailable in Rust-only test binaries")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_is_string_property(_: *const u8, _: usize) -> bool {
+    unimplemented!("Unicode property lookups are unavailable in Rust-only test binaries")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_is_valid_ecma262_property(_: *const u8, _: usize, _: *const u8, _: usize) -> bool {
+    unimplemented!("Unicode property lookups are unavailable in Rust-only test binaries")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn unicode_get_string_property_data(_: *const u8, _: usize, _: *mut u32, _: u32) -> u32 {
+    unimplemented!("Unicode property lookups are unavailable in Rust-only test binaries")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folding_matches_the_cases_the_regex_tests_rely_on() {
+        assert_eq!(fold(u32::from(b'A')), u32::from(b'a'));
+        assert_eq!(fold(0x212A), 'k' as u32); // KELVIN SIGN
+        assert_eq!(fold(0x017F), 's' as u32); // LATIN SMALL LETTER LONG S
+        assert_eq!(fold(0x0130), 0x0130); // LATIN CAPITAL LETTER I WITH DOT ABOVE
+
+        // Non-unicode mode canonicalizes by uppercasing, but never out of the non-ASCII range and into ASCII.
+        assert_eq!(canonicalize('a' as u32, false), 'A' as u32);
+        assert_eq!(canonicalize(0x212A, false), 0x212A);
+        assert_eq!(canonicalize(0x017F, false), 0x017F);
+    }
+
+    #[test]
+    fn case_closures_include_the_compatibility_code_points() {
+        assert_eq!(case_closure('k' as u32), vec!['K' as u32, 'k' as u32, 0x212A]);
+        assert_eq!(case_closure(0x212A), vec!['K' as u32, 'k' as u32, 0x212A]);
+        assert_eq!(case_closure('s' as u32), vec!['S' as u32, 's' as u32, 0x017F]);
+        assert!(unicode_code_point_matches_range_ignoring_case(
+            0x212A, 'a' as u32, 'z' as u32, true
+        ));
+        assert!(!unicode_code_point_matches_range_ignoring_case(
+            0x212A, 'a' as u32, 'z' as u32, false
+        ));
+    }
+}

--- a/Libraries/LibUnicode/Rust/src/lib.rs
+++ b/Libraries/LibUnicode/Rust/src/lib.rs
@@ -10,5 +10,7 @@ mod rust_allocator;
 
 pub mod calendar;
 pub mod character_types;
+#[cfg(any(test, feature = "ffi-stubs"))]
+mod ffi_stubs;
 #[cfg(feature = "idna")]
 pub mod idna;

--- a/Tests/LibRegex/TestRegex.cpp
+++ b/Tests/LibRegex/TestRegex.cpp
@@ -830,3 +830,65 @@ TEST_CASE(restored_long_fork_chain_coverage)
 
     EXPECT_EQ(regex.test(utf16_subject, 0), regex::MatchResult::Match);
 }
+
+TEST_CASE(optimizer_preserves_ordered_alternatives_and_capture_boundaries)
+{
+    auto regex = compile_regex("(abc|ab|abd)(c?)"sv);
+    EXPECT_EQ(regex.exec(u"abc"sv, 0), regex::MatchResult::Match);
+    expect_capture_eq(regex, u"abc"sv, 1, "abc"sv);
+    expect_capture_eq(regex, u"abc"sv, 2, ""sv);
+
+    auto shorter_first = compile_regex("(ab|abc|abd)(c?)"sv);
+    EXPECT_EQ(shorter_first.exec(u"abc"sv, 0), regex::MatchResult::Match);
+    expect_capture_eq(shorter_first, u"abc"sv, 1, "ab"sv);
+    expect_capture_eq(shorter_first, u"abc"sv, 2, "c"sv);
+
+    auto distinct_captures = compile_regex("(?:(ab)|(ac))+(b)?"sv);
+    EXPECT_EQ(distinct_captures.exec(u"abacb"sv, 0), regex::MatchResult::Match);
+    expect_capture_unmatched(distinct_captures, 1);
+    expect_capture_eq(distinct_captures, u"abacb"sv, 2, "ac"sv);
+    expect_capture_eq(distinct_captures, u"abacb"sv, 3, "b"sv);
+}
+
+TEST_CASE(optimizer_seeks_through_captures_without_crossing_line_boundaries)
+{
+    auto regex = compile_regex("^(.*)(a)bc$"sv);
+    EXPECT_EQ(regex.exec(u"a--a--abc"sv, 0), regex::MatchResult::Match);
+    expect_capture_eq(regex, u"a--a--abc"sv, 1, "a--a--"sv);
+    expect_capture_eq(regex, u"a--a--abc"sv, 2, "a"sv);
+    EXPECT_EQ(regex.exec(u"a\nabc"sv, 0), regex::MatchResult::NoMatch);
+
+    auto backward = compile_regex("(?<=(a)(.*))b"sv);
+    EXPECT_EQ(backward.exec(u"a--a--b"sv, 0), regex::MatchResult::Match);
+    expect_capture_eq(backward, u"a--a--b"sv, 1, "a"sv);
+    expect_capture_eq(backward, u"a--a--b"sv, 2, "--a--"sv);
+}
+
+TEST_CASE(optimizer_keeps_overlapping_case_folds_and_modifiers_backtrackable)
+{
+    regex::ECMAScriptCompileFlags flags;
+    flags.unicode = true;
+    flags.ignore_case = true;
+    auto regex = compile_regex("(k*)k(x)"sv, flags);
+    EXPECT_EQ(regex.exec(u"k\u212Ax"sv, 0), regex::MatchResult::Match);
+    expect_capture_eq(regex, u"k\u212Ax"sv, 1, "k"sv);
+
+    auto long_s = compile_regex("(s*)s(x)"sv, flags);
+    EXPECT_EQ(long_s.exec(u"s\u017Fx"sv, 0), regex::MatchResult::Match);
+    expect_capture_eq(long_s, u"s\u017Fx"sv, 1, "s"sv);
+
+    EXPECT(matches("(?i:a*)(?-i:A)b"sv, "aAb"sv));
+    EXPECT(matches("(?-i:a*)(?i:A)b"sv, "aab"sv));
+    EXPECT(matches("([a-cb-da-b]*)([^a-c])a"sv, "abdda"sv));
+}
+
+TEST_CASE(optimizer_minimum_length_and_start_ranges_preserve_nullable_paths)
+{
+    EXPECT(!matches("(?:abc){1000000000}"sv, "abc"sv));
+    EXPECT(matches("(abc)?\\1a"sv, "a"sv));
+    EXPECT(matches("(?=abc)a"sv, "abc"sv));
+    EXPECT(matches("(?<=abc)"sv, "abc"sv));
+    EXPECT(matches("(?:abc|a)b"sv, "ab"sv));
+    EXPECT(matches("(?:[a-b]c|[c-d]a|[x-z]b)"sv, "-----yb"sv));
+    EXPECT(matches("(?:[a-b]c|[c-d]a|)"sv, "-----"sv));
+}


### PR DESCRIPTION
Let's do some regex, the new engine does not spark joy...yet.

```
Suite           Test                                      Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  ----------------------------------------  ---------  ---------------------------------  ---------------------------------  ------------------
SunSpider       3d-cube.js                                1.017      0.017 ± 0.016 … 0.021              0.017 ± 0.015 … 0.022              -0.3% (-0.2 MB)
SunSpider       3d-morph.js                               1.087      0.017 ± 0.016 … 0.018              0.016 ± 0.015 … 0.016              -0.3% (-0.2 MB)
SunSpider       3d-raytrace.js                            1.099      0.020 ± 0.019 … 0.021              0.018 ± 0.017 … 0.018              -0.3% (-0.2 MB)
SunSpider       access-binary-trees.js                    1.084      0.014 ± 0.013 … 0.014              0.013 ± 0.012 … 0.013              -0.3% (-0.2 MB)
SunSpider       access-fannkuch.js                        1.078      0.020 ± 0.019 … 0.021              0.019 ± 0.018 … 0.019              -0.3% (-0.2 MB)
SunSpider       access-nbody.js                           1.068      0.017 ± 0.016 … 0.018              0.016 ± 0.015 … 0.018              -0.3% (-0.2 MB)
SunSpider       access-nsieve.js                          1.107      0.013 ± 0.013 … 0.013              0.012 ± 0.011 … 0.012              -0.3% (-0.2 MB)
SunSpider       bitops-3bit-bits-in-byte.js               1.085      0.011 ± 0.010 … 0.012              0.010 ± 0.010 … 0.010              -0.3% (-0.2 MB)
SunSpider       bitops-bits-in-byte.js                    1.065      0.014 ± 0.014 … 0.014              0.013 ± 0.012 … 0.014              -0.3% (-0.2 MB)
SunSpider       bitops-bitwise-and.js                     1.086      0.015 ± 0.014 … 0.016              0.014 ± 0.014 … 0.014              -0.3% (-0.2 MB)
SunSpider       bitops-nsieve-bits.js                     1.103      0.013 ± 0.013 … 0.013              0.012 ± 0.011 … 0.012              -0.3% (-0.2 MB)
SunSpider       controlflow-recursive.js                  1.055      0.011 ± 0.010 … 0.011              0.010 ± 0.010 … 0.011              -0.3% (-0.2 MB)
SunSpider       crypto-aes.js                             1.087      0.016 ± 0.016 … 0.017              0.015 ± 0.014 … 0.016              -0.3% (-0.2 MB)
SunSpider       crypto-md5.js                             1.086      0.012 ± 0.011 … 0.013              0.011 ± 0.011 … 0.012              -0.3% (-0.2 MB)
SunSpider       crypto-sha1.js                            1.094      0.011 ± 0.010 … 0.012              0.010 ± 0.010 … 0.011              -0.3% (-0.2 MB)
SunSpider       date-format-tofte.js                      1.047      0.060 ± 0.056 … 0.064              0.058 ± 0.055 … 0.062              +0.1% (+0.1 MB)
SunSpider       date-format-xparb.js                      0.987      0.034 ± 0.034 … 0.035              0.035 ± 0.033 … 0.035              -0.3% (-0.2 MB)
SunSpider       math-cordic.js                            0.859      0.018 ± 0.017 … 0.020              0.021 ± 0.017 … 0.030              -0.3% (-0.2 MB)
SunSpider       math-partial-sums.js                      1.071      0.015 ± 0.014 … 0.016              0.014 ± 0.013 … 0.014              -0.3% (-0.2 MB)
SunSpider       math-spectral-norm.js                     1.061      0.011 ± 0.010 … 0.012              0.011 ± 0.010 … 0.012              -0.3% (-0.2 MB)
SunSpider       regexp-dna.js                             0.966      0.135 ± 0.133 … 0.137              0.140 ± 0.138 … 0.142              -0.3% (-0.2 MB)
SunSpider       string-base64.js                          1.067      0.017 ± 0.017 … 0.019              0.016 ± 0.015 … 0.018              -0.3% (-0.2 MB)
SunSpider       string-fasta.js                           1.081      0.025 ± 0.025 … 0.025              0.023 ± 0.023 … 0.023              -0.3% (-0.2 MB)
SunSpider       string-tagcloud.js                        1.133      0.036 ± 0.036 … 0.037              0.032 ± 0.032 … 0.032              -0.3% (-0.2 MB)
SunSpider       string-unpack-code.js                     1.009      0.047 ± 0.044 … 0.050              0.047 ± 0.045 … 0.047              +0.1% (+0.1 MB)
SunSpider       string-validate-input.js                  1.060      0.017 ± 0.015 … 0.019              0.016 ± 0.015 … 0.017              -0.3% (-0.2 MB)
LongSpider      3d-cube.js                                1.005      3.055 ± 2.987 … 3.186              3.039 ± 2.991 … 3.085              -0.3% (-0.2 MB)
LongSpider      3d-morph.js                               1.017      1.483 ± 1.459 … 1.526              1.459 ± 1.454 … 1.463              -0.3% (-0.2 MB)
LongSpider      3d-raytrace.js                            1.040      2.168 ± 2.089 … 2.235              2.085 ± 2.058 … 2.105              -0.3% (-0.2 MB)
LongSpider      access-binary-trees.js                    1.070      7.964 ± 7.745 … 8.168              7.442 ± 7.401 … 7.515              -0.0% (-0.0 MB)
LongSpider      access-fannkuch.js                        1.013      1.104 ± 1.065 … 1.129              1.090 ± 1.073 … 1.099              -0.3% (-0.2 MB)
LongSpider      access-nbody.js                           1.008      3.456 ± 3.417 … 3.486              3.429 ± 3.394 … 3.489              -0.3% (-0.2 MB)
LongSpider      access-nsieve.js                          1.002      1.063 ± 1.057 … 1.072              1.061 ± 1.051 … 1.078              -0.0% (-0.2 MB)
LongSpider      bitops-3bit-bits-in-byte.js               0.998      0.310 ± 0.304 … 0.315              0.311 ± 0.308 … 0.315              -0.3% (-0.2 MB)
LongSpider      bitops-bits-in-byte.js                    1.002      0.458 ± 0.454 … 0.463              0.457 ± 0.455 … 0.459              -0.3% (-0.2 MB)
LongSpider      bitops-nsieve-bits.js                     1.003      1.377 ± 1.354 … 1.419              1.373 ± 1.356 … 1.389              -0.3% (-0.2 MB)
LongSpider      controlflow-recursive.js                  1.021      1.578 ± 1.552 … 1.620              1.546 ± 1.507 … 1.571              -0.3% (-0.2 MB)
LongSpider      crypto-aes.js                             1.035      3.567 ± 3.543 … 3.597              3.448 ± 3.407 … 3.521              -0.3% (-0.2 MB)
LongSpider      crypto-md5.js                             1.005      3.333 ± 3.328 … 3.337              3.318 ± 3.276 … 3.345              -0.3% (-0.3 MB)
LongSpider      crypto-sha1.js                            0.982      5.723 ± 5.682 … 5.761              5.829 ± 5.756 … 5.879              -0.2% (-0.2 MB)
LongSpider      date-format-tofte.js                      1.003      4.873 ± 4.827 … 4.919              4.860 ± 4.842 … 4.874              -0.4% (-0.4 MB)
LongSpider      date-format-xparb.js                      0.988      4.371 ± 4.284 … 4.440              4.426 ± 4.338 … 4.490              -0.3% (-0.2 MB)
LongSpider      hash-map.js                               0.990      0.745 ± 0.727 … 0.763              0.753 ± 0.750 … 0.756              +0.0% (+0.0 MB)
LongSpider      math-cordic.js                            0.996      4.154 ± 4.099 … 4.257              4.169 ± 4.091 … 4.252              -0.3% (-0.2 MB)
LongSpider      math-partial-sums.js                      1.015      0.716 ± 0.711 … 0.719              0.705 ± 0.703 … 0.707              -0.3% (-0.2 MB)
LongSpider      math-spectral-norm.js                     1.000      3.977 ± 3.972 … 3.981              3.976 ± 3.969 … 3.980              -0.3% (-0.2 MB)
LongSpider      string-base64.js                          1.020      1.105 ± 1.092 … 1.120              1.084 ± 1.071 … 1.097              -0.0% (-0.0 MB)
LongSpider      string-fasta.js                           0.976      1.208 ± 1.198 … 1.223              1.238 ± 1.213 … 1.253              -0.3% (-0.2 MB)
LongSpider      string-tagcloud.js                        1.086      0.494 ± 0.491 … 0.497              0.455 ± 0.450 … 0.457              +0.2% (+0.1 MB)
Kraken          ai-astar.js                               1.018      0.479 ± 0.476 … 0.483              0.471 ± 0.470 … 0.472              -0.3% (-0.2 MB)
Kraken          audio-beat-detection.js                   1.003      0.362 ± 0.360 … 0.364              0.361 ± 0.354 … 0.366              -0.3% (-0.3 MB)
Kraken          audio-dft.js                              1.020      0.340 ± 0.336 … 0.343              0.334 ± 0.327 … 0.340              -0.3% (-0.2 MB)
Kraken          audio-fft.js                              1.010      0.311 ± 0.308 … 0.313              0.308 ± 0.305 … 0.309              -0.2% (-0.2 MB)
Kraken          audio-oscillator.js                       0.949      0.335 ± 0.328 … 0.340              0.353 ± 0.330 … 0.392              +0.0% (+0.0 MB)
Kraken          imaging-darkroom.js                       1.004      0.459 ± 0.452 … 0.464              0.457 ± 0.452 … 0.461              +0.0% (+0.0 MB)
Kraken          imaging-desaturate.js                     1.004      0.551 ± 0.548 … 0.555              0.549 ± 0.543 … 0.556              +0.1% (+0.1 MB)
Kraken          imaging-gaussian-blur.js                  1.009      2.090 ± 2.067 … 2.102              2.072 ± 2.064 … 2.082              +0.2% (+0.2 MB)
Kraken          json-parse-financial.js                   0.987      0.036 ± 0.035 … 0.038              0.037 ± 0.036 … 0.038              -0.3% (-0.2 MB)
Kraken          json-stringify-tinderbox.js               1.031      0.051 ± 0.049 … 0.054              0.049 ± 0.048 … 0.052              +0.1% (+0.1 MB)
Kraken          stanford-crypto-aes.js                    0.984      0.154 ± 0.152 … 0.158              0.157 ± 0.155 … 0.160              +0.3% (+0.2 MB)
Kraken          stanford-crypto-ccm.js                    1.068      0.131 ± 0.126 … 0.136              0.123 ± 0.118 … 0.130              +0.4% (+0.3 MB)
Kraken          stanford-crypto-pbkdf2.js                 1.002      0.289 ± 0.287 … 0.292              0.288 ± 0.286 … 0.289              -0.3% (-0.2 MB)
Kraken          stanford-crypto-sha256-iterative.js       0.957      0.107 ± 0.106 … 0.110              0.112 ± 0.107 … 0.115              -0.3% (-0.2 MB)
Octane          box2d.js                                  1.005      9846.667 ± 9812.000 … 9897.000     9900.667 ± 9812.000 … 10012.000    -0.1% (-0.1 MB)
Octane          code-load.js                              1.199      21217.333 ± 19707.000 … 23032.000  25447.667 ± 25167.000 … 25806.000  +23.6% (+336.5 MB)
Octane          crypto.js                                 1.000      5204.000 ± 5114.000 … 5328.000     5206.333 ± 5102.000 … 5319.000     -0.3% (-0.2 MB)
Octane          deltablue.js                              1.010      2711.333 ± 2686.000 … 2757.000     2737.667 ± 2715.000 … 2757.000     -0.3% (-0.2 MB)
Octane          earley-boyer.js                           0.996      5572.000 ± 5521.000 … 5640.000     5550.333 ± 5489.000 … 5613.000     +2.5% (+1.7 MB)
Octane          gbemu.js                                  1.008      20469.667 ± 20183.000 … 20926.000  20639.333 ± 20478.000 … 20740.000  -0.0% (-0.1 MB)
Octane          mandreel.js                               1.008      20384.333 ± 19783.000 … 20685.000  20544.333 ± 20348.000 … 20685.000  +0.0% (+0.1 MB)
Octane          navier-stokes.js                          0.993      6103.000 ± 6099.000 … 6111.000     6060.000 ± 6048.000 … 6078.000     -0.3% (-0.2 MB)
Octane          pdfjs.js                                  0.989      10357.000 ± 10351.000 … 10360.000  10246.000 ± 10180.000 … 10293.000  +1.3% (+2.4 MB)
Octane          raytrace.js                               0.974      3647.667 ± 3565.000 … 3704.000     3551.667 ± 3457.000 … 3612.000     -0.3% (-0.2 MB)
Octane          regexp.js                                 1.014      2453.333 ± 2402.000 … 2513.000     2488.000 ± 2428.000 … 2518.000     +3.4% (+2.6 MB)
Octane          richards.js                               1.004      3157.333 ± 3149.000 … 3163.000     3169.000 ± 3110.000 … 3241.000     -0.3% (-0.2 MB)
Octane          splay.js                                  1.022      9459.000 ± 9304.000 … 9651.000     9668.667 ± 9651.000 … 9688.000     -0.0% (-0.2 MB)
Octane          typescript.js                             1.001      29779.667 ± 29652.000 … 29910.000  29821.667 ± 29673.000 … 29924.000  +0.1% (+0.3 MB)
Octane          zlib.js                                   0.993      8824.667 ± 8639.000 … 8964.000     8761.667 ± 8662.000 … 8817.000     -0.1% (-0.1 MB)
GarBench        array-of-objects.js                       1.025      0.699 ± 0.685 … 0.709              0.682 ± 0.675 … 0.690              -0.0% (-0.1 MB)
GarBench        closures.js                               1.021      0.930 ± 0.926 … 0.938              0.911 ± 0.898 … 0.923              -0.0% (-0.0 MB)
GarBench        cyclic-graph.js                           0.998      1.340 ± 1.321 … 1.364              1.343 ± 1.324 … 1.364              -0.0% (-0.1 MB)
GarBench        deep-linked-list.js                       1.011      0.664 ± 0.660 … 0.670              0.657 ± 0.648 … 0.666              +0.0% (+0.0 MB)
GarBench        finalization.js                           1.060      0.850 ± 0.814 … 0.907              0.801 ± 0.789 … 0.811              +0.0% (+0.2 MB)
GarBench        many-properties.js                        1.002      1.779 ± 1.765 … 1.796              1.775 ± 1.766 … 1.783              -0.0% (-0.3 MB)
GarBench        marking-stress.js                         1.091      1.055 ± 0.958 … 1.239              0.967 ± 0.941 … 1.001              +0.0% (+0.1 MB)
GarBench        mixed-sizes.js                            0.970      0.774 ± 0.771 … 0.778              0.798 ± 0.774 … 0.843              +0.0% (+0.0 MB)
GarBench        sparse-arrays.js                          0.990      2.019 ± 1.990 … 2.075              2.039 ± 1.992 … 2.088              +0.0% (+0.0 MB)
GarBench        string-heavy.js                           0.990      0.969 ± 0.964 … 0.977              0.978 ± 0.966 … 0.990              -0.0% (-0.1 MB)
GarBench        wide-tree.js                              1.005      1.002 ± 0.987 … 1.019              0.997 ± 0.989 … 1.004              -0.0% (-0.0 MB)
JetStream       bigfib.cpp.js                             1.004      3.437 ± 3.410 … 3.468              3.424 ± 3.374 … 3.518              -1.1% (-2.7 MB)
JetStream       cdjs.js                                   1.027      1.646 ± 1.638 … 1.657              1.604 ± 1.576 … 1.632              -0.3% (-0.2 MB)
JetStream       container.cpp.js                          1.012      15.172 ± 14.993 … 15.456           14.993 ± 14.813 … 15.111           +0.1% (+0.1 MB)
JetStream       dry.c.js                                  1.010      7.864 ± 7.826 … 7.886              7.783 ± 7.690 … 7.859              +0.5% (+0.3 MB)
JetStream       float-mm.c.js                             1.004      11.987 ± 11.935 … 12.072           11.938 ± 11.919 … 11.963           +0.1% (+0.1 MB)
JetStream       gcc-loops.cpp.js                          0.983      47.301 ± 47.123 … 47.637           48.102 ± 47.445 … 48.822           +0.1% (+0.1 MB)
JetStream       hash-map.js                               1.017      0.754 ± 0.743 … 0.773              0.741 ± 0.718 … 0.763              -0.0% (-0.0 MB)
JetStream       n-body.c.js                               0.988      14.304 ± 14.164 … 14.463           14.479 ± 14.129 … 14.660           +0.5% (+0.3 MB)
JetStream       quicksort.c.js                            0.993      2.215 ± 2.146 … 2.351              2.230 ± 2.154 … 2.291              +0.3% (+0.2 MB)
JetStream       towers.c.js                               1.014      4.789 ± 4.715 … 4.833              4.720 ± 4.647 … 4.845              +0.3% (+0.2 MB)
JetStream3      js-tokens.js                              1.174      0.214 ± 0.210 … 0.217              0.183 ± 0.181 … 0.184              -0.3% (-0.2 MB)
JetStream3      lazy-collections.js                       1.001      0.643 ± 0.638 … 0.652              0.643 ± 0.635 … 0.652              -0.3% (-0.2 MB)
JetStream3      raytrace-private-class-fields.js          1.017      3.450 ± 3.400 … 3.492              3.393 ± 3.362 … 3.425              -0.3% (-0.2 MB)
JetStream3      raytrace-public-class-fields.js           1.003      2.300 ± 2.272 … 2.317              2.292 ± 2.266 … 2.307              -0.3% (-0.2 MB)
JetStream3      sync-file-system.js                       0.978      1.529 ± 1.526 … 1.530              1.563 ± 1.551 … 1.577              -0.3% (-0.2 MB)
JetStreamExtra  FlightPlanner.js                          1.079      0.750 ± 0.741 … 0.757              0.695 ± 0.691 … 0.699              +0.0% (+0.1 MB)
JetStreamExtra  OfflineAssembler.js                       1.029      0.860 ± 0.854 … 0.871              0.836 ± 0.830 … 0.839              +0.0% (+0.0 MB)
JetStreamExtra  UniPoker.js                               1.069      1.509 ± 1.483 … 1.546              1.411 ± 1.403 … 1.421              -0.3% (-0.2 MB)
JetStreamExtra  async-fs.js                               0.999      1.239 ± 1.226 … 1.263              1.241 ± 1.219 … 1.279              -0.4% (-0.3 MB)
JetStreamExtra  babylonjs-startup-es5.js                  0.996      0.715 ± 0.713 … 0.718              0.718 ± 0.713 … 0.726              -0.5% (-3.5 MB)
JetStreamExtra  babylonjs-startup-es6.js                  1.001      0.839 ± 0.835 … 0.844              0.839 ± 0.835 … 0.844              +0.4% (+3.4 MB)
JetStreamExtra  bigint-bigdenary.js                       1.024      1.389 ± 1.369 … 1.415              1.357 ± 1.353 … 1.361              -0.3% (-0.2 MB)
JetStreamExtra  bigint-noble-bls12-381.js                 1.007      1.670 ± 1.643 … 1.699              1.659 ± 1.643 … 1.683              +0.3% (+0.3 MB)
JetStreamExtra  bigint-noble-ed25519.js                   1.004      1.570 ± 1.566 … 1.573              1.564 ± 1.553 … 1.578              +0.1% (+0.1 MB)
JetStreamExtra  bigint-noble-secp256k1.js                 1.012      1.470 ± 1.468 … 1.475              1.453 ± 1.444 … 1.463              +0.2% (+0.2 MB)
JetStreamExtra  bigint-paillier.js                        0.997      1.509 ± 1.503 … 1.520              1.514 ± 1.492 … 1.535              +0.3% (+0.3 MB)
JetStreamExtra  doxbee-async.js                           1.015      4.594 ± 4.581 … 4.619              4.527 ± 4.498 … 4.555              -1.5% (-2.0 MB)
JetStreamExtra  doxbee-promise.js                         1.004      3.611 ± 3.599 … 3.627              3.596 ± 3.587 … 3.605              +0.4% (+0.8 MB)
JetStreamExtra  first-inspector-code-load.js              1.239      1.791 ± 1.756 … 1.848              1.445 ± 1.428 … 1.461              +3.0% (+50.4 MB)
JetStreamExtra  jsdom-d3-startup.js                       1.006      0.949 ± 0.939 … 0.953              0.943 ± 0.932 … 0.952              +0.0% (+0.2 MB)
JetStreamExtra  json-parse-inspector.js                   1.000      0.520 ± 0.520 … 0.520              0.520 ± 0.515 … 0.524              -0.0% (-0.1 MB)
JetStreamExtra  json-stringify-inspector.js               1.022      0.563 ± 0.558 … 0.567              0.551 ± 0.543 … 0.560              +0.0% (+0.0 MB)
JetStreamExtra  mobx-startup.js                           1.008      1.443 ± 1.434 … 1.448              1.431 ± 1.422 … 1.441              +0.7% (+0.6 MB)
JetStreamExtra  multi-inspector-code-load.js              1.214      1.752 ± 1.722 … 1.771              1.444 ± 1.441 … 1.448              +2.3% (+38.6 MB)
JetStreamExtra  prismjs-startup-es5.js                    1.001      1.406 ± 1.400 … 1.409              1.404 ± 1.378 … 1.428              +2.0% (+1.5 MB)
JetStreamExtra  prismjs-startup-es6.js                    1.044      1.446 ± 1.444 … 1.449              1.385 ± 1.382 … 1.391              +3.7% (+2.7 MB)
JetStreamExtra  proxy-mobx.js                             1.002      1.096 ± 1.082 … 1.106              1.094 ± 1.086 … 1.107              -0.1% (-0.1 MB)
JetStreamExtra  proxy-vue.js                              1.156      0.051 ± 0.048 … 0.057              0.044 ± 0.043 … 0.047              -0.3% (-0.2 MB)
JetStreamExtra  threejs.js                                0.985      1.395 ± 1.388 … 1.405              1.416 ± 1.412 … 1.419              +0.1% (+0.3 MB)
JetStreamExtra  typescript-lib.js                         1.024      0.524 ± 0.511 … 0.541              0.512 ± 0.510 … 0.513              +0.1% (+0.5 MB)
JetStreamExtra  validatorjs.js                            1.043      1.220 ± 1.201 … 1.250              1.170 ± 1.161 … 1.188              +0.1% (+0.1 MB)
JetStreamExtra  web-ssr.js                                0.994      1.408 ± 1.399 … 1.422              1.417 ± 1.392 … 1.431              -0.5% (-1.6 MB)
ARES-6          Air.js                                    1.005      1.347 ± 1.335 … 1.357              1.341 ± 1.336 … 1.349              -0.0% (-0.1 MB)
ARES-6          Babylon.js                                1.012      0.975 ± 0.964 … 0.994              0.964 ± 0.960 … 0.971              -1.0% (-1.0 MB)
ARES-6          Basic.js                                  1.011      1.063 ± 1.049 … 1.070              1.052 ± 1.047 … 1.056              +0.4% (+0.3 MB)
ARES-6          ML.js                                     0.999      1.246 ± 1.234 … 1.261              1.247 ± 1.237 … 1.265              +0.2% (+0.1 MB)
RegExp          speedometer-jquery-regexp-1.js            2.858      0.152 ± 0.145 … 0.157              0.053 ± 0.051 … 0.056              -0.3% (-0.2 MB)
RegExp          speedometer-jquery-regexp-2.js            1.025      0.069 ± 0.064 … 0.078              0.067 ± 0.067 … 0.069              -0.3% (-0.2 MB)
MicroBench      array-destructuring-assignment-rest.js    0.966      0.265 ± 0.256 … 0.279              0.275 ± 0.273 … 0.276              -0.3% (-0.2 MB)
MicroBench      array-destructuring-assignment.js         1.112      2.537 ± 2.224 … 3.020              2.281 ± 2.262 … 2.292              +0.0% (+0.5 MB)
MicroBench      array-dictionary-to-packed.js             0.991      0.084 ± 0.082 … 0.088              0.085 ± 0.084 … 0.086              +0.0% (+0.0 MB)
MicroBench      array-prototype-map.js                    1.019      1.095 ± 1.081 … 1.116              1.075 ± 1.055 … 1.100              -0.0% (-0.0 MB)
MicroBench      array-prototype-shift.js                  0.900      0.012 ± 0.012 … 0.013              0.014 ± 0.012 … 0.017              -0.3% (-0.2 MB)
MicroBench      bound-call-00-args.js                     0.994      0.965 ± 0.952 … 0.977              0.971 ± 0.944 … 1.020              -0.3% (-0.2 MB)
MicroBench      bound-call-04-args.js                     1.008      1.062 ± 1.020 … 1.108              1.054 ± 1.014 … 1.102              -0.3% (-0.2 MB)
MicroBench      bound-call-16-args.js                     1.027      1.242 ± 1.194 … 1.274              1.209 ± 1.188 … 1.220              -0.3% (-0.2 MB)
MicroBench      call-00-args.js                           1.016      0.314 ± 0.309 … 0.320              0.309 ± 0.306 … 0.313              -0.3% (-0.2 MB)
MicroBench      call-01-args.js                           0.994      0.357 ± 0.354 … 0.359              0.359 ± 0.355 … 0.367              -0.3% (-0.2 MB)
MicroBench      call-02-args.js                           1.022      0.376 ± 0.371 … 0.382              0.368 ± 0.364 … 0.372              -0.3% (-0.2 MB)
MicroBench      call-03-args.js                           1.016      0.382 ± 0.371 … 0.390              0.376 ± 0.371 … 0.383              -0.3% (-0.2 MB)
MicroBench      call-04-args.js                           1.001      0.389 ± 0.384 … 0.398              0.389 ± 0.386 … 0.392              -0.3% (-0.2 MB)
MicroBench      call-16-args.js                           0.998      0.526 ± 0.519 … 0.533              0.527 ± 0.522 … 0.535              -0.3% (-0.2 MB)
MicroBench      call-32-args.js                           1.079      0.872 ± 0.830 … 0.921              0.809 ± 0.745 … 0.846              -0.3% (-0.2 MB)
MicroBench      for-in-indexed-properties.js              0.997      0.184 ± 0.177 … 0.187              0.184 ± 0.180 … 0.189              -0.0% (-0.0 MB)
MicroBench      for-in-named-properties.js                0.983      0.146 ± 0.143 … 0.149              0.148 ± 0.147 … 0.150              -0.3% (-0.2 MB)
MicroBench      for-of.js                                 1.010      0.431 ± 0.430 … 0.432              0.427 ± 0.423 … 0.432              -0.3% (-0.2 MB)
MicroBench      object-keys.js                            1.036      0.894 ± 0.863 … 0.947              0.863 ± 0.861 … 0.864              -0.0% (-0.0 MB)
MicroBench      object-set-with-rope-strings.js           1.009      0.421 ± 0.412 … 0.430              0.417 ± 0.414 … 0.424              -0.3% (-0.2 MB)
MicroBench      object-spread.js                          1.006      0.277 ± 0.274 … 0.280              0.276 ± 0.273 … 0.279              -0.3% (-0.2 MB)
MicroBench      pic-add-own.js                            0.992      0.559 ± 0.556 … 0.563              0.563 ± 0.560 … 0.565              -0.3% (-0.2 MB)
MicroBench      pic-get-absent.js                         0.982      0.269 ± 0.263 … 0.273              0.274 ± 0.271 … 0.276              -0.3% (-0.2 MB)
MicroBench      pic-get-own.js                            0.986      0.465 ± 0.460 … 0.471              0.471 ± 0.460 … 0.484              -0.3% (-0.2 MB)
MicroBench      pic-get-pchain.js                         1.004      0.466 ± 0.457 … 0.475              0.464 ± 0.461 … 0.466              -0.3% (-0.2 MB)
MicroBench      pic-put-own.js                            1.005      0.452 ± 0.445 … 0.458              0.450 ± 0.444 … 0.459              -0.3% (-0.2 MB)
MicroBench      pic-put-pchain.js                         1.034      1.338 ± 1.301 … 1.375              1.295 ± 1.275 … 1.326              -0.3% (-0.2 MB)
MicroBench      proxy-call-00-args.js                     1.039      1.178 ± 1.144 … 1.200              1.134 ± 1.084 … 1.177              -0.3% (-0.2 MB)
MicroBench      proxy-call-01-args.js                     1.024      1.084 ± 1.077 … 1.091              1.059 ± 1.027 … 1.086              -0.3% (-0.2 MB)
MicroBench      proxy-call-04-args.js                     0.998      1.084 ± 1.079 … 1.090              1.086 ± 1.079 … 1.095              -0.3% (-0.2 MB)
MicroBench      proxy-call-no-trap.js                     1.015      0.525 ± 0.511 … 0.546              0.518 ± 0.496 … 0.531              -0.3% (-0.2 MB)
MicroBench      proxy-get-trap-with-bind.js               1.016      5.943 ± 5.801 … 6.030              5.848 ± 5.794 … 5.930              -0.6% (-0.4 MB)
MicroBench      proxy-get-trap.js                         0.993      1.123 ± 1.114 … 1.137              1.131 ± 1.117 … 1.140              -0.3% (-0.2 MB)
MicroBench      proxy-nested-call.js                      1.011      2.645 ± 2.564 … 2.692              2.617 ± 2.563 … 2.689              -0.3% (-0.2 MB)
MicroBench      setter-in-prototype-chain.js              1.017      1.429 ± 1.390 … 1.449              1.404 ± 1.364 … 1.452              -0.3% (-0.2 MB)
MicroBench      short-string-concat.js                    0.986      0.230 ± 0.227 … 0.233              0.233 ± 0.230 … 0.236              -0.3% (-0.2 MB)
MicroBench      strictly-equals-object.js                 1.051      0.583 ± 0.552 … 0.640              0.555 ± 0.554 … 0.557              -0.3% (-0.2 MB)
MicroBench      typed-array-prototype-set-equal-width.js  0.983      0.030 ± 0.029 … 0.031              0.031 ± 0.030 … 0.033              -0.0% (-0.0 MB)
AsyncBench      async-call-return.js                      1.025      0.143 ± 0.136 … 0.149              0.139 ± 0.137 … 0.143              -0.3% (-0.2 MB)
AsyncBench      async-class-method.js                     1.001      0.315 ± 0.313 … 0.319              0.315 ± 0.310 … 0.321              -0.3% (-0.2 MB)
AsyncBench      async-fan-out.js                          1.002      0.103 ± 0.097 … 0.108              0.103 ± 0.102 … 0.104              -0.3% (-0.2 MB)
AsyncBench      async-generator.js                        0.978      0.170 ± 0.168 … 0.174              0.174 ± 0.172 … 0.177              -0.3% (-0.2 MB)
AsyncBench      async-iife.js                             1.006      0.243 ± 0.236 … 0.251              0.241 ± 0.236 … 0.247              -0.3% (-0.2 MB)
AsyncBench      async-nested-calls.js                     1.017      0.390 ± 0.383 … 0.399              0.383 ± 0.375 … 0.393              -0.3% (-0.2 MB)
AsyncBench      async-pipeline.js                         1.013      0.202 ± 0.198 … 0.207              0.200 ± 0.197 … 0.205              -0.3% (-0.2 MB)
AsyncBench      async-sequential-awaits.js                0.990      0.112 ± 0.111 … 0.113              0.113 ± 0.112 … 0.115              -0.3% (-0.2 MB)
AsyncBench      async-try-catch-reject.js                 1.021      0.266 ± 0.262 … 0.269              0.260 ± 0.259 … 0.262              -0.3% (-0.2 MB)
AsyncBench      await-primitive.js                        1.063      0.047 ± 0.045 … 0.049              0.044 ± 0.043 … 0.046              -0.3% (-0.2 MB)
AsyncBench      await-resolved-promise.js                 0.994      0.094 ± 0.089 … 0.097              0.094 ± 0.093 … 0.096              -0.3% (-0.2 MB)
AsyncBench      await-thenable.js                         1.011      0.534 ± 0.512 … 0.567              0.528 ± 0.512 … 0.540              -0.3% (-0.2 MB)
AsyncBench      promise-all.js                            1.011      0.283 ± 0.281 … 0.285              0.280 ± 0.276 … 0.287              -0.3% (-0.2 MB)
AsyncBench      promise-allSettled.js                     1.004      0.346 ± 0.340 … 0.351              0.344 ± 0.340 … 0.350              -0.3% (-0.2 MB)
AsyncBench      promise-chain.js                          0.994      0.147 ± 0.145 … 0.151              0.148 ± 0.147 … 0.150              +0.0% (+0.0 MB)
AsyncBench      promise-new-resolve.js                    0.996      0.212 ± 0.211 … 0.214              0.213 ± 0.211 … 0.215              -0.3% (-0.2 MB)
AsyncBench      promise-race.js                           1.007      0.312 ± 0.310 … 0.315              0.310 ± 0.306 … 0.315              -0.3% (-0.2 MB)
WebsitesParse   discord-web-2026-04-03.js                 1.003      0.567 ± 0.563 … 0.572              0.565 ± 0.559 … 0.570              +0.0% (+0.1 MB)
WebsitesParse   google-docs-2026-04-03.js                 1.007      1.138 ± 1.129 … 1.154              1.130 ± 1.130 … 1.131              -0.0% (-0.0 MB)
WebsitesParse   instagram-main-2026-04-03.js              0.999      0.304 ± 0.303 … 0.306              0.304 ± 0.304 … 0.305              +0.2% (+0.6 MB)
WebsitesParse   vscode-workbench-2026-04-03.js            0.995      0.656 ± 0.654 … 0.659              0.660 ± 0.655 … 0.666              +0.1% (+0.6 MB)
WebsitesRun     discord-web-2026-04-03.js                 1.001      0.609 ± 0.598 … 0.620              0.609 ± 0.607 … 0.611              +0.0% (+0.3 MB)
WebsitesRun     google-docs-2026-04-03.js                 0.988      1.531 ± 1.525 … 1.539              1.549 ± 1.542 … 1.556              +0.1% (+1.6 MB)
WebsitesRun     instagram-main-2026-04-03.js              1.001      0.309 ± 0.308 … 0.310              0.308 ± 0.307 … 0.310              +0.1% (+0.2 MB)
WebsitesRun     vscode-workbench-2026-04-03.js            0.985      0.857 ± 0.848 … 0.869              0.870 ± 0.855 … 0.883              -0.6% (-5.3 MB)
SunSpider       Total                                     1.034      0.636                              0.615                              -0.2% (-3.6 MB)
LongSpider      Total                                     1.013      58.285                             57.554                             -0.1% (-3.3 MB)
Kraken          Total                                     1.005      5.696                              5.670                              -0.0% (-0.2 MB)
Octane          Total                                     1.029      159187.000                         163793.000                         +9.4% (+342.3 MB)
GarBench        Total                                     1.011      12.080                             11.948                             -0.0% (-0.2 MB)
JetStream       Total                                     0.995      109.469                            110.014                            -0.2% (-1.6 MB)
JetStream3      Total                                     1.008      8.136                              8.073                              -0.3% (-0.8 MB)
JetStreamExtra  Total                                     1.031      37.291                             36.185                             +1.0% (+92.1 MB)
ARES-6          Total                                     1.006      4.631                              4.603                              -0.1% (-0.7 MB)
RegExp          Total                                     1.833      0.221                              0.121                              -0.3% (-0.3 MB)
MicroBench      Total                                     1.022      32.236                             31.546                             -0.1% (-4.8 MB)
AsyncBench      Total                                     1.007      3.920                              3.891                              -0.2% (-2.5 MB)
WebsitesParse   Total                                     1.002      2.665                              2.659                              +0.0% (+1.2 MB)
WebsitesRun     Total                                     0.991      3.306                              3.336                              -0.1% (-3.2 MB)
All Suites      Total                                     1.007      330.512                            328.156                            +1.0% (+414.5 MB)
```