### PR TITLE
LibWeb: Trim allocations and repeated work in the Rust style engine

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -280,7 +280,7 @@ impl ComputedLonghandTable {
         self.raw_cascaded_font_size = value;
     }
 
-    fn copy_from(&mut self, source: &ComputedLonghandTable) {
+    fn copy_values_and_metadata_from(&mut self, source: &ComputedLonghandTable) {
         assert!(
             !self.frozen,
             "the computed longhand table is immutable once its style is created"
@@ -292,10 +292,14 @@ impl ComputedLonghandTable {
         self.inherited_bits = source.inherited_bits;
         self.evaluated_bits = source.evaluated_bits;
         self.metadata = source.metadata;
-        self.inheritance_dependent.clone_from(&source.inheritance_dependent);
         self.raw_cascaded_font_size.clone_from(&source.raw_cascaded_font_size);
-        self.rebuild_inheritance_dependent_view();
         self.post_compute_restore_values = None;
+    }
+
+    fn copy_from(&mut self, source: &ComputedLonghandTable) {
+        self.copy_values_and_metadata_from(source);
+        self.inheritance_dependent.clone_from(&source.inheritance_dependent);
+        self.rebuild_inheritance_dependent_view();
     }
 
     /// Take one slot back from `source`: its value, provenance and flags, exactly as stored there.
@@ -319,8 +323,8 @@ impl ComputedLonghandTable {
 
     pub(crate) fn copied_for_drive(source: &ComputedLonghandTable) -> Self {
         let mut table = Self::new();
-        table.copy_from(source);
-        table.clear_seeded_state();
+        table.copy_values_and_metadata_from(source);
+        table.evaluated_bits = [0; LONGHAND_BITMAP_BYTES];
         table
     }
 

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -403,14 +403,16 @@ impl ComputedLonghandTable {
     }
 
     fn rebuild_inheritance_dependent_view(&mut self) {
-        self.inheritance_dependent_view = self
-            .inheritance_dependent
-            .iter()
-            .map(|(property, value)| FfiTableInheritanceDependentValue {
-                property: *property,
-                value: value.pointer().cast(),
-            })
-            .collect();
+        self.inheritance_dependent_view.clear();
+        self.inheritance_dependent_view
+            .extend(
+                self.inheritance_dependent
+                    .iter()
+                    .map(|(property, value)| FfiTableInheritanceDependentValue {
+                        property: *property,
+                        value: value.pointer().cast(),
+                    }),
+            );
     }
 
     /// Reset the state a fresh drive must not inherit from the style its

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -565,18 +565,18 @@ impl ComputedLonghandTable {
                     && !second.is_null()
                     && unsafe { crate::css::style_value::rust_style_value_equals(first.cast(), second.cast()) })
         };
-        self.value_view
-            .iter()
-            .zip(&other.value_view)
-            .all(|(&first, &second)| values_equal(first, second))
-            && self.evaluated_bits == other.evaluated_bits
-            && self.important_bits == other.important_bits
+        self.important_bits == other.important_bits
             && self.inherited_bits == other.inherited_bits
             && self.publication_sidecars() == other.publication_sidecars()
             && self.publication_dependency_flags() == other.publication_dependency_flags()
             && self.pseudo_element_styles() == other.pseudo_element_styles()
-            && values_equal(self.raw_cascaded_font_size(), other.raw_cascaded_font_size())
             && self.inheritance_dependent.len() == other.inheritance_dependent.len()
+            && self
+                .value_view
+                .iter()
+                .zip(&other.value_view)
+                .all(|(&first, &second)| values_equal(first, second))
+            && values_equal(self.raw_cascaded_font_size(), other.raw_cascaded_font_size())
             && self.inheritance_dependent.iter().all(|(property, value)| {
                 other
                     .inheritance_dependent

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -325,10 +325,10 @@ impl ComputedLonghandTable {
     }
 
     pub(crate) fn copied_for_partial_drive(source: &ComputedLonghandTable) -> Self {
-        let mut table = Self::copied_for_drive(source);
-        table.inheritance_dependent.clone_from(&source.inheritance_dependent);
+        let mut table = Self::new();
+        table.copy_from(source);
+        table.evaluated_bits = [0; LONGHAND_BITMAP_BYTES];
         table.inheritance_dependent_is_seeded = true;
-        table.rebuild_inheritance_dependent_view();
         table.set_in_display_none_subtree(false);
         table
     }

--- a/Libraries/LibWeb/Rust/src/css/property_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/css/property_metadata.rs
@@ -30,22 +30,24 @@ pub(crate) fn property_name(property_id: u16) -> &'static str {
         .unwrap_or("<unknown>")
 }
 
-fn compare_property_name(candidate: &str, name: &[u16]) -> std::cmp::Ordering {
-    candidate
-        .bytes()
-        .map(u16::from)
-        .cmp(name.iter().copied().map(crate::css::ffi_support::ascii_lowercase))
+fn compare_property_name<T: Copy + Into<u16>>(candidate: &str, name: &[T]) -> std::cmp::Ordering {
+    candidate.bytes().map(u16::from).cmp(
+        name.iter()
+            .copied()
+            .map(Into::into)
+            .map(crate::css::ffi_support::ascii_lowercase),
+    )
 }
 
-pub(crate) fn is_custom_property_name(name: &[u16]) -> bool {
-    name.len() > 2 && name[0] == u16::from(b'-') && name[1] == u16::from(b'-')
+pub(crate) fn is_custom_property_name<T: Copy + Into<u16>>(name: &[T]) -> bool {
+    name.len() > 2 && name[0].into() == u16::from(b'-') && name[1].into() == u16::from(b'-')
 }
 
 // NB: This mirrors the property-name resolution formerly performed by
 //     CSS/Parser/RustSyntaxParsing.cpp:106 and CSS/Parser/RustQueryParsing.cpp:63.
 //     Legacy aliases are accepted by the generated table, while custom property
 //     names map to PropertyID::Custom.
-pub(crate) fn property_id_from_name(name: &[u16]) -> Option<u16> {
+pub(crate) fn property_id_from_name<T: Copy + Into<u16>>(name: &[T]) -> Option<u16> {
     if is_custom_property_name(name) {
         return Some(property_id::CUSTOM);
     }

--- a/Libraries/LibWeb/Rust/src/css/style/atoms.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/atoms.rs
@@ -389,6 +389,12 @@ impl DocumentAtoms {
     }
 
     pub(super) fn finish_sweep(&mut self, reclaimable: &[StyleAtomID]) -> Vec<ReclaimedStyleAtom> {
+        self.pins.releases.set(0);
+        self.reported_pin_releases.set(0);
+        if reclaimable.is_empty() {
+            self.sweep_at = self.raw.len() + self.qualified.len() + 256;
+            return Vec::new();
+        }
         let reclaimable = reclaimable.iter().copied().collect::<HashSet<_>>();
         let mut raw = Vec::new();
         self.raw.retain(|&identity, &mut atom| {
@@ -426,8 +432,6 @@ impl DocumentAtoms {
         }
 
         self.sweep_at = self.raw.len() + self.qualified.len() + 256;
-        self.pins.releases.set(0);
-        self.reported_pin_releases.set(0);
         let mut reclaimed = raw
             .into_iter()
             .map(|(raw, atom)| ReclaimedStyleAtom {

--- a/Libraries/LibWeb/Rust/src/css/style/atoms.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/atoms.rs
@@ -133,16 +133,16 @@ impl GlobalAtoms {
     }
 
     fn release_raw(&mut self, raw: usize, expected: StyleAtomID) {
-        let entry = self
-            .raw
-            .get_mut(&raw)
-            .expect("a document must release a live global atom");
+        let Entry::Occupied(mut occupied) = self.raw.entry(raw) else {
+            unreachable!("a document must release a live global atom");
+        };
+        let entry = occupied.get_mut();
         assert_eq!(entry.atom, expected);
         entry.document_references -= 1;
         if entry.document_references != 0 {
             return;
         }
-        let entry = self.raw.remove(&raw).unwrap();
+        let entry = occupied.remove();
         self.available.insert(entry.atom.0);
         if entry.raw_lifetime == Some(RawAtomLifetime::RetainedFlyString) {
             // SAFETY: acquire_raw retained exactly one global reference for this entry.
@@ -154,16 +154,16 @@ impl GlobalAtoms {
     }
 
     fn release_qualified(&mut self, key: (u32, u32), expected: StyleAtomID) {
-        let entry = self
-            .qualified
-            .get_mut(&key)
-            .expect("a document must release a live global qualified atom");
+        let Entry::Occupied(mut occupied) = self.qualified.entry(key) else {
+            unreachable!("a document must release a live global qualified atom");
+        };
+        let entry = occupied.get_mut();
         assert_eq!(entry.atom, expected);
         entry.document_references -= 1;
         if entry.document_references != 0 {
             return;
         }
-        let entry = self.qualified.remove(&key).unwrap();
+        let entry = occupied.remove();
         self.available.insert(entry.atom.0);
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/style/atoms.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/atoms.rs
@@ -9,6 +9,7 @@ use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::hash_map::Entry;
 use std::hash::BuildHasher;
 use std::rc::Rc;
 use std::sync::Mutex;
@@ -196,7 +197,7 @@ pub(super) struct DocumentAtoms {
 }
 
 pub(super) struct PinnedAtoms {
-    atoms: Vec<StyleAtomID>,
+    atoms: Box<[StyleAtomID]>,
     pins: Rc<AtomPins>,
 }
 
@@ -223,10 +224,13 @@ impl Drop for PinnedAtoms {
     fn drop(&mut self) {
         let mut pinned = self.pins.counts.borrow_mut();
         for atom in &self.atoms {
-            let count = pinned.get_mut(atom).expect("a pinned atom must have a live count");
+            let Entry::Occupied(mut entry) = pinned.entry(*atom) else {
+                unreachable!("a pinned atom must have a live count");
+            };
+            let count = entry.get_mut();
             *count = count.checked_sub(1).expect("pinned atom count underflow");
             if *count == 0 {
-                pinned.remove(atom);
+                entry.remove();
             }
         }
         if !self.atoms.is_empty() {
@@ -318,7 +322,7 @@ impl DocumentAtoms {
     }
 
     pub(super) fn pin(&self, atoms: impl IntoIterator<Item = StyleAtomID>) -> PinnedAtoms {
-        let atoms = atoms.into_iter().filter(|atom| !atom.is_none()).collect::<Vec<_>>();
+        let atoms = atoms.into_iter().filter(|atom| !atom.is_none()).collect::<Box<[_]>>();
         let mut pinned = self.pins.counts.borrow_mut();
         for &atom in &atoms {
             *pinned.entry(atom).or_default() += 1;

--- a/Libraries/LibWeb/Rust/src/css/style/atoms.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/atoms.rs
@@ -222,6 +222,9 @@ pub(super) const PIN_RELEASES_PER_SWEEP: u64 = 256;
 
 impl Drop for PinnedAtoms {
     fn drop(&mut self) {
+        if self.atoms.is_empty() {
+            return;
+        }
         let mut pinned = self.pins.counts.borrow_mut();
         for atom in &self.atoms {
             let Entry::Occupied(mut entry) = pinned.entry(*atom) else {
@@ -233,15 +236,13 @@ impl Drop for PinnedAtoms {
                 entry.remove();
             }
         }
-        if !self.atoms.is_empty() {
-            self.pins.releases.set(
-                self.pins
-                    .releases
-                    .get()
-                    .checked_add(1)
-                    .expect("atom pin release count overflow"),
-            );
-        }
+        self.pins.releases.set(
+            self.pins
+                .releases
+                .get()
+                .checked_add(1)
+                .expect("atom pin release count overflow"),
+        );
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
@@ -244,10 +244,7 @@ pub(super) fn scope_dispatch_shape_and_rules(
             for index in 0..compiled.entries().len() {
                 let metadata = compiled.dispatch_metadata(index);
                 let copies = if metadata.key == DispatchKey::Universal {
-                    let mut branch_keys = metadata.subject_dispatch_keys().to_vec();
-                    branch_keys.sort_unstable();
-                    branch_keys.dedup();
-                    branch_keys.len().max(1)
+                    metadata.subject_dispatch_keys().len().max(1)
                 } else {
                     1
                 };
@@ -327,13 +324,8 @@ pub(super) fn insert_scope_rule(
         // routing relies on, and it comes back empty rather than truncated, so an entry is
         // never unreachable from a key it needs.
         let branch_keys = match key {
-            DispatchKey::Universal if !subject_dispatch.is_empty() => {
-                let mut branch_keys = subject_dispatch.to_vec();
-                branch_keys.sort_unstable();
-                branch_keys.dedup();
-                branch_keys
-            }
-            _ => Vec::new(),
+            DispatchKey::Universal => subject_dispatch,
+            _ => &[],
         };
         if branch_keys.is_empty() {
             let dispatch_entry = dispatch.insert(key, template);
@@ -355,7 +347,7 @@ pub(super) fn insert_scope_rule(
             //     match per registered entry, so registering every copy would report the
             //     same rule once per branch key the element carries; the candidate walk
             //     deduplicates them by the rank the copies share instead.
-            for &branch_key in &branch_keys {
+            for &branch_key in branch_keys {
                 dispatch.insert(
                     branch_key,
                     super::index::DispatchEntry {

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -3435,14 +3435,17 @@ pub unsafe extern "C" fn style_engine_record_benchmark_marker(
     if engine.recording_id().is_none() {
         return;
     }
-    let name = match is_ascii {
-        true => unsafe { borrow(name.cast::<u8>(), length) }
-            .iter()
-            .map(|&code_unit| u16::from(code_unit))
-            .collect::<Vec<_>>(),
-        false => unsafe { borrow(name.cast::<u16>(), length) }.to_vec(),
-    };
-    engine.record_boundary_call(EventKind::BenchmarkMarker, |payload| payload.write_u16_slice(&name));
+    engine.record_boundary_call(EventKind::BenchmarkMarker, |payload| {
+        if is_ascii {
+            let name = unsafe { borrow(name.cast::<u8>(), length) };
+            payload.write_length(name.len());
+            for &code_unit in name {
+                payload.write_u16(u16::from(code_unit));
+            }
+        } else {
+            payload.write_u16_slice(unsafe { borrow(name.cast::<u16>(), length) });
+        }
+    });
 }
 
 unsafe fn borrow<'a, T>(pointer: *const T, count: usize) -> &'a [T] {

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1019,18 +1019,18 @@ impl WinnerGroups {
         candidates: &[CascadeCandidate],
         ceilings: &mut Vec<CascadeContinuationCeiling>,
     ) -> Option<PropertyWinner> {
-        let candidate = candidates
+        let index = candidates
             .iter()
-            .rev()
-            .copied()
-            .find(|candidate| ceilings.iter().all(|&ceiling| candidate.stratum.is_below(ceiling)))?;
+            .rposition(|candidate| ceilings.iter().all(|&ceiling| candidate.stratum.is_below(ceiling)))?;
+        let candidate = candidates[index];
         let mut winner = candidate.winner;
         winner.priority = candidate.priority;
         let Some(ceiling) = candidate.stratum.ceiling(candidate.winner.key.operator) else {
             return Some(winner);
         };
         ceilings.push(ceiling);
-        let continuation_winner = self.resolve_candidates_below(candidates, ceilings);
+        // Higher candidates already failed a ceiling, and the new ceiling excludes this one.
+        let continuation_winner = self.resolve_candidates_below(&candidates[..index], ceilings);
         ceilings.pop();
         let continuation = self.intern_continuation(CascadeContinuation {
             ceiling,

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1421,27 +1421,34 @@ impl WinnerGroups {
     /// priority changed.
     #[must_use]
     pub fn semantic_delta(&self, previous: Option<CascadeStateID>, current: CascadeStateID) -> CascadeWinnerDelta {
+        if previous == Some(current) {
+            return CascadeWinnerDelta::default();
+        }
+        CascadeWinnerDelta {
+            properties: self.semantic_delta_properties(previous, current).collect(),
+        }
+    }
+
+    /// Iterate changed properties in order without allocating a delta list.
+    pub(super) fn semantic_delta_properties(
+        &self,
+        previous: Option<CascadeStateID>,
+        current: CascadeStateID,
+    ) -> impl Iterator<Item = PropertyID> {
         let previous: &[WinnerGroupRef] = previous.map_or(&[], |state| &self.states[state]);
         let current = &self.states[current];
-        let mut properties = Vec::new();
-        for entry in merge_sorted_by(previous, current, |old, new| {
+        merge_sorted_by(previous, current, move |old, new| {
             self.group_bucket(*old).cmp(&self.group_bucket(*new))
-        }) {
-            match entry {
-                SortedMergeEntry::Both(old, new) => {
-                    if old.winners != new.winners {
-                        self.append_group_semantic_delta(Some(old.winners), Some(new.winners), &mut properties);
-                    }
-                }
-                SortedMergeEntry::Left(old) => {
-                    self.append_group_semantic_delta(Some(old.winners), None, &mut properties);
-                }
-                SortedMergeEntry::Right(new) => {
-                    self.append_group_semantic_delta(None, Some(new.winners), &mut properties);
-                }
+        })
+        .filter_map(|entry| match entry {
+            SortedMergeEntry::Both(old, new) if old.winners != new.winners => {
+                Some((Some(old.winners), Some(new.winners)))
             }
-        }
-        CascadeWinnerDelta { properties }
+            SortedMergeEntry::Both(..) => None,
+            SortedMergeEntry::Left(old) => Some((Some(old.winners), None)),
+            SortedMergeEntry::Right(new) => Some((None, Some(new.winners))),
+        })
+        .flat_map(move |(previous, current)| self.group_semantic_delta(previous, current))
     }
 
     /// Hash the set of properties represented by a state, deliberately leaving their values out.
@@ -1461,29 +1468,18 @@ impl WinnerGroups {
             .eq(self.semantic_winners_in_state(right).map(|winner| winner.property))
     }
 
-    fn append_group_semantic_delta(
+    fn group_semantic_delta(
         &self,
         previous: Option<WinnerGroupID>,
         current: Option<WinnerGroupID>,
-        properties: &mut Vec<PropertyID>,
-    ) {
+    ) -> impl Iterator<Item = PropertyID> {
         let previous: &[SemanticPropertyWinner] = previous.map_or(&[], |group| self.groups[group].winners.as_ref());
         let current: &[SemanticPropertyWinner] = current.map_or(&[], |group| self.groups[group].winners.as_ref());
-        for entry in merge_sorted_by(previous, current, |old, new| old.property.cmp(&new.property)) {
-            match entry {
-                SortedMergeEntry::Both(old, new) => {
-                    if old.key != new.key {
-                        properties.push(old.property);
-                    }
-                }
-                SortedMergeEntry::Left(old) => {
-                    properties.push(old.property);
-                }
-                SortedMergeEntry::Right(new) => {
-                    properties.push(new.property);
-                }
-            }
-        }
+        merge_sorted_by(previous, current, |old, new| old.property.cmp(&new.property)).filter_map(|entry| match entry {
+            SortedMergeEntry::Both(old, new) => (old.key != new.key).then_some(old.property),
+            SortedMergeEntry::Left(old) => Some(old.property),
+            SortedMergeEntry::Right(new) => Some(new.property),
+        })
     }
 
     #[must_use]

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1371,16 +1371,18 @@ impl WinnerGroups {
         });
         let group = *groups.get(index)?;
         let winners = &self.groups[group.winners];
-        let provenance = &self.provenance_groups[group.provenance];
         winners
             .binary_search_by_key(&property, |winner| winner.property)
             .ok()
-            .map(|index| PropertyWinner {
-                property: winners[index].property,
-                important: provenance[index].important,
-                key: winners[index].key,
-                priority: self.priorities[provenance[index].priority],
-                source: provenance[index].source,
+            .map(|index| {
+                let provenance = &self.provenance_groups[group.provenance][index];
+                PropertyWinner {
+                    property: winners[index].property,
+                    important: provenance.important,
+                    key: winners[index].key,
+                    priority: self.priorities[provenance.priority],
+                    source: provenance.source,
+                }
             })
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1004,6 +1004,12 @@ impl WinnerGroups {
     /// by `revert` and `revert-layer` operators.
     pub fn resolve_candidates(&mut self, candidates: &mut [CascadeCandidate]) -> Option<PropertyWinner> {
         // CascadePriority is the total declaration order, so equal keys are interchangeable here.
+        let candidate = candidates.iter().max_by_key(|candidate| candidate.priority)?;
+        if candidate.stratum.ceiling(candidate.winner.key.operator).is_none() {
+            let mut winner = candidate.winner;
+            winner.priority = candidate.priority;
+            return Some(winner);
+        }
         candidates.sort_unstable_by_key(|candidate| candidate.priority);
         self.resolve_candidates_below(candidates, &mut Vec::new())
     }

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1448,9 +1448,11 @@ impl WinnerGroups {
     }
 
     pub(super) fn property_shapes_are_equal(&self, left: CascadeStateID, right: CascadeStateID) -> bool {
-        self.semantic_winners_in_state(left)
-            .map(|winner| winner.property)
-            .eq(self.semantic_winners_in_state(right).map(|winner| winner.property))
+        left == right
+            || self
+                .semantic_winners_in_state(left)
+                .map(|winner| winner.property)
+                .eq(self.semantic_winners_in_state(right).map(|winner| winner.property))
     }
 
     fn group_semantic_delta(

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1403,9 +1403,6 @@ impl WinnerGroups {
     /// priority changed.
     #[must_use]
     pub fn semantic_delta(&self, previous: Option<CascadeStateID>, current: CascadeStateID) -> CascadeWinnerDelta {
-        if previous == Some(current) {
-            return CascadeWinnerDelta::default();
-        }
         CascadeWinnerDelta {
             properties: self.semantic_delta_properties(previous, current).collect(),
         }
@@ -1417,8 +1414,14 @@ impl WinnerGroups {
         previous: Option<CascadeStateID>,
         current: CascadeStateID,
     ) -> impl Iterator<Item = PropertyID> {
-        let previous: &[WinnerGroupRef] = previous.map_or(&[], |state| &self.states[state]);
-        let current = &self.states[current];
+        let (previous, current): (&[WinnerGroupRef], &[WinnerGroupRef]) = if previous == Some(current) {
+            (&[], &[])
+        } else {
+            (
+                previous.map_or(&[], |state| self.states[state].as_ref()),
+                self.states[current].as_ref(),
+            )
+        };
         merge_sorted_by(previous, current, move |old, new| {
             self.group_bucket(*old).cmp(&self.group_bucket(*new))
         })

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -836,11 +836,11 @@ impl ShallowCapacityBytes for WinnerRuleReferences {
 /// evicting it changes no semantic version and a later observer reconstructs a state from the
 /// node's cascade input or from the exact cold cascade.
 pub struct WinnerGroups {
-    states: InternTable<CascadeStateID, Vec<WinnerGroupRef>>,
+    states: InternTable<CascadeStateID, Box<[WinnerGroupRef]>>,
     state_reference_counts: Vec<u32>,
-    state_winning_rules: Vec<Vec<RuleID>>,
+    state_winning_rules: Vec<Box<[RuleID]>>,
     groups: InternTable<WinnerGroupID, WinnerGroup>,
-    provenance_groups: InternTable<WinnerProvenanceGroupID, Vec<WinnerProvenance>>,
+    provenance_groups: InternTable<WinnerProvenanceGroupID, Box<[WinnerProvenance]>>,
     priorities: InternTable<CascadePriorityID, CascadePriority>,
     continuations: InternTable<CascadeContinuationID, CascadeContinuation>,
     winner_entry_count: usize,
@@ -876,7 +876,7 @@ struct PseudoWinnerRow {
 
 #[derive(Clone)]
 struct WinnerGroup {
-    winners: Vec<SemanticPropertyWinner>,
+    winners: Box<[SemanticPropertyWinner]>,
     content_hash: u64,
 }
 
@@ -1104,7 +1104,7 @@ impl WinnerGroups {
             groups.push(group);
         }
         if let Some(previous) = previous
-            && self.states[previous] == groups
+            && self.states[previous].as_ref() == groups.as_slice()
         {
             return previous;
         }
@@ -1113,7 +1113,10 @@ impl WinnerGroups {
 
     fn intern_group_ids(&mut self, groups: Vec<WinnerGroupRef>) -> CascadeStateID {
         let hash = content_hash(&groups);
-        if let Some(id) = self.states.find(hash, |_id, candidate| *candidate == groups) {
+        if let Some(id) = self
+            .states
+            .find(hash, |_id, candidate| candidate.as_ref() == groups.as_slice())
+        {
             return id;
         }
         let id = CascadeStateID(u32::try_from(self.states.len()).expect("cascade state space exhausted"));
@@ -1136,9 +1139,10 @@ impl WinnerGroups {
         }
         winning_rules.sort_unstable();
         winning_rules.dedup();
-        self.nested_residency.grow_committed(
-            (groups.capacity() * size_of::<WinnerGroupRef>() + winning_rules.capacity() * size_of::<RuleID>()) as u64,
-        );
+        let groups = groups.into_boxed_slice();
+        let winning_rules = winning_rules.into_boxed_slice();
+        self.nested_residency
+            .grow_committed((size_of_val(groups.as_ref()) + size_of_val(winning_rules.as_ref())) as u64);
         self.states.insert(hash, id, groups);
         self.state_reference_counts.push(0);
         self.state_winning_rules.push(winning_rules);
@@ -1164,7 +1168,7 @@ impl WinnerGroups {
             return (previous, CascadeWinnerDelta::default());
         }
 
-        let mut groups = self.states[previous].clone();
+        let mut groups = self.states[previous].to_vec();
         let mut changed_properties = Vec::new();
         let mut update_start = 0;
         while update_start < updates.len() {
@@ -1228,7 +1232,7 @@ impl WinnerGroups {
             update_start = update_end;
         }
 
-        let state = if self.states[previous] == groups {
+        let state = if self.states[previous].as_ref() == groups.as_slice() {
             previous
         } else {
             self.intern_group_ids(groups)
@@ -1242,14 +1246,14 @@ impl WinnerGroups {
     }
 
     fn intern_group(&mut self, winners: &[PropertyWinner]) -> WinnerGroupRef {
-        let semantic: Vec<_> = winners
+        let semantic: Box<[_]> = winners
             .iter()
             .map(|winner| SemanticPropertyWinner {
                 property: winner.property,
                 key: winner.key,
             })
             .collect();
-        let provenance: Vec<_> = winners
+        let provenance: Box<[_]> = winners
             .iter()
             .map(|winner| WinnerProvenance {
                 important: winner.important,
@@ -1273,7 +1277,7 @@ impl WinnerGroups {
         let id = WinnerGroupID(u32::try_from(self.groups.len()).expect("winner group space exhausted"));
         self.winner_entry_count += semantic.len();
         self.nested_residency
-            .grow_committed((semantic.capacity() * size_of::<SemanticPropertyWinner>()) as u64);
+            .grow_committed(size_of_val(semantic.as_ref()) as u64);
         self.groups.insert(
             hash,
             id,
@@ -1288,7 +1292,7 @@ impl WinnerGroups {
         }
     }
 
-    fn intern_provenance_group(&mut self, provenance: Vec<WinnerProvenance>) -> WinnerProvenanceGroupID {
+    fn intern_provenance_group(&mut self, provenance: Box<[WinnerProvenance]>) -> WinnerProvenanceGroupID {
         let hash = content_hash(&provenance);
         if let Some(id) = self
             .provenance_groups
@@ -1300,7 +1304,7 @@ impl WinnerGroups {
             u32::try_from(self.provenance_groups.len()).expect("winner provenance group space exhausted"),
         );
         self.nested_residency
-            .grow_committed((provenance.capacity() * size_of::<WinnerProvenance>()) as u64);
+            .grow_committed(size_of_val(provenance.as_ref()) as u64);
         self.provenance_groups.insert(hash, id, provenance);
         id
     }
@@ -1463,8 +1467,8 @@ impl WinnerGroups {
         current: Option<WinnerGroupID>,
         properties: &mut Vec<PropertyID>,
     ) {
-        let previous: &[SemanticPropertyWinner] = previous.map_or(&[], |group| self.groups[group].winners.as_slice());
-        let current: &[SemanticPropertyWinner] = current.map_or(&[], |group| self.groups[group].winners.as_slice());
+        let previous: &[SemanticPropertyWinner] = previous.map_or(&[], |group| self.groups[group].winners.as_ref());
+        let current: &[SemanticPropertyWinner] = current.map_or(&[], |group| self.groups[group].winners.as_ref());
         for entry in merge_sorted_by(previous, current, |old, new| old.property.cmp(&new.property)) {
             match entry {
                 SortedMergeEntry::Both(old, new) => {

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -980,7 +980,7 @@ impl WinnerGroups {
     ) -> bool {
         let key = WinnerGroupKey::current(node, program_version);
         let current_rows_are_equal = match (self.token_for(key), other.token_for(key)) {
-            (Lookup::Known((_, left)), Lookup::Known((_, right))) => other.semantic_delta(Some(left), right).is_empty(),
+            (Lookup::Known((_, left)), Lookup::Known((_, right))) => other.states_are_semantically_equal(left, right),
             (Lookup::Missing(_), Lookup::Missing(_)) => true,
             (Lookup::Known(_), Lookup::Missing(_)) | (Lookup::Missing(_), Lookup::Known(_)) => false,
             (Lookup::KnownAbsent, _) | (_, Lookup::KnownAbsent) => unreachable!("winner groups are sparse"),
@@ -991,6 +991,8 @@ impl WinnerGroups {
 
         let mut left: Vec<_> = self.pseudo_states(node).collect();
         let mut right: Vec<_> = other.pseudo_states(node).collect();
+        // NB: Exact verification can materialize pseudo rows missing from the sparse retained
+        //     cache. Compare the retained rows; additional recomputed rows do not imply a change.
         left.sort_unstable_by_key(|row| row.0);
         right.sort_unstable_by_key(|row| row.0);
         left.iter().all(|&(left_pseudo, _, left_state, left_current)| {
@@ -999,7 +1001,7 @@ impl WinnerGroups {
                 .ok()
                 .is_some_and(|index| {
                     let (_, _, right_state, right_current) = right[index];
-                    left_current == right_current && other.semantic_delta(Some(left_state), right_state).is_empty()
+                    left_current == right_current && other.states_are_semantically_equal(left_state, right_state)
                 })
         })
     }
@@ -1390,6 +1392,20 @@ impl WinnerGroups {
         self.states[state].iter().flat_map(|&group| self.group_winners(group))
     }
 
+    pub(super) fn states_are_semantically_equal(&self, left: CascadeStateID, right: CascadeStateID) -> bool {
+        left == right
+            || self.states[left]
+                .iter()
+                .map(|group| group.winners)
+                .eq(self.states[right].iter().map(|group| group.winners))
+    }
+
+    fn semantic_winners_in_state(&self, state: CascadeStateID) -> impl Iterator<Item = &SemanticPropertyWinner> {
+        self.states[state]
+            .iter()
+            .flat_map(move |group| self.groups[group.winners].winners.iter())
+    }
+
     /// Compare the semantic winners consumed by two computed-style publications.
     ///
     /// Missing retained coverage is not the implicit cascade result. It conservatively reports
@@ -1429,16 +1445,16 @@ impl WinnerGroups {
     /// exact semantic delta.
     pub(super) fn property_shape_hash(&self, state: CascadeStateID) -> u64 {
         let mut hasher = fast_hasher();
-        for winner in self.winners_in_state(state) {
+        for winner in self.semantic_winners_in_state(state) {
             winner.property.hash(&mut hasher);
         }
         hasher.finish()
     }
 
     pub(super) fn property_shapes_are_equal(&self, left: CascadeStateID, right: CascadeStateID) -> bool {
-        self.winners_in_state(left)
+        self.semantic_winners_in_state(left)
             .map(|winner| winner.property)
-            .eq(self.winners_in_state(right).map(|winner| winner.property))
+            .eq(self.semantic_winners_in_state(right).map(|winner| winner.property))
     }
 
     fn append_group_semantic_delta(

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1244,13 +1244,10 @@ impl WinnerGroups {
     }
 
     fn intern_group(&mut self, winners: &[PropertyWinner]) -> WinnerGroupRef {
-        let semantic: Box<[_]> = winners
-            .iter()
-            .map(|winner| SemanticPropertyWinner {
-                property: winner.property,
-                key: winner.key,
-            })
-            .collect();
+        let semantic = winners.iter().map(|winner| SemanticPropertyWinner {
+            property: winner.property,
+            key: winner.key,
+        });
         let provenance: Box<[_]> = winners
             .iter()
             .map(|winner| WinnerProvenance {
@@ -1259,18 +1256,27 @@ impl WinnerGroups {
                 priority: self.intern_priority(winner.priority),
             })
             .collect();
-        let hash = content_hash(&semantic);
+        let mut hasher = fast_hasher();
+        winners.len().hash(&mut hasher);
+        for winner in semantic.clone() {
+            winner.hash(&mut hasher);
+        }
+        let hash = hasher.finish();
         #[cfg(test)]
         {
             self.group_hash_computations += 1;
         }
-        if let Some(id) = self.groups.find(hash, |_id, group| *group == semantic) {
+        if let Some(id) = self
+            .groups
+            .find(hash, |_id, group| group.iter().copied().eq(semantic.clone()))
+        {
             return WinnerGroupRef {
                 winners: id,
                 provenance: self.intern_provenance_group(provenance),
             };
         }
         let id = WinnerGroupID(u32::try_from(self.groups.len()).expect("winner group space exhausted"));
+        let semantic: Box<[_]> = semantic.collect();
         self.winner_entry_count += semantic.len();
         self.nested_residency
             .grow_committed(size_of_val(semantic.as_ref()) as u64);

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -839,7 +839,7 @@ pub struct WinnerGroups {
     states: InternTable<CascadeStateID, Box<[WinnerGroupRef]>>,
     state_reference_counts: Vec<u32>,
     state_winning_rules: Vec<Box<[RuleID]>>,
-    groups: InternTable<WinnerGroupID, WinnerGroup>,
+    groups: InternTable<WinnerGroupID, Box<[SemanticPropertyWinner]>>,
     provenance_groups: InternTable<WinnerProvenanceGroupID, Box<[WinnerProvenance]>>,
     priorities: InternTable<CascadePriorityID, CascadePriority>,
     continuations: InternTable<CascadeContinuationID, CascadeContinuation>,
@@ -872,12 +872,6 @@ struct PseudoWinnerRow {
     priority_current: bool,
     /// The flush that published the row's state.
     stamp: u64,
-}
-
-#[derive(Clone)]
-struct WinnerGroup {
-    winners: Box<[SemanticPropertyWinner]>,
-    content_hash: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -1266,9 +1260,7 @@ impl WinnerGroups {
         {
             self.group_hash_computations += 1;
         }
-        if let Some(id) = self.groups.find(hash, |_id, group| {
-            group.content_hash == hash && group.winners == semantic
-        }) {
+        if let Some(id) = self.groups.find(hash, |_id, group| *group == semantic) {
             return WinnerGroupRef {
                 winners: id,
                 provenance: self.intern_provenance_group(provenance),
@@ -1278,14 +1270,7 @@ impl WinnerGroups {
         self.winner_entry_count += semantic.len();
         self.nested_residency
             .grow_committed(size_of_val(semantic.as_ref()) as u64);
-        self.groups.insert(
-            hash,
-            id,
-            WinnerGroup {
-                winners: semantic,
-                content_hash: hash,
-            },
-        );
+        self.groups.insert(hash, id, semantic);
         WinnerGroupRef {
             winners: id,
             provenance: self.intern_provenance_group(provenance),
@@ -1325,7 +1310,6 @@ impl WinnerGroups {
 
     fn group_winners(&self, group: WinnerGroupRef) -> impl Iterator<Item = PropertyWinner> + '_ {
         self.groups[group.winners]
-            .winners
             .iter()
             .zip(&self.provenance_groups[group.provenance])
             .map(|(winner, provenance)| PropertyWinner {
@@ -1339,7 +1323,6 @@ impl WinnerGroups {
 
     fn group_bucket(&self, group: WinnerGroupRef) -> PropertyID {
         self.groups[group.winners]
-            .winners
             .first()
             .expect("a winner group is non-empty")
             .property
@@ -1373,12 +1356,11 @@ impl WinnerGroups {
         let groups = &self.states[state];
         let index = groups.partition_point(|group| {
             self.groups[group.winners]
-                .winners
                 .last()
                 .is_some_and(|winner| winner.property < property)
         });
         let group = *groups.get(index)?;
-        let winners = &self.groups[group.winners].winners;
+        let winners = &self.groups[group.winners];
         let provenance = &self.provenance_groups[group.provenance];
         winners
             .binary_search_by_key(&property, |winner| winner.property)
@@ -1407,7 +1389,7 @@ impl WinnerGroups {
     fn semantic_winners_in_state(&self, state: CascadeStateID) -> impl Iterator<Item = &SemanticPropertyWinner> {
         self.states[state]
             .iter()
-            .flat_map(move |group| self.groups[group.winners].winners.iter())
+            .flat_map(move |group| self.groups[group.winners].iter())
     }
 
     /// Compare the semantic winners consumed by two computed-style publications.
@@ -1473,8 +1455,8 @@ impl WinnerGroups {
         previous: Option<WinnerGroupID>,
         current: Option<WinnerGroupID>,
     ) -> impl Iterator<Item = PropertyID> {
-        let previous: &[SemanticPropertyWinner] = previous.map_or(&[], |group| self.groups[group].winners.as_ref());
-        let current: &[SemanticPropertyWinner] = current.map_or(&[], |group| self.groups[group].winners.as_ref());
+        let previous: &[SemanticPropertyWinner] = previous.map_or(&[], |group| self.groups[group].as_ref());
+        let current: &[SemanticPropertyWinner] = current.map_or(&[], |group| self.groups[group].as_ref());
         merge_sorted_by(previous, current, |old, new| old.property.cmp(&new.property)).filter_map(|entry| match entry {
             SortedMergeEntry::Both(old, new) => (old.key != new.key).then_some(old.property),
             SortedMergeEntry::Left(old) => Some(old.property),

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -368,8 +368,6 @@ impl CascadeStratum {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CascadeCandidate {
     pub winner: PropertyWinner,
-    /// Needed only while reducing contenders, never after the winner is retained.
-    pub priority: CascadePriority,
     pub stratum: CascadeStratum,
 }
 
@@ -1004,13 +1002,11 @@ impl WinnerGroups {
     /// by `revert` and `revert-layer` operators.
     pub fn resolve_candidates(&mut self, candidates: &mut [CascadeCandidate]) -> Option<PropertyWinner> {
         // CascadePriority is the total declaration order, so equal keys are interchangeable here.
-        let candidate = candidates.iter().max_by_key(|candidate| candidate.priority)?;
+        let candidate = candidates.iter().max_by_key(|candidate| candidate.winner.priority)?;
         if candidate.stratum.ceiling(candidate.winner.key.operator).is_none() {
-            let mut winner = candidate.winner;
-            winner.priority = candidate.priority;
-            return Some(winner);
+            return Some(candidate.winner);
         }
-        candidates.sort_unstable_by_key(|candidate| candidate.priority);
+        candidates.sort_unstable_by_key(|candidate| candidate.winner.priority);
         self.resolve_candidates_below(candidates, &mut Vec::new())
     }
 
@@ -1024,7 +1020,6 @@ impl WinnerGroups {
             .rposition(|candidate| ceilings.iter().all(|&ceiling| candidate.stratum.is_below(ceiling)))?;
         let candidate = candidates[index];
         let mut winner = candidate.winner;
-        winner.priority = candidate.priority;
         let Some(ceiling) = candidate.stratum.ceiling(candidate.winner.key.operator) else {
             return Some(winner);
         };
@@ -2180,7 +2175,6 @@ mod tests {
         winner.priority = priority;
         CascadeCandidate {
             winner,
-            priority,
             stratum: CascadeStratum::new(origin, important, 0, layer, layer_rank, CascadeAttachment::StyleSheet),
         }
     }

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1164,6 +1164,8 @@ impl WinnerGroups {
 
         let mut groups = self.states[previous].to_vec();
         let mut changed_properties = Vec::new();
+        let mut old_winners = Vec::new();
+        let mut winners = Vec::new();
         let mut update_start = 0;
         while update_start < updates.len() {
             let bucket = updates[update_start].property / WINNER_GROUP_PROPERTY_COUNT;
@@ -1175,11 +1177,13 @@ impl WinnerGroups {
                 .get(group_index)
                 .copied()
                 .filter(|&group| self.group_bucket(group) == bucket);
-            let old_winners: Vec<PropertyWinner> = old_group
-                .map(|group| self.group_winners(group).collect())
-                .unwrap_or_default();
+            old_winners.clear();
+            if let Some(group) = old_group {
+                old_winners.extend(self.group_winners(group));
+            }
             let bucket_updates = &updates[update_start..update_end];
-            let mut winners = Vec::with_capacity(old_winners.len() + bucket_updates.len());
+            winners.clear();
+            winners.reserve(old_winners.len() + bucket_updates.len());
             for entry in merge_sorted_by(&old_winners, bucket_updates, |old, update| {
                 old.property.cmp(&update.property)
             }) {

--- a/Libraries/LibWeb/Rust/src/css/style/catalog.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/catalog.rs
@@ -138,7 +138,7 @@ impl MatchAnswerCatalog {
             if let Some(identity) = self.identity(prepared, hash) {
                 return identity;
             }
-            return self.insert_new(prepared.to_vec(), hash);
+            return self.insert_new(Rc::from(&*prepared), hash);
         }
         let mut prepared: Vec<RetainedRuleMatch> =
             answer.iter().copied().map(RetainedRuleMatch::from_rule_match).collect();
@@ -151,10 +151,10 @@ impl MatchAnswerCatalog {
         if let Some(identity) = self.identity(&answer, hash) {
             return identity;
         }
-        self.insert_new(answer, hash)
+        self.insert_new(answer.into(), hash)
     }
 
-    pub(super) fn insert_new(&mut self, answer: Vec<RetainedRuleMatch>, hash: u64) -> MatchAnswerID {
+    pub(super) fn insert_new(&mut self, answer: Rc<[RetainedRuleMatch]>, hash: u64) -> MatchAnswerID {
         let identity = MatchAnswerID(
             u32::try_from(self.answers.len())
                 .ok()
@@ -165,7 +165,7 @@ impl MatchAnswerCatalog {
             hash,
             identity,
             Some(MatchAnswerCatalogEntry {
-                answer: answer.into(),
+                answer,
                 prefix_references: 0,
                 cascade_references: 0,
                 cascade_payload_accounted: false,
@@ -308,7 +308,7 @@ impl MatchAnswerCatalog {
 
     pub(super) fn insert_retained(&mut self, answer: Vec<RetainedRuleMatch>, hash: u64) -> MatchAnswerID {
         debug_assert!(self.identity(&answer, hash).is_none());
-        let identity = self.insert_new(answer, hash);
+        let identity = self.insert_new(answer.into(), hash);
         self.retain_identity(identity);
         identity
     }

--- a/Libraries/LibWeb/Rust/src/css/style/catalog.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/catalog.rs
@@ -941,7 +941,6 @@ impl RetainedAnswerDeltaMemoEntry {
     }
 }
 
-#[derive(Clone)]
 pub(super) struct RetainedAnswerDeltaTransition {
     pub(super) new_answer: MatchAnswerID,
     /// The compact identity after the transition. Equal to the asker's old identity exactly when

--- a/Libraries/LibWeb/Rust/src/css/style/catalog.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/catalog.rs
@@ -776,6 +776,14 @@ pub(super) fn prepare_selector_truth_set(
 }
 
 pub(super) fn merge_retained_match_answers(answer: &mut Vec<RetainedRuleMatch>, suffix: &[RetainedRuleMatch]) {
+    if answer
+        .last()
+        .zip(suffix.first())
+        .is_none_or(|(last, first)| last <= first)
+    {
+        answer.extend_from_slice(suffix);
+        return;
+    }
     let mut answer_index = answer.len();
     let mut suffix_index = suffix.len();
     answer.extend_from_slice(suffix);

--- a/Libraries/LibWeb/Rust/src/css/style/child_reactions.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/child_reactions.rs
@@ -42,8 +42,8 @@ impl StyleEngine {
         if self.facts.is_slot(node)
             && (!invalidation_is_none || did_change_custom_properties || ancestor_became_visible)
         {
-            let assigned: Vec<StyleNodeID> = self.tree.assigned_nodes_of(node).to_vec();
-            for assigned in assigned {
+            for index in 0..self.tree.assigned_nodes_of(node).len() {
+                let assigned = self.tree.assigned_nodes_of(node)[index];
                 self.record_derived_element_style_input(assigned, STYLE_REACTION_RECOMPUTE_STYLE, 0);
             }
         }
@@ -52,17 +52,6 @@ impl StyleEngine {
         if !has(fact::HAS_STYLE) {
             return;
         }
-
-        let light_children: Vec<StyleNodeID> = self
-            .tree
-            .children(node)
-            .filter(|&child| self.tree.assigned_slot_of(child).is_none())
-            .collect();
-        let shadow_children: Vec<StyleNodeID> = self
-            .tree
-            .shadow_root_of(node)
-            .map(|shadow_root| self.tree.children(shadow_root).collect())
-            .unwrap_or_default();
 
         if has(fact::IS_DISPLAY_NONE) {
             let (child_reaction, groups) = if has(fact::WAS_UNSTYLED) {
@@ -80,8 +69,17 @@ impl StyleEngine {
                 }
                 (child_reaction, inherited_style_groups_changed)
             };
-            for child in light_children.into_iter().chain(shadow_children) {
-                self.record_derived_element_style_input(child, child_reaction, groups);
+            if child_reaction == 0 {
+                return;
+            }
+            for parent in [Some(node), self.tree.shadow_root_of(node)].into_iter().flatten() {
+                let mut next = self.tree.first_element_child(parent);
+                while let Some(child) = next {
+                    next = self.tree.next_element_sibling(child);
+                    if parent != node || self.tree.assigned_slot_of(child).is_none() {
+                        self.record_derived_element_style_input(child, child_reaction, groups);
+                    }
+                }
             }
             return;
         }
@@ -112,7 +110,12 @@ impl StyleEngine {
         // A child's box-type transformation reads its parent's display: when that moved, the
         // child's record is driven again in full, whatever its own winners did.
         let display_changed = has(fact::DISPLAY_CHANGED);
-        for child in light_children {
+        let mut next = self.tree.first_element_child(node);
+        while let Some(child) = next {
+            next = self.tree.next_element_sibling(child);
+            if self.tree.assigned_slot_of(child).is_some() {
+                continue;
+            }
             let (light_reaction, light_groups) = child_reaction(
                 !invalidation_is_none
                     && (has(fact::CHILDREN_EXPLICITLY_INHERIT)
@@ -123,7 +126,12 @@ impl StyleEngine {
                 self.parent_inputs_moved_nodes.insert(child);
             }
         }
-        for child in shadow_children {
+        let mut next = self
+            .tree
+            .shadow_root_of(node)
+            .and_then(|root| self.tree.first_element_child(root));
+        while let Some(child) = next {
+            next = self.tree.next_element_sibling(child);
             let (shadow_reaction, shadow_groups) = child_reaction(
                 !invalidation_is_none
                     && (has(fact::SHADOW_CHILDREN_EXPLICITLY_INHERIT)

--- a/Libraries/LibWeb/Rust/src/css/style/compiler.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/compiler.rs
@@ -967,22 +967,16 @@ impl<'a> SelectorCompiler<'a> {
                 // Both are forgiving, so an argument list whose every selector is invalid parses to
                 // an empty one - and an empty list matches nothing. Compiling it to no constraint
                 // left the compound matching every element instead.
-                let branches = self.compile_argument_list(pseudo_class, marker);
-                if branches.is_empty() {
+                let Some(any_of) = self.compile_argument_list(pseudo_class, marker) else {
                     return Some(self.builder.push_never());
-                }
-                let any_of = self.builder.push_any_of(&branches);
+                };
                 if pseudo_class.pseudo_class == Pc::Where {
                     return Some(self.builder.push(SelectorOp::Where(any_of)));
                 }
                 Some(any_of)
             }
             Pc::Not => {
-                let branches = self.compile_argument_list(pseudo_class, marker);
-                if branches.is_empty() {
-                    return None;
-                }
-                let any_of = self.builder.push_any_of(&branches);
+                let any_of = self.compile_argument_list(pseudo_class, marker)?;
                 Some(self.builder.push(SelectorOp::Not(any_of)))
             }
             Pc::Has => self.compile_has(pseudo_class, marker),
@@ -1045,12 +1039,9 @@ impl<'a> SelectorCompiler<'a> {
 
             // Shadow encapsulation. `:host` with an argument constrains the host itself.
             Pc::Host => {
-                let branches = self.compile_argument_list(pseudo_class, marker);
-                let inner = if branches.is_empty() {
-                    self.builder.push_feature(FeatureTest::AnyElement)
-                } else {
-                    self.builder.push_any_of(&branches)
-                };
+                let inner = self
+                    .compile_argument_list(pseudo_class, marker)
+                    .unwrap_or_else(|| self.builder.push_feature(FeatureTest::AnyElement));
                 Some(self.builder.push(SelectorOp::Host(inner)))
             }
 
@@ -1204,27 +1195,33 @@ impl<'a> SelectorCompiler<'a> {
         &mut self,
         pseudo_class: &PseudoClassSelector,
         marker: &mut Option<CompilationMarker>,
-    ) -> Vec<SelectorNodeID> {
+    ) -> Option<SelectorNodeID> {
+        // A branch that targets a pseudo-element cannot match the originating element, so it
+        // contributes nothing to the disjunction. Compiling it anyway would leave a compound
+        // with no feature left in it, and a disjunction with one such branch distinguishes
+        // nothing at all: `:is(button, ::file-selector-button):hover` would then be reachable
+        // from a hover on any element whatsoever.
+        let mut arguments = pseudo_class
+            .argument_selector_list
+            .iter()
+            .filter(|argument| !argument.compound_selectors.is_empty() && argument.target_pseudo_element.is_none());
+        let first = arguments.next()?;
+        let compounds = &first.compound_selectors;
+        let subject_index = compounds.len() - 1;
+        let subject = &raw const compounds[subject_index];
+        let first = self.compile_chain_with_subject(compounds, subject_index, marker, subject);
+        let Some(second) = arguments.next() else {
+            return Some(first);
+        };
         let mut branches = Vec::with_capacity(pseudo_class.argument_selector_list.len());
-        for argument in &pseudo_class.argument_selector_list {
+        branches.push(first);
+        for argument in std::iter::once(second).chain(arguments) {
             let compounds = &argument.compound_selectors;
-            if compounds.is_empty() {
-                continue;
-            }
-            // A branch that targets a pseudo-element cannot match the originating element, so it
-            // contributes nothing to the disjunction. Compiling it anyway would leave a compound
-            // with no feature left in it, and a disjunction with one such branch distinguishes
-            // nothing at all: `:is(button, ::file-selector-button):hover` would then be reachable
-            // from a hover on any element whatsoever.
-            if argument.target_pseudo_element.is_some() {
-                continue;
-            }
             let subject_index = compounds.len() - 1;
             let subject = &raw const compounds[subject_index];
-            let branch = self.compile_chain_with_subject(compounds, subject_index, marker, subject);
-            branches.push(branch);
+            branches.push(self.compile_chain_with_subject(compounds, subject_index, marker, subject));
         }
-        branches
+        Some(self.builder.push_any_of(&branches))
     }
 
     fn compile_nth_of(
@@ -1237,11 +1234,10 @@ impl<'a> SelectorCompiler<'a> {
         }
         // An `of` list whose every selector names nothing counts an empty sequence, which is not
         // the same as counting every sibling - which is what leaving the filter out would do.
-        let branches = self.compile_argument_list(pseudo_class, marker);
-        if branches.is_empty() {
-            return Some(self.builder.push_never());
-        }
-        Some(self.builder.push_any_of(&branches))
+        Some(
+            self.compile_argument_list(pseudo_class, marker)
+                .unwrap_or_else(|| self.builder.push_never()),
+        )
     }
 
     /// `:has()` compiles to a relative query per argument. A selector list holds when any one of its

--- a/Libraries/LibWeb/Rust/src/css/style/compiler.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/compiler.rs
@@ -649,23 +649,21 @@ impl<'a> SelectorCompiler<'a> {
             };
             // The names go under the host op rather than beside it, so that one level of
             // `exportparts` forwarding has to answer for both halves at once.
-            let names: Vec<SelectorNodeID> = part
-                .identifier_identities
-                .iter()
-                .map(|identity| {
-                    let atom = (self.intern)(identity.raw(), None);
-                    self.builder.push(SelectorOp::Part(atom))
-                })
-                .collect();
-            if names.is_empty() {
+            operands.clear();
+            for identity in &part.identifier_identities {
+                let atom = (self.intern)(identity.raw(), None);
+                operands.push(self.builder.push(SelectorOp::Part(atom)));
+            }
+            if operands.is_empty() {
                 marker.get_or_insert(CompilationMarker::KnownNeverMatches(
                     CompilationMarkerReason::PseudoElement,
                 ));
             }
-            let parts = self.builder.push_compound(&names);
-            let mut exposed = vec![self.builder.push(SelectorOp::ExposedToHost { host, parts })];
-            exposed.extend(on_the_part);
-            return self.builder.push_compound(&exposed);
+            let parts = self.builder.push_compound(&operands);
+            operands.clear();
+            operands.push(self.builder.push(SelectorOp::ExposedToHost { host, parts }));
+            operands.extend(on_the_part);
+            return self.builder.push_compound(&operands);
         }
 
         if operands.is_empty() {

--- a/Libraries/LibWeb/Rust/src/css/style/compiler.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/compiler.rs
@@ -315,11 +315,13 @@ impl<'a> SelectorCompiler<'a> {
 
         let mut inner = self.builder.entry_root(entry.entry);
         let mut innermost_root = None;
+        let mut scope_selectors = Vec::new();
         for (level, &(root_start, root_end, limit_start, limit_end)) in levels.iter().enumerate().rev() {
             let innermost = level + 1 == levels.len();
-            let mut roots = Vec::with_capacity(root_end - root_start + 1);
+            scope_selectors.clear();
+            scope_selectors.reserve(root_end - root_start + 1);
             if let Some(implicit) = implicit_root_of(level) {
-                roots.push(self.push_implicit_scope_root(implicit));
+                scope_selectors.push(self.push_implicit_scope_root(implicit));
             }
             for root_selector in &scope_roots[root_start..root_end] {
                 let compounds = &root_selector.compound_selectors;
@@ -331,21 +333,22 @@ impl<'a> SelectorCompiler<'a> {
                 // the scope enclosing it - which is bound while this level's candidates are tested.
                 // The outermost level has none unless this compile is itself inside a scope.
                 let bound = std::mem::replace(&mut self.scope_root_is_bound, level > 0 || outer_bound);
-                roots.push(self.compile_chain(compounds, compounds.len() - 1, &mut marker));
+                scope_selectors.push(self.compile_chain(compounds, compounds.len() - 1, &mut marker));
                 self.scope_root_is_bound = bound;
             }
             // An explicit `<scope-start>` whose selectors all failed parent substitution matches
             // no roots. An omitted start is represented by an implicit root above.
-            if roots.is_empty() {
+            if scope_selectors.is_empty() {
                 marker.get_or_insert(CompilationMarker::KnownNeverMatches(CompilationMarkerReason::Malformed));
                 inner = self.builder.push_never();
                 break;
             }
-            let root = self.builder.push_any_of(&roots);
+            let root = self.builder.push_any_of(&scope_selectors);
 
             // `:scope` inside a `<scope-end>` names the root of the scope that end belongs to,
             // which is this level's own.
-            let mut limits = Vec::with_capacity(limit_end - limit_start);
+            scope_selectors.clear();
+            scope_selectors.reserve(limit_end - limit_start);
             let bound = std::mem::replace(&mut self.scope_root_is_bound, true);
             for limit_selector in &scope_limits[limit_start..limit_end] {
                 let compounds = &limit_selector.compound_selectors;
@@ -353,10 +356,10 @@ impl<'a> SelectorCompiler<'a> {
                     marker.get_or_insert(CompilationMarker::KnownNeverMatches(CompilationMarkerReason::Malformed));
                     continue;
                 }
-                limits.push(self.compile_chain(compounds, compounds.len() - 1, &mut marker));
+                scope_selectors.push(self.compile_chain(compounds, compounds.len() - 1, &mut marker));
             }
             self.scope_root_is_bound = bound;
-            let limit = (!limits.is_empty()).then(|| self.builder.push_any_of(&limits));
+            let limit = (!scope_selectors.is_empty()).then(|| self.builder.push_any_of(&scope_selectors));
 
             // A scoped selector carries an implied `:scope ` prefix unless it names `:scope`, so
             // the subject is a strict descendant of the innermost root. An enclosing scope is

--- a/Libraries/LibWeb/Rust/src/css/style/compiler.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/compiler.rs
@@ -1257,14 +1257,15 @@ impl<'a> SelectorCompiler<'a> {
             return Some(self.builder.push_never());
         }
 
+        if let [argument] = pseudo_class.argument_selector_list.as_ref() {
+            return self.compile_has_argument(argument, marker);
+        }
+
         let mut alternatives = Vec::with_capacity(pseudo_class.argument_selector_list.len());
         for argument in &pseudo_class.argument_selector_list {
             // An alternative that cannot be compiled cannot be dropped: the query holds when any one
             // of them does, so leaving one out would answer a narrower question than the rule asks.
             alternatives.push(self.compile_has_argument(argument, marker)?);
-        }
-        if alternatives.len() == 1 {
-            return Some(alternatives[0]);
         }
         Some(self.builder.push_any_of(&alternatives))
     }

--- a/Libraries/LibWeb/Rust/src/css/style/compiler.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/compiler.rs
@@ -282,8 +282,10 @@ impl<'a> SelectorCompiler<'a> {
         // enclosing scope is a constraint of its own. Within one scope the roots are alternatives.
         // An empty level list means one scope holding everything, which is what a caller with a
         // single `@scope` passes.
-        let levels: Vec<(usize, usize, usize, usize)> = if scope_levels.is_empty() {
-            vec![(0, scope_roots.len(), 0, scope_limits.len())]
+        let single_level = [(0, scope_roots.len(), 0, scope_limits.len())];
+        let nested_levels;
+        let levels: &[(usize, usize, usize, usize)] = if scope_levels.is_empty() {
+            &single_level
         } else {
             let mut spans = Vec::with_capacity(scope_levels.len());
             let mut root_start = 0usize;
@@ -295,7 +297,8 @@ impl<'a> SelectorCompiler<'a> {
                 root_start = root_end;
                 limit_start = limit_end;
             }
-            spans
+            nested_levels = spans;
+            &nested_levels
         };
 
         // https://drafts.csswg.org/css-cascade-6/#scoped-rules

--- a/Libraries/LibWeb/Rust/src/css/style/compiler.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/compiler.rs
@@ -1087,12 +1087,9 @@ impl<'a> SelectorCompiler<'a> {
                 match pseudo_class.languages.is_empty() {
                     true => Some(self.builder.push_never()),
                     false => {
-                        let ranges: Vec<&[u16]> = pseudo_class
-                            .languages
-                            .iter()
-                            .map(|range| range.value.as_ref())
-                            .collect();
-                        let (first, count) = self.builder.push_language_ranges(&ranges);
+                        let (first, count) = self
+                            .builder
+                            .push_language_ranges(pseudo_class.languages.iter().map(|range| &range.value));
                         Some(self.builder.push(SelectorOp::Language { first, count }))
                     }
                 }

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -1227,8 +1227,19 @@ impl ComputedGroupSets {
             _ => return None,
         };
 
-        let mut groups = self.group_identities(old_record.groups);
-        groups[..INHERITED_GROUP_COUNT].copy_from_slice(parent_groups);
+        let mut groups: Vec<_> = parent_groups
+            .iter()
+            .copied()
+            .chain(
+                old_group_set
+                    .payloads
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .skip(INHERITED_GROUP_COUNT)
+                    .map(|(index, payload)| self.group_identity(index, payload)),
+            )
+            .collect();
         if let Some(table) = swapped_table
             && current_color_dependencies & !INHERITED_GROUP_MASK != 0
         {

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -3396,13 +3396,15 @@ impl ComputedGroupSets {
                 self.style_record_generation_is_live(style_record, final_style_record.base_generation()),
                 "base style-record is not live"
             );
-            let pin_count = self
-                .base_style_record_pins
-                .get_mut(&style_record)
-                .expect("base style-record is pinned");
+            let std::collections::hash_map::Entry::Occupied(mut entry) =
+                self.base_style_record_pins.entry(style_record)
+            else {
+                unreachable!("base style-record is pinned");
+            };
+            let pin_count = entry.get_mut();
             *pin_count = pin_count.checked_sub(1).expect("base style-record is pinned");
             if *pin_count == 0 {
-                self.base_style_record_pins.remove(&style_record);
+                entry.remove();
             }
             return;
         }

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -3534,12 +3534,14 @@ fn longhand_table_hash_with_slot_hash_sum(table: &ComputedLonghandTable, slot_ha
     table.pseudo_element_styles().hash(&mut hasher);
     unsafe { crate::css::style_value::style_value_content_hash(table.raw_cascaded_font_size().cast()) }
         .hash(&mut hasher);
-    let mut inheritance_dependent = table.inheritance_dependent_values().collect::<Vec<_>>();
-    inheritance_dependent.sort_unstable_by_key(|(property, _)| *property);
-    for (property, value) in inheritance_dependent {
-        property.hash(&mut hasher);
-        unsafe { crate::css::style_value::style_value_content_hash(value.cast()) }.hash(&mut hasher);
+    // NB: Inheritance-dependent values compare independently of insertion order. Sum the
+    //     property-mixed hashes, as for longhand slots, without copying and sorting the values.
+    let mut inheritance_dependent_hash_sum = 0_u64;
+    for (property, value) in table.inheritance_dependent_values() {
+        inheritance_dependent_hash_sum =
+            inheritance_dependent_hash_sum.wrapping_add(longhand_slot_hash(usize::from(property), value));
     }
+    inheritance_dependent_hash_sum.hash(&mut hasher);
     hasher.finish()
 }
 

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -1158,16 +1158,15 @@ impl ComputedGroupSets {
             return None;
         }
         let old_group_set = self.sets.get_index(old_record.groups.0 as usize)?;
-        let old_payloads = old_group_set.payloads.to_vec();
         let parent_inherited = self.columns.inherited_groups(parent_index)?;
-        let parent_groups = self.inherited_sets.get_index(parent_inherited.0 as usize)?.to_vec();
+        let parent_groups = self.inherited_sets.get_index(parent_inherited.0 as usize)?.as_ref();
         if parent_groups.len() != INHERITED_GROUP_COUNT || old_group_set.payloads.len() < INHERITED_GROUP_COUNT {
             return None;
         }
 
         if current_color_dependencies & !INHERITED_GROUP_MASK != 0 {
             let inherited_box = unsafe {
-                &*old_payloads[crate::css::computed_value_types::STYLE_GROUP_INDEX_INHERITED_BOX]
+                &*old_group_set.payloads[crate::css::computed_value_types::STYLE_GROUP_INDEX_INHERITED_BOX]
                     .cast::<crate::css::computed_values::InheritedBoxValues>()
             };
             let dependencies = self.current_color_dependency_properties(target)?;
@@ -1232,7 +1231,7 @@ impl ComputedGroupSets {
         };
 
         let mut groups = self.group_identities(old_record.groups);
-        groups[..INHERITED_GROUP_COUNT].copy_from_slice(&parent_groups);
+        groups[..INHERITED_GROUP_COUNT].copy_from_slice(parent_groups);
         if let Some(table) = swapped_table
             && current_color_dependencies & !INHERITED_GROUP_MASK != 0
         {
@@ -1246,27 +1245,28 @@ impl ComputedGroupSets {
                     .payload
                     .cast::<crate::css::computed_value_types::InheritedUIValues>()
             };
-            for group in INHERITED_GROUP_COUNT..groups.len() {
+            for (group, group_identity) in groups.iter_mut().enumerate().skip(INHERITED_GROUP_COUNT) {
                 if current_color_dependencies & (1 << group) == 0 {
                     continue;
                 }
+                let old_payload = self.groups[*group_identity].payload;
                 let payload = unsafe {
                     crate::css::table_group_builder::rebuild_group_for_inherited_current_color(
                         &*table,
                         group,
-                        old_payloads[group],
+                        old_payload,
                         inherited_text.color,
                         inherited_ui.color_scheme,
                     )
                 }
                 .expect("a supported currentcolor group rebuilds from its computed table");
-                let identity = if payload == old_payloads[group] {
-                    groups[group]
+                let identity = if payload == old_payload {
+                    *group_identity
                 } else {
                     self.intern_group(group, payload).0
                 };
                 release_group_payload(group, payload);
-                groups[group] = identity;
+                *group_identity = identity;
             }
         }
         let group_set = self.intern_group_set(&groups).0;
@@ -1337,9 +1337,8 @@ impl ComputedGroupSets {
         let old_record = *self.style_records.get_index(base_style_record_identity.index())?;
         let old_table = old_record.longhand_table?;
         let old_group_set = self.sets.get_index(old_record.groups.0 as usize)?;
-        let old_payloads = old_group_set.payloads.to_vec();
-        if groups_to_rebuild >> old_payloads.len() != 0
-            || old_payloads.len() <= crate::css::computed_value_types::STYLE_GROUP_INDEX_INHERITED_UI
+        if groups_to_rebuild >> old_group_set.payloads.len() != 0
+            || old_group_set.payloads.len() <= crate::css::computed_value_types::STYLE_GROUP_INDEX_INHERITED_UI
         {
             return None;
         }
@@ -1408,16 +1407,17 @@ impl ComputedGroupSets {
 
         let mut groups = self.group_identities(old_record.groups);
         let mut canonicalized_groups = 0_u32;
-        for group in 0..groups.len() {
+        for (group, group_identity) in groups.iter_mut().enumerate() {
             if groups_to_rebuild & (1 << group) == 0 {
                 continue;
             }
+            let old_payload = self.groups[*group_identity].payload;
             let payload = if group == STYLE_GROUP_INDEX_FONT {
                 unsafe {
                     crate::css::table_group_builder::rebuild_font_group_from_table(
                         &*table,
                         font.expect("a font group rebuild carries the resolved font"),
-                        old_payloads[group],
+                        old_payload,
                     )
                 }
             } else {
@@ -1425,7 +1425,7 @@ impl ComputedGroupSets {
                     crate::css::table_group_builder::rebuild_group_from_table(
                         &*table,
                         group,
-                        old_payloads[group],
+                        old_payload,
                         current_color,
                         used_color_scheme,
                         Some(length),
@@ -1438,15 +1438,14 @@ impl ComputedGroupSets {
             };
             // An equal payload keeps the old identity, as a C++ build adopts its parent's and
             // predecessor's identical payloads.
-            let identity =
-                if payload == old_payloads[group] || style_group_payloads_equal(group, old_payloads[group], payload) {
-                    canonicalized_groups += 1;
-                    groups[group]
-                } else {
-                    self.intern_group(group, payload).0
-                };
+            let identity = if payload == old_payload || style_group_payloads_equal(group, old_payload, payload) {
+                canonicalized_groups += 1;
+                *group_identity
+            } else {
+                self.intern_group(group, payload).0
+            };
             release_group_payload(group, payload);
-            groups[group] = identity;
+            *group_identity = identity;
         }
         let group_set = self.intern_group_set(&groups).0;
         let holds_image_values = self

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -1356,7 +1356,7 @@ impl ComputedGroupSets {
             let specified = table
                 .retained_inheritance_dependent_values()
                 .find(|(candidate, value)| *candidate == property && retained_value_depends_on_current_color(value))
-                .map(|(_, value)| value.clone_retained());
+                .map(|(_, value)| value);
             let Some(specified) = specified else {
                 continue;
             };

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -63,7 +63,7 @@ pub(super) const ENGINE_INHERITED_GROUP_COUNT: usize = 7;
 pub(super) fn table_inherited_group_swap_eligible(table: &ComputedLonghandTable) -> bool {
     table.property_inheritance_is_standard()
         && !table.display_is_list_item()
-        && crate::css::style_compute::active_transition_properties(table).is_empty()
+        && !crate::css::style_compute::has_active_transition_properties(table)
 }
 
 /// What assembling an engine-computed record produced, for the publication counters.
@@ -1151,9 +1151,7 @@ impl ComputedGroupSets {
             || old_record
                 .longhand_table
                 .and_then(|table| self.computed_longhand_tables.get_index(table.index()))
-                .is_none_or(|retained| {
-                    !crate::css::style_compute::active_transition_properties(retained.table()).is_empty()
-                })
+                .is_none_or(|retained| crate::css::style_compute::has_active_transition_properties(retained.table()))
         {
             return None;
         }
@@ -1214,8 +1212,7 @@ impl ComputedGroupSets {
             .and_then(|record| self.style_records.get_index(record.index()))
             .and_then(|record| record.longhand_table);
         if parent_table.is_some_and(|table| {
-            !crate::css::style_compute::active_transition_properties(self.computed_longhand_tables[table].table())
-                .is_empty()
+            crate::css::style_compute::has_active_transition_properties(self.computed_longhand_tables[table].table())
         }) {
             return None;
         }

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -2262,16 +2262,20 @@ impl ComputedGroupSets {
         {
             return false;
         }
-        let first_groups = &self.sets[first.groups].payloads;
-        let second_groups = &self.sets[second.groups].payloads;
-        if first_groups.len() != second_groups.len()
-            || first_groups
-                .iter()
-                .zip(second_groups)
-                .enumerate()
-                .any(|(index, (&first, &second))| first != second && !style_group_payloads_equal(index, first, second))
-        {
-            return false;
+        if first.groups != second.groups {
+            let first_groups = &self.sets[first.groups].payloads;
+            let second_groups = &self.sets[second.groups].payloads;
+            if first_groups.len() != second_groups.len()
+                || first_groups
+                    .iter()
+                    .zip(second_groups)
+                    .enumerate()
+                    .any(|(index, (&first, &second))| {
+                        first != second && !style_group_payloads_equal(index, first, second)
+                    })
+            {
+                return false;
+            }
         }
         match (first.longhand_table, second.longhand_table) {
             (None, None) => true,

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -2987,35 +2987,43 @@ impl ComputedGroupSets {
                 .shrink_committed(size_of_val(set.payloads.as_ref()) as u64);
             self.sets.retire_identity(set.identity_hash, identity);
         }
-        for identity in self.inherited_sets.live_identities().collect::<Vec<_>>() {
-            if reachable.inherited_sets[identity.index()] {
-                continue;
-            }
+        for identity in self
+            .inherited_sets
+            .live_identities()
+            .filter(|identity| !reachable.inherited_sets[identity.index()])
+            .collect::<Vec<_>>()
+        {
             let groups = std::mem::take(self.inherited_sets.get_mut(identity));
             self.group_set_nested_memory
                 .shrink_committed(size_of_val(groups.as_ref()) as u64);
             self.inherited_sets.retire_identity(content_hash(&groups), identity);
         }
-        for identity in self.custom_property_environments.live_identities().collect::<Vec<_>>() {
-            if reachable.custom_property_environments[identity.index()] {
-                continue;
-            }
+        for identity in self
+            .custom_property_environments
+            .live_identities()
+            .filter(|identity| !reachable.custom_property_environments[identity.index()])
+            .collect::<Vec<_>>()
+        {
             let environment = *self.custom_property_environments.get(identity);
             self.custom_property_environments
                 .retire_identity(content_hash(environment), identity);
         }
-        for identity in self.computed_fixed_metadata.live_identities().collect::<Vec<_>>() {
-            if reachable.fixed_metadata[identity.index()] {
-                continue;
-            }
+        for identity in self
+            .computed_fixed_metadata
+            .live_identities()
+            .filter(|identity| !reachable.fixed_metadata[identity.index()])
+            .collect::<Vec<_>>()
+        {
             let metadata = *self.computed_fixed_metadata.get(identity);
             self.computed_fixed_metadata
                 .retire_identity(content_hash(metadata), identity);
         }
-        for identity in self.computed_longhand_tables.live_identities().collect::<Vec<_>>() {
-            if reachable.longhand_tables[identity.index()] {
-                continue;
-            }
+        for identity in self
+            .computed_longhand_tables
+            .live_identities()
+            .filter(|identity| !reachable.longhand_tables[identity.index()])
+            .collect::<Vec<_>>()
+        {
             let retained = &self.computed_longhand_tables[identity];
             let hash = longhand_table_hash_with_slot_hash_sum(retained.table(), retained.slot_hash_sum);
             let table = std::mem::replace(
@@ -3029,10 +3037,12 @@ impl ComputedGroupSets {
                 .shrink_committed(size_of_val(table.value_view()) as u64);
             self.computed_longhand_tables.retire_identity(hash, identity);
         }
-        for identity in self.groups.live_identities().collect::<Vec<_>>() {
-            if reachable.groups[identity.index()] {
-                continue;
-            }
+        for identity in self
+            .groups
+            .live_identities()
+            .filter(|identity| !reachable.groups[identity.index()])
+            .collect::<Vec<_>>()
+        {
             let group = std::mem::replace(
                 self.groups.get_mut(identity),
                 ComputedGroup {

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -308,6 +308,13 @@ impl StyleEngine {
                 written,
             });
         }
+        if let [candidate] = candidates.as_slice() {
+            return Some(if candidate.stratum.ceiling(candidate.declared.operator).is_none() {
+                vec![(candidate.declared, candidate.written.clone_retained())]
+            } else {
+                Vec::new()
+            });
+        }
         // Keep insertion order for declarations with equal cascade priority.
         candidates.sort_by_key(|candidate| candidate.priority);
         let mut name_indices = HashMap::default();

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -320,8 +320,9 @@ impl StyleEngine {
             candidates_by_name[index].push(candidate);
         }
         let mut cascaded: Vec<(CustomDeclaration, RetainedStyleValueData)> = Vec::new();
+        let mut ceilings = Vec::new();
         for candidates in candidates_by_name {
-            let mut ceilings = Vec::new();
+            ceilings.clear();
             for candidate in candidates.into_iter().rev() {
                 if !ceilings.iter().all(|&ceiling| candidate.stratum.is_below(ceiling)) {
                     continue;

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -264,12 +264,12 @@ impl StyleEngine {
         &self,
         node: StyleNodeID,
     ) -> Option<Vec<(CustomDeclaration, RetainedStyleValueData)>> {
-        struct Candidate {
+        struct Candidate<'a> {
             priority: CascadePriority,
             order: usize,
             stratum: CascadeStratum,
             declared: CustomDeclaration,
-            written: RetainedStyleValueData,
+            written: &'a RetainedStyleValueData,
         }
 
         let mut candidates = Vec::new();
@@ -289,7 +289,7 @@ impl StyleEngine {
                     order: candidates.len(),
                     stratum: self.cascade_stratum_of(rule, tree_scope, declared.important),
                     declared,
-                    written: written.clone_retained(),
+                    written,
                 });
             }
         });
@@ -308,7 +308,7 @@ impl StyleEngine {
                 order: candidates.len(),
                 stratum: self.element_cascade_stratum(node, ElementDeclarationKind::InlineStyle, declared.important),
                 declared,
-                written: written.clone_retained(),
+                written,
             });
         }
         candidates.sort_by_key(|candidate| (candidate.priority, candidate.order));
@@ -329,7 +329,7 @@ impl StyleEngine {
                     continue;
                 }
                 let Some(ceiling) = candidate.stratum.ceiling(candidate.declared.operator) else {
-                    cascaded.push((candidate.declared, candidate.written));
+                    cascaded.push((candidate.declared, candidate.written.clone_retained()));
                     break;
                 };
                 ceilings.push(ceiling);

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -326,7 +326,7 @@ impl StyleEngine {
             });
             candidates_by_name[index].push(candidate);
         }
-        let mut cascaded: Vec<(CustomDeclaration, RetainedStyleValueData)> = Vec::new();
+        let mut cascaded = Vec::with_capacity(candidates_by_name.len());
         let mut ceilings = Vec::new();
         for candidates in candidates_by_name {
             ceilings.clear();

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -395,7 +395,7 @@ impl StyleEngine {
             &cascaded,
         );
         if self.custom_property_environments.memoized(&key).is_none() {
-            let written_values = cascaded.iter().map(|(_, written)| written.clone_retained()).collect();
+            let written_values = cascaded.into_iter().map(|(_, written)| written).collect();
             self.custom_property_environments
                 .remember(key, environment, written_values);
         }
@@ -470,7 +470,7 @@ impl StyleEngine {
             ));
         }
         if values.is_empty() {
-            let written_values = cascaded.iter().map(|(_, written)| written.clone_retained()).collect();
+            let written_values = cascaded.into_iter().map(|(_, written)| written).collect();
             self.custom_property_environments
                 .remember(key, parent_environment, written_values);
             return Some(parent_environment);
@@ -512,7 +512,7 @@ impl StyleEngine {
                     .adopt_engine_environment(resolved.rust_store, parent_environment)
             }
         };
-        let written_values = cascaded.iter().map(|(_, written)| written.clone_retained()).collect();
+        let written_values = cascaded.into_iter().map(|(_, written)| written).collect();
         self.custom_property_environments
             .remember(key, identity, written_values);
         Some(identity)

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -266,7 +266,6 @@ impl StyleEngine {
     ) -> Option<Vec<(CustomDeclaration, RetainedStyleValueData)>> {
         struct Candidate<'a> {
             priority: CascadePriority,
-            order: usize,
             stratum: CascadeStratum,
             declared: CustomDeclaration,
             written: &'a RetainedStyleValueData,
@@ -286,7 +285,6 @@ impl StyleEngine {
                     self.cascade_priority_of(rule, tree_scope, specificity, scope_proximity, declared.important);
                 candidates.push(Candidate {
                     priority,
-                    order: candidates.len(),
                     stratum: self.cascade_stratum_of(rule, tree_scope, declared.important),
                     declared,
                     written,
@@ -305,13 +303,13 @@ impl StyleEngine {
             let priority = self.element_cascade_priority(node, ElementDeclarationKind::InlineStyle, declared.important);
             candidates.push(Candidate {
                 priority,
-                order: candidates.len(),
                 stratum: self.element_cascade_stratum(node, ElementDeclarationKind::InlineStyle, declared.important),
                 declared,
                 written,
             });
         }
-        candidates.sort_by_key(|candidate| (candidate.priority, candidate.order));
+        // Keep insertion order for declarations with equal cascade priority.
+        candidates.sort_by_key(|candidate| candidate.priority);
         let mut name_indices = HashMap::default();
         let mut candidates_by_name: Vec<Vec<Candidate>> = Vec::new();
         for candidate in candidates {

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -464,7 +464,7 @@ impl StyleEngine {
             }
             values.push((
                 name.raw.raw(),
-                name.text.clone(),
+                name.text.to_vec(),
                 declared.important,
                 value.pointer().cast(),
             ));

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_environments.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_environments.rs
@@ -59,7 +59,7 @@ struct EngineEnvironment {
 /// values alive prevents later declarations from being allocated at the same addresses.
 struct MemoizedEnvironment {
     identity: u64,
-    written_values: Vec<RetainedStyleValueData>,
+    written_values: Box<[RetainedStyleValueData]>,
 }
 
 /// One substituted value and the written value whose identity names it. Keeping the written value
@@ -206,14 +206,12 @@ impl CustomPropertyEnvironments {
     ) {
         let environment = MemoizedEnvironment {
             identity,
-            written_values,
+            written_values: written_values.into_boxed_slice(),
         };
-        self.nested_capacity_bytes +=
-            (environment.written_values.capacity() * size_of::<RetainedStyleValueData>()) as u64;
+        self.nested_capacity_bytes += size_of_val(environment.written_values.as_ref()) as u64;
         match self.memo.entry(inputs) {
             Entry::Occupied(mut entry) => {
-                self.nested_capacity_bytes -=
-                    (entry.get().written_values.capacity() * size_of::<RetainedStyleValueData>()) as u64;
+                self.nested_capacity_bytes -= size_of_val(entry.get().written_values.as_ref()) as u64;
                 entry.insert(environment);
             }
             Entry::Vacant(entry) => {
@@ -283,7 +281,7 @@ impl CustomPropertyEnvironments {
             let retain = is_live(environment.identity) && (inputs.parent == 0 || is_live(inputs.parent));
             if !retain {
                 self.nested_capacity_bytes -= (inputs.cascaded.capacity() * size_of::<CascadedCustomProperty>()
-                    + environment.written_values.capacity() * size_of::<RetainedStyleValueData>())
+                    + size_of_val(environment.written_values.as_ref()))
                     as u64;
             }
             retain
@@ -317,7 +315,7 @@ mod tests {
                 .iter()
                 .map(|(inputs, environment)| {
                     inputs.cascaded.capacity() * size_of::<CascadedCustomProperty>()
-                        + environment.written_values.capacity() * size_of::<RetainedStyleValueData>()
+                        + size_of_val(environment.written_values.as_ref())
                 })
                 .sum::<usize>();
         assert_eq!(environments.nested_capacity_bytes, expected as u64);

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_environments.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_environments.rs
@@ -46,7 +46,7 @@ pub(super) struct CascadedCustomProperty {
 pub(super) struct EnvironmentInputs {
     pub(super) parent: u64,
     pub(super) registration_generation: u64,
-    pub(super) cascaded: Vec<CascadedCustomProperty>,
+    pub(super) cascaded: Box<[CascadedCustomProperty]>,
 }
 
 /// An environment the engine resolved: its store, and the environment it was resolved over.
@@ -215,8 +215,7 @@ impl CustomPropertyEnvironments {
                 entry.insert(environment);
             }
             Entry::Vacant(entry) => {
-                self.nested_capacity_bytes +=
-                    (entry.key().cascaded.capacity() * size_of::<CascadedCustomProperty>()) as u64;
+                self.nested_capacity_bytes += size_of_val(entry.key().cascaded.as_ref()) as u64;
                 entry.insert(environment);
             }
         }
@@ -280,9 +279,8 @@ impl CustomPropertyEnvironments {
         self.memo.retain(|inputs, environment| {
             let retain = is_live(environment.identity) && (inputs.parent == 0 || is_live(inputs.parent));
             if !retain {
-                self.nested_capacity_bytes -= (inputs.cascaded.capacity() * size_of::<CascadedCustomProperty>()
-                    + size_of_val(environment.written_values.as_ref()))
-                    as u64;
+                self.nested_capacity_bytes -=
+                    (size_of_val(inputs.cascaded.as_ref()) + size_of_val(environment.written_values.as_ref())) as u64;
             }
             retain
         });
@@ -314,8 +312,7 @@ mod tests {
                 .memo
                 .iter()
                 .map(|(inputs, environment)| {
-                    inputs.cascaded.capacity() * size_of::<CascadedCustomProperty>()
-                        + size_of_val(environment.written_values.as_ref())
+                    size_of_val(inputs.cascaded.as_ref()) + size_of_val(environment.written_values.as_ref())
                 })
                 .sum::<usize>();
         assert_eq!(environments.nested_capacity_bytes, expected as u64);
@@ -330,15 +327,19 @@ mod tests {
             assert!(!environments.note_name(StyleAtomID(1), 0, &[45, 45, 120]));
         }
         assert_nested_capacity(&environments);
-        let inputs = |capacity| EnvironmentInputs {
+        let inputs = || EnvironmentInputs {
             parent: 0,
             registration_generation: 1,
-            cascaded: Vec::with_capacity(capacity),
+            cascaded: Box::new([CascadedCustomProperty {
+                name: StyleAtomID(1),
+                important: false,
+                written_value: 0,
+            }]),
         };
-        environments.remember(inputs(3), 1, Vec::with_capacity(2));
+        environments.remember(inputs(), 1, Vec::with_capacity(2));
         assert_nested_capacity(&environments);
         // Equal keys retain the original key's allocation when replacing the value.
-        environments.remember(inputs(7), 2, Vec::with_capacity(5));
+        environments.remember(inputs(), 2, Vec::with_capacity(5));
         assert_nested_capacity(&environments);
         environments.forget_names(&[StyleAtomID(1), StyleAtomID(1)]);
         assert_nested_capacity(&environments);

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_environments.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_environments.rs
@@ -102,7 +102,7 @@ impl Drop for RetainedCustomPropertyStore {
 /// by the fly string, and a `var()` reference names one by its text.
 pub(super) struct CustomPropertyName {
     pub(super) raw: RetainedUtf16FlyString,
-    pub(super) text: Vec<u16>,
+    pub(super) text: Box<[u16]>,
 }
 
 #[derive(Default)]
@@ -135,8 +135,8 @@ impl CustomPropertyEnvironments {
         let Entry::Vacant(entry) = self.names.entry(name) else {
             return false;
         };
-        let text = text.to_vec();
-        self.nested_capacity_bytes += (text.capacity() * size_of::<u16>()) as u64;
+        let text: Box<[u16]> = text.into();
+        self.nested_capacity_bytes += size_of_val(text.as_ref()) as u64;
         entry.insert(CustomPropertyName {
             raw: unsafe { RetainedUtf16FlyString::from_borrowed_raw(raw) },
             text,
@@ -152,7 +152,7 @@ impl CustomPropertyEnvironments {
     pub(super) fn forget_names(&mut self, names: &[StyleAtomID]) {
         for name in names {
             if let Some(name) = self.names.remove(name) {
-                self.nested_capacity_bytes -= (name.text.capacity() * size_of::<u16>()) as u64;
+                self.nested_capacity_bytes -= size_of_val(name.text.as_ref()) as u64;
             }
         }
     }
@@ -310,7 +310,7 @@ mod tests {
         let expected = environments
             .names
             .values()
-            .map(|name| name.text.capacity() * size_of::<u16>())
+            .map(|name| size_of_val(name.text.as_ref()))
             .sum::<usize>()
             + environments
                 .memo

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -2853,10 +2853,10 @@ impl RuleDispatch {
     ///
     /// Cascade matching reads this directly while walking candidates. Keeping it in the immutable
     /// dispatch avoids looking the rule up through several program maps for every element.
-    pub fn assign_cascade_properties(
+    pub fn assign_cascade_properties<Properties: ExactSizeIterator<Item = u16>>(
         &mut self,
         mut blocks_pruning: impl FnMut(DispatchEntry) -> bool,
-        mut properties_of: impl FnMut(DispatchEntry) -> Option<Vec<u16>>,
+        mut properties_of: impl FnMut(DispatchEntry) -> Option<Properties>,
     ) {
         self.cascade_properties.clear();
         self.cascade_entries.clear();

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -3456,7 +3456,7 @@ pub struct ElementFactStore {
     /// One entry per distinct set of declared custom property names, and the sets each name is in.
     /// A theme is one set however many elements it decides for, which is what keeps the index
     /// proportional to the stylesheet rather than to the document times the stylesheet.
-    custom_property_name_sets: super::intern_table::InternTable<CustomPropertyNameSetID, Vec<StyleAtomID>>,
+    custom_property_name_sets: super::intern_table::InternTable<CustomPropertyNameSetID, Box<[StyleAtomID]>>,
     custom_property_name_set_vacancies: Vec<u32>,
     custom_property_set_ids_by_name: PagedOwnedColumn<Vec<u32>>,
     /// Authoritative semantic references from committed fact rows and per-element metadata. This
@@ -4678,7 +4678,7 @@ impl ElementFactStore {
         let hash = super::intern_table::content_hash(names);
         if let Some(candidate) = self
             .custom_property_name_sets
-            .find(hash, |_identity, candidate| candidate == names)
+            .find(hash, |_identity, candidate| candidate.as_ref() == names)
         {
             return candidate.0;
         }
@@ -4686,7 +4686,7 @@ impl ElementFactStore {
             u32::try_from(self.custom_property_name_sets.len() + 1).expect("custom property name set space exhausted")
         });
         self.custom_property_name_sets
-            .insert(hash, CustomPropertyNameSetID(id), names.to_vec());
+            .insert(hash, CustomPropertyNameSetID(id), names.into());
         for name in names {
             self.custom_property_set_ids_by_name.entry(name.0 as usize).push(id);
         }
@@ -5129,7 +5129,7 @@ impl ElementFactStore {
                 if !self.custom_property_name_sets[identity].is_empty() {
                     let hash = super::intern_table::content_hash(&self.custom_property_name_sets[identity]);
                     self.custom_property_name_sets.remove_identity(hash, identity);
-                    self.custom_property_name_sets[identity] = Vec::new();
+                    self.custom_property_name_sets[identity] = Box::default();
                 }
                 self.custom_property_name_set_vacancies.push(id as u32);
                 continue;
@@ -5239,7 +5239,7 @@ impl ElementFactStore {
         let custom_property_name_payloads = self
             .custom_property_name_sets
             .iter()
-            .map(|names| names.capacity() * size_of::<StyleAtomID>())
+            .map(|names| size_of_val(names.as_ref()))
             .sum::<usize>();
         let custom_property_name_index_payloads = self
             .custom_property_set_ids_by_name

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -4987,18 +4987,19 @@ impl ElementFactStore {
     }
 
     pub fn set_parts(&mut self, node: StyleNodeID, parts: &[StyleAtomID], memory: &mut MemoryController) {
-        let previous = self.parts_of(node).to_vec();
+        let previous = self.edit_staged_row(node, |facts| std::mem::replace(&mut facts.parts, parts.to_vec()));
         for &part in previous.iter().filter(|part| !parts.contains(part)) {
             self.postings.remove(SelectorPostingKey::Part(part), node);
         }
         for &part in parts.iter().filter(|part| !previous.contains(part)) {
             self.postings.insert(SelectorPostingKey::Part(part), node, memory);
         }
-        self.edit_staged_row(node, |facts| facts.parts = parts.to_vec());
     }
 
     pub fn set_custom_states(&mut self, node: StyleNodeID, states: &[StyleAtomID], memory: &mut MemoryController) {
-        let previous = self.custom_states_of(node).to_vec();
+        let previous = self.edit_staged_row(node, |facts| {
+            std::mem::replace(&mut facts.custom_states, states.to_vec())
+        });
         for &state in previous.iter().filter(|state| !states.contains(state)) {
             self.postings.remove(SelectorPostingKey::CustomState(state), node);
         }
@@ -5006,7 +5007,6 @@ impl ElementFactStore {
             self.postings
                 .insert(SelectorPostingKey::CustomState(state), node, memory);
         }
-        self.edit_staged_row(node, |facts| facts.custom_states = states.to_vec());
     }
 
     pub fn forget(&mut self, node: StyleNodeID) {

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -366,8 +366,8 @@ impl<T: Clone + Default> ShallowCapacityBytes for PagedOwnedColumn<T> {
 #[derive(Clone, Default)]
 struct AttributeCatalogs {
     name_forms: PagedCopyColumn<AttributeNameForms>,
-    value_texts: PagedOwnedColumn<Option<Vec<u16>>>,
-    language_texts: PagedOwnedColumn<Option<Vec<u16>>>,
+    value_texts: PagedOwnedColumn<Option<Box<[u16]>>>,
+    language_texts: PagedOwnedColumn<Option<Box<[u16]>>>,
 }
 
 const NO_ROW: u32 = u32::MAX;
@@ -4486,7 +4486,7 @@ impl ElementFactStore {
         self.memory_dirty = true;
         self.attribute_catalogs_mut()
             .language_texts
-            .insert(index, Some(text.to_vec()));
+            .insert(index, Some(text.into()));
     }
 
     pub fn set_language(&mut self, node: StyleNodeID, language: StyleAtomID) {
@@ -4961,7 +4961,7 @@ impl ElementFactStore {
         self.memory_dirty = true;
         self.attribute_catalogs_mut()
             .value_texts
-            .insert(index, Some(text.to_vec()));
+            .insert(index, Some(text.into()));
         self.attribute_value_catalog_version = self
             .attribute_value_catalog_version
             .checked_add(1)
@@ -5251,14 +5251,14 @@ impl ElementFactStore {
             .language_texts
             .iter()
             .flatten()
-            .map(|text| text.capacity() * size_of::<u16>())
+            .map(|text| text.len() * size_of::<u16>())
             .sum::<usize>();
         let attribute_value_payloads = self
             .attribute_catalogs
             .value_texts
             .iter()
             .flatten()
-            .map(|text| text.capacity() * size_of::<u16>())
+            .map(|text| text.len() * size_of::<u16>())
             .sum::<usize>();
 
         capacity_bytes! {
@@ -5822,7 +5822,7 @@ mod tests {
             facts.sweep_auxiliary_catalogs();
             assert_eq!(
                 facts.rows.attribute_catalogs.language_texts.get(language.0 as usize),
-                Some(&Some(vec![index as u16]))
+                Some(&Some(Box::from([index as u16])))
             );
             assert_eq!(
                 facts.rows.attribute_catalogs.name_forms.get(attribute_name.0 as usize),

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -51,6 +51,8 @@ use super::program::SelectorProgramID;
 use super::selector::AttributeCase;
 use super::selector::AttributeOperator;
 use super::selector::AttributeTest;
+use super::sorted_merge::SortedMergeEntry;
+use super::sorted_merge::merge_sorted_by;
 use super::transaction::ElementDeclarationKind;
 use super::transaction::StateFact;
 use super::tree::StyleNodeID;
@@ -4546,23 +4548,26 @@ impl ElementFactStore {
         let mut sorted: Vec<StyleAtomID> = names.to_vec();
         sorted.sort_unstable_by_key(|name| name.0);
         sorted.dedup();
-        let previous = self
+        if self
             .metadata_of(node)
-            .map_or_else(Vec::new, |metadata| metadata.animation_names.clone());
-        if previous == sorted {
+            .map_or(&[][..], |metadata| &metadata.animation_names)
+            == sorted
+        {
             return;
         }
-        for &name in &previous {
-            if !sorted.contains(&name) {
-                self.postings.remove(DependencyPostingKey::AnimationName(name), node);
-                Self::decrement_atom_count(&mut self.atom_live_counts, name);
-            }
-        }
-        for name in &sorted {
-            if !previous.contains(name) {
-                self.postings
-                    .insert(DependencyPostingKey::AnimationName(*name), node, memory);
-                Self::increment_atom_count(&mut self.atom_live_counts, *name);
+        let previous = std::mem::take(&mut self.metadata_mut(node).animation_names);
+        for entry in merge_sorted_by(&previous, &sorted, |left, right| left.0.cmp(&right.0)) {
+            match entry {
+                SortedMergeEntry::Left(&name) => {
+                    self.postings.remove(DependencyPostingKey::AnimationName(name), node);
+                    Self::decrement_atom_count(&mut self.atom_live_counts, name);
+                }
+                SortedMergeEntry::Right(&name) => {
+                    self.postings
+                        .insert(DependencyPostingKey::AnimationName(name), node, memory);
+                    Self::increment_atom_count(&mut self.atom_live_counts, name);
+                }
+                SortedMergeEntry::Both(..) => {}
             }
         }
         self.metadata_mut(node).animation_names = sorted;

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -1846,11 +1846,11 @@ impl StyleEngine {
         if let Some(incidences) = self.retained_selector_incidences.lookup(program) {
             return Some(Rc::clone(incidences));
         }
-        let (scope_program, dispatch) = self.ranked_scope_program(TreeScopeID::DOCUMENT);
-        let compiled = self.programs.get(program);
-        if compiled.can_leave_its_scope() {
+        if self.programs.get(program).can_leave_its_scope() {
             return None;
         }
+        let (scope_program, dispatch) = self.ranked_scope_program(TreeScopeID::DOCUMENT);
+        let compiled = self.programs.get(program);
         let mut incidences = Vec::new();
         for (entry_index, entry) in compiled.entries().iter().enumerate() {
             let posting_key = compiled.dispatch_key(entry);
@@ -1914,7 +1914,7 @@ impl StyleEngine {
                 match MatchEvaluator::new(&self.tree, self.facts.primary()).matches_entry_after_dispatch(
                     compiled,
                     entry,
-                    compiled.dispatch_key(entry),
+                    posting_key,
                     node,
                     &mut self.counters,
                 ) {

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -1122,7 +1122,7 @@ impl StyleEngine {
                 if declared.iter().any(|property| property.important) {
                     return None;
                 }
-                Some(declared.iter().map(|property| property.property).collect())
+                Some(declared.iter().map(|property| property.property))
             },
         );
         dispatch.settle_memory(&mut self.memory);

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -1864,6 +1864,15 @@ impl StyleEngine {
             };
             let subject_required = compiled.subject_required_keys(entry_index);
             let position = compiled.subject_position(entry_index);
+            let prefix_entry = entry
+                .has_prefix_chain()
+                .then(|| {
+                    self.programs.entry_id(
+                        program,
+                        u32::try_from(entry_index).expect("selector entry identity space exhausted"),
+                    )
+                })
+                .filter(|&entry| dispatch.prefixes().contains_entry(entry));
             for node in candidates {
                 if !self.node_is_within_subject_position(node, position) {
                     continue;
@@ -1885,20 +1894,13 @@ impl StyleEngine {
                 if !carries_required {
                     continue;
                 }
-                if entry.has_prefix_chain()
-                    && dispatch.prefixes().contains_entry(self.programs.entry_id(
-                        program,
-                        u32::try_from(entry_index).expect("selector entry identity space exhausted"),
-                    ))
-                {
+                if let Some(prefix_entry) = prefix_entry {
                     let retained_prefix_match = {
                         let caches = self.prefix_caches.borrow();
                         caches.states.lookup(scope_program).sparse().ok().and_then(|states| {
-                            states.retained_matches_for(node).map(|matches| {
-                                matches
-                                    .iter()
-                                    .any(|&matched| matched == self.programs.entry_id(program, entry_index as u32))
-                            })
+                            states
+                                .retained_matches_for(node)
+                                .map(|matches| matches.contains(&prefix_entry))
                         })
                     };
                     if let Some(matches) = retained_prefix_match {

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -1929,10 +1929,11 @@ impl StyleEngine {
         }
         incidences.sort_unstable();
         incidences.dedup();
-        let mut selected = Vec::<RetainedSelectorIncidence>::new();
-        for incidence in incidences {
+        let mut selected_count = 0;
+        for index in 0..incidences.len() {
+            let incidence = incidences[index];
             let entry = &compiled.entries()[incidence.entry as usize];
-            let existing = selected
+            let existing = incidences[..selected_count]
                 .iter_mut()
                 .rev()
                 .take_while(|existing| existing.node == incidence.node)
@@ -1942,12 +1943,14 @@ impl StyleEngine {
                     *existing = incidence;
                 }
             } else {
-                selected.push(incidence);
+                incidences[selected_count] = incidence;
+                selected_count += 1;
             }
         }
-        selected.sort_unstable();
+        incidences.truncate(selected_count);
+        incidences.sort_unstable();
         self.retained_selector_incidences
-            .remember(program, selected, &mut self.memory)
+            .remember(program, incidences, &mut self.memory)
     }
 
     /// Read one selector entry's pre-transaction truth from the retained exact answer.

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -334,7 +334,9 @@ impl StyleEngine {
                 Lookup::Missing(_) => return false,
             }
         }
-        self.ensure_query_preorder_ranks(root);
+        if !candidates.is_empty() {
+            self.ensure_query_preorder_ranks(root);
+        }
         let ranks = &self.query_preorder_ranks;
         // A candidate without a rank lies outside the queried subtree.
         let mut ranked: Vec<(u32, StyleNodeID)> = candidates

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -3605,7 +3605,7 @@ impl StyleEngine {
             Lookup::Known((current_generation, current)) if current_generation == previous_generation => current,
             Lookup::Known(_) | Lookup::KnownAbsent | Lookup::Missing(_) => return false,
         };
-        self.winner_groups.semantic_delta(Some(previous), current).is_empty()
+        self.winner_groups.states_are_semantically_equal(previous, current)
     }
 
     /// Consume the complete current answer which the immediately preceding style plan retained.
@@ -3800,7 +3800,7 @@ impl StyleEngine {
                     match winner_groups.token_for(WinnerGroupKey::current_pseudo(node, pseudo, self.program.version()))
                     {
                         Lookup::Known((retained_generation, state)) if retained_generation == computed.0 => {
-                            winner_groups.semantic_delta(Some(computed.1), state).is_empty()
+                            winner_groups.states_are_semantically_equal(computed.1, state)
                         }
                         Lookup::Known(_) | Lookup::KnownAbsent | Lookup::Missing(_) => false,
                     }
@@ -3827,7 +3827,7 @@ impl StyleEngine {
                                 .map(|(_, state)| state)
                                 .is_some_and(|computed| {
                                     computed.0 == generation
-                                        && winner_groups.semantic_delta(Some(computed.1), state).is_empty()
+                                        && winner_groups.states_are_semantically_equal(computed.1, state)
                                 })
                         })
                 })

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -5,6 +5,7 @@
  */
 
 use super::batch_matcher::{append_selector_truth_matches, insert_scope_rule};
+use super::cascade::CascadeContinuationID;
 use super::selector::{AttributeCase, AttributeOperator};
 use super::*;
 
@@ -2533,7 +2534,7 @@ impl StyleEngine {
                 let Some(winner) = self.winner_groups.winner_in_state(previous, declared.property) else {
                     return false;
                 };
-                if self.winner_groups.continuation(winner.key.continuation).is_some() {
+                if winner.key.continuation != CascadeContinuationID::default() {
                     return false;
                 }
                 match delta.change {
@@ -3520,7 +3521,7 @@ impl StyleEngine {
                     self.counters.bump(Counter::TransitionProofWinnerGap);
                     return false;
                 };
-                if self.winner_groups.continuation(winner.key.continuation).is_some() {
+                if winner.key.continuation != CascadeContinuationID::default() {
                     self.counters.bump(Counter::TransitionProofOperatorOrContinuation);
                     return false;
                 }

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -2276,24 +2276,26 @@ impl StyleEngine {
                     evaluate: true,
                 }),
         );
-        let removed_programs: Vec<SelectorProgramID> = affected
+        let mut removed_programs: Vec<SelectorProgramID> = affected
             .iter()
             .filter_map(|affected| (!affected.evaluate).then_some(affected.program))
             .collect();
-        for program in removed_programs {
+        if !removed_programs.is_empty() {
+            removed_programs.sort_unstable();
+            removed_programs.dedup();
             affected.extend(
                 self.program
                     .sheets_in_scope(TreeScopeID::DOCUMENT)
                     .iter()
                     .flat_map(|&sheet| self.program.rules_in_sheet(sheet))
                     .filter_map(|current_rule| {
-                        (self.program.rule_version(current_rule).selector_program == Some(program)).then_some(
-                            RetainedAnswerPatchSelectionRule {
-                                rule: current_rule,
-                                program,
-                                evaluate: true,
-                            },
-                        )
+                        let program = self.program.rule_version(current_rule).selector_program?;
+                        removed_programs.binary_search(&program).ok()?;
+                        Some(RetainedAnswerPatchSelectionRule {
+                            rule: current_rule,
+                            program,
+                            evaluate: true,
+                        })
                     }),
             );
         }

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -2705,7 +2705,7 @@ impl StyleEngine {
         if let Some(key) = &memo_key
             && let Some(entry) = patch.delta_memo.get(key)
             && Self::retained_answer_delta_memo_entry_matches(entry, deltas)
-            && let transition = entry.transition.clone()
+            && let transition = &entry.transition
             && self
                 .retained_match_answers
                 .set_interned_identity(node, &mut self.match_answers, transition.new_answer)
@@ -2714,10 +2714,6 @@ impl StyleEngine {
             let stopped = transition.new_cascade_input == old_cascade_input;
             if let Some((state, version)) = transition.winner_state {
                 let _ = self.winner_groups.set(node, state, version);
-                // The pseudo-element rows replay with the winner state, of the same version.
-                for &(pseudo, state) in transition.pseudo_winner_states.iter() {
-                    let _ = self.winner_groups.set_pseudo(node, pseudo, state, version);
-                }
             }
             // Pseudo-element rows are independent of the element's sparse winner row.
             for &(pseudo, state) in transition.pseudo_winner_states.iter() {

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -862,6 +862,9 @@ impl StyleEngine {
                     matched.scope_proximity,
                     declared.important,
                 );
+                if previous_winner.is_some_and(|winner| priority < winner.priority) {
+                    continue;
+                }
                 let winner = PropertyWinner {
                     property: declared.property,
                     important: declared.important,
@@ -873,13 +876,6 @@ impl StyleEngine {
                     let pending = update.winner.as_mut().expect("an added declaration carries a winner");
                     if priority >= pending.priority {
                         *pending = winner;
-                    }
-                } else if let Some(previous_winner) = previous_winner {
-                    if priority >= previous_winner.priority {
-                        updates.push(PropertyWinnerUpdate {
-                            property: declared.property,
-                            winner: Some(winner),
-                        });
                     }
                 } else {
                     updates.push(PropertyWinnerUpdate {

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -822,7 +822,6 @@ impl StyleEngine {
 
         let mut repair_properties = Vec::new();
         let mut updates: Vec<PropertyWinnerUpdate> = Vec::new();
-        let mut update_priorities = Vec::new();
         for delta in deltas {
             let entry = *self.programs.entry(delta.entry).1;
             if entry.pseudo_element != pseudo {
@@ -869,10 +868,10 @@ impl StyleEngine {
                     priority,
                     source: WinnerSource::Rule(delta.rule),
                 };
-                if let Some(index) = updates.iter().position(|update| update.property == declared.property) {
-                    if priority >= update_priorities[index] {
-                        updates[index].winner = Some(winner);
-                        update_priorities[index] = priority;
+                if let Some(update) = updates.iter_mut().find(|update| update.property == declared.property) {
+                    let pending = update.winner.as_mut().expect("an added declaration carries a winner");
+                    if priority >= pending.priority {
+                        *pending = winner;
                     }
                 } else if let Some(previous_winner) = self.winner_groups.winner_in_state(previous, declared.property) {
                     if priority >= previous_winner.priority {
@@ -880,14 +879,12 @@ impl StyleEngine {
                             property: declared.property,
                             winner: Some(winner),
                         });
-                        update_priorities.push(priority);
                     }
                 } else {
                     updates.push(PropertyWinnerUpdate {
                         property: declared.property,
                         winner: Some(winner),
                     });
-                    update_priorities.push(priority);
                 }
             }
         }

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -1232,8 +1232,10 @@ impl StyleEngine {
         declaration_changes.retain(|change| {
             transaction
                 .inputs
-                .iter()
-                .any(|input| input.key == InputKey::RuleField(change.rule, RuleField::Declarations))
+                .binary_search_by_key(&InputKey::RuleField(change.rule, RuleField::Declarations), |input| {
+                    input.key
+                })
+                .is_ok()
         });
         transaction.install_rule_declaration_changes(
             declaration_changes

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use super::cascade::{CascadeAttachment, Top1Winner};
+use super::cascade::{CascadeAttachment, CascadeContinuationID, Top1Winner};
 use super::*;
 
 #[derive(Clone, Copy)]
@@ -842,9 +842,7 @@ impl StyleEngine {
                     continue;
                 }
                 let previous_winner = self.winner_groups.winner_in_state(previous, declared.property);
-                if previous_winner
-                    .is_some_and(|winner| self.winner_groups.continuation(winner.key.continuation).is_some())
-                {
+                if previous_winner.is_some_and(|winner| winner.key.continuation != CascadeContinuationID::default()) {
                     repair_properties.push(declared.property);
                     continue;
                 }

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -828,6 +828,7 @@ impl StyleEngine {
             if entry.pseudo_element != pseudo {
                 continue;
             }
+            let mut matched_rule = None;
             for &declared in self.program.declared_properties_of(delta.rule) {
                 if !property_is_longhand(declared.property) {
                     continue;
@@ -845,9 +846,13 @@ impl StyleEngine {
                     repair_properties.push(declared.property);
                     continue;
                 }
-                let Some(matched) = matches.iter().find(|matched| {
-                    matched.rule == delta.rule && self.programs.entry_id(matched.program, matched.entry) == delta.entry
-                }) else {
+                if matched_rule.is_none() {
+                    matched_rule = matches.iter().find(|matched| {
+                        matched.rule == delta.rule
+                            && self.programs.entry_id(matched.program, matched.entry) == delta.entry
+                    });
+                }
+                let Some(matched) = matched_rule else {
                     return false;
                 };
                 let priority = self.cascade_priority_of(

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -259,7 +259,6 @@ impl StyleEngine {
                         priority,
                         source: WinnerSource::Rule(entry.rule),
                     },
-                    priority,
                     stratum: self.cascade_stratum_of(entry.rule, entry.tree_scope, declared.important),
                 });
             }
@@ -288,7 +287,6 @@ impl StyleEngine {
                             priority,
                             source: WinnerSource::Element(kind),
                         },
-                        priority,
                         stratum: self.element_cascade_stratum(node, kind, declared.important),
                     });
                 }

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -832,16 +832,15 @@ impl StyleEngine {
                 if !property_is_longhand(declared.property) {
                     continue;
                 }
-                let retained_winner_has_continuation = self
-                    .winner_groups
-                    .winner_in_state(previous, declared.property)
-                    .is_some_and(|winner| self.winner_groups.continuation(winner.key.continuation).is_some());
                 if delta.change == SetChange::Removed
-                    || retained_winner_has_continuation
                     || matches!(
                         declared.operator,
                         CascadeOperator::Revert | CascadeOperator::RevertLayer
                     )
+                    || self
+                        .winner_groups
+                        .winner_in_state(previous, declared.property)
+                        .is_some_and(|winner| self.winner_groups.continuation(winner.key.continuation).is_some())
                 {
                     repair_properties.push(declared.property);
                     continue;

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -837,10 +837,13 @@ impl StyleEngine {
                         declared.operator,
                         CascadeOperator::Revert | CascadeOperator::RevertLayer
                     )
-                    || self
-                        .winner_groups
-                        .winner_in_state(previous, declared.property)
-                        .is_some_and(|winner| self.winner_groups.continuation(winner.key.continuation).is_some())
+                {
+                    repair_properties.push(declared.property);
+                    continue;
+                }
+                let previous_winner = self.winner_groups.winner_in_state(previous, declared.property);
+                if previous_winner
+                    .is_some_and(|winner| self.winner_groups.continuation(winner.key.continuation).is_some())
                 {
                     repair_properties.push(declared.property);
                     continue;
@@ -873,7 +876,7 @@ impl StyleEngine {
                     if priority >= pending.priority {
                         *pending = winner;
                     }
-                } else if let Some(previous_winner) = self.winner_groups.winner_in_state(previous, declared.property) {
+                } else if let Some(previous_winner) = previous_winner {
                     if priority >= previous_winner.priority {
                         updates.push(PropertyWinnerUpdate {
                             property: declared.property,

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -1397,16 +1397,17 @@ impl StyleEngine {
         let mut reclaimable = self.atoms.reclaimable_for_sweep(&live);
         if let Some(recorded) = replay_reclaimed {
             assert!(
-                recorded.iter().all(|atom| reclaimable.contains(atom)),
+                recorded.iter().all(|atom| reclaimable.binary_search(atom).is_ok()),
                 "a recorded atom release still has a semantic replay owner"
             );
             reclaimable = recorded;
+            reclaimable.sort_unstable();
         }
         self.facts.forget_atoms(&reclaimable);
         self.custom_property_environments.forget_names(&reclaimable);
         let requirement_count = self.attribute_value_text_names.len();
         self.attribute_value_text_names
-            .retain(|atom| !reclaimable.contains(atom));
+            .retain(|atom| reclaimable.binary_search(atom).is_err());
         if self.attribute_value_text_names.len() != requirement_count {
             self.attribute_value_text_requirements_version += 1;
         }

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -764,16 +764,15 @@ impl StyleEngine {
             candidates,
         );
 
+        // Winners are an ordered subset of the requested properties.
+        let mut winners = winners.into_iter().peekable();
         Some(
             properties
                 .iter()
                 .copied()
                 .map(|property| PropertyWinnerUpdate {
                     property,
-                    winner: winners
-                        .binary_search_by_key(&property, |winner| winner.property)
-                        .ok()
-                        .map(|index| winners[index]),
+                    winner: winners.next_if(|winner| winner.property == property),
                 })
                 .collect(),
         )

--- a/Libraries/LibWeb/Rust/src/css/style/planning.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/planning.rs
@@ -62,7 +62,7 @@ impl RemainingPostingDirectory {
 }
 
 pub(super) struct ImpactPlanningWorkspace {
-    pub(super) batches: HashMap<Vec<ImpactRegion>, Rc<ImpactRegionBatch>>,
+    pub(super) batches: HashMap<Box<[ImpactRegion]>, Rc<ImpactRegionBatch>>,
     // Fact postings cannot change while one transaction is being planned, and the exact-node plan
     // only grows. Removing planned nodes here is therefore permanent for the lifetime of this
     // workspace: later routes see the posting members that can still contribute, not the same
@@ -574,22 +574,14 @@ impl ImpactPlanningWorkspace {
     }
 
     pub(super) fn insert_batch(&mut self, regions: &[ImpactRegion], batch: Rc<ImpactRegionBatch>) {
-        let previous_batch_bytes = self.batches.get(regions).map_or(0, |previous| previous.storage_bytes());
-        let regions = regions.to_vec();
-        let region_bytes = regions.capacity() * size_of::<ImpactRegion>();
-        let batch_bytes = batch.storage_bytes();
-        let payload_bytes = region_bytes + batch_bytes;
-        if self.batches.insert(regions, batch).is_some() {
-            if batch_bytes >= previous_batch_bytes {
-                self.nested_memory
-                    .grow_committed((batch_bytes - previous_batch_bytes) as u64);
-            } else {
-                self.nested_memory
-                    .shrink_committed((previous_batch_bytes - batch_bytes) as u64);
-            }
-        } else {
-            self.nested_memory.grow_committed(payload_bytes as u64);
-        }
+        let regions: Box<[ImpactRegion]> = regions.into();
+        let payload_bytes = size_of_val(regions.as_ref()) + batch.storage_bytes();
+        let previous = self.batches.insert(regions, batch);
+        assert!(
+            previous.is_none(),
+            "region batches are inserted only after a cache miss"
+        );
+        self.nested_memory.grow_committed(payload_bytes as u64);
     }
 
     pub(super) fn settle_memory(&mut self, memory: &mut MemoryController) {

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -571,28 +571,30 @@ impl PrefixAutomaton {
         for (order, &step) in step_by_dispatch_order.iter().enumerate() {
             remap[step.0 as usize] = u32::try_from(order).expect("selector prefix step space exhausted");
         }
-        let old_steps = std::mem::take(&mut self.steps);
-        self.steps = step_by_dispatch_order
-            .iter()
-            .map(|step| old_steps[step.0 as usize].clone())
-            .collect();
-        let mut old_builders = std::mem::take(&mut self.step_output_builders);
-        self.step_output_builders = step_by_dispatch_order
-            .iter()
-            .map(|step| std::mem::take(&mut old_builders[step.0 as usize]))
-            .collect();
-        let old_predecessors = std::mem::take(&mut self.step_predecessors);
-        self.step_predecessors = step_by_dispatch_order
-            .iter()
-            .map(|step| {
-                let predecessor = old_predecessors[step.0 as usize];
-                if predecessor == u32::MAX {
-                    u32::MAX
-                } else {
-                    remap[predecessor as usize]
+        // Apply each permutation cycle to the parallel arrays in place. Replacing a visited
+        // source with its own index makes the cycle a no-op when reached again.
+        for start in 0..step_by_dispatch_order.len() {
+            let mut current = start;
+            loop {
+                let next = step_by_dispatch_order[current].0 as usize;
+                step_by_dispatch_order[current] =
+                    PrefixStepID(u32::try_from(current).expect("selector prefix step space exhausted"));
+                if next == start {
+                    break;
                 }
-            })
-            .collect();
+                self.steps.swap(current, next);
+                self.step_output_builders.swap(current, next);
+                self.step_predecessors.swap(current, next);
+                current = next;
+            }
+        }
+        for predecessor in &mut self.step_predecessors {
+            if *predecessor != u32::MAX {
+                *predecessor = remap[*predecessor as usize];
+            }
+        }
+        self.steps.shrink_to_fit();
+        self.step_predecessors.shrink_to_fit();
         let remap_steps = |steps: &mut Vec<PrefixStepID>| {
             for step in steps {
                 step.0 = remap[step.0 as usize];

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -21,6 +21,7 @@
 use super::capacity::capacity_bytes;
 use super::fast_hash::FastMap as HashMap;
 use super::fast_hash::fast_hasher;
+use std::collections::hash_map::Entry;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::mem::size_of;
@@ -445,14 +446,14 @@ impl PrefixAutomaton {
                     local: chain_step.local,
                 },
             };
-            let compound = match self.compound_ids.get(&predicate).copied() {
-                Some(compound) => compound,
-                None => {
+            let compound = match self.compound_ids.entry(predicate) {
+                Entry::Occupied(entry) => *entry.get(),
+                Entry::Vacant(entry) => {
                     let compound = PrefixCompoundID(
                         u32::try_from(self.compounds.len()).expect("selector prefix compound space exhausted"),
                     );
                     let dispatch_key = program.prefix_dispatch_key(chain_step.local);
-                    let runtime_predicate = match &predicate {
+                    let runtime_predicate = match entry.key() {
                         PrefixPredicateKey::Features {
                             features,
                             required_positional_bits,
@@ -477,7 +478,7 @@ impl PrefixAutomaton {
                         dispatch_key,
                     });
                     self.buckets.entry(dispatch_key).or_default();
-                    self.compound_ids.insert(predicate, compound);
+                    entry.insert(compound);
                     compound
                 }
             };
@@ -486,9 +487,9 @@ impl PrefixAutomaton {
                 predecessor,
                 axis: chain_step.axis,
             };
-            let step = match self.step_ids.get(&key).copied() {
-                Some(step) => step,
-                None => {
+            let step = match self.step_ids.entry(key) {
+                Entry::Occupied(entry) => *entry.get(),
+                Entry::Vacant(entry) => {
                     let step =
                         PrefixStepID(u32::try_from(self.steps.len()).expect("selector prefix step space exhausted"));
                     self.steps.push(PrefixStep {
@@ -498,7 +499,7 @@ impl PrefixAutomaton {
                     });
                     self.step_predecessors.push(predecessor.map_or(u32::MAX, |step| step.0));
                     self.step_output_builders.push(PrefixStepOutputBuilder::default());
-                    self.step_ids.insert(key, step);
+                    entry.insert(step);
                     // Only root steps dispatch through buckets: a continuation step is reachable
                     // exactly when its predecessor put it in the parent state, so transitions find
                     // it by walking the (small) active set and asking whether the row carries its

--- a/Libraries/LibWeb/Rust/src/css/style/program.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/program.rs
@@ -613,15 +613,15 @@ impl StyleSheetProgram {
             .map_or(&[], Vec::as_slice)
     }
 
-    pub(crate) fn set_sheets_in_scope(&mut self, tree_scope: TreeScopeID, sheets: &[SheetID]) {
+    pub(crate) fn set_sheets_in_scope(&mut self, tree_scope: TreeScopeID, sheets: Vec<SheetID>) {
         let index = tree_scope.0 as usize;
         self.capacity_bytes += self.sheet_order.ensure(index);
         self.capacity_bytes += self.sheets_by_scope.ensure(index);
         let previous_scope_capacity = (self.sheets_by_scope[index].capacity() * size_of::<SheetID>()) as u64;
-        let previous_sheets = std::mem::replace(&mut self.sheets_by_scope[index], sheets.to_vec());
+        let previous_sheets = std::mem::replace(&mut self.sheets_by_scope[index], sheets);
         let mut attachment_presence: Vec<_> = previous_sheets
             .iter()
-            .chain(sheets)
+            .chain(&self.sheets_by_scope[index])
             .map(|&sheet| (sheet, self.sheet_is_attached_somewhere(sheet)))
             .collect();
         attachment_presence.sort_unstable_by_key(|&(sheet, _)| sheet);
@@ -634,7 +634,8 @@ impl StyleSheetProgram {
                 .retain(|attachment| attachment.tree_scope != tree_scope);
         }
         let mut order = OrderMaintenance::new();
-        for &sheet in sheets {
+        for position in 0..self.sheets_by_scope[index].len() {
+            let sheet = self.sheets_by_scope[index][position];
             let attachment = Attachment {
                 tree_scope,
                 order: order.insert_last(),
@@ -1686,14 +1687,14 @@ mod tests {
         program.append_rule(second, None, RuleKind::Style);
         let unattached_version = program.routing_liveness_version();
 
-        program.set_sheets_in_scope(TreeScopeID::DOCUMENT, &[first, second]);
+        program.set_sheets_in_scope(TreeScopeID::DOCUMENT, vec![first, second]);
         let attached_version = program.routing_liveness_version();
         assert!(attached_version > unattached_version);
 
-        program.set_sheets_in_scope(TreeScopeID::DOCUMENT, &[second, first]);
+        program.set_sheets_in_scope(TreeScopeID::DOCUMENT, vec![second, first]);
         assert_eq!(program.routing_liveness_version(), attached_version);
 
-        program.set_sheets_in_scope(TreeScopeID::DOCUMENT, &[]);
+        program.set_sheets_in_scope(TreeScopeID::DOCUMENT, Vec::new());
         assert!(program.routing_liveness_version() > attached_version);
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/program_updates.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/program_updates.rs
@@ -723,7 +723,7 @@ impl StyleEngine {
         if !sheet_orders.is_empty() {
             sheet_orders.sort_unstable_by_key(|(scope, _)| *scope);
             for (scope, sheets) in sheet_orders {
-                self.program.set_sheets_in_scope(scope, &sheets);
+                self.program.set_sheets_in_scope(scope, sheets);
             }
             self.settle_program();
         }

--- a/Libraries/LibWeb/Rust/src/css/style/program_updates.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/program_updates.rs
@@ -214,19 +214,24 @@ impl StyleEngine {
             return;
         }
         let custom_declarations_changed = self.current_custom_declarations_of(rule) != custom_declarations;
-        let mut new_properties: Vec<u16> = declared.iter().map(|declared| declared.property).collect();
-        new_properties.sort_unstable();
-        new_properties.dedup();
         if let Some(change) = self
             .program_staging
             .rule_declaration_changes
             .iter_mut()
             .find(|change| change.rule == rule)
         {
-            change.new_properties = new_properties;
+            change.new_properties.clear();
+            change
+                .new_properties
+                .extend(declared.iter().map(|declared| declared.property));
+            change.new_properties.sort_unstable();
+            change.new_properties.dedup();
             change.custom_declarations_changed |= custom_declarations_changed;
             return;
         }
+        let mut new_properties: Vec<u16> = declared.iter().map(|declared| declared.property).collect();
+        new_properties.sort_unstable();
+        new_properties.dedup();
         let previous = self
             .replacement_rule(rule)
             .map(|replacement| replacement.declared.as_slice())

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -1296,12 +1296,9 @@ impl StyleEngine {
                     self.counters.bump(Counter::EngineComputedRecordBailRecordParent);
                     return None;
                 };
-                (
-                    parent_view.payloads.to_vec(),
-                    parent_view.dependency_flags & (1 << 2) != 0,
-                )
+                (parent_view.payloads, parent_view.dependency_flags & (1 << 2) != 0)
             }
-            None => (vec![std::ptr::null(); group_index::COUNT], false),
+            None => (&[std::ptr::null(); group_index::COUNT][..], false),
         };
         let Ok(used_color_scheme) = u8::try_from(table.effective_color_scheme()) else {
             self.counters.bump(Counter::EngineComputedRecordBailDrive);

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -1961,7 +1961,6 @@ impl StyleEngine {
                 self.counters.bump(Counter::EngineComputedRecordBailWinnerSpelling);
                 return None;
             };
-            let value = value.clone_retained();
             // A longhand declared through a shorthand keeps the whole shorthand as its written
             // value; the store takes the longhand's own part of it.
             let value = match value.data() {
@@ -1976,6 +1975,7 @@ impl StyleEngine {
                 // C++ cascade substitutes it; a value invalid at computed-value time is unset.
                 crate::css::style_value::StyleValueData::Unresolved { .. } => {
                     *substituted = true;
+                    let value = value.clone_retained();
                     let value = self.substitute_written_value(environment, winner.property, &value)?;
                     invalid_as_unset(value)
                 }
@@ -1997,7 +1997,7 @@ impl StyleEngine {
                         _ => expanded_longhand_value(shorthand, winner.property, &resolved).unwrap_or_else(unset_value),
                     }
                 }
-                _ => value,
+                _ => value.clone_retained(),
             };
             if !value_computes_without_document_context(value.data())
                 || (pseudo_kind.is_some()

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -931,9 +931,8 @@ impl StyleEngine {
                 })
                 .min_by_key(|donor| {
                     self.winner_groups
-                        .semantic_delta(Some(donor.state), state)
-                        .properties()
-                        .len()
+                        .semantic_delta_properties(Some(donor.state), state)
+                        .count()
                 })
         });
         if let Some(donor) = donor {
@@ -2029,10 +2028,8 @@ impl StyleEngine {
         // nothing the descendant inherits may move; custom properties inherit unless registered
         // otherwise, and a child's box-type transformation reads its parent's display.
         self.winner_groups
-            .semantic_delta(Some(previous_state), state)
-            .properties()
-            .iter()
-            .all(|&property| {
+            .semantic_delta_properties(Some(previous_state), state)
+            .all(|property| {
                 property != crate::css::property_metadata::property_id::CUSTOM
                     && property != crate::css::property_metadata::property_id::DISPLAY
                     && !crate::css::property_metadata::property_is_inherited(property)

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -1080,7 +1080,7 @@ impl StyleEngine {
             .is_none_or(|view| {
                 !view.animated_overlay.is_null()
                     || (unsafe { view.longhand_table.as_ref() })
-                        .is_none_or(|table| !crate::css::style_compute::active_transition_properties(table).is_empty())
+                        .is_none_or(crate::css::style_compute::has_active_transition_properties)
             })
     }
 
@@ -1309,7 +1309,7 @@ impl StyleEngine {
         table.freeze();
         let swap_eligible = table.property_inheritance_is_standard()
             && !table.display_is_list_item()
-            && crate::css::style_compute::active_transition_properties(&table).is_empty();
+            && !crate::css::style_compute::has_active_transition_properties(&table);
         let table = table.into_raw_shared();
         let release_table = |table: *const ComputedLonghandTable| unsafe {
             crate::css::computed_longhand_table::rust_computed_longhand_table_release(table.cast_mut());

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -1551,15 +1551,21 @@ impl StyleEngine {
     /// Whether C++ may publish one record as the answer for another element with this winner
     /// state. Values which read per-element or external context are never shared opaquely.
     fn state_is_opaque_record_shareable(&mut self, node: StyleNodeID, state: CascadeStateID) -> bool {
-        let winners = self
+        for winner in self
             .winner_groups
             .winners_in_state(state)
             .filter_map(|winner| self.winner_groups.resolved_winner(winner))
-            .collect::<Vec<_>>();
-        winners.into_iter().all(|winner| {
-            self.written_winner_value(node, &winner)
-                .is_some_and(|(_, value)| value_computes_without_document_context(value.data()))
-        })
+        {
+            match self.written_winner_value(node, &winner) {
+                Ok(Some((_, value))) if value_computes_without_document_context(value.data()) => {}
+                Err(counter) => {
+                    self.counters.bump(counter);
+                    return false;
+                }
+                _ => return false,
+            }
+        }
+        true
     }
 
     fn remember_state_admission(&mut self, key: (u64, CascadeStateID, u64, u64), admitted: bool) {
@@ -1760,15 +1766,16 @@ impl StyleEngine {
     /// cascade's canonical identity may have rewritten. A rule keeps its written values beside its
     /// declarations, and an element's own declarations keep theirs beside the facts.
     fn written_winner_value(
-        &mut self,
+        &self,
         node: StyleNodeID,
         winner: &PropertyWinner,
-    ) -> Option<(usize, crate::css::style_value::RetainedStyleValueData)> {
+    ) -> Result<Option<(usize, &crate::css::style_value::RetainedStyleValueData)>, Counter> {
         match winner.source {
-            WinnerSource::Rule(rule) => self
-                .program
-                .written_winner_declaration(rule, winner.property, winner.important, winner.key.value)
-                .map(|(index, value)| (index, value.clone_retained())),
+            WinnerSource::Rule(rule) => {
+                Ok(self
+                    .program
+                    .written_winner_declaration(rule, winner.property, winner.important, winner.key.value))
+            }
             WinnerSource::Element(kind) => {
                 let (declared, _) = self.facts.element_declared_properties(node, kind);
                 let complete = self
@@ -1776,22 +1783,18 @@ impl StyleEngine {
                     .element_declarations_are_complete_but_for_custom_properties(node, kind);
                 let written = self.facts.element_written_declared_values(node, kind);
                 if !complete || written.len() != declared.len() {
-                    self.counters.bump(Counter::EngineComputedRecordBailWinnerElement);
-                    return None;
+                    return Err(Counter::EngineComputedRecordBailWinnerElement);
                 }
-                declared
+                Ok(declared
                     .iter()
                     .rposition(|declared| {
                         declared.property == winner.property
                             && declared.important == winner.important
                             && declared.value == winner.key.value
                     })
-                    .map(|index| (index, written[index].clone_retained()))
+                    .map(|index| (index, &written[index])))
             }
-            WinnerSource::ExactCascade => {
-                self.counters.bump(Counter::EngineComputedRecordBailWinnerOperator);
-                None
-            }
+            WinnerSource::ExactCascade => Err(Counter::EngineComputedRecordBailWinnerOperator),
         }
     }
 
@@ -1947,10 +1950,18 @@ impl StyleEngine {
             if winner.property < crate::css::property_metadata::FIRST_LONGHAND_PROPERTY_ID {
                 continue;
             }
-            let Some((index, value)) = self.written_winner_value(node, &winner) else {
+            let written = match self.written_winner_value(node, &winner) {
+                Ok(written) => written,
+                Err(counter) => {
+                    self.counters.bump(counter);
+                    None
+                }
+            };
+            let Some((index, value)) = written else {
                 self.counters.bump(Counter::EngineComputedRecordBailWinnerSpelling);
                 return None;
             };
+            let value = value.clone_retained();
             // A longhand declared through a shorthand keeps the whole shorthand as its written
             // value; the store takes the longhand's own part of it.
             let value = match value.data() {

--- a/Libraries/LibWeb/Rust/src/css/style/publication/drive.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication/drive.rs
@@ -47,7 +47,7 @@ impl StyleEngine {
         // A record under display:none may no longer be the style C++ holds, and a property change
         // on an element with active transitions starts one in the C++ computation.
         if view.dependency_flags & (1 << 2) != 0
-            || !crate::css::style_compute::active_transition_properties(old_table).is_empty()
+            || crate::css::style_compute::has_active_transition_properties(old_table)
         {
             self.counters.bump(Counter::EngineComputedRecordBailRecordOverlay);
             return None;
@@ -266,7 +266,7 @@ impl StyleEngine {
                     return None;
                 };
                 if view.dependency_flags & (1 << 2) != 0
-                    || !crate::css::style_compute::active_transition_properties(old_table).is_empty()
+                    || crate::css::style_compute::has_active_transition_properties(old_table)
                 {
                     self.counters.bump(Counter::EngineComputedRecordBailRecordOverlay);
                     return None;

--- a/Libraries/LibWeb/Rust/src/css/style/publication/pseudo.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication/pseudo.rs
@@ -224,7 +224,7 @@ impl StyleEngine {
                     return None;
                 };
                 let transitioning = (unsafe { view.longhand_table.as_ref() })
-                    .is_some_and(|table| !crate::css::style_compute::active_transition_properties(table).is_empty());
+                    .is_some_and(crate::css::style_compute::has_active_transition_properties);
                 if !view.animated_overlay.is_null() || transitioning {
                     self.counters.bump(Counter::EngineComputedRecordBailRecordOverlay);
                     return None;

--- a/Libraries/LibWeb/Rust/src/css/style/publication/pseudo.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication/pseudo.rs
@@ -51,8 +51,7 @@ impl StyleEngine {
                 .winner_groups
                 .winner_in_state(state, crate::css::property_metadata::property_id::DISPLAY)
                 .and_then(|winner| self.winner_groups.resolved_winner(winner))
-            && let Lookup::Known(value) = self.specified_values.retained_value(winner.key.value)
-            && let StyleValueData::Display { raw } = value.data()
+            && let Lookup::Known(StyleValueData::Display { raw }) = self.specified_values.value(winner.key.value)
             && crate::css::display::FfiDisplay::from_raw(*raw).is_list_item()
         {
             explicit_kinds |= 1 << MARKER;

--- a/Libraries/LibWeb/Rust/src/css/style/publication/pseudo.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication/pseudo.rs
@@ -291,7 +291,7 @@ impl StyleEngine {
                 let unchanged = match (state, bound) {
                     (Some(state), Some((bound_generation, bound_state))) => {
                         bound_generation == generation
-                            && self.winner_groups.semantic_delta(Some(bound_state), state).is_empty()
+                            && self.winner_groups.states_are_semantically_equal(bound_state, state)
                     }
                     (None, None) => true,
                     _ => false,

--- a/Libraries/LibWeb/Rust/src/css/style/relative_selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/relative_selector.rs
@@ -295,10 +295,14 @@ impl RelationalWitnesses {
     /// Retain `witness` for `key`, returning whether it was stored. A full table sheds the
     /// entries whose anchor or witness identity has been retired before refusing.
     pub fn retain(&mut self, key: RelationalWitnessKey, witness: StyleNodeID, tree: &StyleNodeTree) -> bool {
-        if !self.admitting && !self.entries.contains_key(&key) {
-            return false;
-        }
-        if self.entries.len() >= MAX_RETAINED_WITNESSES && !self.entries.contains_key(&key) {
+        if !self.admitting || self.entries.len() >= MAX_RETAINED_WITNESSES {
+            if let Some(retained) = self.entries.get_mut(&key) {
+                *retained = witness;
+                return true;
+            }
+            if !self.admitting {
+                return false;
+            }
             self.entries
                 .retain(|entry, retained| tree.is_live(entry.anchor) && tree.is_live(*retained));
             if self.entries.len() >= MAX_RETAINED_WITNESSES {

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -4391,9 +4391,7 @@ impl StyleEngine {
                             .all(|entry| compiled.dispatch_key(entry).has_selector_posting()))
                     .then(|| {
                         self.winner_groups.winning_nodes(rule).map(|nodes| {
-                            nodes
-                                .filter(|&node| scopes.binary_search(&self.tree.tree_scope(node)).is_ok())
-                                .collect::<Vec<_>>()
+                            nodes.filter(|&node| scopes.binary_search(&self.tree.tree_scope(node)).is_ok())
                         })
                     })
                     .flatten();

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -2995,12 +2995,10 @@ impl RouteDirectory {
     }
 
     fn flatten(building: HashMap<RoutingKey, Vec<RouteID>>, after_change: bool) -> Self {
-        let mut entries = building.into_iter().collect::<Vec<_>>();
-        entries.sort_unstable_by_key(|(key, _)| *key);
-        let route_count = entries.iter().map(|(_, routes)| routes.len()).sum();
-        let mut ranges = HashMap::with_capacity_and_hasher(entries.len(), Default::default());
+        let route_count = building.values().map(Vec::len).sum();
+        let mut ranges = HashMap::with_capacity_and_hasher(building.len(), Default::default());
         let mut flat_routes = Vec::with_capacity(route_count);
-        for (key, routes) in entries {
+        for (key, routes) in building {
             let offset = u32::try_from(flat_routes.len()).expect("routing directory space exhausted");
             flat_routes.extend_from_slice(&routes);
             ranges.insert(

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -1764,9 +1764,14 @@ impl SelectorProgram {
                         }
                     }
                     out[start..].sort_unstable();
-                    let mut tail = out.split_off(start);
-                    tail.dedup();
-                    out.extend_from_slice(&tail);
+                    let mut unique_end = start;
+                    for read_index in start..out.len() {
+                        if unique_end == start || out[read_index] != out[unique_end - 1] {
+                            out[unique_end] = out[read_index];
+                            unique_end += 1;
+                        }
+                    }
+                    out.truncate(unique_end);
                     true
                 }
                 DispatchQuery::Required => {

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -2417,14 +2417,13 @@ impl Drop for SharedSelectorProgram {
             let Ok(mut shared) = shared.try_borrow_mut() else {
                 return;
             };
-            let remove_bucket = if let Some(bucket) = shared.by_hash.get_mut(&self.hash) {
-                bucket.retain(|candidate| candidate.strong_count() != 0);
-                bucket.is_empty()
-            } else {
-                false
+            let std::collections::hash_map::Entry::Occupied(mut entry) = shared.by_hash.entry(self.hash) else {
+                return;
             };
-            if remove_bucket {
-                shared.by_hash.remove(&self.hash);
+            let bucket = entry.get_mut();
+            bucket.retain(|candidate| candidate.strong_count() != 0);
+            if bucket.is_empty() {
+                entry.remove();
             }
         });
     }

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -2478,7 +2478,7 @@ fn share_selector_program(program: SelectorProgram) -> Rc<SharedSelectorProgram>
 }
 
 enum SelectorProgramStorage {
-    Document(SelectorProgram),
+    Document(Box<SelectorProgram>),
     Process(Rc<SharedSelectorProgram>),
 }
 
@@ -2492,7 +2492,7 @@ impl SelectorProgramStorage {
 
     fn document_capacity_bytes(&self) -> u64 {
         match self {
-            Self::Document(program) => program.capacity_bytes(),
+            Self::Document(program) => size_of::<SelectorProgram>() as u64 + program.capacity_bytes(),
             Self::Process(_) => 0,
         }
     }
@@ -2595,12 +2595,10 @@ impl SelectorPrograms {
             SelectorProgramID(u32::try_from(self.programs.len()).expect("selector program space exhausted"))
         });
         let program = match self.scope {
-            SelectorProgramScope::Document => {
-                self.program_memory.grow_committed(program.capacity_bytes());
-                SelectorProgramStorage::Document(program)
-            }
+            SelectorProgramScope::Document => SelectorProgramStorage::Document(Box::new(program)),
             SelectorProgramScope::Process => SelectorProgramStorage::Process(share_selector_program(program)),
         };
+        self.program_memory.grow_committed(program.document_capacity_bytes());
         if id.0 as usize == self.programs.len() {
             self.programs.push(Some(program));
         } else {

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -946,22 +946,22 @@ impl SelectorProgramBuilder {
         // Conjunction is associative, and one compound is one node: routing reads a compound's
         // operands to find what the selector says about the subject's parent, and an operand that
         // is itself a conjunction would hide the rest of the compound from the walk that reads it.
-        let mut flattened: Vec<SelectorNodeID> = Vec::with_capacity(operands.len());
+        let first = self.program.operands.len();
+        self.program.operands.reserve(operands.len());
         for &operand in operands {
             match self.program.node(operand) {
                 SelectorOp::And { first, count } => {
-                    flattened.extend_from_slice(self.program.operands(first, count));
+                    let start = first as usize;
+                    self.program.operands.extend_from_within(start..start + count as usize);
                 }
-                _ => flattened.push(operand),
+                _ => self.program.operands.push(operand),
             }
         }
-        let mut sorted = flattened;
-        sorted.sort_by_key(|&operand| self.program.node(operand).cost_rank());
-        let first = u32::try_from(self.program.operands.len()).expect("selector operand space exhausted");
-        self.program.operands.extend_from_slice(&sorted);
+        let nodes = &self.program.nodes;
+        self.program.operands[first..].sort_by_key(|operand| nodes[operand.0 as usize].cost_rank());
         self.push(SelectorOp::And {
-            first,
-            count: u32::try_from(sorted.len()).expect("selector operand space exhausted"),
+            first: u32::try_from(first).expect("selector operand space exhausted"),
+            count: u32::try_from(self.program.operands.len() - first).expect("selector operand space exhausted"),
         })
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -620,6 +620,7 @@ impl Hash for CachedDispatchMetadata {
 }
 
 impl SelectorDispatchMetadata {
+    /// Sorted, distinct keys through which this entry can be reached.
     #[must_use]
     pub(super) fn subject_dispatch_keys(&self) -> &[DispatchKey] {
         &self.subject_dispatch_keys

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -4871,16 +4871,10 @@ impl MatchRelationCache {
     ) -> (PrecedingSiblingParentID, Option<PrecedingSiblingPrefix>) {
         let parent = {
             let mut parent_ids = self.preceding_sibling_parent_ids.borrow_mut();
-            match parent_ids.get(&parent).copied() {
-                Some(parent) => parent,
-                None => {
-                    let id = PrecedingSiblingParentID(
-                        u32::try_from(parent_ids.len()).expect("preceding sibling parent space exhausted"),
-                    );
-                    parent_ids.insert(parent, id);
-                    id
-                }
-            }
+            let next_id = parent_ids.len();
+            *parent_ids.entry(parent).or_insert_with(|| {
+                PrecedingSiblingParentID(u32::try_from(next_id).expect("preceding sibling parent space exhausted"))
+            })
         };
         (
             parent,

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -924,15 +924,15 @@ impl SelectorProgramBuilder {
     }
 
     /// Add the extended language ranges of one `:lang()` and return their range.
-    pub fn push_language_ranges(&mut self, ranges: &[&[u16]]) -> (u32, u32) {
+    pub fn push_language_ranges(&mut self, ranges: impl IntoIterator<Item = impl AsRef<[u16]>>) -> (u32, u32) {
         let first = u32::try_from(self.program.language_ranges.len()).expect("language range space exhausted");
         for range in ranges {
-            let literal = self.push_literal(range);
+            let literal = self.push_literal(range.as_ref());
             self.program.language_ranges.push(literal);
         }
         (
             first,
-            u32::try_from(ranges.len()).expect("language range space exhausted"),
+            u32::try_from(self.program.language_ranges.len() - first as usize).expect("language range space exhausted"),
         )
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -605,7 +605,7 @@ pub(super) struct SelectorDispatchMetadata {
 
 /// Derived acceleration is not part of a selector program's semantic identity.
 #[derive(Default)]
-struct CachedDispatchMetadata(Vec<SelectorDispatchMetadata>);
+struct CachedDispatchMetadata(Box<[SelectorDispatchMetadata]>);
 
 impl PartialEq for CachedDispatchMetadata {
     fn eq(&self, _other: &Self) -> bool {

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -640,7 +640,6 @@ enum DispatchRelation {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum DispatchQuery {
-    Single,
     Alternatives,
     Required,
 }
@@ -1650,10 +1649,6 @@ impl SelectorProgram {
         query: DispatchQuery,
         out: &mut Vec<DispatchKey>,
     ) -> bool {
-        if relation == DispatchRelation::Subject && query == DispatchQuery::Single {
-            out.push(self.single_dispatch_key_of(id));
-            return true;
-        }
         if relation != DispatchRelation::Subject {
             let operands = match self.node(id) {
                 SelectorOp::And { first, count } => self.operands(first, count),
@@ -1717,7 +1712,6 @@ impl SelectorProgram {
             SelectorOp::Feature(test) => {
                 let key = Self::dispatch_key_for_feature(test);
                 match query {
-                    DispatchQuery::Single => out.push(key),
                     DispatchQuery::Alternatives | DispatchQuery::Required if key == DispatchKey::Universal => {
                         return query == DispatchQuery::Required;
                     }
@@ -1730,20 +1724,6 @@ impl SelectorProgram {
                     for &operand in self.operands(first, count) {
                         self.dispatch_analysis(operand, relation, query, out);
                     }
-                    true
-                }
-                DispatchQuery::Single => {
-                    let key = self
-                        .operands(first, count)
-                        .iter()
-                        .map(|&operand| {
-                            let mut candidate = Vec::new();
-                            self.dispatch_analysis(operand, relation, query, &mut candidate);
-                            candidate[0]
-                        })
-                        .min_by_key(|key| dispatch_selectivity(*key))
-                        .unwrap_or(DispatchKey::Universal);
-                    out.push(key);
                     true
                 }
                 DispatchQuery::Alternatives => {
@@ -1772,10 +1752,6 @@ impl SelectorProgram {
                 }
             },
             SelectorOp::Or { first, count } => match query {
-                DispatchQuery::Single => {
-                    out.push(DispatchKey::Universal);
-                    true
-                }
                 DispatchQuery::Alternatives => {
                     let start = out.len();
                     for &operand in self.operands(first, count) {
@@ -1803,15 +1779,7 @@ impl SelectorProgram {
             SelectorOp::Where(inner)
             | SelectorOp::Host(inner)
             | SelectorOp::Slotted(inner)
-            | SelectorOp::ExposedToHost { parts: inner, .. } => {
-                if query == DispatchQuery::Single
-                    && matches!(self.node(id), SelectorOp::Host(_) | SelectorOp::Slotted(_))
-                {
-                    out.push(DispatchKey::Universal);
-                    return true;
-                }
-                self.dispatch_analysis(inner, relation, query, out)
-            }
+            | SelectorOp::ExposedToHost { parts: inner, .. } => self.dispatch_analysis(inner, relation, query, out),
             SelectorOp::InScope { inner, .. } if query != DispatchQuery::Required => {
                 self.dispatch_analysis(inner, relation, query, out)
             }
@@ -1833,42 +1801,22 @@ impl SelectorProgram {
                 out.push(DispatchKey::Directionality(value));
                 true
             }
-            SelectorOp::Root if query == DispatchQuery::Single => {
-                out.push(DispatchKey::Root);
-                true
-            }
-            SelectorOp::State(state) if query == DispatchQuery::Single => {
-                out.push(DispatchKey::State(state));
-                true
-            }
-            SelectorOp::Heading(_) if query == DispatchQuery::Single => {
-                out.push(DispatchKey::Heading);
-                true
-            }
-            _ if query == DispatchQuery::Single => {
-                out.push(DispatchKey::Universal);
-                true
-            }
             _ => query == DispatchQuery::Required,
         }
     }
 
     fn dispatch_key_of(&self, id: SelectorNodeID) -> DispatchKey {
-        self.single_dispatch_key_of(id)
-    }
-
-    fn single_dispatch_key_of(&self, id: SelectorNodeID) -> DispatchKey {
         match self.node(id) {
             SelectorOp::Feature(test) => Self::dispatch_key_for_feature(test),
             SelectorOp::And { first, count } => self
                 .operands(first, count)
                 .iter()
-                .map(|&operand| self.single_dispatch_key_of(operand))
+                .map(|&operand| self.dispatch_key_of(operand))
                 .min_by_key(|&key| dispatch_selectivity(key))
                 .unwrap_or(DispatchKey::Universal),
             SelectorOp::Where(inner)
             | SelectorOp::InScope { inner, .. }
-            | SelectorOp::ExposedToHost { parts: inner, .. } => self.single_dispatch_key_of(inner),
+            | SelectorOp::ExposedToHost { parts: inner, .. } => self.dispatch_key_of(inner),
             SelectorOp::Part(part) => DispatchKey::Part(part),
             SelectorOp::ValueState {
                 kind: ValueStateTestKind::CustomState,

--- a/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
@@ -169,10 +169,7 @@ fn will_change_mentions(value: Option<&StyleValueData>, predicate: impl Fn(u16) 
         };
         crate::css::serialize::with_fly_string_units(custom_ident, |units| {
             let property = match units {
-                crate::css::serialize::StringUnits::Ascii(bytes) => {
-                    let units = bytes.iter().copied().map(u16::from).collect::<Vec<_>>();
-                    property_metadata::property_id_from_name(&units)
-                }
+                crate::css::serialize::StringUnits::Ascii(bytes) => property_metadata::property_id_from_name(bytes),
                 crate::css::serialize::StringUnits::Utf16(units) => property_metadata::property_id_from_name(units),
             };
             property.is_some_and(&predicate)

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -28,11 +28,11 @@ fn environment_memo_retains_its_written_value_keys() {
     let inputs = custom_property_environments::EnvironmentInputs {
         parent: 0,
         registration_generation: 0,
-        cascaded: vec![custom_property_environments::CascadedCustomProperty {
+        cascaded: Box::new([custom_property_environments::CascadedCustomProperty {
             name: StyleAtomID(1),
             important: false,
             written_value: written_pointer as usize,
-        }],
+        }]),
     };
     environments.remember(inputs, 1, vec![written.clone_retained()]);
 

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -9983,7 +9983,12 @@ fn engine_atom_reuse_replaces_custom_property_names() {
         engine.note_custom_property_name(new_name, 0, &new_text);
     }
     assert_eq!(
-        engine.custom_property_environments.name(new_name).unwrap().text,
+        engine
+            .custom_property_environments
+            .name(new_name)
+            .unwrap()
+            .text
+            .as_ref(),
         new_text
     );
 }

--- a/Libraries/LibWeb/Rust/src/css/style/transaction.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/transaction.rs
@@ -681,20 +681,16 @@ impl NormalizationJournal {
             .collect();
         if !arriving_nodes.is_empty() {
             inputs.retain(|input| {
-                let Some(node) = input.key.style_node() else {
+                let (InputKey::LocalFeature(node, _) | InputKey::State(node, _)) = input.key else {
                     return true;
                 };
                 if arriving_nodes.binary_search(&node).is_err() {
                     return true;
                 }
-                match input.key {
-                    InputKey::LocalFeature(_, LocalFeatureKey::ArrivingFacts) => false,
-                    InputKey::LocalFeature(..) | InputKey::State(..) => {
-                        counters.bump(Counter::ArrivingNodeFactsFolded);
-                        false
-                    }
-                    _ => true,
+                if !matches!(input.key, InputKey::LocalFeature(_, LocalFeatureKey::ArrivingFacts)) {
+                    counters.bump(Counter::ArrivingNodeFactsFolded);
                 }
+                false
             });
             inputs.extend(arriving_nodes.into_iter().map(|node| NormalizedInput {
                 key: InputKey::LocalFeature(node, LocalFeatureKey::ArrivingFacts),

--- a/Libraries/LibWeb/Rust/src/css/style/tree.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tree.rs
@@ -850,7 +850,7 @@ impl StyleNodeTree {
         if pairs.is_empty() {
             shadow.part_hosts.remove(&node);
         } else {
-            shadow.part_hosts.insert(node, pairs.to_vec());
+            pairs.clone_into(shadow.part_hosts.entry(node).or_default());
         }
         let current = self.shadow_capacity_bytes();
         self.record_capacity_change(memory, before, current);

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -4671,10 +4671,7 @@ fn property_id_from_custom_ident(
 ) -> Option<u16> {
     let name = unsafe { ak::utf16_string_units(custom_ident.raw_word()) };
     match name {
-        ak::Utf16StringUnits::Ascii(name) => {
-            let name: Vec<u16> = name.iter().copied().map(u16::from).collect();
-            crate::css::property_metadata::property_id_from_name(&name)
-        }
+        ak::Utf16StringUnits::Ascii(name) => crate::css::property_metadata::property_id_from_name(name),
         ak::Utf16StringUnits::Utf16(name) => crate::css::property_metadata::property_id_from_name(name),
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -4713,26 +4713,45 @@ fn computed_writing_mode_and_direction(table: &ComputedLonghandTable) -> (u8, u8
     (writing_mode, direction)
 }
 
-pub(crate) fn active_transition_properties(table: &ComputedLonghandTable) -> Vec<u16> {
+fn active_transition_property_ids(table: &ComputedLonghandTable) -> impl Iterator<Item = u16> {
     use crate::css::property_metadata::property_id as prop;
 
     let property_values = computed_value_list(table, prop::TRANSITION_PROPERTY);
     let duration_values = computed_value_list(table, prop::TRANSITION_DURATION);
     let delay_values = computed_value_list(table, prop::TRANSITION_DELAY);
+    property_values
+        .iter()
+        .enumerate()
+        .filter_map(move |(index, property_value)| {
+            let duration = time_value_to_milliseconds(duration_values[index % duration_values.len()].data());
+            let delay = time_value_to_milliseconds(delay_values[index % delay_values.len()].data());
+            if duration.max(0.0) + delay <= 0.0 {
+                return None;
+            }
+            let StyleValueData::CustomIdent { custom_ident } = property_value.data() else {
+                return None;
+            };
+            property_id_from_custom_ident(custom_ident)
+        })
+}
+
+pub(crate) fn has_active_transition_properties(table: &ComputedLonghandTable) -> bool {
+    fn has_longhand(property: u16) -> bool {
+        if property_is_shorthand(property) {
+            longhands_for_shorthand(property).iter().copied().any(has_longhand)
+        } else {
+            property != crate::css::property_metadata::property_id::CUSTOM
+        }
+    }
+
+    active_transition_property_ids(table).any(has_longhand)
+}
+
+fn active_transition_properties(table: &ComputedLonghandTable) -> Vec<u16> {
     let (writing_mode, direction) = computed_writing_mode_and_direction(table);
     let mut properties = Vec::new();
-    for (index, property_value) in property_values.iter().enumerate() {
-        let duration = time_value_to_milliseconds(duration_values[index % duration_values.len()].data());
-        let delay = time_value_to_milliseconds(delay_values[index % delay_values.len()].data());
-        if duration.max(0.0) + delay <= 0.0 {
-            continue;
-        }
-        let StyleValueData::CustomIdent { custom_ident } = property_value.data() else {
-            continue;
-        };
-        if let Some(property) = property_id_from_custom_ident(custom_ident) {
-            append_transition_longhands(&mut properties, property, writing_mode, direction);
-        }
+    for property in active_transition_property_ids(table) {
+        append_transition_longhands(&mut properties, property, writing_mode, direction);
     }
     properties
 }


### PR DESCRIPTION
A collection of style-engine cleanups that borrow values instead of cloning them, reuse scratch buffers, compact immutable data, and remove redundant lookups and selector walks.

On 64-bit builds, replacing immutable vectors with boxed slices reduces their headers from 24 to 16 bytes. Dropping duplicate winner-group hashes saves another 8 bytes per group. Ordinary cascade winner selection becomes a linear scan instead of a sort, and removed-selector processing scans document rules once instead of once per removed program.
