### PR TITLE
LibWebView: Create top-level traversables in the UI process

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1634,10 +1634,52 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
     //    agent's configuration and abilities — it is determined by the rules given for the first applicable option
     //    from the following list:
     if (!chosen) {
+        // NB: Steps 2 to 6 of the "create a new top-level traversable" branch below only read state, and the owner
+        //     needs their result to create the traversable, so they run before the request. Step 1 stays in the
+        //     branch: activation is consumed only once a traversable was created.
+
+        // 2. Set windowType to "new and unrestricted".
+        auto new_window_type = WindowType::NewAndUnrestricted;
+        auto new_no_opener = no_opener;
+        auto new_name = name;
+
+        // 3. Let currentDocument be currentNavigable's active document.
+        // 4. If currentDocument's opener policy's value is "same-origin" or "same-origin-plus-COEP",
+        //    and currentDocument's origin is not same origin with currentDocument's relevant settings object's top-level origin, then:
+        auto current_document_for_opener_policy = active_document();
+        if (current_document_for_opener_policy
+            && (current_document_for_opener_policy->opener_policy().value == OpenerPolicyValue::SameOrigin || current_document_for_opener_policy->opener_policy().value == OpenerPolicyValue::SameOriginPlusCOEP)
+            && !current_document_for_opener_policy->origin().is_same_origin(relevant_settings_object(*current_document_for_opener_policy).top_level_origin.value())) {
+
+            // 1. Set noopener to true.
+            new_no_opener = TokenizedFeature::NoOpener::Yes;
+
+            // 2. Set name to "_blank".
+            new_name = u"_blank"sv;
+
+            // 3. Set windowType to "new with no opener".
+            new_window_type = WindowType::NewWithNoOpener;
+        }
+        // NOTE: In the presence of an opener policy,
+        //       nested documents that are cross-origin with their top-level browsing context's active document always set noopener to true.
+
+        // 5. Let targetName be the empty string.
+        Utf16String new_target_name;
+
+        // 6. If name is not an ASCII case-insensitive match for "_blank", then set targetName to name.
+        if (!new_name.equals_ignoring_ascii_case(u"_blank"sv))
+            new_target_name = Utf16String::from_utf16(new_name);
+
         auto request_new_web_view = [&] {
             TokenizedFeature::Map empty_window_features;
             auto hints = WebViewHints::from_tokenised_features(window_features.has_value() ? *window_features : empty_window_features, traversable_navigable()->page());
-            return traversable_navigable()->page().client().page_did_request_new_web_view(activate_tab, hints);
+            Optional<CrossProcessId> opener_navigable_id;
+            Optional<URL::URL> opener_base_url;
+            if (new_no_opener == TokenizedFeature::NoOpener::No) {
+                opener_navigable_id = id();
+                opener_base_url = active_document()->base_url();
+            }
+            return traversable_navigable()->page().client().page_did_request_new_web_view(activate_tab, hints, opener_navigable_id, move(opener_base_url), new_target_name);
         };
 
         // --> If currentNavigable's active window does not have transient activation and the user agent has been configured to
@@ -1658,38 +1700,13 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
             // 1. Consume user activation of currentNavigable's active window.
             active_window()->consume_user_activation();
 
-            // 2. Set windowType to "new and unrestricted".
-            window_type = WindowType::NewAndUnrestricted;
-
-            // 3. Let currentDocument be currentNavigable's active document.
-            auto current_document = active_document();
-
-            // 4. If currentDocument's opener policy's value is "same-origin" or "same-origin-plus-COEP",
-            //    and currentDocument's origin is not same origin with currentDocument's relevant settings object's top-level origin, then:
-            if ((current_document->opener_policy().value == OpenerPolicyValue::SameOrigin || current_document->opener_policy().value == OpenerPolicyValue::SameOriginPlusCOEP)
-                && !current_document->origin().is_same_origin(relevant_settings_object(*current_document).top_level_origin.value())) {
-
-                // 1. Set noopener to true.
-                no_opener = TokenizedFeature::NoOpener::Yes;
-
-                // 2. Set name to "_blank".
-                name = u"_blank"sv;
-
-                // 3. Set windowType to "new with no opener".
-                window_type = WindowType::NewWithNoOpener;
-            }
-            // NOTE: In the presence of an opener policy,
-            //       nested documents that are cross-origin with their top-level browsing context's active document always set noopener to true.
-
-            // 5. Let targetName be the empty string.
-            Utf16String target_name;
-
-            // 6. If name is not an ASCII case-insensitive match for "_blank", then set targetName to name.
-            if (!name.equals_ignoring_ascii_case(u"_blank"sv))
-                target_name = Utf16String::from_utf16(name);
+            // 2 to 6. Computed above, before the traversable's owner was asked to create it.
+            no_opener = new_no_opener;
+            name = new_name;
+            window_type = new_window_type;
 
             auto create_new_traversable = [&](GC::Ptr<BrowsingContext> opener) -> GC::Ref<LocalTraversableNavigable> {
-                auto traversable = LocalTraversableNavigable::create_a_new_top_level_traversable(*new_web_view.page, opener, target_name, {}, new_web_view.system_visibility_state);
+                auto traversable = LocalTraversableNavigable::create_a_new_top_level_traversable(*new_web_view.page, opener, new_web_view.initial_history_entry.release_value(), new_web_view.system_visibility_state);
                 new_web_view.page->set_local_root_navigable(traversable);
                 traversable->set_window_handle(Utf16String::from_ascii_without_validation(new_web_view.window_handle.bytes()));
                 return traversable;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -70,10 +70,17 @@ BrowsingContextAndDocument create_a_new_top_level_browsing_context_and_document(
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-top-level-traversable
-GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_level_traversable(GC::Ref<Page> page, GC::Ptr<HTML::BrowsingContext> opener, Utf16String target_name, Optional<CrossProcessId> initial_document_state_id, VisibilityState system_visibility_state)
+GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_level_traversable(GC::Ref<Page> page, GC::Ptr<HTML::BrowsingContext> opener, Optional<SessionHistoryEntryDescriptor> initial_history_entry_from_owner, VisibilityState system_visibility_state)
 {
     auto& vm = Bindings::main_thread_vm();
     page->ensure_compositor_host();
+
+    // NB: A traversable with no owning process, such as an SVG image's, mints its own entry
+    auto initial_entry = initial_history_entry_from_owner.has_value()
+        ? initial_history_entry_from_owner.release_value()
+        : create_initial_session_history_entry_descriptor(page->client().allocate_cross_process_id(),
+              opener ? Optional<URL::Origin> { opener->active_document()->origin() } : Optional<URL::Origin> {},
+              opener ? Optional<URL::URL> { opener->active_document()->base_url() } : Optional<URL::URL> {}, {});
 
     // 1. Let document be null.
     GC::Ptr<DOM::Document> document = nullptr;
@@ -89,9 +96,7 @@ GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_l
     }
 
     // 4. Let documentState be a new document state, with
-    if (!initial_document_state_id.has_value())
-        initial_document_state_id = page->client().allocate_cross_process_id();
-    auto document_state = DocumentState::create(*initial_document_state_id);
+    auto document_state = DocumentState::create(initial_entry.document_state.id);
 
     // document: document (now owned by LocalNavigable::m_active_document, not DocumentState)
 
@@ -102,7 +107,7 @@ GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_l
     document_state->set_origin(document->origin());
 
     // navigable target name: targetName
-    document_state->set_navigable_target_name(target_name);
+    document_state->set_navigable_target_name(initial_entry.document_state.navigable_target_name);
 
     // about base URL: document's about base URL
     document_state->set_about_base_url(document->about_base_url());
@@ -120,13 +125,13 @@ GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_l
     // 8. Set initialHistoryEntry's step to 0.
     initial_history_entry->set_step(0);
 
+    // NB: The owner's copy of this entry and this one must be the same entry, so take its identity
+    initial_history_entry->set_navigation_api_key(initial_entry.navigation_api_key);
+    initial_history_entry->set_navigation_api_id(initial_entry.navigation_api_id);
+
     // 9. Append initialHistoryEntry to traversable's session history entries.
-    // NB: The UI process keeps the canonical session history, so report the traversable's creation to it.
+    // NB: A traversable's owner keeps the canonical session history; this entry is the owner's initial entry.
     traversable->set_has_session_history_entry_and_ready_for_navigation();
-    Optional<CrossProcessId> opener_navigable_id;
-    if (opener)
-        opener_navigable_id = opener->active_document()->navigable()->id();
-    page->client().page_did_create_top_level_traversable(traversable->id(), create_session_history_entry_descriptor(*initial_history_entry), opener_navigable_id);
 
     // 10. If opener is non-null, then legacy-clone a traversable storage shed given opener's top-level traversable and traversable. [STORAGE]
     if (opener) {
@@ -142,10 +147,10 @@ GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_l
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#create-a-fresh-top-level-traversable
-GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_fresh_top_level_traversable(GC::Ref<Page> page, URL::URL const& initial_navigation_url, DocumentResource initial_navigation_post_resource, CrossProcessId initial_document_state_id, VisibilityState system_visibility_state)
+GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_fresh_top_level_traversable(GC::Ref<Page> page, URL::URL const& initial_navigation_url, DocumentResource initial_navigation_post_resource, SessionHistoryEntryDescriptor initial_history_entry, VisibilityState system_visibility_state)
 {
     // 1. Let traversable be the result of creating a new top-level traversable given null and the empty string.
-    auto traversable = create_a_new_top_level_traversable(page, nullptr, {}, initial_document_state_id, system_visibility_state);
+    auto traversable = create_a_new_top_level_traversable(page, nullptr, move(initial_history_entry), system_visibility_state);
     page->set_local_root_navigable(traversable);
 
     // AD-HOC: Deny geolocation until the UI process sends the browser-wide setting via IPC. This prevents a request

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -29,8 +29,8 @@ class WEB_API LocalTraversableNavigable final : public LocalNavigable {
     GC_DECLARE_ALLOCATOR(LocalTraversableNavigable);
 
 public:
-    static GC::Ref<LocalTraversableNavigable> create_a_new_top_level_traversable(GC::Ref<Page>, GC::Ptr<BrowsingContext> opener, Utf16String target_name, Optional<CrossProcessId> initial_document_state_id = {}, VisibilityState system_visibility_state = VisibilityState::Hidden);
-    static GC::Ref<LocalTraversableNavigable> create_a_fresh_top_level_traversable(GC::Ref<Page>, URL::URL const& initial_navigation_url, DocumentResource, CrossProcessId initial_document_state_id, VisibilityState system_visibility_state);
+    static GC::Ref<LocalTraversableNavigable> create_a_new_top_level_traversable(GC::Ref<Page>, GC::Ptr<BrowsingContext> opener, Optional<SessionHistoryEntryDescriptor> initial_history_entry = {}, VisibilityState system_visibility_state = VisibilityState::Hidden);
+    static GC::Ref<LocalTraversableNavigable> create_a_fresh_top_level_traversable(GC::Ref<Page>, URL::URL const& initial_navigation_url, DocumentResource, SessionHistoryEntryDescriptor initial_history_entry, VisibilityState system_visibility_state);
 
     virtual ~LocalTraversableNavigable() override;
 

--- a/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
+++ b/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
@@ -49,6 +49,36 @@ SessionHistoryEntry::SessionHistoryEntry()
 {
 }
 
+SessionHistoryEntryDescriptor create_initial_session_history_entry_descriptor(CrossProcessId document_state_id, Optional<URL::Origin> opener_origin, Optional<URL::URL> opener_base_url, Utf16String navigable_target_name)
+{
+    // NB: An origin and about base URL are recorded only where they are inherited from an opener. The process hosting
+    //     this traversable determines the origin of a document that inherits none, and nothing outside it needs to know which.
+    return {
+        .step = 0,
+        .url = URL::about_blank(),
+        .document_state = {
+            .id = document_state_id,
+            .history_policy_container = DocumentState::Client::Tag,
+            .request_referrer = Fetch::Infrastructure::Request::Referrer::Client,
+            .request_referrer_policy = ReferrerPolicy::DEFAULT_REFERRER_POLICY,
+            .initiator_origin = opener_origin,
+            .origin = move(opener_origin),
+            .about_base_url = move(opener_base_url),
+            .resource = Empty {},
+            .reload_pending = false,
+            .ever_populated = false,
+            .navigable_target_name = move(navigable_target_name),
+            .nested_histories = {},
+        },
+        .classic_history_api_state = {},
+        .navigation_api_state = {},
+        .navigation_api_key = generate_random_uuid_utf16(),
+        .navigation_api_id = generate_random_uuid_utf16(),
+        .scroll_restoration_mode = ScrollRestorationMode::Auto,
+        .scroll_position_data = {},
+    };
+}
+
 SessionHistoryDocumentStateDescriptor create_session_history_document_state_descriptor(DocumentState const& document_state)
 {
     return {

--- a/Libraries/LibWeb/HTML/SessionHistoryEntry.h
+++ b/Libraries/LibWeb/HTML/SessionHistoryEntry.h
@@ -193,6 +193,8 @@ private:
 };
 
 WEB_API SessionHistoryEntryDescriptor create_session_history_entry_descriptor(SessionHistoryEntry const&);
+
+WEB_API SessionHistoryEntryDescriptor create_initial_session_history_entry_descriptor(CrossProcessId document_state_id, Optional<URL::Origin> opener_origin, Optional<URL::URL> opener_base_url, Utf16String navigable_target_name);
 WEB_API SessionHistoryDocumentStateDescriptor create_session_history_document_state_descriptor(DocumentState const&);
 WEB_API PendingSessionHistoryEntryDescriptor create_pending_session_history_entry_descriptor(SessionHistoryEntry const&);
 WEB_API PendingSessionHistoryEntryDescriptor create_pending_session_history_entry_descriptor(SessionHistoryEntryDescriptor);

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -627,11 +627,11 @@ public:
         GC::Ptr<Page> page;
         HTML::VisibilityState system_visibility_state { HTML::VisibilityState::Hidden };
         String window_handle;
+        Optional<HTML::SessionHistoryEntryDescriptor> initial_history_entry;
     };
-    virtual NewWebViewResult page_did_request_new_web_view(HTML::ActivateTab, HTML::WebViewHints) { return {}; }
+    virtual NewWebViewResult page_did_request_new_web_view(HTML::ActivateTab, HTML::WebViewHints, [[maybe_unused]] Optional<HTML::CrossProcessId> opener_navigable_id, [[maybe_unused]] Optional<URL::URL> opener_base_url, [[maybe_unused]] Utf16String const& target_name) { return {}; }
     virtual void page_did_request_activate_tab() { }
     virtual void page_did_close_top_level_traversable() { }
-    virtual void page_did_create_top_level_traversable([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryDescriptor const& initial_history_entry, [[maybe_unused]] Optional<HTML::CrossProcessId> opener_navigable_id) { }
     virtual void page_did_update_session_history_entry_navigation_api_state([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryIdentity const& entry_identity, [[maybe_unused]] HTML::StorageSerializationRecord const& navigation_api_state) { }
     virtual void page_did_update_session_history_entry_scroll_restoration_mode([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryIdentity const& entry_identity, [[maybe_unused]] HTML::ScrollRestorationMode scroll_restoration_mode) { }
     virtual void page_did_update_session_history_entry_document_state_navigable_target_name([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryIdentity const& entry_identity, [[maybe_unused]] Utf16String const& navigable_target_name) { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -820,7 +820,7 @@ void Application::open_bookmark_in_new_window(String const& bookmark_id, IsPriva
         open_url_in_new_window(bookmark->bookmark().url, is_private);
 }
 
-ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, IsPrivate is_private, u64 initial_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id, Optional<Web::HTML::CrossProcessId> initial_document_state_id)
+ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, IsPrivate is_private, u64 initial_page_id, Optional<Web::HTML::CrossProcessId> navigable_to_adopt, Optional<Web::HTML::CrossProcessId> initial_document_state_id)
 {
     auto request_server_handle = TRY(connect_new_request_server_client(is_private));
     auto image_decoder_handle = TRY(connect_new_image_decoder_client());
@@ -829,14 +829,20 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(
 #endif
 
     auto cross_process_id_allocator = allocate_cross_process_id_allocator();
-    if (!root_navigable_id.has_value())
-        root_navigable_id = cross_process_id_allocator.allocate();
+    auto root_navigable_id = navigable_to_adopt.has_value() ? *navigable_to_adopt : cross_process_id_allocator.allocate();
     if (!initial_document_state_id.has_value())
         initial_document_state_id = cross_process_id_allocator.allocate();
 
-    auto client = TRY(WebView::launch_web_content_process(is_private, initial_page_id, *root_navigable_id));
+    auto client = TRY(WebView::launch_web_content_process(is_private, initial_page_id, root_navigable_id));
     auto system_visibility_state = view.has_value() ? view->traversable().system_visibility_state() : Web::HTML::VisibilityState::Hidden;
-    client->async_initialize(initial_page_id, *root_navigable_id, cross_process_id_allocator, *initial_document_state_id, system_visibility_state);
+
+    // A process replacing another adopts the view's traversable, so this entry only bootstraps its about:blank:
+    // the entry's identity is never observed, and the canonical entry it will host arrives with the traversal.
+    auto initial_history_entry = Web::HTML::create_initial_session_history_entry_descriptor(*initial_document_state_id, {}, {}, {});
+    client->async_initialize(initial_page_id, root_navigable_id, cross_process_id_allocator, initial_history_entry, system_visibility_state);
+
+    if (!navigable_to_adopt.has_value())
+        client->set_initial_top_level_history_entry({}, move(initial_history_entry));
     if (view.has_value())
         client->assign_view({}, *view);
 
@@ -1177,15 +1183,15 @@ void Application::crash_compositor_process()
     m_compositor_client->async_crash();
 }
 
-ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process(ViewImplementation& view, Optional<Web::HTML::CrossProcessId> root_navigable_id, Optional<Web::HTML::CrossProcessId> initial_document_state_id)
+ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process(ViewImplementation& view, Optional<Web::HTML::CrossProcessId> navigable_to_adopt, Optional<Web::HTML::CrossProcessId> initial_document_state_id)
 {
     if (view.is_private() == IsPrivate::Yes)
-        return create_web_content_client(view, IsPrivate::Yes, allocate_page_id(), root_navigable_id, initial_document_state_id);
+        return create_web_content_client(view, IsPrivate::Yes, allocate_page_id(), navigable_to_adopt, initial_document_state_id);
 
-    if (root_navigable_id.has_value() || initial_document_state_id.has_value())
-        return create_web_content_client(view, IsPrivate::No, allocate_page_id(), root_navigable_id, initial_document_state_id);
+    if (navigable_to_adopt.has_value() || initial_document_state_id.has_value())
+        return create_web_content_client(view, IsPrivate::No, allocate_page_id(), navigable_to_adopt, initial_document_state_id);
 
-    if (m_spare_web_content_process && m_spare_web_content_process->is_ready_for_view_assignment({})) {
+    if (m_spare_web_content_process) {
         auto web_content_client = m_spare_web_content_process.release_nonnull();
         launch_spare_web_content_process();
 
@@ -1238,11 +1244,6 @@ void Application::launch_spare_web_content_process()
         if (auto process = find_process(m_spare_web_content_process->pid()); process.has_value())
             process->set_title("(spare)"_utf16);
     });
-}
-
-bool Application::has_ready_spare_web_content_process() const
-{
-    return m_spare_web_content_process && m_spare_web_content_process->is_ready_for_view_assignment({});
 }
 
 ErrorOr<void> Application::launch_services()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -153,7 +153,7 @@ public:
     ErrorOr<Core::GeolocationProvider::WatchId, Core::GeolocationError> start_watching_geolocation_position(Core::GeolocationProvider::SuccessCallback on_success, Core::GeolocationProvider::ErrorCallback on_error);
     void stop_watching_geolocation_position(Core::GeolocationProvider::WatchId);
 
-    ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&, Optional<Web::HTML::CrossProcessId> root_navigable_id = {}, Optional<Web::HTML::CrossProcessId> initial_document_state_id = {});
+    ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&, Optional<Web::HTML::CrossProcessId> navigable_to_adopt = {}, Optional<Web::HTML::CrossProcessId> initial_document_state_id = {});
     struct ChildFrameWebContentProcess {
         NonnullRefPtr<WebContentClient> client;
         u64 page_id { 0 };
@@ -341,10 +341,11 @@ protected:
     virtual void on_devtools_disabled() const;
 
     Main::Arguments& arguments() { return m_arguments; }
-    bool has_ready_spare_web_content_process() const;
+
+    bool has_spare_web_content_process() const { return m_spare_web_content_process; }
 
 private:
-    ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, IsPrivate, u64 initial_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id = {}, Optional<Web::HTML::CrossProcessId> initial_document_state_id = {});
+    ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, IsPrivate, u64 initial_page_id, Optional<Web::HTML::CrossProcessId> navigable_to_adopt = {}, Optional<Web::HTML::CrossProcessId> initial_document_state_id = {});
     PrivateBrowsingSession& ensure_private_browsing_session();
     ErrorOr<void> launch_services();
     void launch_spare_web_content_process();

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -102,6 +102,7 @@ public:
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-bc
     CanonicalBrowsingContext& active_browsing_context() const;
+    bool has_active_browsing_context() const { return m_active_browsing_context; }
     void set_active_browsing_context(NonnullRefPtr<CanonicalBrowsingContext>);
 
     NonnullRefPtr<CanonicalBrowsingContext> obtain_a_browsing_context_to_use_for_a_navigation_response(Web::HTML::OpenerPolicyEnforcementResult const&);

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -169,14 +169,15 @@ void CanonicalTraversable::prepare_for_reload()
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-top-level-traversable
-void CanonicalTraversable::did_create_top_level_traversable(Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<CanonicalNavigable&> opener, WebContentClient& process)
+void CanonicalTraversable::create_a_new_top_level_traversable(Optional<CanonicalNavigable&> opener, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, WebContentClient& process)
 {
-    // NB: A replacement process creates a traversable of its own for this canonical one, which stays as it is.
-    if (!m_session_history.entries().is_empty())
-        return;
+    // A canonical traversable is created once, by the UI process, and hosted by whichever process holds its
+    // active document. A replacement process adopts this one rather than creating another.
+    VERIFY(!has_active_browsing_context());
 
     // 1. Let document be null.
-    // NB: The reporting process created document, which initialHistoryEntry's document state describes.
+    // NB: The process hosting this traversable creates document. Its origin is only inherited from an opener, so
+    //     for a traversable without one this is the opaque origin that keys the UI process's own agent.
     auto document_origin = initial_history_entry.document_state.origin.value_or(URL::Origin::create_opaque());
 
     // 2. If opener is null, then set document to the second return value of creating a new top-level browsing context and document.

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -111,7 +111,7 @@ public:
     ByteString pending_same_document_session_history_entries_for_debug() const;
 
     void prepare_for_reload();
-    void did_create_top_level_traversable(Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<CanonicalNavigable&> opener, WebContentClient& process);
+    void create_a_new_top_level_traversable(Optional<CanonicalNavigable&> opener, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, WebContentClient& process);
     bool update_session_history_entry_navigation_api_state(CanonicalNavigable&, Web::HTML::SessionHistoryEntryIdentity const&, Web::HTML::StorageSerializationRecord navigation_api_state);
     bool update_session_history_entry_scroll_restoration_mode(CanonicalNavigable&, Web::HTML::SessionHistoryEntryIdentity const&, Web::HTML::ScrollRestorationMode scroll_restoration_mode);
     bool update_session_history_entry_document_state_navigable_target_name(CanonicalNavigable&, Web::HTML::SessionHistoryEntryIdentity const&, Utf16String navigable_target_name);

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -184,7 +184,9 @@ ErrorOr<SiteIsolationManager::DocumentHost> SiteIsolationManager::obtain_child_d
     u64 page_id;
     if (host) {
         page_id = Application::the().allocate_page_id();
-        host->async_create_embedded_page(page_id, navigable.id(), current_entry->document_state.id, traversable.system_visibility_state());
+        host->async_create_embedded_page(page_id, navigable.id(),
+            Web::HTML::create_initial_session_history_entry_descriptor(current_entry->document_state.id, {}, {}, {}),
+            traversable.system_visibility_state());
     } else {
         auto process = TRY(Application::the().launch_child_frame_web_content_process(navigable.reporting_client().is_private(), navigable.id(), current_entry->document_state.id));
         host = move(process.client);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2009,13 +2009,6 @@ void ViewImplementation::did_change_screen_wake_lock_state(Badge<WebContentClien
         on_screen_wake_lock_state_changed(m_screen_wake_lock_state);
 }
 
-void ViewImplementation::did_create_top_level_traversable(Badge<WebContentClient>, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<CanonicalNavigable&> opener, WebContentClient& process)
-{
-    m_top_level_traversable.did_create_top_level_traversable(move(initial_history_entry), opener, process);
-    update_navigation_action_state();
-    dump_session_history("created-top-level-traversable"sv);
-}
-
 void ViewImplementation::did_change_needs_beforeunload_check(Badge<WebContentClient>, bool needs_beforeunload_check)
 {
     m_needs_beforeunload_check = needs_beforeunload_check;
@@ -2141,8 +2134,8 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client, Op
 
         cancel_all_native_geolocation_requests();
 
-        // Replacing WebContent does not create a new top-level traversable.
-        auto root_navigable_id = m_client_state.client
+        // Only a view's first process creates its traversable. A process replacing another adopts it
+        auto navigable_to_adopt = m_top_level_traversable.has_active_browsing_context()
             ? Optional<Web::HTML::CrossProcessId> { m_top_level_traversable.id() }
             : Optional<Web::HTML::CrossProcessId> {};
         auto client_handle = m_client_state.client_handle;
@@ -2154,7 +2147,7 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client, Op
         m_client_state.hosts_committed_entry = !replaces_existing_client;
 
         // FIXME: Fail to open the tab, rather than crashing the whole application if this fails.
-        auto client_or_error = Application::the().launch_web_content_process(*this, root_navigable_id, initial_document_state_id);
+        auto client_or_error = Application::the().launch_web_content_process(*this, navigable_to_adopt, initial_document_state_id);
         if (client_or_error.is_error())
             warnln("Failed to launch WebContent during process swap: {}", client_or_error.error());
         m_client_state.client = client_or_error.release_value_but_fixme_should_propagate_errors();

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -328,7 +328,6 @@ public:
     void did_change_screen_wake_lock_state(Badge<WebContentClient>, Web::ScreenWakeLockState);
     Web::ScreenWakeLockState screen_wake_lock_state() const { return m_screen_wake_lock_state; }
 
-    void did_create_top_level_traversable(Badge<WebContentClient>, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<CanonicalNavigable&> opener, WebContentClient& process);
     void request_history_operation(Badge<WebContentClient>, WebContentClient&, u64 requesting_page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationParameters);
     void did_receive_history_operation_ready(Badge<WebContentClient>, WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationReadyResult);
     void did_receive_history_step_unload_cancelation_result(Badge<WebContentClient>, WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult, Web::HTML::UnloadPromptShown);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -216,8 +216,10 @@ void WebContentClient::assign_view(Badge<Application>, ViewImplementation& view)
     view.traversable().set_id(m_root_navigable_id);
     m_views.set(m_initial_page_id, view);
 
-    if (m_initial_top_level_history_entry_awaiting_view.has_value())
-        view.did_create_top_level_traversable({}, m_initial_top_level_history_entry_awaiting_view.release_value(), {}, *this);
+    if (m_initial_top_level_history_entry.has_value()) {
+        view.traversable().create_a_new_top_level_traversable({}, m_initial_top_level_history_entry.release_value(), *this);
+        view.update_navigation_action_state();
+    }
 }
 
 void WebContentClient::set_compositor_connection_id(Badge<Application>, i32 compositor_connection_id)
@@ -1999,8 +2001,17 @@ void WebContentClient::did_post_broadcast_channel_message(u64, Web::HTML::Broadc
     WorkerProcessManager::the().broadcast_channel_message_from_web_content(message, m_is_private);
 }
 
-Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints)
+Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Optional<Web::HTML::CrossProcessId> opener_navigable_id, Optional<URL::URL> opener_base_url, Utf16String target_name)
 {
+    // The opener is a navigable the requesting page hosts. A request naming one it does not is refused before the
+    // chrome is asked for a view, so nothing is created for a traversable that never will be.
+    Optional<CanonicalNavigable&> opener;
+    if (opener_navigable_id.has_value()) {
+        opener = hosted_navigable_for_page(page_id, *opener_navigable_id);
+        if (!opener.has_value() || !opener->replicated_state().has_value())
+            return { {}, {}, {}, Web::HTML::VisibilityState::Hidden, {} };
+    }
+
     auto new_page_id = Application::the().allocate_page_id();
     String handle;
     auto opener_view = owning_view_for_page_id(page_id);
@@ -2011,12 +2022,22 @@ Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_r
 
     auto view = view_for_page_id(new_page_id);
     if (!view.has_value())
-        return { {}, {}, Web::HTML::VisibilityState::Hidden, move(handle) };
+        return { {}, {}, {}, Web::HTML::VisibilityState::Hidden, move(handle) };
 
     auto root_navigable_id = Application::the().allocate_ui_process_cross_process_id();
     view->traversable().set_id(root_navigable_id);
 
-    return { new_page_id, root_navigable_id, view->traversable().system_visibility_state(), move(handle) };
+    // An auxiliary traversable's initial about:blank inherits its opener's origin and base URL
+    Optional<URL::Origin> opener_origin;
+    if (opener.has_value())
+        opener_origin = opener->replicated_state()->active_document_origin;
+
+    auto initial_history_entry = Web::HTML::create_initial_session_history_entry_descriptor(
+        Application::the().allocate_ui_process_cross_process_id(), move(opener_origin), move(opener_base_url), move(target_name));
+    view->traversable().create_a_new_top_level_traversable(opener, initial_history_entry, *this);
+    view->update_navigation_action_state();
+
+    return { new_page_id, root_navigable_id, move(initial_history_entry), view->traversable().system_visibility_state(), move(handle) };
 }
 
 void WebContentClient::did_request_activate_tab(u64 page_id)
@@ -2265,33 +2286,6 @@ void WebContentClient::did_change_screen_wake_lock_state(u64 page_id, Web::Scree
 {
     if (auto view = view_for_page_id(page_id); view.has_value())
         view->did_change_screen_wake_lock_state({}, wake_lock_state);
-}
-
-void WebContentClient::did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id)
-{
-    if (page_id == m_initial_page_id && navigable_id == m_root_navigable_id) {
-        if (m_did_create_initial_top_level_traversable)
-            return;
-        m_did_create_initial_top_level_traversable = true;
-
-        if (m_views.is_empty()) {
-            m_initial_top_level_history_entry_awaiting_view = move(initial_history_entry);
-            return;
-        }
-    }
-
-    auto navigable = hosted_navigable_for_page(page_id, navigable_id);
-    if (!navigable.has_value() || !navigable->is_top_level_traversable())
-        return;
-
-    auto view = ViewImplementation::find_view_for_traversable(navigable->top_level_traversable());
-    if (!view.has_value())
-        return;
-
-    Optional<CanonicalNavigable&> opener;
-    if (opener_navigable_id.has_value())
-        opener = hosted_navigable(*opener_navigable_id);
-    view->did_create_top_level_traversable({}, move(initial_history_entry), opener, *this);
 }
 
 void WebContentClient::did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::StorageSerializationRecord navigation_api_state)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -84,7 +84,7 @@ public:
     IsPrivate is_private() const { return m_is_private; }
 
     void assign_view(Badge<Application>, ViewImplementation&);
-    bool is_ready_for_view_assignment(Badge<Application>) const { return m_did_create_initial_top_level_traversable; }
+    void set_initial_top_level_history_entry(Badge<Application>, Web::HTML::SessionHistoryEntryDescriptor entry) { m_initial_top_level_history_entry = move(entry); }
     void register_view(u64 page_id, ViewImplementation&);
     void unregister_view(u64 page_id);
 
@@ -248,7 +248,7 @@ private:
     virtual void did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<Utf16String> key, Optional<Utf16String> old_value, Optional<Utf16String> new_value) override;
     virtual void did_update_indexed_database(u64 page_id, String update) override;
     virtual void did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) override;
-    virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints) override;
+    virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints, Optional<Web::HTML::CrossProcessId> opener_navigable_id, Optional<URL::URL> opener_base_url, Utf16String target_name) override;
     virtual void did_request_activate_tab(u64 page_id) override;
     virtual void did_close_browsing_context(u64 page_id) override;
     virtual void did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) override;
@@ -285,7 +285,6 @@ private:
     virtual void did_update_primary_selection(u64 page_id, String) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_change_screen_wake_lock_state(u64 page_id, Web::ScreenWakeLockState) override;
-    virtual void did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id) override;
     virtual void did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::StorageSerializationRecord navigation_api_state) override;
     virtual void did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;
     virtual void did_update_session_history_entry_document_state_navigable_target_name(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Utf16String navigable_target_name) override;
@@ -332,8 +331,7 @@ private:
     Optional<i32> m_compositor_connection_id;
     u64 m_initial_page_id { 0 };
     Web::HTML::CrossProcessId m_root_navigable_id;
-    bool m_did_create_initial_top_level_traversable { false };
-    Optional<Web::HTML::SessionHistoryEntryDescriptor> m_initial_top_level_history_entry_awaiting_view;
+    Optional<Web::HTML::SessionHistoryEntryDescriptor> m_initial_top_level_history_entry;
 
     ProcessHandle m_process_handle;
     RefPtr<Core::Timer> m_detached_page_close_timer;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -195,15 +195,15 @@ void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 genera
     Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(m_enable_test_mode, m_font_provider));
 }
 
-void ConnectionFromClient::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state)
+void ConnectionFromClient::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Web::HTML::VisibilityState system_visibility_state)
 {
-    m_page_host->initialize(initial_page_id, root_navigable_id, cross_process_id_allocator, initial_document_state_id, system_visibility_state);
+    m_page_host->initialize(initial_page_id, root_navigable_id, cross_process_id_allocator, move(initial_history_entry), system_visibility_state);
 }
 
-void ConnectionFromClient::create_embedded_page(u64 page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state)
+void ConnectionFromClient::create_embedded_page(u64 page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Web::HTML::VisibilityState system_visibility_state)
 {
     auto& page = m_page_host->create_page(page_id, root_navigable_id);
-    Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(page.page(), URL::about_blank(), Empty {}, initial_document_state_id, system_visibility_state);
+    Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(page.page(), URL::about_blank(), Empty {}, move(initial_history_entry), system_visibility_state);
 }
 
 void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -84,8 +84,8 @@ private:
 
     virtual Messages::WebContentServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual void set_font_catalog(IPC::File, u64 size, u64 generation) override;
-    virtual void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) override;
-    virtual void create_embedded_page(u64 page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) override;
+    virtual void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Web::HTML::VisibilityState system_visibility_state) override;
+    virtual void create_embedded_page(u64 page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Web::HTML::VisibilityState system_visibility_state) override;
     virtual void continue_history_navigation_population(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Web::Bindings::NavigationType>, Web::HTML::HistoryNavigationPopulation) override;
     virtual void close_server() override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1369,13 +1369,13 @@ void PageClient::page_did_update_resource_count(i32 count_waiting)
     client().async_did_update_resource_count(m_id, count_waiting);
 }
 
-PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints)
+PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Optional<Web::HTML::CrossProcessId> opener_navigable_id, Optional<URL::URL> opener_base_url, Utf16String const& target_name)
 {
     // FIXME: Create an abstraction to let this WebContent process know about a new process we create?
     // FIXME: For now, just create a new page in the same process anyway
     // FIXME: Proper agent-cluster separation must also cover same-process
     // COOP/noopener popups before they receive distinct main-world cells.
-    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestNewWebView>(m_id, activate_tab, hints);
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestNewWebView>(m_id, activate_tab, hints, opener_navigable_id, move(opener_base_url), target_name);
     if (!response) {
         dbgln("WebContent client disconnected during DidRequestNewWebView. Exiting peacefully.");
         Core::Process::terminate_immediately(0);
@@ -1384,9 +1384,10 @@ PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML
     if (!response->new_page_id().has_value())
         return {};
     VERIFY(response->root_navigable_id().has_value());
+    VERIFY(response->initial_history_entry().has_value());
 
     auto& new_client = m_owner.create_page(*response->new_page_id(), *response->root_navigable_id());
-    return { &new_client.page(), response->system_visibility_state(), response->take_handle() };
+    return { &new_client.page(), response->system_visibility_state(), response->take_handle(), response->take_initial_history_entry() };
 }
 
 void PageClient::page_did_request_activate_tab()
@@ -1404,11 +1405,6 @@ void PageClient::page_did_close_top_level_traversable()
     // NOTE: This only removes the strong reference the PageHost has for this PageClient.
     //       It will be GC'd 'later'.
     m_owner.remove_page({}, m_id);
-}
-
-void PageClient::page_did_create_top_level_traversable(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id)
-{
-    client().async_did_create_top_level_traversable(m_id, navigable_id, initial_history_entry, opener_navigable_id);
 }
 
 void PageClient::page_did_change_needs_beforeunload_check(bool needs_beforeunload_check)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -265,10 +265,9 @@ private:
     virtual void page_did_broadcast_storage_change(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& url, Optional<Utf16String> const& key, Optional<Utf16String> const& old_value, Optional<Utf16String> const& new_value) override;
     virtual void page_did_update_indexed_database(String const& url, Web::IndexedDB::TransactionChanges const&) override;
     virtual void page_did_update_resource_count(i32) override;
-    virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints) override;
+    virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Optional<Web::HTML::CrossProcessId> opener_navigable_id, Optional<URL::URL> opener_base_url, Utf16String const& target_name) override;
     virtual void page_did_request_activate_tab() override;
     virtual void page_did_close_top_level_traversable() override;
-    virtual void page_did_create_top_level_traversable(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id) override;
     virtual void page_did_change_needs_beforeunload_check(bool needs_beforeunload_check) override;
     virtual void page_did_update_session_history_entry_navigation_api_state(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity const& entry_identity, Web::HTML::StorageSerializationRecord const& navigation_api_state) override;
     virtual void page_did_update_session_history_entry_scroll_restoration_mode(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity const& entry_identity, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -22,12 +22,12 @@ PageHost::PageHost(ConnectionFromClient& client)
 {
 }
 
-void PageHost::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state)
+void PageHost::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Web::HTML::VisibilityState system_visibility_state)
 {
     VERIFY(m_pages.is_empty());
     m_cross_process_id_allocator = cross_process_id_allocator;
     auto& first_page = create_page(initial_page_id, root_navigable_id);
-    Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank(), Empty {}, initial_document_state_id, system_visibility_state);
+    Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank(), Empty {}, move(initial_history_entry), system_visibility_state);
 }
 
 PageClient& PageHost::create_page(u64 page_id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id)

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -37,7 +37,7 @@ public:
     static NonnullOwnPtr<PageHost> create(ConnectionFromClient& client) { return adopt_own(*new PageHost(client)); }
     virtual ~PageHost();
 
-    void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state);
+    void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Web::HTML::VisibilityState system_visibility_state);
     Optional<PageClient&> page(u64 page_id);
     PageClient& create_page(u64 page_id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id = {});
     void remove_page(Badge<PageClient>, u64 page_id);

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -173,7 +173,7 @@ endpoint WebContentClient
     did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) =|
 
     did_update_resource_count(u64 page_id, i32 count_waiting) =|
-    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints) => (Optional<u64> new_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id, Web::HTML::VisibilityState system_visibility_state, String handle)
+    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Optional<Web::HTML::CrossProcessId> opener_navigable_id, Optional<URL::URL> opener_base_url, Utf16String target_name) => (Optional<u64> new_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id, Optional<Web::HTML::SessionHistoryEntryDescriptor> initial_history_entry, Web::HTML::VisibilityState system_visibility_state, String handle)
     did_request_activate_tab(u64 page_id) =|
     did_close_browsing_context(u64 page_id) =|
     did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) =|
@@ -204,7 +204,6 @@ endpoint WebContentClient
     did_request_primary_paste(u64 page_id) =|
     did_update_primary_selection(u64 page_id, String text) =|
 
-    did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id) =|
     did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::StorageSerializationRecord navigation_api_state) =|
     did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::ScrollRestorationMode scroll_restoration_mode) =|
     did_update_session_history_entry_document_state_navigable_target_name(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Utf16String navigable_target_name) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -50,8 +50,8 @@ endpoint WebContentServer
 {
     init_transport(int peer_pid) => (int peer_pid)
     set_font_catalog(IPC::File file, u64 size, u64 generation) =|
-    initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) =|
-    create_embedded_page(u64 page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) =|
+    initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Web::HTML::VisibilityState system_visibility_state) =|
+    create_embedded_page(u64 page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Web::HTML::VisibilityState system_visibility_state) =|
     close_server() =|
 
     get_window_handle(u64 page_id) => (String handle)

--- a/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
+++ b/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
@@ -33,9 +33,9 @@ public:
     {
     }
 
-    bool has_ready_spare_web_content_process() const
+    bool has_spare_web_content_process() const
     {
-        return WebView::Application::has_ready_spare_web_content_process();
+        return WebView::Application::has_spare_web_content_process();
     }
 
     virtual void create_platform_options(WebView::BrowserOptions& browser_options, WebView::RequestServerOptions&, WebView::WebContentOptions& web_content_options) override
@@ -101,7 +101,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Core::EventLoop::current().spin_until([&]() { return loads_finished >= expected_loads; });
 
     // A spare can create its initial traversable before a view adopts it. Preserve that entry across assignment.
-    Core::EventLoop::current().spin_until([&]() { return app->has_ready_spare_web_content_process(); });
+    Core::EventLoop::current().spin_until([&]() { return app->has_spare_web_content_process(); });
     auto spare_view = WebView::HeadlessWebView::create(move(theme), { 800, 600 });
     VERIFY(spare_view->traversable().session_history().current_step() == 0);
     VERIFY(spare_view->traversable().session_history().current_entry());
@@ -200,6 +200,11 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Core::EventLoop::current().spin_until([&] { return history_boundary_traversal_ready; });
     VERIFY(browser_history_traversals_completed == completed_traversals_before_history_boundary + 1);
 
+    // Reopening a closed tab restores its history into a view whose process is still starting up.
+    auto closed_tab_history = view->session_history_snapshot();
+    VERIFY(closed_tab_history.has_value());
+    auto closed_tab_url = view->url();
+
     // Closing a view may synchronously cause the UI to generate input, geometry, and visibility events while removing
     // the view from its container. Events received after the browsing context closes must be discarded.
     bool did_close = false;
@@ -214,7 +219,23 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     };
     view->request_close();
     Core::EventLoop::current().spin_until([&] { return did_close; });
-    Core::EventLoop::current().spin_until([&] { return app->has_ready_spare_web_content_process(); });
+    Core::EventLoop::current().spin_until([&] { return app->has_spare_web_content_process(); });
+
+    // Take the spare, so the restored view launches a process of its own the way a private window's tab does. A
+    // spare is relaunched from a deferred task, so none is available until the event loop next runs.
+    auto restored_theme = TRY(Gfx::load_system_theme(theme_path.string()));
+    auto spare_consumer = WebView::HeadlessWebView::create(restored_theme, { 800, 600 });
+    VERIFY(!app->has_spare_web_content_process());
+
+    auto restored_view = WebView::HeadlessWebView::create(restored_theme, { 800, 600 });
+    VERIFY(&restored_view->client() != &spare_consumer->client());
+
+    // The restored URL is shown before the traversal runs, so wait for the document behind it to load.
+    size_t restored_view_loads_finished = 0;
+    restored_view->on_load_finish = [&](auto const&) { ++restored_view_loads_finished; };
+    MUST(restored_view->restore_session_history_from_snapshot(closed_tab_history.release_value()));
+    Core::EventLoop::current().spin_until([&] { return restored_view_loads_finished >= 1 && restored_view->url() == closed_tab_url; });
+    VERIFY(restored_view->traversable().session_history().current_entry()->url == closed_tab_url);
 
     outln("PASS: browser history traversal");
     return 0;


### PR DESCRIPTION
Fixes a crash when reopening a closed tab in a private window.

The UI process owns the canonical traversable, but learned of its creation from an async report sent by the hosting WebContent process. Private views take no spare process, so on restore the report was still in flight when the session history was seeded. The handler's "have I run yet" guard then rejected it, and the browsing context was never created.

The UI process now creates the traversable itself and hands its identity down at initialize. window.open does the same during its synchronous request, with the opener's origin and base URL supplied by the requesting process. The creation report, its guard, and the spare process's replay stash are gone, so creation is synchronous and happens exactly once per view.

Fixes: #11605