### PR TITLE
Throttle a hidden document’s timers the way Chrome does (and make propublica.org stop eating CPU in a background tab)

### DIFF
--- a/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -250,7 +250,7 @@ void EventLoopManagerUnix::wait_for_events(EventLoopImplementation::PumpMode mod
 
     bool has_pending_events = ThreadEventQueue::current().has_pending_events();
 
-    auto time_at_iteration_start = MonotonicTime::now_coarse();
+    auto time_at_iteration_start = MonotonicTime::now();
     thread_data.timeouts.absolutize_relative_timeouts(time_at_iteration_start);
 
     // Figure out how long to wait at maximum.
@@ -273,7 +273,7 @@ void EventLoopManagerUnix::wait_for_events(EventLoopImplementation::PumpMode mod
 try_select_again:
     // select() and wait for file system events, calls to wake(), POSIX signals, or timer expirations.
     auto error_or_marked_fd_count = System::poll(thread_data.poll_fds, should_wait_forever ? -1 : timeout);
-    auto time_after_poll = MonotonicTime::now_coarse();
+    auto time_after_poll = MonotonicTime::now();
     // Because POSIX, we might spuriously return from select() with EINTR; just select again.
     if (error_or_marked_fd_count.is_error()) {
         if (error_or_marked_fd_count.error().code() == EINTR)
@@ -556,7 +556,10 @@ intptr_t EventLoopManagerUnix::register_timer(EventReceiver& object, int millise
     timer->owner_thread = thread_data.thread_id;
     timer->owner = object;
     timer->interval = AK::Duration::from_milliseconds(milliseconds);
-    timer->reload(MonotonicTime::now_coarse());
+    // NB: The timer is armed and expired on the precise clock. CLOCK_MONOTONIC_COARSE lags it by up to a scheduler
+    //     tick on Linux, so a timer armed against the coarse clock could fire that much before its deadline on the
+    //     clock everything else measures with, performance.now() included.
+    timer->reload(MonotonicTime::now());
     timer->should_reload = should_reload;
     thread_data.timeouts.schedule_absolute(timer);
     return bit_cast<intptr_t>(timer);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4767,6 +4767,19 @@ bool Document::hidden() const
     return m_visibility_state == HTML::VisibilityState::Hidden;
 }
 
+bool Document::is_playing_audio() const
+{
+    return page().has_media_element_playing_audio(*this);
+}
+
+// A hidden document playing audio keeps its timers on their own deadlines (see
+// WindowOrWorkerGlobalScopeMixin::timers_are_throttled()), so the Window has to hear when that starts or stops.
+void Document::media_element_audio_play_state_changed(Badge<HTML::HTMLMediaElement>)
+{
+    if (auto window = this->window(); window && &window->associated_document() == this)
+        window->document_audio_play_state_changed({});
+}
+
 // https://html.spec.whatwg.org/multipage/interaction.html#update-the-visibility-state
 void Document::update_the_visibility_state(HTML::VisibilityState visibility_state)
 {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4791,6 +4791,9 @@ void Document::update_the_visibility_state(HTML::VisibilityState visibility_stat
         return document_observer.document_visibility_state_observer();
     },
         m_visibility_state);
+    // The page visibility change steps for timers (see WindowOrWorkerGlobalScopeMixin::document_visibility_state_changed()).
+    if (auto window = this->window(); window && &window->associated_document() == this)
+        window->document_visibility_state_changed({});
 
     // 7. Fire an event named visibilitychange at document, with its bubbles attribute initialized to true.
     auto event = DOM::Event::create(
@@ -6208,6 +6211,10 @@ void Document::set_initial_visibility_state(HTML::VisibilityState visibility_sta
 {
     // 1. Set document's visibility state to visibility state.
     m_visibility_state = visibility_state;
+    // The Window's timers follow the document's visibility from here on (see
+    // WindowOrWorkerGlobalScopeMixin::document_visibility_state_changed()).
+    if (auto window = this->window(); window && &window->associated_document() == this)
+        window->document_visibility_state_changed({});
 
     // TODO: 2. Queue a new VisibilityStateEntry whose visibility state is document's visibility state and whose timestamp is 0.
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -746,6 +746,10 @@ public:
     bool hidden() const;
     HTML::VisibilityState visibility_state() const { return m_visibility_state; }
 
+    // Whether a media element of this document is producing audible output (see HTMLMediaElement::update_audio_play_state()).
+    bool is_playing_audio() const;
+    void media_element_audio_play_state_changed(Badge<HTML::HTMLMediaElement>);
+
     // https://html.spec.whatwg.org/multipage/interaction.html#update-the-visibility-state
     void update_the_visibility_state(HTML::VisibilityState);
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -331,6 +331,13 @@ void HTMLMediaElement::adopted_from(DOM::Document& old_document)
     //     second fetch on top of it.
     m_document_observer->retarget_for_adoption(document());
 
+    // An element playing audio takes the timer exemption it earns its document along with it (see
+    // Document::is_playing_audio()).
+    if (m_is_playing_audio) {
+        old_document.media_element_audio_play_state_changed({});
+        document().media_element_audio_play_state_changed({});
+    }
+
     // https://html.spec.whatwg.org/multipage/media.html#delaying-the-load-event-flag
     // While the delaying-the-load-event flag is true, the element must delay the load event of its document.
     // NB: The flag delays the load event of the element's current node document, so it follows the element when it is
@@ -2917,6 +2924,7 @@ void HTMLMediaElement::update_audio_play_state()
     m_is_playing_audio = is_playing_audio;
     document().page().client().page_did_change_audio_play_state(
         m_is_playing_audio ? AudioPlayState::Playing : AudioPlayState::Paused);
+    document().media_element_audio_play_state_changed({});
 }
 
 void HTMLMediaElement::set_show_poster(bool show_poster)

--- a/Libraries/LibWeb/HTML/Timer.cpp
+++ b/Libraries/LibWeb/HTML/Timer.cpp
@@ -12,13 +12,15 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(Timer);
 
-GC::Ref<Timer> Timer::create(i32 milliseconds, Function<void()> callback, i32 id, Repeating repeating)
+GC::Ref<Timer> Timer::create(i32 milliseconds, Function<void()> callback, i32 id, Repeating repeating, TimerThrottlingClass throttling_class, double deadline)
 {
-    return GC::Heap::the().allocate<Timer>(milliseconds, move(callback), id, repeating);
+    return GC::Heap::the().allocate<Timer>(milliseconds, move(callback), id, repeating, throttling_class, deadline);
 }
 
-Timer::Timer(i32 milliseconds, Function<void()> callback, i32 id, Repeating repeating)
+Timer::Timer(i32 milliseconds, Function<void()> callback, i32 id, Repeating repeating, TimerThrottlingClass throttling_class, double deadline)
     : m_id(id)
+    , m_throttling_class(throttling_class)
+    , m_deadline(deadline)
 {
     if (repeating == Repeating::Yes)
         m_timer = Core::Timer::create_repeating(milliseconds, move(callback));
@@ -46,6 +48,16 @@ void Timer::start()
 void Timer::stop()
 {
     m_timer->stop();
+}
+
+void Timer::restart(i32 milliseconds)
+{
+    m_timer->restart(milliseconds);
+}
+
+bool Timer::is_active() const
+{
+    return m_timer->is_active();
 }
 
 void Timer::set_callback(Function<void()> callback)

--- a/Libraries/LibWeb/HTML/Timer.h
+++ b/Libraries/LibWeb/HTML/Timer.h
@@ -17,6 +17,13 @@
 
 namespace Web::HTML {
 
+// How a hidden document treats the timer: it leaves an immediate one alone, and holds a delayed one back until the
+// next of the wake-ups it lets its timers run at.
+enum class TimerThrottlingClass : u8 {
+    Immediate,
+    Delayed,
+};
+
 class Timer final : public JS::Cell {
     GC_CELL(Timer, JS::Cell);
     GC_DECLARE_ALLOCATOR(Timer);
@@ -29,22 +36,33 @@ public:
 
     static constexpr bool OVERRIDES_FINALIZE = true;
 
-    static GC::Ref<Timer> create(i32 milliseconds, Function<void()> callback, i32 id, Repeating);
+    static GC::Ref<Timer> create(i32 milliseconds, Function<void()> callback, i32 id, Repeating, TimerThrottlingClass, double deadline);
 
     void start();
     void stop();
+    void restart(i32 milliseconds);
+    bool is_active() const;
 
     void set_callback(Function<void()>);
     void set_interval(i32 milliseconds);
 
+    TimerThrottlingClass throttling_class() const { return m_throttling_class; }
+    void set_throttling_class(TimerThrottlingClass throttling_class) { m_throttling_class = throttling_class; }
+
+    // When the timer would fire if nothing held it back: a moment on the monotonic clock, in milliseconds.
+    double deadline() const { return m_deadline; }
+    void set_deadline(double deadline) { m_deadline = deadline; }
+
 private:
-    Timer(i32 milliseconds, Function<void()> callback, i32 id, Repeating);
+    Timer(i32 milliseconds, Function<void()> callback, i32 id, Repeating, TimerThrottlingClass, double deadline);
 
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void finalize() override;
 
     RefPtr<Core::Timer> m_timer;
     i32 m_id { 0 };
+    TimerThrottlingClass m_throttling_class { TimerThrottlingClass::Delayed };
+    double m_deadline { 0 };
 };
 
 }

--- a/Libraries/LibWeb/HTML/Timer.h
+++ b/Libraries/LibWeb/HTML/Timer.h
@@ -17,11 +17,13 @@
 
 namespace Web::HTML {
 
-// How a hidden document treats the timer: it leaves an immediate one alone, and holds a delayed one back until the
-// next of the wake-ups it lets its timers run at.
+// How a hidden document treats the timer: it leaves an immediate one alone, holds a delayed one back until the next of
+// the wake-ups it lets its timers run at, and holds a chained one — a timer the page re-armed from a timer callback,
+// or a timeout another specification waits on — back to a much rarer wake-up once it has been hidden for a while.
 enum class TimerThrottlingClass : u8 {
     Immediate,
     Delayed,
+    Chained,
 };
 
 class Timer final : public JS::Cell {

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -858,7 +858,8 @@ void Window::start_an_idle_period()
     auto& pending_list = m_idle_request_callbacks;
     // 3. Let run_list be window's list of runnable idle callbacks.
     auto& run_list = m_runnable_idle_callbacks;
-    run_list.extend(pending_list);
+    for (auto& [handle, callback] : pending_list)
+        run_list.set(handle, move(callback));
     // 4. Clear pending_list.
     pending_list.clear();
 
@@ -911,22 +912,14 @@ void Window::invoke_idle_callback_timeout(u32 handle)
 {
     // 1. Let callback be the result of finding the entry in window's list of idle request callbacks or the list of
     //    runnable idle callbacks that is associated with the value given by the handle argument passed to the algorithm.
-    RefPtr<IdleCallback> callback;
-    auto take_callback = [&](auto& callbacks) {
-        for (size_t index = 0; index < callbacks.size(); ++index) {
-            if (callbacks[index]->handle() == handle) {
-                callback = callbacks.take(index);
-                return;
-            }
-        }
-    };
-    take_callback(m_idle_request_callbacks);
-    if (!callback)
-        take_callback(m_runnable_idle_callbacks);
+    auto taken = m_idle_request_callbacks.take(handle);
+    if (!taken.has_value())
+        taken = m_runnable_idle_callbacks.take(handle);
 
     // 2. If callback is not undefined:
-    if (!callback)
+    if (!taken.has_value())
         return;
+    auto callback = taken.release_value();
 
     callback->clear_timeout_timer_id();
 
@@ -2044,7 +2037,7 @@ u32 Window::request_idle_callback(IdleCallbackHandler callback, IdleRequestOptio
 
     // 4. Push callback to the end of window's list of idle request callbacks, associated with handle.
     auto idle_callback = adopt_ref(*new IdleCallback(move(callback), handle));
-    m_idle_request_callbacks.append(idle_callback);
+    m_idle_request_callbacks.set(handle, idle_callback);
 
     // 5. Return handle and then continue running this algorithm asynchronously.
 
@@ -2078,14 +2071,11 @@ void Window::cancel_idle_callback(u32 handle)
     //    that is associated with the value handle.
     // 3. If there is such an entry, remove it from both window's list of idle request callbacks and the list of runnable idle callbacks.
     auto remove_callback = [&](auto& callbacks) {
-        for (size_t index = 0; index < callbacks.size(); ++index) {
-            if (callbacks[index]->handle() != handle)
-                continue;
-            auto callback = callbacks.take(index);
-            if (callback->timeout_timer_id().has_value())
-                clear_timeout(*callback->timeout_timer_id());
+        auto callback = callbacks.take(handle);
+        if (!callback.has_value())
             return;
-        }
+        if ((*callback)->timeout_timer_id().has_value())
+            clear_timeout(*(*callback)->timeout_timer_id());
     };
     remove_callback(m_idle_request_callbacks);
     remove_callback(m_runnable_idle_callbacks);

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -10,6 +10,7 @@
 #include <AK/Badge.h>
 #include <AK/FlyString.h>
 #include <AK/Function.h>
+#include <AK/HashMap.h>
 #include <AK/IterationDecision.h>
 #include <AK/Optional.h>
 #include <AK/RefPtr.h>
@@ -353,10 +354,12 @@ private:
 
     GC::Ptr<AnimationFrameCallbackDriver> m_animation_frame_callback_driver;
 
+    // NB: Both lists are keyed by handle — so a timeout or cancelIdleCallback() finds its callback without walking past
+    //     every other pending one — and ordered, so an idle period still runs them first-in first-out.
     // https://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks
-    Vector<NonnullRefPtr<IdleCallback>> m_idle_request_callbacks;
+    OrderedHashMap<u32, NonnullRefPtr<IdleCallback>> m_idle_request_callbacks;
     // https://w3c.github.io/requestidlecallback/#dfn-list-of-runnable-idle-callbacks
-    Vector<NonnullRefPtr<IdleCallback>> m_runnable_idle_callbacks;
+    OrderedHashMap<u32, NonnullRefPtr<IdleCallback>> m_runnable_idle_callbacks;
     // https://w3c.github.io/requestidlecallback/#dfn-idle-callback-identifier
     u32 m_idle_callback_identifier = 0;
 

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -14,6 +14,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
+#include <LibCore/Timer.h>
 #include <LibGC/Function.h>
 #include <LibGC/Heap.h>
 #include <LibGC/HeapVector.h>
@@ -147,6 +148,8 @@ void WindowOrWorkerGlobalScopeMixin::visit_edges(JS::Cell::Visitor& visitor)
 void WindowOrWorkerGlobalScopeMixin::finalize()
 {
     clear_map_of_active_timers();
+    if (m_intensive_timer_throttling_grace_timer)
+        m_intensive_timer_throttling_grace_timer->stop();
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#dom-origin
@@ -690,8 +693,13 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
         timeout = 4;
 
     // A hidden document leaves a timer with no delay alone — the page's own yield points, which Chrome keeps prompt
-    // too — and holds every other one back (see throttled_timer_delay()).
-    auto throttling_class = timeout == 0 ? TimerThrottlingClass::Immediate : TimerThrottlingClass::Delayed;
+    // too — and holds every other one back, a timer past nesting level 5 the hardest: a page re-arming timers from
+    // their own callbacks is just what a hidden page shouldn't stay busy with (see throttled_timer_delay()).
+    auto throttling_class = TimerThrottlingClass::Delayed;
+    if (nesting_level > 5)
+        throttling_class = TimerThrottlingClass::Chained;
+    else if (timeout == 0)
+        throttling_class = TimerThrottlingClass::Immediate;
 
     // 6. Let realm be global's relevant realm.
     auto& realm = relevant_realm(*this);
@@ -1248,8 +1256,8 @@ i32 WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout(i32 timeout, Funct
         completion_step();
     };
     // NB: A timeout another specification waits on — an idle callback's, an AbortSignal's — isn't one of the page's
-    //     own yield points, so a hidden document holds it back like any delayed timer, however short it is.
-    run_steps_after_a_timeout_impl(timeout, TimerThrottlingClass::Delayed, move(remove_timer_and_complete), timer_key);
+    //     own yield points, so a hidden document holds it back like a chained timer, however short it is.
+    run_steps_after_a_timeout_impl(timeout, TimerThrottlingClass::Chained, move(remove_timer_and_complete), timer_key);
     return timer_key;
 }
 
@@ -1262,6 +1270,21 @@ void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout,
     //     throttled_timer_delay()), so the delay the timer is armed with can differ from the one it was asked for.
     auto deadline = HighResolutionTime::unsafe_shared_current_time() + timeout;
     auto throttled_delay = throttled_timer_delay(throttling_class, deadline);
+
+    // NB: The intensive tier paces chained timers by their wake-ups (see throttled_timer_delay()), so note when one
+    //     runs while the document is hidden. The step itself goes into a GC::Function rather than into the wrapper's
+    //     captures: Timer::visit_edges() scans only the bytes of the callable the timer holds, and an AK::Function
+    //     nested in there keeps its own captures out of line once they outgrow its inline storage, where that scan
+    //     can't see them. An AbortSignal.timeout() signal lives nowhere else until it aborts, so a collection would
+    //     sweep it. A GC::Function scans its own callable's captures, whatever their size.
+    if (throttling_class == TimerThrottlingClass::Chained) {
+        auto step = GC::create_function(GC::Heap::the(), move(completion_step));
+        completion_step = [this, step] {
+            if (document_is_hidden())
+                m_last_chained_timer_wake_up = HighResolutionTime::unsafe_shared_current_time();
+            step->function()();
+        };
+    }
 
     // NB: We deviate from the spec here slightly by reusing existing timers if a timer_key is provided.
     GC::Ptr<Timer> existing_timer;
@@ -1316,24 +1339,32 @@ static i32 timer_delay_from(double milliseconds)
     return static_cast<i32>(min(ceil(max(milliseconds, 0.0)), static_cast<double>(NumericLimits<i32>::max())));
 }
 
+// Whether the document holds its timers back at all. A document takes its visibility state from its navigable when
+// that activates it; until then — while it's still being populated, e.g. — the state is the default, hidden. So only
+// a fully active document counts as hidden here.
+bool WindowOrWorkerGlobalScopeMixin::document_is_hidden() const
+{
+    auto const* window = as_if<Window>(this_impl());
+    if (!window)
+        return false;
+    auto& document = window->associated_document();
+    return document.is_fully_active() && document.hidden();
+}
+
 // A hidden document runs a delayed timer only at a wake-up. The wake-ups are one wake-up interval apart, on a grid
 // aligned to the time origin of the page's local root document — the same grid for every frame of the page, so all
 // of their timers run in one wake-up rather than each frame's in its own — and the timer runs at the first wake-up
-// at or after its deadline. Returns the delay that takes the timer there, or nothing when the timer runs at its
-// deadline as usual: the document is visible, the timer has no delay, or the global isn't a Window at all.
+// at or after its deadline. Once the document has been hidden for the grace period, a chained timer runs only at an
+// intensive wake-up, an intensive interval apart on the same grid — though the next ordinary wake-up will do when no
+// chained timer has run for an intensive interval, so a page that wakes rarely isn't made to wait a whole one for a
+// single wake-up. That's Chrome's rule too. Returns the delay that takes the timer to its wake-up, or nothing when the
+// timer runs at its deadline as usual: the document is visible, the timer has no delay, or the global isn't a Window.
 Optional<i32> WindowOrWorkerGlobalScopeMixin::throttled_timer_delay(TimerThrottlingClass throttling_class, double deadline) const
 {
-    if (throttling_class == TimerThrottlingClass::Immediate)
-        return {};
-    auto const* window = as_if<Window>(this_impl());
-    if (!window)
-        return {};
-    // NB: A document takes its visibility state from its navigable when that activates it; until then — while it's
-    //     still being populated, e.g. — the state is the default, hidden. So only a fully active document is held back.
-    auto& document = window->associated_document();
-    if (!document.is_fully_active() || !document.hidden())
+    if (throttling_class == TimerThrottlingClass::Immediate || !document_is_hidden())
         return {};
 
+    auto& document = as<Window>(this_impl()).associated_document();
     auto grid_origin = [&] {
         auto& page = document.page();
         if (page.has_local_root_navigable()) {
@@ -1342,16 +1373,24 @@ Optional<i32> WindowOrWorkerGlobalScopeMixin::throttled_timer_delay(TimerThrottl
         }
         return relevant_settings_object(document).time_origin();
     }();
+    auto wake_up_at_or_after = [&](double time, double interval) {
+        return grid_origin + ceil((time - grid_origin) / interval) * interval;
+    };
+
     auto now = HighResolutionTime::unsafe_shared_current_time();
+    auto due = max(now, deadline);
     auto interval = m_hidden_document_timer_wake_up_interval;
-    auto wake_up = grid_origin + ceil((max(now, deadline) - grid_origin) / interval) * interval;
+    auto wake_up = wake_up_at_or_after(due, interval);
+    if (throttling_class == TimerThrottlingClass::Chained && m_chained_timers_intensively_throttled) {
+        auto intensive_interval = m_intensive_timer_wake_up_interval;
+        auto ordinary_wake_up_from = m_last_chained_timer_wake_up.has_value() ? max(due, *m_last_chained_timer_wake_up + intensive_interval) : due;
+        wake_up = min(wake_up_at_or_after(due, intensive_interval), wake_up_at_or_after(ordinary_wake_up_from, interval));
+    }
     return timer_delay_from(wake_up - now);
 }
 
-// The page visibility change steps for timers: every timer still on the clock is re-armed for the document's new
-// visibility — a hidden document's delayed timers wait for their wake-up, and a visible document's fire at their own
-// deadlines, right away if those have passed.
-void WindowOrWorkerGlobalScopeMixin::document_visibility_state_changed(Badge<DOM::Document>)
+// Re-arms every timer still on the clock for the wake-up it's due at now (see throttled_timer_delay()).
+void WindowOrWorkerGlobalScopeMixin::realign_timers()
 {
     auto now = HighResolutionTime::unsafe_shared_current_time();
     for (auto& [id, timer] : m_timers) {
@@ -1361,6 +1400,33 @@ void WindowOrWorkerGlobalScopeMixin::document_visibility_state_changed(Badge<DOM
         auto delay = throttled_timer_delay(timer->throttling_class(), timer->deadline());
         timer->restart(delay.value_or(timer_delay_from(timer->deadline() - now)));
     }
+}
+
+// The page visibility change steps for timers: every timer still on the clock is re-armed for the document's new
+// visibility — a hidden document's delayed timers wait for their wake-up, and a visible document's fire at their own
+// deadlines, right away if those have passed. And the grace period before a hidden document's chained timers move
+// to the intensive tier starts over whenever the document hides, and is off while it's visible. Which grace period
+// applies is decided as the document hides — the shorter one if it had finished loading by then, the longer one if
+// it was still loading — so a document that finishes loading while hidden keeps the longer one, as in Chrome.
+void WindowOrWorkerGlobalScopeMixin::document_visibility_state_changed(Badge<DOM::Document>)
+{
+    m_chained_timers_intensively_throttled = false;
+    if (document_is_hidden()) {
+        if (!m_intensive_timer_throttling_grace_timer) {
+            m_intensive_timer_throttling_grace_timer = Core::Timer::create_single_shot(0, [this] {
+                m_chained_timers_intensively_throttled = true;
+                realign_timers();
+            });
+        }
+        auto& document = as<Window>(this_impl()).associated_document();
+        auto grace_period = document.readiness() == DocumentReadyState::Complete
+            ? m_intensive_timer_throttling_grace_period_once_loaded
+            : m_intensive_timer_throttling_grace_period_while_loading;
+        m_intensive_timer_throttling_grace_timer->restart(timer_delay_from(grace_period));
+    } else if (m_intensive_timer_throttling_grace_timer) {
+        m_intensive_timer_throttling_grace_timer->stop();
+    }
+    realign_timers();
 }
 
 // https://streams.spec.whatwg.org/#count-queuing-strategy-size-function

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -29,6 +29,7 @@
 #include <LibWeb/Bindings/WrapperWorld.h>
 #include <LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h>
 #include <LibWeb/Crypto/Crypto.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/BindingsGlue.h>
 #include <LibWeb/Fetch/FetchMethod.h>
 #include <LibWeb/HTML/CanvasRenderingContext2D.h>
@@ -38,6 +39,7 @@
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/EventSource.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
+#include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/PromiseRejectionEvent.h>
 #include <LibWeb/HTML/Scripting/Agent.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
@@ -687,6 +689,10 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
     if (nesting_level > 5 && timeout < 4)
         timeout = 4;
 
+    // A hidden document leaves a timer with no delay alone — the page's own yield points, which Chrome keeps prompt
+    // too — and holds every other one back (see throttled_timer_delay()).
+    auto throttling_class = timeout == 0 ? TimerThrottlingClass::Immediate : TimerThrottlingClass::Delayed;
+
     // 6. Let realm be global's relevant realm.
     auto& realm = relevant_realm(*this);
 
@@ -822,7 +828,7 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
     // 13. Set uniqueHandle to the result of running steps after a timeout given global, "setTimeout/setInterval",
     //     timeout, and completionStep.
     //     FIXME: run_steps_after_a_timeout() needs to be updated to return a unique internal value that can be used here.
-    run_steps_after_a_timeout_impl(timeout, move(completion_step), id, repeat);
+    run_steps_after_a_timeout_impl(timeout, throttling_class, move(completion_step), id, repeat);
 
     // FIXME: 14. Set global's map of setTimeout and setInterval IDs[id] to uniqueHandle.
 
@@ -1241,14 +1247,21 @@ i32 WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout(i32 timeout, Funct
         m_timers.remove(timer_key);
         completion_step();
     };
-    run_steps_after_a_timeout_impl(timeout, move(remove_timer_and_complete), timer_key);
+    // NB: A timeout another specification waits on — an idle callback's, an AbortSignal's — isn't one of the page's
+    //     own yield points, so a hidden document holds it back like any delayed timer, however short it is.
+    run_steps_after_a_timeout_impl(timeout, TimerThrottlingClass::Delayed, move(remove_timer_and_complete), timer_key);
     return timer_key;
 }
 
-void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout, Function<void()> completion_step, Optional<i32> timer_key, Repeat repeat)
+void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout, TimerThrottlingClass throttling_class, Function<void()> completion_step, Optional<i32> timer_key, Repeat repeat)
 {
     // 1. Assert: if timerKey is given, then the caller of this algorithm is the timer initialization steps. (Other specifications must not pass timerKey.)
     // Note: This is enforced by the caller.
+
+    // NB: A hidden document holds a delayed timer back past its deadline to its next wake-up (see
+    //     throttled_timer_delay()), so the delay the timer is armed with can differ from the one it was asked for.
+    auto deadline = HighResolutionTime::unsafe_shared_current_time() + timeout;
+    auto throttled_delay = throttled_timer_delay(throttling_class, deadline);
 
     // NB: We deviate from the spec here slightly by reusing existing timers if a timer_key is provided.
     GC::Ptr<Timer> existing_timer;
@@ -1257,7 +1270,14 @@ void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout,
         if (result.has_value()) {
             existing_timer = result.value().ptr();
             existing_timer->set_callback(move(completion_step));
-            existing_timer->set_interval(timeout);
+            existing_timer->set_throttling_class(throttling_class);
+            existing_timer->set_deadline(deadline);
+            // A throttled delay runs from now to the wake-up, so the timer restarts on it; unthrottled, a repeating
+            // timer keeps the schedule it's on (see below).
+            if (throttled_delay.has_value())
+                existing_timer->restart(*throttled_delay);
+            else
+                existing_timer->set_interval(timeout);
         }
     } else {
         // 2. If timerKey is not given, then set it to a new unique non-numeric value.
@@ -1271,7 +1291,7 @@ void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout,
     // completed. The task callback still calls run_timer_initialization_steps to update nesting
     // levels and potentially clamp the interval.
     auto repeating = repeat == Repeat::Yes ? Timer::Repeating::Yes : Timer::Repeating::No;
-    auto timer = existing_timer ? GC::Ref { *existing_timer } : Timer::create(timeout, move(completion_step), timer_key.value(), repeating);
+    auto timer = existing_timer ? GC::Ref { *existing_timer } : Timer::create(throttled_delay.value_or(timeout), move(completion_step), timer_key.value(), repeating, throttling_class, deadline);
 
     // FIXME: 4. Set global's map of active timers[timerKey] to startTime plus milliseconds.
     m_timers.set(timer_key.value(), timer);
@@ -1288,6 +1308,59 @@ void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout,
     // restarting it would cause drift (next fire = now + interval instead of previous fire + interval).
     if (!existing_timer)
         timer->start();
+}
+
+// A delay for Core::Timer: whole milliseconds, never negative, and no more than it can hold.
+static i32 timer_delay_from(double milliseconds)
+{
+    return static_cast<i32>(min(ceil(max(milliseconds, 0.0)), static_cast<double>(NumericLimits<i32>::max())));
+}
+
+// A hidden document runs a delayed timer only at a wake-up. The wake-ups are one wake-up interval apart, on a grid
+// aligned to the time origin of the page's local root document — the same grid for every frame of the page, so all
+// of their timers run in one wake-up rather than each frame's in its own — and the timer runs at the first wake-up
+// at or after its deadline. Returns the delay that takes the timer there, or nothing when the timer runs at its
+// deadline as usual: the document is visible, the timer has no delay, or the global isn't a Window at all.
+Optional<i32> WindowOrWorkerGlobalScopeMixin::throttled_timer_delay(TimerThrottlingClass throttling_class, double deadline) const
+{
+    if (throttling_class == TimerThrottlingClass::Immediate)
+        return {};
+    auto const* window = as_if<Window>(this_impl());
+    if (!window)
+        return {};
+    // NB: A document takes its visibility state from its navigable when that activates it; until then — while it's
+    //     still being populated, e.g. — the state is the default, hidden. So only a fully active document is held back.
+    auto& document = window->associated_document();
+    if (!document.is_fully_active() || !document.hidden())
+        return {};
+
+    auto grid_origin = [&] {
+        auto& page = document.page();
+        if (page.has_local_root_navigable()) {
+            if (auto root_document = page.local_root_navigable()->active_document())
+                return relevant_settings_object(*root_document).time_origin();
+        }
+        return relevant_settings_object(document).time_origin();
+    }();
+    auto now = HighResolutionTime::unsafe_shared_current_time();
+    auto interval = m_hidden_document_timer_wake_up_interval;
+    auto wake_up = grid_origin + ceil((max(now, deadline) - grid_origin) / interval) * interval;
+    return timer_delay_from(wake_up - now);
+}
+
+// The page visibility change steps for timers: every timer still on the clock is re-armed for the document's new
+// visibility — a hidden document's delayed timers wait for their wake-up, and a visible document's fire at their own
+// deadlines, right away if those have passed.
+void WindowOrWorkerGlobalScopeMixin::document_visibility_state_changed(Badge<DOM::Document>)
+{
+    auto now = HighResolutionTime::unsafe_shared_current_time();
+    for (auto& [id, timer] : m_timers) {
+        // A timer that has fired and has its task queued is done with the clock.
+        if (!timer->is_active())
+            continue;
+        auto delay = throttled_timer_delay(timer->throttling_class(), timer->deadline());
+        timer->restart(delay.value_or(timer_delay_from(timer->deadline() - now)));
+    }
 }
 
 // https://streams.spec.whatwg.org/#count-queuing-strategy-size-function

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -1280,7 +1280,7 @@ void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout,
     if (throttling_class == TimerThrottlingClass::Chained) {
         auto step = GC::create_function(GC::Heap::the(), move(completion_step));
         completion_step = [this, step] {
-            if (document_is_hidden())
+            if (timers_are_throttled())
                 m_last_chained_timer_wake_up = HighResolutionTime::unsafe_shared_current_time();
             step->function()();
         };
@@ -1351,6 +1351,13 @@ bool WindowOrWorkerGlobalScopeMixin::document_is_hidden() const
     return document.is_fully_active() && document.hidden();
 }
 
+// Whether the document holds its timers back right now: it's hidden, and it isn't playing audio — a document playing
+// audio is doing what the user asked of it, as a music player is, so it keeps its timers, as it does in Chrome.
+bool WindowOrWorkerGlobalScopeMixin::timers_are_throttled() const
+{
+    return document_is_hidden() && !as<Window>(this_impl()).associated_document().is_playing_audio();
+}
+
 // A hidden document runs a delayed timer only at a wake-up. The wake-ups are one wake-up interval apart, on a grid
 // aligned to the time origin of the page's local root document — the same grid for every frame of the page, so all
 // of their timers run in one wake-up rather than each frame's in its own — and the timer runs at the first wake-up
@@ -1358,10 +1365,11 @@ bool WindowOrWorkerGlobalScopeMixin::document_is_hidden() const
 // intensive wake-up, an intensive interval apart on the same grid — though the next ordinary wake-up will do when no
 // chained timer has run for an intensive interval, so a page that wakes rarely isn't made to wait a whole one for a
 // single wake-up. That's Chrome's rule too. Returns the delay that takes the timer to its wake-up, or nothing when the
-// timer runs at its deadline as usual: the document is visible, the timer has no delay, or the global isn't a Window.
+// timer runs at its deadline as usual: the document is visible or playing audio, the timer has no delay, or the
+// global isn't a Window.
 Optional<i32> WindowOrWorkerGlobalScopeMixin::throttled_timer_delay(TimerThrottlingClass throttling_class, double deadline) const
 {
-    if (throttling_class == TimerThrottlingClass::Immediate || !document_is_hidden())
+    if (throttling_class == TimerThrottlingClass::Immediate || !timers_are_throttled())
         return {};
 
     auto& document = as<Window>(this_impl()).associated_document();
@@ -1405,9 +1413,10 @@ void WindowOrWorkerGlobalScopeMixin::realign_timers()
 // The page visibility change steps for timers: every timer still on the clock is re-armed for the document's new
 // visibility — a hidden document's delayed timers wait for their wake-up, and a visible document's fire at their own
 // deadlines, right away if those have passed. And the grace period before a hidden document's chained timers move
-// to the intensive tier starts over whenever the document hides, and is off while it's visible. Which grace period
-// applies is decided as the document hides — the shorter one if it had finished loading by then, the longer one if
-// it was still loading — so a document that finishes loading while hidden keeps the longer one, as in Chrome.
+// to the intensive tier starts over whenever the document hides, playing audio or not, and is off while it's
+// visible. Which grace period applies is decided as the document hides — the shorter one if it had finished loading
+// by then, the longer one if it was still loading — so a document that finishes loading while hidden keeps the
+// longer one, as in Chrome.
 void WindowOrWorkerGlobalScopeMixin::document_visibility_state_changed(Badge<DOM::Document>)
 {
     m_chained_timers_intensively_throttled = false;
@@ -1426,6 +1435,13 @@ void WindowOrWorkerGlobalScopeMixin::document_visibility_state_changed(Badge<DOM
     } else if (m_intensive_timer_throttling_grace_timer) {
         m_intensive_timer_throttling_grace_timer->stop();
     }
+    realign_timers();
+}
+
+// A document that starts or stops playing audio while hidden loses or regains its throttling (see
+// timers_are_throttled()); the grace period keeps running either way.
+void WindowOrWorkerGlobalScopeMixin::document_audio_play_state_changed(Badge<DOM::Document>)
+{
     realign_timers();
 }
 

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -14,6 +14,7 @@
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
 #include <AK/Variant.h>
+#include <LibCore/Forward.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -103,6 +104,13 @@ public:
         VERIFY(milliseconds > 0);
         m_hidden_document_timer_wake_up_interval = milliseconds;
     }
+    void set_hidden_document_intensive_timer_throttling(Badge<Internals::Internals>, double wake_up_interval, double grace_period_once_loaded, double grace_period_while_loading)
+    {
+        VERIFY(wake_up_interval > 0 && grace_period_once_loaded >= 0 && grace_period_while_loading >= 0);
+        m_intensive_timer_wake_up_interval = wake_up_interval;
+        m_intensive_timer_throttling_grace_period_once_loaded = grace_period_once_loaded;
+        m_intensive_timer_throttling_grace_period_while_loading = grace_period_while_loading;
+    }
 
     void report_error(JS::Value e);
 
@@ -151,7 +159,9 @@ private:
     };
     i32 run_timer_initialization_steps(TimerHandler handler, i32 timeout, GC::RootVector<JS::Value> arguments, Repeat repeat, Optional<i32> previous_id = {});
     void run_steps_after_a_timeout_impl(i32 timeout, TimerThrottlingClass, Function<void()> completion_step, Optional<i32> timer_key, Repeat repeat = Repeat::No);
+    bool document_is_hidden() const;
     Optional<i32> throttled_timer_delay(TimerThrottlingClass, double deadline) const;
+    void realign_timers();
 
     void create_image_bitmap_impl(JS::Realm&, GC::Ref<WebIDL::Promise>, ImageBitmapSource& image, Optional<WebIDL::Long> sx, Optional<WebIDL::Long> sy, Optional<WebIDL::Long> sw, Optional<WebIDL::Long> sh, ImageBitmapOptions options) const;
 
@@ -165,6 +175,16 @@ private:
 
     // The interval between the wake-ups a hidden document holds its delayed timers back to; a test can shorten it.
     double m_hidden_document_timer_wake_up_interval { 1000 };
+    // The rarer wake-ups a hidden document holds its chained timers back to once it has been hidden for the grace
+    // period — a minute for a document that had finished loading when it hid, five for one that was still loading,
+    // which are Chrome's values; a test can shorten all three.
+    double m_intensive_timer_wake_up_interval { 60'000 };
+    double m_intensive_timer_throttling_grace_period_once_loaded { 60'000 };
+    double m_intensive_timer_throttling_grace_period_while_loading { 300'000 };
+    RefPtr<Core::Timer> m_intensive_timer_throttling_grace_timer;
+    bool m_chained_timers_intensively_throttled { false };
+    // When a chained timer last ran while the document was hidden (see throttled_timer_delay()).
+    Optional<double> m_last_chained_timer_wake_up;
 
     // https://www.w3.org/TR/performance-timeline/#performance-timeline
     // Each global object has:

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -99,6 +99,7 @@ public:
     i32 run_steps_after_a_timeout(i32 timeout, Function<void()> completion_step);
 
     void document_visibility_state_changed(Badge<DOM::Document>);
+    void document_audio_play_state_changed(Badge<DOM::Document>);
     void set_hidden_document_timer_wake_up_interval(Badge<Internals::Internals>, double milliseconds)
     {
         VERIFY(milliseconds > 0);
@@ -160,6 +161,7 @@ private:
     i32 run_timer_initialization_steps(TimerHandler handler, i32 timeout, GC::RootVector<JS::Value> arguments, Repeat repeat, Optional<i32> previous_id = {});
     void run_steps_after_a_timeout_impl(i32 timeout, TimerThrottlingClass, Function<void()> completion_step, Optional<i32> timer_key, Repeat repeat = Repeat::No);
     bool document_is_hidden() const;
+    bool timers_are_throttled() const;
     Optional<i32> throttled_timer_delay(TimerThrottlingClass, double deadline) const;
     void realign_timers();
 

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -19,6 +19,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ImageBitmap.h>
 #include <LibWeb/HTML/Scripting/ImportMap.h>
+#include <LibWeb/HTML/Timer.h>
 #include <LibWeb/PerformanceTimeline/PerformanceEntry.h>
 #include <LibWeb/PerformanceTimeline/PerformanceEntryTuple.h>
 #include <LibWeb/WebSockets/WebSocket.h>
@@ -96,6 +97,13 @@ public:
 
     i32 run_steps_after_a_timeout(i32 timeout, Function<void()> completion_step);
 
+    void document_visibility_state_changed(Badge<DOM::Document>);
+    void set_hidden_document_timer_wake_up_interval(Badge<Internals::Internals>, double milliseconds)
+    {
+        VERIFY(milliseconds > 0);
+        m_hidden_document_timer_wake_up_interval = milliseconds;
+    }
+
     void report_error(JS::Value e);
 
     enum class OmitError {
@@ -142,7 +150,8 @@ private:
         No,
     };
     i32 run_timer_initialization_steps(TimerHandler handler, i32 timeout, GC::RootVector<JS::Value> arguments, Repeat repeat, Optional<i32> previous_id = {});
-    void run_steps_after_a_timeout_impl(i32 timeout, Function<void()> completion_step, Optional<i32> timer_key, Repeat repeat = Repeat::No);
+    void run_steps_after_a_timeout_impl(i32 timeout, TimerThrottlingClass, Function<void()> completion_step, Optional<i32> timer_key, Repeat repeat = Repeat::No);
+    Optional<i32> throttled_timer_delay(TimerThrottlingClass, double deadline) const;
 
     void create_image_bitmap_impl(JS::Realm&, GC::Ref<WebIDL::Promise>, ImageBitmapSource& image, Optional<WebIDL::Long> sx, Optional<WebIDL::Long> sy, Optional<WebIDL::Long> sw, Optional<WebIDL::Long> sh, ImageBitmapOptions options) const;
 
@@ -153,6 +162,9 @@ private:
 
     IDAllocator m_timer_id_allocator;
     HashMap<int, GC::Ref<Timer>> m_timers;
+
+    // The interval between the wake-ups a hidden document holds its delayed timers back to; a test can shorten it.
+    double m_hidden_document_timer_wake_up_interval { 1000 };
 
     // https://www.w3.org/TR/performance-timeline/#performance-timeline
     // Each global object has:

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1773,6 +1773,11 @@ void Internals::set_hidden_document_timer_wake_up_interval(double milliseconds)
     window().set_hidden_document_timer_wake_up_interval({}, milliseconds);
 }
 
+void Internals::set_hidden_document_intensive_timer_throttling(double wake_up_interval, double grace_period_once_loaded, double grace_period_while_loading)
+{
+    window().set_hidden_document_intensive_timer_throttling({}, wake_up_interval, grace_period_once_loaded, grace_period_while_loading);
+}
+
 Utf16String Internals::canvas_color_scheme()
 {
     auto& document = window().associated_document();

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1768,6 +1768,11 @@ void Internals::set_system_visibility_state(Utf16String const& state)
     page().client().page_did_request_set_system_visibility_state(visibility_state);
 }
 
+void Internals::set_hidden_document_timer_wake_up_interval(double milliseconds)
+{
+    window().set_hidden_document_timer_wake_up_interval({}, milliseconds);
+}
+
 Utf16String Internals::canvas_color_scheme()
 {
     auto& document = window().associated_document();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -233,6 +233,7 @@ public:
     void set_page_focus(bool has_focus);
     void set_system_visibility_state(Utf16String const& state);
     void set_hidden_document_timer_wake_up_interval(double milliseconds);
+    void set_hidden_document_intensive_timer_throttling(double wake_up_interval, double grace_period_once_loaded, double grace_period_while_loading);
     Utf16String canvas_color_scheme();
     WebIDL::ExceptionOr<GC::Ref<JS::Object>> image_animation_state_for_url(Utf16String const& url);
     bool media_element_is_fetching(HTML::HTMLMediaElement&);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -232,6 +232,7 @@ public:
     void set_preferred_color_scheme(Utf16String const& color_scheme);
     void set_page_focus(bool has_focus);
     void set_system_visibility_state(Utf16String const& state);
+    void set_hidden_document_timer_wake_up_interval(double milliseconds);
     Utf16String canvas_color_scheme();
     WebIDL::ExceptionOr<GC::Ref<JS::Object>> image_animation_state_for_url(Utf16String const& url);
     bool media_element_is_fetching(HTML::HTMLMediaElement&);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -242,6 +242,9 @@ interface Internals {
     undefined setSystemVisibilityState(DOMString state);
     // Overrides the interval between the wake-ups a hidden document holds its delayed timers back to (1000 ms by default).
     undefined setHiddenDocumentTimerWakeUpInterval(double milliseconds);
+    // Overrides the interval between the wake-ups a hidden document holds its chained timers back to once it has been
+    // hidden for the grace period, and that grace period, both in milliseconds (60000 ms and 300000 ms by default).
+    undefined setHiddenDocumentIntensiveTimerThrottling(double wakeUpInterval, double gracePeriodOnceLoaded, double gracePeriodWhileLoading);
     DOMString canvasColorScheme();
     // Returns the selector-insight cache state for stylesheet invalidation tests.
     object imageAnimationStateForURL(USVString url);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -240,6 +240,8 @@ interface Internals {
     undefined setPageFocus(boolean hasFocus);
     // Simulates the page being shown or hidden (e.g. switching to another tab). Accepts "visible" or "hidden".
     undefined setSystemVisibilityState(DOMString state);
+    // Overrides the interval between the wake-ups a hidden document holds its delayed timers back to (1000 ms by default).
+    undefined setHiddenDocumentTimerWakeUpInterval(double milliseconds);
     DOMString canvasColorScheme();
     // Returns the selector-insight cache state for stylesheet invalidation tests.
     object imageAnimationStateForURL(USVString url);

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -836,6 +836,16 @@ void Page::for_each_media_element(Callback&& callback)
     }
 }
 
+bool Page::has_media_element_playing_audio(DOM::Document const& document) const
+{
+    for (auto media_id : m_media_elements) {
+        auto* node = DOM::Node::from_unique_id(media_id);
+        if (node && &node->document() == &document && as<HTML::HTMLMediaElement>(*node).is_playing_audio())
+            return true;
+    }
+    return false;
+}
+
 void Page::sync_media_element_video_sink_ticking()
 {
     for_each_media_element([&](auto& media_element) {

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -262,6 +262,7 @@ public:
 
     void register_media_element(Badge<HTML::HTMLMediaElement>, UniqueNodeID media_id);
     void unregister_media_element(Badge<HTML::HTMLMediaElement>, UniqueNodeID media_id);
+    bool has_media_element_playing_audio(DOM::Document const&) const;
 
     void sync_media_element_video_sink_ticking();
     void restore_all_media_element_video_sinks();

--- a/Tests/LibCore/TestLibCoreEventLoop.cpp
+++ b/Tests/LibCore/TestLibCoreEventLoop.cpp
@@ -177,6 +177,41 @@ TEST_CASE(stopped_timer_does_not_fire)
     EXPECT_EQ(stopped_count, 0);
 }
 
+// A timer fires no earlier than its interval, on the monotonic clock the rest of the process reads. The loop is kept
+// busy for a moment after each start: a clock that moves once per scheduler tick counts up to a tick more across that
+// moment than really passed, so a loop timing its wait by that clock wakes early by the difference and fires the timer
+// before the interval is up on the precise clock. The rounds drift through the tick, so a fair share of them hit that.
+TEST_CASE(timer_does_not_fire_before_its_interval)
+{
+    Core::EventLoop loop;
+    static constexpr int interval_ms = 10;
+    static constexpr int rounds = 50;
+    int round = 0;
+    auto started_at = MonotonicTime::now();
+    RefPtr<Core::Timer> timer;
+    auto start_timer = [&] {
+        started_at = MonotonicTime::now();
+        timer->start();
+        auto busy_until = started_at + AK::Duration::from_microseconds(2500);
+        while (MonotonicTime::now() < busy_until)
+            ;
+    };
+    timer = Core::Timer::create_single_shot(interval_ms, [&] {
+        auto elapsed = MonotonicTime::now() - started_at;
+        auto interval = AK::Duration::from_milliseconds(interval_ms);
+        if (elapsed < interval)
+            warnln("Round {}: the timer fired {} us early", round, (interval - elapsed).to_microseconds());
+        EXPECT(elapsed >= interval);
+        if (++round == rounds)
+            loop.quit(0);
+        else
+            start_timer();
+    });
+    start_timer();
+    loop.exec();
+    EXPECT_EQ(round, rounds);
+}
+
 #if !defined(AK_OS_WINDOWS)
 // Signals delivered to threads without event-loop state must wake the registering event loop.
 TEST_CASE(signal_delivered_on_thread_without_event_loop)

--- a/Tests/LibWeb/Text/expected/HTML/timer-throttling-audible-document.txt
+++ b/Tests/LibWeb/Text/expected/HTML/timer-throttling-audible-document.txt
@@ -1,0 +1,7 @@
+the video is playing audio: true
+while the document plays audio, a delayed timer fires at its deadline: true
+while the document plays audio, an idle callback's timeout fires at its deadline: true
+the video is playing audio: false
+once the audio stops, a delayed timer waits for the wake-up: true
+the video is playing audio: true
+audio starting puts a waiting timer back on its deadline: true

--- a/Tests/LibWeb/Text/expected/HTML/timer-throttling-hidden-document-intensive-grace.txt
+++ b/Tests/LibWeb/Text/expected/HTML/timer-throttling-hidden-document-intensive-grace.txt
@@ -1,0 +1,4 @@
+the document has loaded and the frame is still loading when the page hides: true
+the loaded document's chained timers move to the intensive tier once the shorter grace period ends: true
+the frame that was still loading keeps its base wake-ups past the shorter grace period, even once it has finished loading: true
+the frame's chained timers move to the intensive tier once the longer grace period ends: true

--- a/Tests/LibWeb/Text/expected/HTML/timer-throttling-hidden-document-intensive.txt
+++ b/Tests/LibWeb/Text/expected/HTML/timer-throttling-hidden-document-intensive.txt
@@ -1,0 +1,7 @@
+before the grace period ends, a chained timer takes the next base wake-up: true
+a chained timer already armed when the grace period ends is re-armed for the intensive tier: true
+after the grace period, a chained timer right after a chained wake-up waits for the intensive wake-up: true
+a timer nested past level 5 counts as chained: true
+a delayed timer keeps taking the next base wake-up: true
+a chained timer runs at the next base wake-up once no chained timer has run for an intensive interval: true
+hiding the document again starts a new grace period: true

--- a/Tests/LibWeb/Text/expected/HTML/timer-throttling-hidden-document.txt
+++ b/Tests/LibWeb/Text/expected/HTML/timer-throttling-hidden-document.txt
@@ -1,0 +1,9 @@
+a delayed timer waits for the wake-up after its deadline: true
+timers due before the same wake-up fire in it: true
+a timer due after that wake-up waits for the following one: true
+a timer with no delay doesn't wait for a wake-up: true
+an interval fires once per wake-up: true
+an idle callback's timeout waits for the wake-up: true
+AbortSignal.timeout() waits for the wake-up: true
+becoming visible puts a timer back on its own deadline: true
+a timer armed while visible waits for the wake-up once the document hides: true

--- a/Tests/LibWeb/Text/expected/abortsignal-timeout-survives-gc.txt
+++ b/Tests/LibWeb/Text/expected/abortsignal-timeout-survives-gc.txt
@@ -1,0 +1,2 @@
+visible: 21 of 21 pending timeouts ran after a garbage collection
+hidden: 21 of 21 pending timeouts ran after a garbage collection

--- a/Tests/LibWeb/Text/expected/request-idle-callback-handles.txt
+++ b/Tests/LibWeb/Text/expected/request-idle-callback-handles.txt
@@ -1,0 +1,7 @@
+handles increase: true
+order: first, second, third, registered from first
+after canceling b: a, c
+after x cancels z: x, y
+callback with a timeout that ran in an idle period ran 1 time(s)
+canceled callback with a timeout ran: false
+busy, timed out on the runnable list: true

--- a/Tests/LibWeb/Text/expected/request-idle-callback-timeouts-with-pending-backlog.txt
+++ b/Tests/LibWeb/Text/expected/request-idle-callback-timeouts-with-pending-backlog.txt
@@ -1,0 +1,1 @@
+timed-out callbacks behind a pending backlog cost the same as without one: true

--- a/Tests/LibWeb/Text/input/HTML/timer-throttling-audible-document.html
+++ b/Tests/LibWeb/Text/input/HTML/timer-throttling-audible-document.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>internals.setAutoplayPolicy("allow-audio-and-video");</script>
+<video autoplay muted loop src="../../../Assets/test-webm.webm"></video>
+<script>
+    // A hidden document that's playing audio keeps its timers on their own deadlines — it's doing what the user asked
+    // of it, as a music player is. Once the audio stops, its timers wait for the wake-ups again.
+    asyncTest(async done => {
+        internals.setTestTimeout(15_000);
+        const wakeUpInterval = 500;
+        internals.setHiddenDocumentTimerWakeUpInterval(wakeUpInterval);
+
+        // performance.now() is coarsened down to a tenth of a millisecond, so a timer that fires right at a wake-up
+        // can read a hair less than it.
+        const coarsening = 0.1;
+        const wakeUpAtOrAfter = time => Math.ceil(time / wakeUpInterval) * wakeUpInterval;
+        // Spins until the current time sits early in a wake-up interval, so that a short timer's deadline lies well
+        // before the next wake-up and a wait for that wake-up can't be mistaken for the timer's own delay.
+        const waitForEarlyPhase = () => {
+            while (performance.now() % wakeUpInterval >= 60)
+                ;
+        };
+        const fireTime = delay => new Promise(resolve => setTimeout(() => resolve(performance.now()), delay));
+        const report = (what, ok, details) => {
+            println(`${what}: ${ok}`);
+            if (!ok)
+                println(`    ${JSON.stringify(details)}`);
+        };
+
+        const video = document.querySelector("video");
+        await new Promise(resolve => video.addEventListener("playing", resolve, { once: true }));
+        video.muted = false;
+        println(`the video is playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        await setSystemVisibilityState("hidden");
+        try {
+            waitForEarlyPhase();
+            let armedAt = performance.now();
+            let wakeUp = wakeUpAtOrAfter(armedAt + 10);
+            let firedAt = await fireTime(10);
+            report("while the document plays audio, a delayed timer fires at its deadline",
+                firedAt >= armedAt + 10 - coarsening && firedAt < wakeUp, { armedAt, wakeUp, firedAt });
+
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 10);
+            const idle = await new Promise(resolve => requestIdleCallback(
+                deadline => resolve({ firedAt: performance.now(), didTimeout: deadline.didTimeout }), { timeout: 10 }));
+            report("while the document plays audio, an idle callback's timeout fires at its deadline",
+                idle.didTimeout && idle.firedAt < wakeUp, { armedAt, wakeUp, idle });
+
+            video.muted = true;
+            println(`the video is playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 10);
+            firedAt = await fireTime(10);
+            report("once the audio stops, a delayed timer waits for the wake-up", firedAt >= wakeUp - coarsening,
+                { armedAt, wakeUp, firedAt });
+
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 10);
+            const armedWhileSilent = fireTime(10);
+            video.muted = false;
+            println(`the video is playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+            firedAt = await armedWhileSilent;
+            report("audio starting puts a waiting timer back on its deadline",
+                firedAt >= armedAt + 10 - coarsening && firedAt < wakeUp, { armedAt, wakeUp, firedAt });
+        } finally {
+            video.pause();
+            await setSystemVisibilityState("visible");
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/timer-throttling-hidden-document-intensive-grace.html
+++ b/Tests/LibWeb/Text/input/HTML/timer-throttling-hidden-document-intensive-grace.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // The grace period before a hidden document's chained timers move to the intensive tier depends on whether the
+    // document had finished loading when it hid: a shorter one if it had, a longer one if it was still loading. That's
+    // judged once, as the document hides — a document that finishes loading while hidden keeps the longer period. Here
+    // the document has loaded when the page hides, and a frame's document is still loading, held open with
+    // document.open(). The intervals are shortened to keep the test quick.
+    asyncTest(async done => {
+        const wakeUpInterval = 400;
+        const intensiveWakeUpInterval = 1600;
+        const gracePeriodOnceLoaded = 1200;
+        // Long enough that, by the time it ends, an intensive interval has passed since the frame's last chained
+        // wake-up below — so the wake-ups of the last check fall where the arithmetic says, whichever side of
+        // a boundary that wake-up was read on.
+        const gracePeriodWhileLoading = 4400;
+        internals.setHiddenDocumentTimerWakeUpInterval(wakeUpInterval);
+        internals.setHiddenDocumentIntensiveTimerThrottling(intensiveWakeUpInterval, gracePeriodOnceLoaded, gracePeriodWhileLoading);
+
+        // performance.now() is coarsened down to a tenth of a millisecond, so a timer that fires right at a wake-up
+        // can read a hair less than it.
+        const coarsening = 0.1;
+        const wakeUpAtOrAfter = (time, interval) => Math.ceil(time / interval) * interval;
+        const firedIn = (time, wakeUp, interval) => time >= wakeUp - coarsening && time < wakeUp + interval;
+        // Where a chained timer with the given deadline runs once the intensive tier applies: at the next intensive
+        // wake-up, or at the next base wake-up if that's at least an intensive interval past the last chained wake-up.
+        const intensiveWakeUpAtOrAfter = (deadline, lastChainedWakeUp) => Math.min(
+            wakeUpAtOrAfter(deadline, intensiveWakeUpInterval),
+            wakeUpAtOrAfter(Math.max(deadline, lastChainedWakeUp + intensiveWakeUpInterval), wakeUpInterval));
+        // Gets near the next boundary of the grid with a timer, then spins the rest of the way, so that the current
+        // time sits early in an interval of that grid and a short timer's deadline lies well before its next wake-up.
+        const waitForEarlyPhase = async interval => {
+            const phase = performance.now() % interval;
+            if (phase >= 60)
+                await timeout(interval - phase);
+            while (performance.now() % interval >= 60)
+                ;
+        };
+        // One delayed timer, so as not to nest timers past the level where they'd count as chained; it fires at the
+        // first base wake-up at or after the given time.
+        const waitUntil = async time => {
+            if (performance.now() < time)
+                await timeout(time - performance.now());
+        };
+        // A chained timer in the given window: an idle callback's timeout. The time is read from this document's
+        // clock, which is the one the page's wake-up grid is aligned to.
+        const chainedFireTime = (window, delay) => new Promise(resolve =>
+            window.requestIdleCallback(() => resolve(performance.now()), { timeout: delay }));
+        // A chained wake-up followed by a chained timer armed right after it: where the second one fires tells which
+        // tier the window is in.
+        const chainedWakeUpThenFireTime = async window => {
+            const lastChainedWakeUp = await chainedFireTime(window, 10);
+            const armedAt = performance.now();
+            const firedAt = await chainedFireTime(window, 10);
+            return { lastChainedWakeUp, armedAt, firedAt };
+        };
+        const report = (what, ok, details) => {
+            println(`${what}: ${ok}`);
+            if (!ok)
+                println(`    ${JSON.stringify(details)}`);
+        };
+
+        if (document.readyState !== "complete")
+            await new Promise(resolve => addEventListener("load", resolve, { once: true }));
+        const frame = document.createElement("iframe");
+        document.body.append(frame);
+        const frameDocument = frame.contentDocument;
+        frameDocument.open();
+        frameDocument.write("<!DOCTYPE html><p>still loading</p>");
+        // The intervals are per-window; the frame's window has its own.
+        frame.contentWindow.internals.setHiddenDocumentTimerWakeUpInterval(wakeUpInterval);
+        frame.contentWindow.internals.setHiddenDocumentIntensiveTimerThrottling(intensiveWakeUpInterval, gracePeriodOnceLoaded, gracePeriodWhileLoading);
+
+        // Line the hide up with the intensive grid, so that every wake-up below falls where the arithmetic says.
+        await waitForEarlyPhase(intensiveWakeUpInterval);
+        await setSystemVisibilityState("hidden");
+        const hiddenAt = performance.now();
+        try {
+            report("the document has loaded and the frame is still loading when the page hides",
+                document.readyState === "complete" && frameDocument.readyState === "loading",
+                { document: document.readyState, frame: frameDocument.readyState });
+
+            // Past the shorter grace period, short of the longer one: the document's chained timers are in the
+            // intensive tier, the frame's are not — even once the frame finishes loading, since that was judged as
+            // the page hid.
+            await waitUntil(hiddenAt + gracePeriodOnceLoaded + 100);
+            frameDocument.close();
+            const [top, inFrame] = await Promise.all([chainedWakeUpThenFireTime(window), chainedWakeUpThenFireTime(frame.contentWindow)]);
+            let wakeUp = intensiveWakeUpAtOrAfter(top.armedAt + 10, top.lastChainedWakeUp);
+            let baseWakeUp = wakeUpAtOrAfter(top.armedAt + 10, wakeUpInterval);
+            report("the loaded document's chained timers move to the intensive tier once the shorter grace period ends",
+                firedIn(top.firedAt, wakeUp, wakeUpInterval) && wakeUp !== baseWakeUp, { ...top, wakeUp, baseWakeUp });
+            wakeUp = wakeUpAtOrAfter(inFrame.armedAt + 10, wakeUpInterval);
+            const intensiveWakeUp = intensiveWakeUpAtOrAfter(inFrame.armedAt + 10, inFrame.lastChainedWakeUp);
+            report("the frame that was still loading keeps its base wake-ups past the shorter grace period, even once it has finished loading",
+                firedIn(inFrame.firedAt, wakeUp, wakeUpInterval) && wakeUp !== intensiveWakeUp, { ...inFrame, wakeUp, intensiveWakeUp });
+
+            // Past the longer grace period, the frame's chained timers are in the intensive tier too.
+            await waitUntil(hiddenAt + gracePeriodWhileLoading + 100);
+            const later = await chainedWakeUpThenFireTime(frame.contentWindow);
+            wakeUp = intensiveWakeUpAtOrAfter(later.armedAt + 10, later.lastChainedWakeUp);
+            baseWakeUp = wakeUpAtOrAfter(later.armedAt + 10, wakeUpInterval);
+            report("the frame's chained timers move to the intensive tier once the longer grace period ends",
+                firedIn(later.firedAt, wakeUp, wakeUpInterval) && wakeUp !== baseWakeUp, { ...later, wakeUp, baseWakeUp });
+        } finally {
+            await setSystemVisibilityState("visible");
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/timer-throttling-hidden-document-intensive.html
+++ b/Tests/LibWeb/Text/input/HTML/timer-throttling-hidden-document-intensive.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // Once a document has been hidden for a grace period, a chained timer — a setTimeout past nesting level 5, an idle
+    // callback's timeout, an AbortSignal's timeout — runs only at an intensive wake-up, several base wake-ups apart,
+    // unless no chained timer has run for an intensive interval, in which case the next base wake-up will do. A delayed
+    // timer keeps its base wake-ups throughout. The intervals are shortened here to keep the test quick.
+    asyncTest(async done => {
+        const wakeUpInterval = 400;
+        const intensiveWakeUpInterval = 1600;
+        const gracePeriod = 1200;
+        internals.setHiddenDocumentTimerWakeUpInterval(wakeUpInterval);
+        // The grace period for a document that was still loading when it hid is long enough to time the test out
+        // if it were the one applied; the document is made to finish loading before it hides.
+        internals.setHiddenDocumentIntensiveTimerThrottling(intensiveWakeUpInterval, gracePeriod, 60_000);
+
+        // performance.now() is coarsened down to a tenth of a millisecond, so a timer that fires right at a wake-up
+        // can read a hair less than it.
+        const coarsening = 0.1;
+        const wakeUpAtOrAfter = (time, interval) => Math.ceil(time / interval) * interval;
+        const firedIn = (time, wakeUp, interval) => time >= wakeUp - coarsening && time < wakeUp + interval;
+        // Where a chained timer with the given deadline runs once the intensive tier applies: at the next intensive
+        // wake-up, or at the next base wake-up if that's at least an intensive interval past the last chained wake-up.
+        const intensiveWakeUpAtOrAfter = (deadline, lastChainedWakeUp) => Math.min(
+            wakeUpAtOrAfter(deadline, intensiveWakeUpInterval),
+            wakeUpAtOrAfter(Math.max(deadline, lastChainedWakeUp + intensiveWakeUpInterval), wakeUpInterval));
+        // Gets near the next boundary of the grid with a timer, then spins the rest of the way, so that the current
+        // time sits early in an interval of that grid and a short timer's deadline lies well before its next wake-up.
+        const waitForEarlyPhase = async interval => {
+            const phase = performance.now() % interval;
+            if (phase >= 60)
+                await timeout(interval - phase);
+            while (performance.now() % interval >= 60)
+                ;
+        };
+        const chainedFireTime = delay => new Promise(resolve =>
+            requestIdleCallback(() => resolve(performance.now()), { timeout: delay }));
+        const delayedFireTime = delay => new Promise(resolve => setTimeout(() => resolve(performance.now()), delay));
+        // A timer registered from the sixth nested setTimeout callback, i.e. at nesting level 6 — past the level
+        // where the 4 ms clamp starts.
+        const nestedFireTimes = delay => new Promise(resolve => {
+            let armedAt;
+            const nest = depth => {
+                if (depth === 0) {
+                    armedAt = performance.now();
+                    setTimeout(() => resolve({ armedAt, firedAt: performance.now() }), delay);
+                } else {
+                    setTimeout(() => nest(depth - 1), 0);
+                }
+            };
+            nest(6);
+        });
+        const report = (what, ok, details) => {
+            println(`${what}: ${ok}`);
+            if (!ok)
+                println(`    ${JSON.stringify(details)}`);
+        };
+
+        if (document.readyState !== "complete")
+            await new Promise(resolve => addEventListener("load", resolve, { once: true }));
+        // Line the hide up with the intensive grid, so that every wake-up below falls where the arithmetic says.
+        await waitForEarlyPhase(intensiveWakeUpInterval);
+        await setSystemVisibilityState("hidden");
+        try {
+            let armedAt = performance.now();
+            let wakeUp = wakeUpAtOrAfter(armedAt + 10, wakeUpInterval);
+            let chained = await chainedFireTime(10);
+            report("before the grace period ends, a chained timer takes the next base wake-up",
+                firedIn(chained, wakeUp, wakeUpInterval), { armedAt, wakeUp, chained });
+            let lastChainedWakeUp = chained;
+
+            // Armed before the grace period ends, due after it: the timer is moved off its base wake-up when the
+            // grace period ends.
+            armedAt = performance.now();
+            wakeUp = intensiveWakeUpAtOrAfter(armedAt + 1300, lastChainedWakeUp);
+            chained = await chainedFireTime(1300);
+            report("a chained timer already armed when the grace period ends is re-armed for the intensive tier",
+                firedIn(chained, wakeUp, wakeUpInterval), { armedAt, wakeUp, chained, lastChainedWakeUp });
+            lastChainedWakeUp = chained;
+
+            armedAt = performance.now();
+            wakeUp = intensiveWakeUpAtOrAfter(armedAt + 10, lastChainedWakeUp);
+            const baseWakeUp = wakeUpAtOrAfter(armedAt + 10, wakeUpInterval);
+            const [chainedAgain, nested, delayed] = await Promise.all([chainedFireTime(10), nestedFireTimes(10), delayedFireTime(10)]);
+            report("after the grace period, a chained timer right after a chained wake-up waits for the intensive wake-up",
+                firedIn(chainedAgain, wakeUp, wakeUpInterval), { armedAt, wakeUp, chainedAgain, lastChainedWakeUp });
+            report("a timer nested past level 5 counts as chained",
+                firedIn(nested.firedAt, intensiveWakeUpAtOrAfter(nested.armedAt + 10, lastChainedWakeUp), wakeUpInterval),
+                { nested, lastChainedWakeUp });
+            report("a delayed timer keeps taking the next base wake-up", firedIn(delayed, baseWakeUp, wakeUpInterval),
+                { armedAt, baseWakeUp, delayed });
+            lastChainedWakeUp = Math.max(chainedAgain, nested.firedAt);
+
+            // Let an intensive interval pass with no chained timer running.
+            while (performance.now() < lastChainedWakeUp + intensiveWakeUpInterval + 60)
+                await timeout(50);
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 10, wakeUpInterval);
+            chained = await chainedFireTime(10);
+            report("a chained timer runs at the next base wake-up once no chained timer has run for an intensive interval",
+                firedIn(chained, wakeUp, wakeUpInterval) && wakeUp === intensiveWakeUpAtOrAfter(armedAt + 10, lastChainedWakeUp),
+                { armedAt, wakeUp, chained, lastChainedWakeUp });
+
+            // Showing the document ends its grace period; hiding it again starts a fresh one.
+            await setSystemVisibilityState("visible");
+            await waitForEarlyPhase(intensiveWakeUpInterval);
+            await setSystemVisibilityState("hidden");
+            await chainedFireTime(10);
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 10, wakeUpInterval);
+            chained = await chainedFireTime(10);
+            report("hiding the document again starts a new grace period", firedIn(chained, wakeUp, wakeUpInterval),
+                { armedAt, wakeUp, chained });
+        } finally {
+            await setSystemVisibilityState("visible");
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/timer-throttling-hidden-document.html
+++ b/Tests/LibWeb/Text/input/HTML/timer-throttling-hidden-document.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // A hidden document runs its timers only at wake-ups a fixed interval apart, aligned to its time origin, so a
+    // page that keeps re-arming short timers in a background tab costs one wake-up per interval rather than a task
+    // per timer. A timer with no delay is exempt, and a document that becomes visible again puts every timer back on
+    // its own deadline. The interval is shortened here to keep the test quick.
+    asyncTest(async done => {
+        const wakeUpInterval = 500;
+        internals.setHiddenDocumentTimerWakeUpInterval(wakeUpInterval);
+
+        // performance.now() is coarsened down to a tenth of a millisecond, so a timer that fires right at a wake-up
+        // can read a hair less than it.
+        const coarsening = 0.1;
+        const wakeUpAtOrAfter = time => Math.ceil(time / wakeUpInterval) * wakeUpInterval;
+        const firedAtOrAfter = (time, wakeUp) => time >= wakeUp - coarsening;
+        // Spins until the current time sits early in a wake-up interval, so that a short timer's deadline lies well
+        // before the next wake-up and a wait for that wake-up can't be mistaken for the timer's own delay.
+        const waitForEarlyPhase = () => {
+            while (performance.now() % wakeUpInterval >= 60)
+                ;
+        };
+        const fireTime = delay => new Promise(resolve => setTimeout(() => resolve(performance.now()), delay));
+        const report = (what, ok, details) => {
+            println(`${what}: ${ok}`);
+            if (!ok)
+                println(`    ${JSON.stringify(details)}`);
+        };
+
+        await setSystemVisibilityState("hidden");
+        try {
+            waitForEarlyPhase();
+            let armedAt = performance.now();
+            let wakeUp = wakeUpAtOrAfter(armedAt + 10);
+            let firedAt = await fireTime(10);
+            report("a delayed timer waits for the wake-up after its deadline", firedAtOrAfter(firedAt, wakeUp),
+                { armedAt, wakeUp, firedAt });
+
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 50);
+            const laterWakeUp = wakeUpAtOrAfter(armedAt + wakeUpInterval + 10);
+            const [first, second, third, later] = await Promise.all(
+                [fireTime(10), fireTime(30), fireTime(50), fireTime(wakeUpInterval + 10)]);
+            report("timers due before the same wake-up fire in it",
+                [first, second, third].every(time => firedAtOrAfter(time, wakeUp) && time < wakeUp + wakeUpInterval),
+                { armedAt, wakeUp, first, second, third });
+            report("a timer due after that wake-up waits for the following one", firedAtOrAfter(later, laterWakeUp),
+                { armedAt, laterWakeUp, later });
+
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 1);
+            firedAt = await fireTime(0);
+            report("a timer with no delay doesn't wait for a wake-up", firedAt < wakeUp, { armedAt, wakeUp, firedAt });
+
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 130);
+            const intervalFireTimes = await new Promise(resolve => {
+                const times = [];
+                const id = setInterval(() => {
+                    times.push(performance.now());
+                    if (times.length === 3) {
+                        clearInterval(id);
+                        resolve(times);
+                    }
+                }, 130);
+            });
+            report("an interval fires once per wake-up",
+                intervalFireTimes.every((time, i) => firedAtOrAfter(time, wakeUp + i * wakeUpInterval)
+                    && time < wakeUp + (i + 1) * wakeUpInterval),
+                { armedAt, wakeUp, intervalFireTimes });
+
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 10);
+            const idle = await new Promise(resolve => requestIdleCallback(
+                deadline => resolve({ firedAt: performance.now(), didTimeout: deadline.didTimeout }), { timeout: 10 }));
+            report("an idle callback's timeout waits for the wake-up", idle.didTimeout && firedAtOrAfter(idle.firedAt, wakeUp),
+                { armedAt, wakeUp, idle });
+
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 10);
+            firedAt = await new Promise(resolve =>
+                AbortSignal.timeout(10).addEventListener("abort", () => resolve(performance.now())));
+            report("AbortSignal.timeout() waits for the wake-up", firedAtOrAfter(firedAt, wakeUp), { armedAt, wakeUp, firedAt });
+
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 10);
+            const armedHidden = fireTime(10);
+            await setSystemVisibilityState("visible");
+            firedAt = await armedHidden;
+            report("becoming visible puts a timer back on its own deadline",
+                firedAt >= armedAt + 10 - coarsening && firedAt < wakeUp, { armedAt, wakeUp, firedAt });
+
+            waitForEarlyPhase();
+            armedAt = performance.now();
+            wakeUp = wakeUpAtOrAfter(armedAt + 250);
+            const armedVisible = fireTime(250);
+            await setSystemVisibilityState("hidden");
+            firedAt = await armedVisible;
+            report("a timer armed while visible waits for the wake-up once the document hides", firedAtOrAfter(firedAt, wakeUp),
+                { armedAt, wakeUp, firedAt });
+        } finally {
+            await setSystemVisibilityState("visible");
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/abortsignal-timeout-survives-gc.html
+++ b/Tests/LibWeb/Text/input/abortsignal-timeout-survives-gc.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    // Until it aborts, an AbortSignal.timeout() signal is referenced only from the steps its timeout runs, and a
+    // chained timer's task likewise hangs off the steps its timer runs. A garbage collection while those timeouts are
+    // pending mustn't sweep what the steps hold on to. Two collections each time, since the second finishes the
+    // sweep the first one starts.
+    asyncTest(async done => {
+        const collectGarbage = () => {
+            internals.gc();
+            internals.gc();
+        };
+        const timeoutSignalAborts = () => new Promise(resolve => {
+            AbortSignal.timeout(1).addEventListener("abort", event => resolve(event.target.aborted));
+        });
+        // A timer counts as chained past nesting level 5, so arm these from the sixth nested timer callback.
+        const chainedTimersFire = count => new Promise(resolve => {
+            const armAtDepth = depth => {
+                if (depth < 6) {
+                    setTimeout(() => armAtDepth(depth + 1), 0);
+                    return;
+                }
+                let fired = 0;
+                for (let i = 0; i < count; ++i) {
+                    setTimeout(() => {
+                        if (++fired === count)
+                            resolve(true);
+                    }, 1);
+                }
+                collectGarbage();
+            };
+            armAtDepth(0);
+        });
+
+        internals.setHiddenDocumentTimerWakeUpInterval(10);
+        for (const state of ["visible", "hidden"]) {
+            await setSystemVisibilityState(state);
+            const pending = [];
+            for (let i = 0; i < 20; ++i)
+                pending.push(timeoutSignalAborts());
+            pending.push(chainedTimersFire(20));
+            collectGarbage();
+            const outcomes = await Promise.all(pending);
+            const ran = outcomes.filter(Boolean).length;
+            println(`${state}: ${ran} of ${outcomes.length} pending timeouts ran after a garbage collection`);
+        }
+        await setSystemVisibilityState("visible");
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/request-idle-callback-handles.html
+++ b/Tests/LibWeb/Text/input/request-idle-callback-handles.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    asyncTest(async done => {
+        const order = [];
+        const idlePeriod = () => new Promise(resolve => requestIdleCallback(resolve));
+
+        // Callbacks run in registration order, and one registered from inside an idle callback waits for a later
+        // idle period instead of joining the current one.
+        const first = requestIdleCallback(() => {
+            order.push("first");
+            requestIdleCallback(() => order.push("registered from first"));
+        });
+        const second = requestIdleCallback(() => order.push("second"));
+        requestIdleCallback(() => order.push("third"));
+        println(`handles increase: ${second > first}`);
+        await idlePeriod();
+        await idlePeriod();
+        println(`order: ${order.join(", ")}`);
+
+        // Canceling a pending callback removes only that one; canceling a handle twice, a handle that already ran,
+        // and handles that never existed are all no-ops.
+        order.length = 0;
+        requestIdleCallback(() => order.push("a"));
+        const b = requestIdleCallback(() => order.push("b"));
+        requestIdleCallback(() => order.push("c"));
+        cancelIdleCallback(b);
+        cancelIdleCallback(b);
+        cancelIdleCallback(first);
+        cancelIdleCallback(0);
+        cancelIdleCallback(1000000);
+        await idlePeriod();
+        println(`after canceling b: ${order.join(", ")}`);
+
+        // A callback can cancel another one that is already on the runnable list of the same idle period.
+        order.length = 0;
+        let zHandle;
+        requestIdleCallback(() => {
+            order.push("x");
+            cancelIdleCallback(zHandle);
+        });
+        requestIdleCallback(() => order.push("y"));
+        zHandle = requestIdleCallback(() => order.push("z"));
+        await idlePeriod();
+        println(`after x cancels z: ${order.join(", ")}`);
+
+        // A callback registered with a timeout that gets to run in an idle period runs exactly once; its timeout
+        // must not invoke it a second time.
+        let runs = 0;
+        requestIdleCallback(() => ++runs, { timeout: 30 });
+        await idlePeriod();
+        await timeout(60);
+        println(`callback with a timeout that ran in an idle period ran ${runs} time(s)`);
+
+        // A callback registered with a timeout and canceled before either fires never runs.
+        order.length = 0;
+        const canceled = requestIdleCallback(() => order.push("canceled"), { timeout: 10 });
+        cancelIdleCallback(canceled);
+        await timeout(40);
+        println(`canceled callback with a timeout ran: ${order.includes("canceled")}`);
+
+        // A callback that outlasts the idle deadline leaves the rest of the runnable list waiting. Keeping the
+        // event loop busy afterwards stops a new idle period from starting, so the timeout of the callback still
+        // on the runnable list is what runs it.
+        order.length = 0;
+        const channel = new MessageChannel();
+        let keepEventLoopBusy = true;
+        channel.port1.onmessage = () => {
+            if (keepEventLoopBusy)
+                channel.port2.postMessage(undefined);
+        };
+        await timeout(0);
+        requestIdleCallback(() => {
+            channel.port2.postMessage(undefined);
+            const end = performance.now() + 80;
+            while (performance.now() < end)
+                ;
+            order.push("busy");
+        });
+        await new Promise(resolve => requestIdleCallback(deadline => {
+            order.push(`timed out on the runnable list: ${deadline.didTimeout}`);
+            keepEventLoopBusy = false;
+            resolve();
+        }, { timeout: 20 }));
+        channel.port1.close();
+        channel.port2.close();
+        println(order.join(", "));
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/request-idle-callback-timeouts-with-pending-backlog.html
+++ b/Tests/LibWeb/Text/input/request-idle-callback-timeouts-with-pending-backlog.html
@@ -24,6 +24,10 @@
         };
         const bestOfThree = async () => Math.min(await timeBatch(), await timeBatch(), await timeBatch());
 
+        // A hidden document runs a delayed timer only at its next wake-up, so at the default wake-up interval a
+        // batch's time would be the wait for a wake-up rather than the cost of its callbacks' timeouts. Wake the
+        // document up every millisecond instead.
+        internals.setHiddenDocumentTimerWakeUpInterval(1);
         await setSystemVisibilityState("hidden");
         try {
             const baseline = await bestOfThree();

--- a/Tests/LibWeb/Text/input/request-idle-callback-timeouts-with-pending-backlog.html
+++ b/Tests/LibWeb/Text/input/request-idle-callback-timeouts-with-pending-backlog.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    // A hidden document never starts an idle period, so idle callbacks registered without a timeout stay pending
+    // for as long as the document is hidden. Timed-out callbacks registered behind such a backlog must be found
+    // and removed without paying for the backlog: the time to run a batch of timed-out callbacks with a large
+    // backlog in front of them is compared against the same batch with no backlog at all.
+    asyncTest(async done => {
+        const backlogSize = 300000;
+        const batchSize = 2000;
+
+        const timeBatch = async () => {
+            let remaining = batchSize;
+            const { promise, resolve } = Promise.withResolvers();
+            const start = performance.now();
+            for (let i = 0; i < batchSize; ++i) {
+                requestIdleCallback(() => {
+                    if (--remaining === 0)
+                        resolve();
+                }, { timeout: 1 });
+            }
+            await promise;
+            return performance.now() - start;
+        };
+        const bestOfThree = async () => Math.min(await timeBatch(), await timeBatch(), await timeBatch());
+
+        await setSystemVisibilityState("hidden");
+        try {
+            const baseline = await bestOfThree();
+            for (let i = 0; i < backlogSize; ++i)
+                requestIdleCallback(() => {});
+            const withBacklog = await bestOfThree();
+            const ok = withBacklog < 4 * baseline + 100;
+            println(`timed-out callbacks behind a pending backlog cost the same as without one: ${ok}`);
+            if (!ok)
+                println(`baseline ${baseline.toFixed(1)} ms, with backlog ${withBacklog.toFixed(1)} ms`);
+        } finally {
+            await setSystemVisibilityState("visible");
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -44,6 +44,7 @@
 #include <LibURL/Parser.h>
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
+#include <LibWeb/HTML/VisibilityState.h>
 #include <LibWebView/Process.h>
 #include <LibWebView/Utilities.h>
 
@@ -1219,6 +1220,11 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
                 view->reset_line_box_borders();
                 view->reset_viewport_size(window_size);
             }
+
+            // The system visibility state lives in this view's traversable, and a test that hid the page only puts it
+            // back from signalTestIsDone(). A test that times out or crashes while hidden would otherwise hand the
+            // hidden state to every test that follows in this view, a respawned WebContent included.
+            view->set_system_visibility_state(Web::HTML::VisibilityState::Visible);
 
             auto& test = tests[test_index];
             if (test.timeout_timer) {


### PR DESCRIPTION
A background tab on https://propublica.org (and one on https://aljazeera.com) kept its WebContent process at 25-50% CPU for as long as it stayed hidden. Both sites run Google reCAPTCHA, whose scheduler re-arms a few hundred `requestIdleCallback` chains with short timeouts. A hidden document never gets an idle period, so every one of those callbacks ran on its timeout — about 3,000 timer tasks a second — and each of them found its callback by scanning a pile of tens of thousands of idle callbacks parked without a timeout.

Two fixes, from the same profile, and two more that fell out of the new tests (below). The second commit finds idle callbacks by handle instead of scanning the lists. The three after it hold a hidden document’s timers back the same way the other engines do — Blink and WebKit align a hidden page’s timers to a one-second grid, and Gecko clamps them to a one-second minimum delay — and they follow Blink’s design closely (`PageSchedulerImpl` and its `WakeUpBudgetPool`s):

- A hidden document runs its timers only at wake-ups one second apart, on one grid for every frame of the page. A timer with no delay is left alone, as in Chrome.
- Once hidden for a minute (five, if the page was still loading when it hid — judged by its load event, where Chrome looks at the main frame’s first paint), chained timers (a `setTimeout()` chain past nesting level 5, or the timeout of an idle callback or of `AbortSignal.timeout()`) move to one wake-up a minute — Chrome’s intensive wake-up throttling, including its rule that the next one-second wake-up will do when no chained timer has run for a minute.
- A document playing audio keeps its timers on their own deadlines, as Chrome does for an audible page.

Put together, the three commits decide where a timer runs like this:

```mermaid
%%{init: {"flowchart": {"wrappingWidth": 230, "rankSpacing": 45, "nodeSpacing": 25}}}%%
flowchart LR
    IM["Immediate: no delay, nesting level 5 or below"]
    DE["Delayed: a delay, nesting level 5 or below"]
    CH["Chained: past nesting level 5, or a timeout another spec waits on (an idle callback’s, AbortSignal.timeout()’s)"]
    IM --> D
    IM ~~~ H
    DE --> H
    CH --> H
    H{"Document hidden, and<br/>not playing audio?"}
    H -->|no| D
    H -->|yes| C{"Chained, and hidden<br/>past the grace period?"}
    C ~~~ D
    C -->|no| G
    C -->|yes| I
    D["Fires at its own deadline — right away, if that has passed"]
    G["Held back to the first point of the 1s grid at or after due"]
    I["Held back to the earlier of:<br/>• the first point of the 60s grid at or after due<br/>• the first point of the 1s grid at or after max(due, last chained run + 60s)"]

    classDef deadline fill:#e3f2e6,stroke:#2e7d32,color:#000
    classDef wakeup fill:#fdebd3,stroke:#ef6c00,color:#000
    class D deadline
    class G,I wakeup
```

_“Due”_ is the timer’s deadline — or now, if that has already passed. The 1s and 60s grids run from the time origin of the page’s local root document, and _“last chained run”_ is the last time a chained timer ran while the document was hidden — before any has, the next 1s wake-up will do.

A LibCore fix opens the series; the new tests flushed it out, and it goes first so that no commit ships a flaky test. On Linux, the event loop armed and expired its timers on `CLOCK_MONOTONIC_COARSE`, which lags the precise clock by up to a scheduler tick — so a timer could fire up to a tick before its interval was up as the page measures time, and the new hidden-document tests flaked on the Linux CI jobs and nowhere else. The timers now run on `MonotonicTime::now()`.

A test-web fix closes the series, prompted by review of the new tests: a test that hid its document and then timed out or crashed left the page hidden for every test that followed in the same view, since only `signalTestIsDone()` put it back, and a respawned WebContent even inherited the state from the UI side. The runner’s between-tests cleanup now sets the view back to visible, whatever a test’s result.

---

> [!NOTE]
> ### Where this departs from Blink, deliberately:
>
> - The audible exemption is per-document, not per-page. The document playing audio is the one doing what the user asked, and its timers are the ones driving the playback; a per-page exemption would hand a pass to every other frame on the page — an ad’s, reCAPTCHA’s — for as long as a video plays, and a news site with a video playing in a background tab is the very tab this PR is about. Ladybird also already knows which document each media element belongs to, so per-document is what makes sense for us.
> - The no-recent-wake-up rule is tracked per-page, not per same-origin frame group. Blink shares one record among a page’s same-origin frames, and denies the rule to cross-origin frames altogether — since a record shared across origins would let one frame learn about another’s wake-ups. A per-page record shares nothing, so there’s nothing to learn — and every frame, cross-origin or not, keeps the rule. The cost: Two same-origin frames can each take a one-second wake-up in the same minute where Chrome would grant them one.