### PR TITLE
LibWeb: Reduce allocation and repeated work in the Rust style engine

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
@@ -1067,18 +1067,16 @@ impl<'a> BatchMatcher<'a> {
             let compiled = self.programs.get(program);
             for (entry_index, entry) in compiled.entries().iter().enumerate() {
                 let subject_dispatch = compiled.subject_dispatch_keys(entry_index);
-                if !subject_dispatch.is_empty()
-                    && !subject_dispatch
-                        .iter()
-                        .any(|&key| self.facts.carries_dispatch_key(row, key, is_document_root))
-                {
+                let matched_dispatch_key = subject_dispatch
+                    .iter()
+                    .copied()
+                    .find(|&key| self.facts.carries_dispatch_key(row, key, is_document_root));
+                if !subject_dispatch.is_empty() && matched_dispatch_key.is_none() {
                     continue;
                 }
-                if compiled
-                    .subject_required_keys(entry_index)
-                    .iter()
-                    .any(|&key| !self.facts.carries_dispatch_key(row, key, is_document_root))
-                {
+                if compiled.subject_required_keys(entry_index).iter().any(|&key| {
+                    Some(key) != matched_dispatch_key && !self.facts.carries_dispatch_key(row, key, is_document_root)
+                }) {
                     continue;
                 }
                 let entry_index = u32::try_from(entry_index).expect("selector entry space exhausted");

--- a/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
@@ -1370,7 +1370,7 @@ impl<'a> BatchMatcher<'a> {
             .ancestor_requirements
             .map(|requirements| requirements.dispatch_facts(row));
         let mut cascade_winners = Top1Cascade::with_capacity(0);
-        let mut matched_pseudo_targets = Vec::new();
+        let mut matched_pseudo_targets: SmallVec<[_; 2]> = SmallVec::new();
         if self.cascade_only {
             for matched in out
                 .matches
@@ -1445,12 +1445,13 @@ impl<'a> BatchMatcher<'a> {
                 let pseudo_target_is_known = entry
                     .pseudo_element
                     .is_none_or(|target| matched_pseudo_targets.contains(&target));
-                let every_property_has_a_winner = properties.iter().all(|&property| {
-                    cascade_winners
-                        .winner(&(entry.pseudo_element, property))
-                        .is_some_and(|winner| winner.priority >= candidate.cascade_order)
-                });
-                if pseudo_target_is_known && every_property_has_a_winner {
+                if pseudo_target_is_known
+                    && properties.iter().all(|&property| {
+                        cascade_winners
+                            .winner(&(entry.pseudo_element, property))
+                            .is_some_and(|winner| winner.priority >= candidate.cascade_order)
+                    })
+                {
                     counters.bump(Counter::CascadeCandidatesRejectedByWinner);
                     if let Some(completed) = completed.as_deref_mut() {
                         completed[candidate_index] = true;

--- a/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
@@ -157,8 +157,13 @@ impl RuleMatches {
         }
     }
 
-    pub(super) fn prepared_selector_truth(&self) -> Option<Vec<super::SelectorTruth>> {
-        let mut truth = self.selector_truth.clone()?;
+    pub(super) fn take_prepared_selector_truth(
+        &mut self,
+        memory: &mut MemoryController,
+    ) -> Option<Vec<super::SelectorTruth>> {
+        self.settle_memory(memory);
+        let mut truth = self.selector_truth.take()?;
+        self.settle_memory(memory);
         truth.sort_unstable();
         truth.dedup();
         Some(truth)

--- a/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
@@ -11,6 +11,7 @@
 //! output is exact, but its accelerators make it unsuitable as the correctness reference. That role
 //! belongs to [`super::exact_matcher::ExactMatcher`].
 
+use smallvec::SmallVec;
 use std::mem::size_of;
 
 use super::ScopeDispatchShape;
@@ -1353,7 +1354,7 @@ impl<'a> BatchMatcher<'a> {
         // Copies of a multi-key entry share one cascade order; an element carrying two of the
         // entry's branch keys walks past the second copy here. The list stays tiny because only
         // disjunction subjects are multi-key.
-        let mut seen_multi_key_orders: Vec<u32> = Vec::new();
+        let mut seen_multi_key_orders: SmallVec<[u32; 4]> = SmallVec::new();
         let is_document_root = self.tree.parent(node).is_none();
         let parent_facts = match self.tree.parent(node) {
             None => ParentDispatchFacts::NoElementParent,

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -462,6 +462,10 @@ where
         self.winner_by_key.get(key).map(|&index| &self.winners[index])
     }
 
+    pub(super) fn unordered_winners(&self) -> impl Iterator<Item = &Top1Winner<Key, Priority, Payload>> {
+        self.winners.iter()
+    }
+
     pub(super) fn winners(&mut self) -> impl Iterator<Item = &Top1Winner<Key, Priority, Payload>> {
         if !self.sorted {
             self.winners.sort_unstable_by_key(|winner| winner.key);

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1218,7 +1218,7 @@ impl WinnerGroups {
                     groups.remove(group_index);
                 }
                 (Some(old_group), false) => {
-                    let new_group = if self.group_matches(old_group, &winners) {
+                    let new_group = if old_winners == winners {
                         old_group
                     } else {
                         self.intern_group(&winners)

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1631,19 +1631,20 @@ impl WinnerGroups {
         program_version: ProgramVersion,
         memory: &mut MemoryController,
     ) -> Option<usize> {
+        if !self.admitting {
+            return None;
+        }
         let (_, state) = self
             .token_for(WinnerGroupKey::current(source, program_version))
             .sparse()
             .ok()?;
-        let pseudo_states: Vec<_> = self.pseudo_states(source).collect();
-        let scratch_bytes = (pseudo_states.capacity()
-            * size_of::<(PseudoElementTarget, ProgramVersion, CascadeStateID, bool)>())
-            as u64;
+        let pseudo_states: SmallVec<[_; 2]> = self.pseudo_states(source).collect();
+        let scratch_bytes = if pseudo_states.spilled() {
+            (pseudo_states.capacity() * size_of::<(PseudoElementTarget, ProgramVersion, CascadeStateID, bool)>()) as u64
+        } else {
+            0
+        };
         memory.reserve_required(MemoryCategory::BatchScratch, scratch_bytes);
-        if !self.admitting {
-            memory.release(MemoryCategory::BatchScratch, scratch_bytes);
-            return None;
-        }
         self.remove(target);
         assert!(self.set(target, state, program_version));
         for (pseudo, version, state, priority_current) in &pseudo_states {

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1408,10 +1408,10 @@ impl WinnerGroups {
                 .eq(self.states[right].iter().map(|group| group.winners))
     }
 
-    fn semantic_winners_in_state(&self, state: CascadeStateID) -> impl Iterator<Item = &SemanticPropertyWinner> {
+    pub(super) fn properties_in_state(&self, state: CascadeStateID) -> impl Iterator<Item = PropertyID> {
         self.states[state]
             .iter()
-            .flat_map(move |group| self.groups[group.winners].iter())
+            .flat_map(move |group| self.groups[group.winners].iter().map(|winner| winner.property))
     }
 
     /// Compare the semantic winners consumed by two computed-style publications.
@@ -1463,8 +1463,8 @@ impl WinnerGroups {
     /// exact semantic delta.
     pub(super) fn property_shape_hash(&self, state: CascadeStateID) -> u64 {
         let mut hasher = fast_hasher();
-        for winner in self.semantic_winners_in_state(state) {
-            winner.property.hash(&mut hasher);
+        for property in self.properties_in_state(state) {
+            property.hash(&mut hasher);
         }
         hasher.finish()
     }

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -34,6 +34,7 @@ use super::intern_table::InternIdentity;
 use super::intern_table::InternTable;
 use super::intern_table::content_hash;
 
+use smallvec::SmallVec;
 use std::hash::Hash;
 use std::hash::Hasher;
 
@@ -1249,7 +1250,7 @@ impl WinnerGroups {
             property: winner.property,
             key: winner.key,
         });
-        let provenance: Box<[_]> = winners
+        let provenance: SmallVec<[_; WINNER_GROUP_PROPERTY_COUNT as usize]> = winners
             .iter()
             .map(|winner| WinnerProvenance {
                 important: winner.important,
@@ -1273,7 +1274,7 @@ impl WinnerGroups {
         {
             return WinnerGroupRef {
                 winners: id,
-                provenance: self.intern_provenance_group(provenance),
+                provenance: self.intern_provenance_group(&provenance),
             };
         }
         let id = WinnerGroupID(u32::try_from(self.groups.len()).expect("winner group space exhausted"));
@@ -1284,24 +1285,23 @@ impl WinnerGroups {
         self.groups.insert(hash, id, semantic);
         WinnerGroupRef {
             winners: id,
-            provenance: self.intern_provenance_group(provenance),
+            provenance: self.intern_provenance_group(&provenance),
         }
     }
 
-    fn intern_provenance_group(&mut self, provenance: Box<[WinnerProvenance]>) -> WinnerProvenanceGroupID {
-        let hash = content_hash(&provenance);
+    fn intern_provenance_group(&mut self, provenance: &[WinnerProvenance]) -> WinnerProvenanceGroupID {
+        let hash = content_hash(provenance);
         if let Some(id) = self
             .provenance_groups
-            .find(hash, |_id, candidate| *candidate == provenance)
+            .find(hash, |_id, candidate| candidate.as_ref() == provenance)
         {
             return id;
         }
         let id = WinnerProvenanceGroupID(
             u32::try_from(self.provenance_groups.len()).expect("winner provenance group space exhausted"),
         );
-        self.nested_residency
-            .grow_committed(size_of_val(provenance.as_ref()) as u64);
-        self.provenance_groups.insert(hash, id, provenance);
+        self.nested_residency.grow_committed(size_of_val(provenance) as u64);
+        self.provenance_groups.insert(hash, id, provenance.into());
         id
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1470,11 +1470,25 @@ impl WinnerGroups {
     }
 
     pub(super) fn property_shapes_are_equal(&self, left: CascadeStateID, right: CascadeStateID) -> bool {
-        left == right
-            || self
-                .semantic_winners_in_state(left)
-                .map(|winner| winner.property)
-                .eq(self.semantic_winners_in_state(right).map(|winner| winner.property))
+        if left == right {
+            return true;
+        }
+        let left = &self.states[left];
+        let right = &self.states[right];
+        // Each property belongs to a fixed bucket, so equal shapes have corresponding groups.
+        left.len() == right.len()
+            && left.iter().zip(right.iter()).all(|(left, right)| {
+                if left.winners == right.winners {
+                    return true;
+                }
+                let left = &self.groups[left.winners];
+                let right = &self.groups[right.winners];
+                left.len() == right.len()
+                    && left
+                        .iter()
+                        .map(|winner| winner.property)
+                        .eq(right.iter().map(|winner| winner.property))
+            })
     }
 
     fn group_semantic_delta(

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -171,6 +171,8 @@ impl CascadePriority {
 pub type PropertyID = u16;
 
 const WINNER_GROUP_PROPERTY_COUNT: PropertyID = 32;
+const INLINE_WINNER_GROUP_COUNT: usize =
+    crate::css::property_metadata::LAST_LONGHAND_PROPERTY_ID as usize / WINNER_GROUP_PROPERTY_COUNT as usize + 1;
 
 /// Canonical identity of a specified value. Two declarations that specify the same value share it,
 /// however differently they were written and whichever rule they came from.
@@ -1076,7 +1078,7 @@ impl WinnerGroups {
     /// Intern an already sorted state, reusing unchanged groups directly from its previous state.
     pub fn intern_sorted(&mut self, winners: &[PropertyWinner], previous: Option<CascadeStateID>) -> CascadeStateID {
         debug_assert!(winners.windows(2).all(|pair| pair[0].property < pair[1].property));
-        let mut groups = Vec::new();
+        let mut groups = SmallVec::new();
         let mut previous_group_index = 0;
         for winners in winners.chunk_by(|left, right| {
             left.property / WINNER_GROUP_PROPERTY_COUNT == right.property / WINNER_GROUP_PROPERTY_COUNT
@@ -1107,7 +1109,7 @@ impl WinnerGroups {
         self.intern_group_ids(groups)
     }
 
-    fn intern_group_ids(&mut self, groups: Vec<WinnerGroupRef>) -> CascadeStateID {
+    fn intern_group_ids(&mut self, groups: SmallVec<[WinnerGroupRef; INLINE_WINNER_GROUP_COUNT]>) -> CascadeStateID {
         let hash = content_hash(&groups);
         if let Some(id) = self
             .states
@@ -1164,7 +1166,7 @@ impl WinnerGroups {
             return (previous, CascadeWinnerDelta::default());
         }
 
-        let mut groups = self.states[previous].to_vec();
+        let mut groups = SmallVec::from_slice(&self.states[previous]);
         let mut changed_properties = Vec::new();
         let mut old_winners = Vec::new();
         let mut winners = Vec::new();

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1187,7 +1187,7 @@ impl WinnerGroups {
             }
             let bucket_updates = &updates[update_start..update_end];
             winners.clear();
-            winners.reserve(old_winners.len() + bucket_updates.len());
+            winners.reserve((old_winners.len() + bucket_updates.len()).min(WINNER_GROUP_PROPERTY_COUNT as usize));
             for entry in merge_sorted_by(&old_winners, bucket_updates, |old, update| {
                 old.property.cmp(&update.property)
             }) {

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -449,8 +449,8 @@ where
             }
             std::collections::hash_map::Entry::Vacant(entry) => {
                 entry.insert(self.winners.len());
+                self.sorted = self.sorted && self.winners.last().is_none_or(|winner| winner.key < key);
                 self.winners.push(Top1Winner { key, priority, payload });
-                self.sorted = false;
             }
         }
     }

--- a/Libraries/LibWeb/Rust/src/css/style/cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/cascade.rs
@@ -1387,6 +1387,13 @@ impl WinnerGroups {
             })
     }
 
+    pub(super) fn winner_count_in_state(&self, state: CascadeStateID) -> usize {
+        self.states[state]
+            .iter()
+            .map(|group| self.groups[group.winners].len())
+            .sum()
+    }
+
     pub fn winners_in_state(&self, state: CascadeStateID) -> impl Iterator<Item = PropertyWinner> + '_ {
         self.states[state].iter().flat_map(|&group| self.group_winners(group))
     }

--- a/Libraries/LibWeb/Rust/src/css/style/catalog.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/catalog.rs
@@ -817,7 +817,8 @@ pub(super) struct RetainedMatchAnswers {
 /// exact selector truth without evaluating the selector again. It is Tier-3 state: incomplete
 /// retained coverage or closed admission simply leaves program routing on its cold path.
 pub(super) struct RetainedSelectorIncidences {
-    pub(super) by_program: Vec<Option<Rc<[RetainedSelectorIncidence]>>>,
+    by_program: Vec<Option<Rc<[RetainedSelectorIncidence]>>>,
+    nested_capacity_bytes: u64,
     pub(super) residency: MemoryLease,
 }
 
@@ -831,6 +832,7 @@ impl Default for RetainedSelectorIncidences {
     fn default() -> Self {
         Self {
             by_program: Vec::new(),
+            nested_capacity_bytes: 0,
             residency: MemoryLease::new(MemoryCategory::RetainedSelectorIncidence),
         }
     }
@@ -844,13 +846,8 @@ impl RetainedSelectorIncidences {
     pub(super) fn capacity_bytes(&self) -> u64 {
         capacity_bytes! {
             shallow [self.by_program];
-            cached [];
-            nested [self
-                .by_program
-                .iter()
-                .flatten()
-                .map(|incidences| incidences.len() * size_of::<RetainedSelectorIncidence>())
-                .sum::<usize>()];
+            cached [self.nested_capacity_bytes];
+            nested [];
             skip [self.residency];
         }
     }
@@ -871,7 +868,10 @@ impl RetainedSelectorIncidences {
         if self.by_program.len() < required_len {
             self.by_program.resize(required_len, None);
         }
-        self.by_program[program.0 as usize] = Some(Rc::clone(&incidences));
+        if let Some(previous) = self.by_program[program.0 as usize].replace(Rc::clone(&incidences)) {
+            self.nested_capacity_bytes -= size_of_val(previous.as_ref()) as u64;
+        }
+        self.nested_capacity_bytes += size_of_val(incidences.as_ref()) as u64;
         let bytes = self.capacity_bytes();
         self.residency.reconcile_committed(memory, bytes);
         memory.finish_committed_acceleration_growth(MemoryCategory::RetainedSelectorIncidence);
@@ -880,6 +880,7 @@ impl RetainedSelectorIncidences {
 
     pub(super) fn clear(&mut self) {
         self.by_program = Vec::new();
+        self.nested_capacity_bytes = 0;
         self.residency.release();
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -15,6 +15,7 @@
 //! elements use dense columns, while actual pseudo-element kinds use sparse assignments. The
 //! complete tuple is interned as the base `StyleRecordID` published for each style target.
 
+use smallvec::SmallVec;
 use std::ffi::c_void;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -1228,7 +1229,7 @@ impl ComputedGroupSets {
             _ => return None,
         };
 
-        let mut groups: Vec<_> = parent_groups
+        let mut groups: SmallVec<[_; crate::css::table_group_builder::group_index::COUNT]> = parent_groups
             .iter()
             .copied()
             .chain(

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -779,12 +779,14 @@ impl ComputedGroupSets {
             return;
         };
         if self.style_record_generation_is_live(record, final_record.base_generation()) {
-            self.shared_style_records.entry(key).or_insert(SharedStyleRecord {
-                record: raw_record,
-                inherited_group_swap_eligible: node
-                    .element_index()
-                    .is_some_and(|index| self.columns.inherited_group_swap_eligible(index as usize)),
-            });
+            self.shared_style_records
+                .entry(key)
+                .or_insert_with(|| SharedStyleRecord {
+                    record: raw_record,
+                    inherited_group_swap_eligible: node
+                        .element_index()
+                        .is_some_and(|index| self.columns.inherited_group_swap_eligible(index as usize)),
+                });
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -2397,6 +2397,9 @@ impl ComputedGroupSets {
         else {
             return false;
         };
+        if record.groups == node_set {
+            return true;
+        }
         // Reclamation interns an equal payload under a new identity, so the groups compare by
         // content past their identities.
         let record_groups = &self.sets[record.groups].payloads;

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -816,14 +816,13 @@ impl ComputedGroupSets {
             .expect("computed group-set payload names a live group")
     }
 
-    fn group_identities(&self, set: ComputedGroupSetID) -> Vec<ComputedGroupID> {
+    fn group_identities(&self, set: ComputedGroupSetID) -> impl Iterator<Item = ComputedGroupID> {
         self.sets[set]
             .payloads
             .iter()
             .copied()
             .enumerate()
-            .map(|(index, payload)| self.group_identity(index, payload))
-            .collect()
+            .map(move |(index, payload)| self.group_identity(index, payload))
     }
 
     fn pseudo_rows(&self, node: StyleNodeID) -> &[PseudoComputedRow] {
@@ -1415,7 +1414,8 @@ impl ComputedGroupSets {
             crate::css::computed_longhand_table::rust_computed_longhand_table_release(table.cast_mut());
         };
 
-        let mut groups = self.group_identities(old_record.groups);
+        let mut groups: SmallVec<[_; crate::css::table_group_builder::group_index::COUNT]> =
+            self.group_identities(old_record.groups).collect();
         let mut canonicalized_groups = 0_u32;
         for (group, group_identity) in groups.iter_mut().enumerate() {
             if groups_to_rebuild & (1 << group) == 0 {
@@ -3149,7 +3149,6 @@ impl ComputedGroupSets {
         let record = self.style_records.get_index(base_style_record.index())?;
         Some(
             self.group_identities(record.groups)
-                .into_iter()
                 .map(|identity| identity.0)
                 .collect(),
         )

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -2965,7 +2965,7 @@ impl ComputedGroupSets {
     pub(super) fn reclaim_unreachable(&mut self) -> ComputedGroupRetention {
         let reachable = self.reachability();
         let retention = ComputedGroupRetention {
-            retained: self.groups.live_identities().count(),
+            retained: self.groups.live_identities().len(),
             reachable: reachable.groups.iter().filter(|&&reachable| reachable).count(),
         };
         if replaying_style_groups() {
@@ -3090,7 +3090,7 @@ impl ComputedGroupSets {
         }
         self.style_records_interned_since_reclamation = 0;
         let retention = self.reclaim_unreachable();
-        self.next_reclamation_after = self.style_records.live_identities().count().max(1024);
+        self.next_reclamation_after = self.style_records.live_identities().len().max(1024);
         Some(retention)
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -290,12 +290,24 @@ impl StyleEngine {
             if written.len() != declared.len() {
                 return ControlFlow::Break(());
             }
+            let mut priority_and_stratum_by_importance = [None; 2];
             for (&declared, written) in declared.iter().zip(written) {
-                let priority =
-                    self.cascade_priority_of(rule, tree_scope, specificity, scope_proximity, declared.important);
+                let (priority, stratum) = *priority_and_stratum_by_importance[declared.important as usize]
+                    .get_or_insert_with(|| {
+                        (
+                            self.cascade_priority_of(
+                                rule,
+                                tree_scope,
+                                specificity,
+                                scope_proximity,
+                                declared.important,
+                            ),
+                            self.cascade_stratum_of(rule, tree_scope, declared.important),
+                        )
+                    });
                 candidates.push(Candidate {
                     priority,
-                    stratum: self.cascade_stratum_of(rule, tree_scope, declared.important),
+                    stratum,
                     declared,
                     written,
                 });
@@ -310,11 +322,18 @@ impl StyleEngine {
         if written.len() != declared.len() {
             return None;
         }
+        let mut priority_and_stratum_by_importance = [None; 2];
         for (&declared, written) in declared.iter().zip(written) {
-            let priority = self.element_cascade_priority(node, ElementDeclarationKind::InlineStyle, declared.important);
+            let (priority, stratum) = *priority_and_stratum_by_importance[declared.important as usize]
+                .get_or_insert_with(|| {
+                    (
+                        self.element_cascade_priority(node, ElementDeclarationKind::InlineStyle, declared.important),
+                        self.element_cascade_stratum(node, ElementDeclarationKind::InlineStyle, declared.important),
+                    )
+                });
             candidates.push(Candidate {
                 priority,
-                stratum: self.element_cascade_stratum(node, ElementDeclarationKind::InlineStyle, declared.important),
+                stratum,
                 declared,
                 written,
             });

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -220,11 +220,10 @@ impl StyleEngine {
     /// complete as any. A pseudo-element's rules keep the strict reading, since a pseudo-element's
     /// environment is still C++'s to compute.
     pub(super) fn cascade_winners_are_complete_but_for_custom_properties(&self, node: StyleNodeID) -> bool {
-        let mut complete = ElementDeclarationKind::ALL.iter().all(|&kind| {
+        if !ElementDeclarationKind::ALL.iter().all(|&kind| {
             self.facts
                 .element_declarations_are_complete_but_for_custom_properties(node, kind)
-        });
-        if !complete {
+        }) {
             return false;
         }
         // A rule deciding from another tree scope orders by its context like any other; the
@@ -240,19 +239,17 @@ impl StyleEngine {
         if let Some(answer) = self.published_match_answers.lookup(node)
             && let Some(matches) = self.published_match_answers.matches_for(answer)
         {
-            for entry in matches {
-                complete &= rule_is_complete(entry.rule, entry.tree_scope, entry.pseudo_element.is_some());
-            }
-            return complete;
+            return matches
+                .iter()
+                .all(|entry| rule_is_complete(entry.rule, entry.tree_scope, entry.pseudo_element.is_some()));
         }
         let Lookup::Known(answer) = self.retained_match_answer(node) else {
             return false;
         };
-        for rule_match in answer.iter() {
+        answer.iter().all(|rule_match| {
             let entry = &self.programs.get(rule_match.program).entries()[rule_match.entry as usize];
-            complete &= rule_is_complete(rule_match.rule, rule_match.tree_scope, entry.pseudo_element.is_some());
-        }
-        complete
+            rule_is_complete(rule_match.rule, rule_match.tree_scope, entry.pseudo_element.is_some())
+        })
     }
 
     /// The custom properties the node's cascade decides, each with its winning declaration and

--- a/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/custom_property_cascade.rs
@@ -14,6 +14,7 @@
 //! the environment the element inherits.
 
 use std::ffi::c_void;
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use super::*;
@@ -134,36 +135,42 @@ fn custom_property_value_is_engine_resolvable(value: &StyleValueData) -> bool {
 
 impl StyleEngine {
     /// Hand each of a node's element-target matches, with the cascade inputs its priority is
-    /// computed from, to `visit`. `false` when the node has no answer to read.
-    fn for_each_element_match(
+    /// computed from, to `visit`, stopping when it breaks. `None` when the node has no answer to read.
+    fn try_for_each_element_match(
         &self,
         node: StyleNodeID,
-        mut visit: impl FnMut(RuleID, TreeScopeID, Specificity, u32),
-    ) -> bool {
+        mut visit: impl FnMut(RuleID, TreeScopeID, Specificity, u32) -> ControlFlow<()>,
+    ) -> Option<ControlFlow<()>> {
         if let Some(answer) = self.published_match_answers.lookup(node)
             && let Some(matches) = self.published_match_answers.matches_for(answer)
         {
             for entry in matches.iter().filter(|entry| entry.pseudo_element.is_none()) {
-                visit(entry.rule, entry.tree_scope, entry.specificity, entry.scope_proximity);
+                if visit(entry.rule, entry.tree_scope, entry.specificity, entry.scope_proximity).is_break() {
+                    return Some(ControlFlow::Break(()));
+                }
             }
-            return true;
+            return Some(ControlFlow::Continue(()));
         }
         let Lookup::Known(answer) = self.retained_match_answer(node) else {
-            return false;
+            return None;
         };
         for rule_match in answer.iter() {
             let entry = &self.programs.get(rule_match.program).entries()[rule_match.entry as usize];
             if entry.pseudo_element.is_some() {
                 continue;
             }
-            visit(
+            if visit(
                 rule_match.rule,
                 rule_match.tree_scope,
                 entry.specificity,
                 rule_match.scope_proximity,
-            );
+            )
+            .is_break()
+            {
+                return Some(ControlFlow::Break(()));
+            }
         }
-        true
+        Some(ControlFlow::Continue(()))
     }
 
     /// Whether anything in the document declares a custom property. Nothing declaring one means
@@ -179,11 +186,16 @@ impl StyleEngine {
         if !self.facts.element_custom_declarations(node).is_empty() {
             return true;
         }
-        let mut declares = false;
-        self.for_each_element_match(node, |rule, _, _, _| {
-            declares |= !self.program.custom_declarations_of(rule).is_empty();
-        });
-        declares
+        matches!(
+            self.try_for_each_element_match(node, |rule, _, _, _| {
+                if self.program.custom_declarations_of(rule).is_empty() {
+                    ControlFlow::Continue(())
+                } else {
+                    ControlFlow::Break(())
+                }
+            }),
+            Some(ControlFlow::Break(()))
+        )
     }
 
     /// Whether a reaction on the node may move its custom-property environment, which its
@@ -269,13 +281,14 @@ impl StyleEngine {
         }
 
         let mut candidates = Vec::new();
-        let mut written_missing = false;
-        let visited = self.for_each_element_match(node, |rule, tree_scope, specificity, scope_proximity| {
+        let result = self.try_for_each_element_match(node, |rule, tree_scope, specificity, scope_proximity| {
             let declared = self.program.custom_declarations_of(rule);
+            if declared.is_empty() {
+                return ControlFlow::Continue(());
+            }
             let written = self.program.custom_written_values_of(rule);
             if written.len() != declared.len() {
-                written_missing |= !declared.is_empty();
-                return;
+                return ControlFlow::Break(());
             }
             for (&declared, written) in declared.iter().zip(written) {
                 let priority =
@@ -287,8 +300,9 @@ impl StyleEngine {
                     written,
                 });
             }
-        });
-        if !visited || written_missing {
+            ControlFlow::Continue(())
+        })?;
+        if result.is_break() {
             return None;
         }
         let declared = self.facts.element_custom_declarations(node);

--- a/Libraries/LibWeb/Rust/src/css/style/font_resolution.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/font_resolution.rs
@@ -8,14 +8,14 @@ use super::HashMap;
 use super::bridge::{FfiFontResolutionRequest, FfiResolvedFont};
 use crate::css::style_value::{RetainedStyleValueData, retain_style_value};
 use std::ffi::c_void;
-use std::hash::{Hash, Hasher};
 
 pub type ResolveFontCallback = unsafe extern "C" fn(*mut c_void, FfiFontResolutionRequest) -> FfiResolvedFont;
 pub type RetainFontCallback = unsafe extern "C" fn(*const c_void);
 pub type ReleaseFontCallback = unsafe extern "C" fn(*const c_void);
 
+#[derive(PartialEq, Eq, Hash)]
 struct FontResolutionKey {
-    font_family: RetainedStyleValueData,
+    font_family: usize,
     font_size_raw: i32,
     font_slope: i32,
     font_weight: u64,
@@ -23,31 +23,9 @@ struct FontResolutionKey {
     font_optical_sizing: u8,
 }
 
-impl PartialEq for FontResolutionKey {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.font_family.pointer(), other.font_family.pointer())
-            && self.font_size_raw == other.font_size_raw
-            && self.font_slope == other.font_slope
-            && self.font_weight == other.font_weight
-            && self.font_width == other.font_width
-            && self.font_optical_sizing == other.font_optical_sizing
-    }
-}
-
-impl Eq for FontResolutionKey {}
-
-impl Hash for FontResolutionKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        (self.font_family.pointer() as usize).hash(state);
-        self.font_size_raw.hash(state);
-        self.font_slope.hash(state);
-        self.font_weight.hash(state);
-        self.font_width.hash(state);
-        self.font_optical_sizing.hash(state);
-    }
-}
-
 struct ResolvedFont {
+    // Keep the family alive for the pointer identity in the cache key.
+    _font_family: RetainedStyleValueData,
     ffi: FfiResolvedFont,
     release: ReleaseFontCallback,
 }
@@ -91,9 +69,7 @@ impl FontResolver {
             self.generation = Some(request.font_environment_generation);
         }
         let key = FontResolutionKey {
-            font_family: unsafe {
-                RetainedStyleValueData::from_retained_pointer(retain_style_value(request.font_family.cast()))
-            },
+            font_family: request.font_family as usize,
             font_size_raw: request.font_size_raw,
             font_slope: request.font_slope,
             font_weight: request.font_weight.to_bits(),
@@ -103,6 +79,8 @@ impl FontResolver {
         if let Some(resolved) = self.cache.get(&key) {
             return Some(resolved.ffi);
         }
+        let font_family =
+            unsafe { RetainedStyleValueData::from_retained_pointer(retain_style_value(request.font_family.cast())) };
         let resolved = unsafe { (self.resolve)(self.context, request) };
         if resolved.handle.is_null() {
             return None;
@@ -111,6 +89,7 @@ impl FontResolver {
         self.cache.insert(
             key,
             ResolvedFont {
+                _font_family: font_family,
                 ffi,
                 release: self.release,
             },

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -1821,8 +1821,8 @@ impl FeaturePostings {
 
     fn update_selector_posting_limit(&mut self, live_element_count: usize) {
         self.set_selector_posting_limit((live_element_count / 4).max(4096));
-        let grown: Vec<_> = self.grown_selector_postings.drain().collect();
-        for key in grown {
+        let mut grown = std::mem::take(&mut self.grown_selector_postings);
+        for key in grown.drain() {
             if self
                 .postings
                 .get(&key)
@@ -1832,6 +1832,7 @@ impl FeaturePostings {
                 self.remember_cardinality_limited(key);
             }
         }
+        self.grown_selector_postings = grown;
     }
 
     /// Discard every posting. Memory pressure reduces retained acceleration, never correctness.

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -74,14 +74,16 @@ impl StyleAtomID {
 }
 
 fn attribute_value_equals(value: &[u16], literal: &[u16], insensitive: bool) -> bool {
+    if !insensitive {
+        return value == literal;
+    }
     value.len() == literal.len()
         && value.iter().zip(literal).all(|(&left, &right)| {
             left == right
-                || (insensitive
-                    && match (u8::try_from(left), u8::try_from(right)) {
-                        (Ok(left), Ok(right)) => left.eq_ignore_ascii_case(&right),
-                        _ => false,
-                    })
+                || match (u8::try_from(left), u8::try_from(right)) {
+                    (Ok(left), Ok(right)) => left.eq_ignore_ascii_case(&right),
+                    _ => false,
+                }
         })
 }
 

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -1434,6 +1434,13 @@ impl Posting {
         self.chunks.iter().flat_map(|chunk| chunk.iter().copied())
     }
 
+    pub(super) fn append_candidates_to(&self, candidates: &mut Vec<StyleNodeID>) {
+        candidates.reserve(self.length);
+        for chunk in &self.chunks {
+            candidates.extend_from_slice(chunk);
+        }
+    }
+
     #[must_use]
     pub(super) fn len(&self) -> usize {
         self.length
@@ -4717,7 +4724,7 @@ impl ElementFactStore {
         let mut nodes = Vec::new();
         for &set in sets {
             match self.postings.lookup(DependencyPostingKey::CustomPropertySet(set)) {
-                Lookup::Known(posting) => nodes.extend(posting.candidates()),
+                Lookup::Known(posting) => posting.append_candidates_to(&mut nodes),
                 Lookup::KnownAbsent => {}
                 Lookup::Missing(gap) => return Err(gap),
             }
@@ -4809,7 +4816,7 @@ impl ElementFactStore {
         let mut candidates = Vec::new();
         for &value in values {
             match self.postings.lookup(SelectorPostingKey::AttributeValue(value)) {
-                Lookup::Known(posting) => candidates.extend(posting.candidates()),
+                Lookup::Known(posting) => posting.append_candidates_to(&mut candidates),
                 Lookup::KnownAbsent => {}
                 Lookup::Missing(_) => return None,
             }

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -104,8 +104,8 @@ fn attribute_value_may_match(value: &[u16], literal: &[u16], operator: Attribute
         AttributeOperator::DashMatch => {
             attribute_value_equals(value, literal, insensitive)
                 || (value.len() > literal.len()
-                    && attribute_value_starts_with(value, literal, insensitive)
-                    && value[literal.len()] == u16::from(b'-'))
+                    && value[literal.len()] == u16::from(b'-')
+                    && attribute_value_starts_with(value, literal, insensitive))
         }
         AttributeOperator::Prefix => !literal.is_empty() && attribute_value_starts_with(value, literal, insensitive),
         AttributeOperator::Suffix => {

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -1182,8 +1182,9 @@ impl StyleNodeFacts {
             // one of them and which one depends on how the selector wrote it.
             visit(DispatchKey::AttributeName(attribute.name), Some(attribute.value));
             let forms = self.attribute_name_forms(attribute.name);
-            for other in [forms.local, forms.folded_name, forms.folded_local] {
-                if !other.is_none() && other != attribute.name {
+            let aliases = [forms.local, forms.folded_name, forms.folded_local];
+            for (index, &other) in aliases.iter().enumerate() {
+                if !other.is_none() && other != attribute.name && !aliases[..index].contains(&other) {
                     visit(DispatchKey::AttributeName(other), Some(attribute.value));
                 }
             }

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -4545,14 +4545,16 @@ impl ElementFactStore {
     /// This arrives from computed style rather than from the DOM, so it is published as a set rather
     /// than one name at a time: an element's `animation-name` is recomputed whole.
     pub fn set_animation_names(&mut self, node: StyleNodeID, names: &[StyleAtomID], memory: &mut MemoryController) {
+        let previous = self
+            .metadata_of(node)
+            .map_or(&[][..], |metadata| &metadata.animation_names);
+        if previous == names {
+            return;
+        }
         let mut sorted: Vec<StyleAtomID> = names.to_vec();
         sorted.sort_unstable_by_key(|name| name.0);
         sorted.dedup();
-        if self
-            .metadata_of(node)
-            .map_or(&[][..], |metadata| &metadata.animation_names)
-            == sorted
-        {
+        if previous == sorted {
             return;
         }
         let previous = std::mem::take(&mut self.metadata_mut(node).animation_names);

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -850,25 +850,21 @@ impl StyleNodeFacts {
         let old_class_handle = was_resident.then(|| self.class_handles[row]);
         let old_attribute_handle = was_resident.then(|| self.attribute_handles[row]);
         let mut stale_payload_bytes = 0_u64;
-        let length = row.checked_add(1).expect("element fact row space exhausted");
-        self.tag.resize(self.tag.len().max(length), StyleAtomID::NONE);
-        self.folded_tag
-            .resize(self.folded_tag.len().max(length), StyleAtomID::NONE);
-        self.id.resize(self.id.len().max(length), StyleAtomID::NONE);
-        self.states.resize(self.states.len().max(length), StateSet::default());
-        self.directionality
-            .resize(self.directionality.len().max(length), StyleAtomID::NONE);
-        self.language.resize(self.language.len().max(length), StyleAtomID::NONE);
-        self.has_text_content
-            .resize(self.has_text_content.len().max(length), false);
-        self.language_text.resize(self.language_text.len().max(length), (0, 0));
-        self.namespace
-            .resize(self.namespace.len().max(length), StyleAtomID::NONE);
-        self.class_handles
-            .resize(self.class_handles.len().max(length), PayloadHandle::default());
-        self.attribute_handles
-            .resize(self.attribute_handles.len().max(length), PayloadHandle::default());
-        self.dispatch_bloom.resize(self.dispatch_bloom.len().max(length), 0);
+        if row >= self.tag.len() {
+            let length = row.checked_add(1).expect("element fact row space exhausted");
+            self.tag.resize(length, StyleAtomID::NONE);
+            self.folded_tag.resize(length, StyleAtomID::NONE);
+            self.id.resize(length, StyleAtomID::NONE);
+            self.states.resize(length, StateSet::default());
+            self.directionality.resize(length, StyleAtomID::NONE);
+            self.language.resize(length, StyleAtomID::NONE);
+            self.has_text_content.resize(length, false);
+            self.language_text.resize(length, (0, 0));
+            self.namespace.resize(length, StyleAtomID::NONE);
+            self.class_handles.resize(length, PayloadHandle::default());
+            self.attribute_handles.resize(length, PayloadHandle::default());
+            self.dispatch_bloom.resize(length, 0);
+        }
 
         self.tag[row] = facts.tag;
         self.folded_tag[row] = facts.folded_tag;

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -5390,7 +5390,14 @@ impl ElementFactStore {
             if let Some(snapshot) = pair.before {
                 before.push_row_from_primary_snapshot(node, &self.rows, snapshot);
             } else {
-                append_fact_row(node, &StagedFactRow::default(), &mut before);
+                before.push_row(
+                    node,
+                    StyleAtomID::NONE,
+                    StyleAtomID::NONE,
+                    StateSet::default(),
+                    &[],
+                    &[],
+                );
             }
         }
         before
@@ -5408,33 +5415,6 @@ impl ElementFactStore {
         self.memory.resize_required_to(memory, current);
         self.settled_non_apply_capacity_bytes = current - self.apply_capacity_bytes();
     }
-}
-
-fn append_fact_row(node: StyleNodeID, facts: &StagedFactRow, batch: &mut StyleNodeFacts) {
-    let attributes: Vec<AttributeFact> = facts
-        .attributes
-        .iter()
-        .map(|&(name, value)| AttributeFact {
-            name,
-            value,
-            text_offset: u32::MAX,
-            text_length: 0,
-        })
-        .collect();
-    batch.push_row(node, facts.tag, facts.id, facts.states, &facts.classes, &attributes);
-    batch.set_row_folded_tag(facts.folded_tag);
-    batch.set_row_namespace(facts.namespace);
-    batch.set_row_part_exposure(facts.part_exposure);
-    batch.set_row_has_text_content(facts.has_text_content);
-    let row = u32::try_from(batch.row_count() - 1).expect("fact batch row space exhausted");
-    batch.set_row_parameters(
-        row,
-        facts.directionality,
-        facts.language,
-        facts.heading_level,
-        &facts.custom_states,
-        &facts.parts,
-    );
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -3917,14 +3917,33 @@ impl ElementFactStore {
         }
     }
 
-    fn remove_row_catalog_references(&mut self, facts: &StagedFactRow) {
-        Self::for_each_row_atom(facts, |atom| {
+    fn remove_row_catalog_references(&mut self, row: u32) {
+        for atom in [
+            self.rows.tag_of(row),
+            self.rows.folded_tag_of(row),
+            self.rows.id_of(row),
+            self.rows.language_of(row),
+            self.rows.namespace_of(row),
+            self.rows.part_exposure_of(row),
+            self.rows.directionality_of(row),
+        ] {
             Self::decrement_atom_count(&mut self.atom_live_counts, atom);
-        });
-        Self::decrement_atom_count(&mut self.language_live_counts, facts.language);
-        for &(name, value) in &facts.attributes {
-            Self::decrement_atom_count(&mut self.attribute_name_live_counts, name);
-            Self::decrement_atom_count(&mut self.attribute_value_live_counts, value);
+        }
+        for atoms in [
+            self.rows.custom_states_of(row),
+            self.rows.parts_of(row),
+            self.rows.classes_of(row),
+        ] {
+            for &atom in atoms {
+                Self::decrement_atom_count(&mut self.atom_live_counts, atom);
+            }
+        }
+        Self::decrement_atom_count(&mut self.language_live_counts, self.rows.language_of(row));
+        for attribute in self.rows.attributes_of(row) {
+            Self::decrement_atom_count(&mut self.atom_live_counts, attribute.name);
+            Self::decrement_atom_count(&mut self.atom_live_counts, attribute.value);
+            Self::decrement_atom_count(&mut self.attribute_name_live_counts, attribute.name);
+            Self::decrement_atom_count(&mut self.attribute_value_live_counts, attribute.value);
         }
     }
 
@@ -4997,7 +5016,7 @@ impl ElementFactStore {
         let row_bytes = self.rows.logical_bytes_of_row(row);
         let payload_bytes = self.rows.payload_bytes_of_row(row);
         let facts = self.snapshot_row(node);
-        self.remove_row_catalog_references(&facts);
+        self.remove_row_catalog_references(row);
         Rc::get_mut(&mut self.rows)
             .expect("forgetting a fact row requires unique primary rows")
             .forget_row(node);
@@ -5311,16 +5330,10 @@ impl ElementFactStore {
         self.sync_attribute_catalogs();
         let mut staging = std::mem::take(&mut self.staging);
         for (node, facts) in staging.dirty_rows() {
-            let previous = self.rows.row_of(node).map(|_| self.snapshot_row(node));
-            let replaced_bytes = self
-                .rows
-                .row_of(node)
-                .map_or(0, |row| self.rows.logical_bytes_of_row(row));
-            let replaced_payload_bytes = self
-                .rows
-                .row_of(node)
-                .map_or(0, |row| self.rows.payload_bytes_of_row(row));
-            if let Some(previous) = &previous {
+            let previous = self.rows.row_of(node);
+            let replaced_bytes = previous.map_or(0, |row| self.rows.logical_bytes_of_row(row));
+            let replaced_payload_bytes = previous.map_or(0, |row| self.rows.payload_bytes_of_row(row));
+            if let Some(previous) = previous {
                 self.remove_row_catalog_references(previous);
             }
             self.add_row_catalog_references(facts);

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -936,17 +936,18 @@ impl StyleNodeFacts {
         if !attributes_are_unchanged {
             stale_payload_bytes +=
                 old_attribute_handle.map_or(0, |old| size_of_val(old.slice(&self.attributes)) as u64);
-            let attributes: Vec<AttributeFact> = facts
-                .attributes
-                .iter()
-                .map(|&(name, value)| AttributeFact {
+            let offset = u32::try_from(self.attributes.len()).expect("fact payload offset overflow");
+            self.attributes
+                .extend(facts.attributes.iter().map(|&(name, value)| AttributeFact {
                     name,
                     value,
                     text_offset: u32::MAX,
                     text_length: 0,
-                })
-                .collect();
-            self.attribute_handles[row] = PayloadHandle::appended_to(&mut self.attributes, &attributes);
+                }));
+            self.attribute_handles[row] = PayloadHandle {
+                offset,
+                length: u32::try_from(facts.attributes.len()).expect("fact payload length overflow"),
+            };
         }
         self.resident.set(row, true);
         self.dispatch_bloom[row] = self.compute_dispatch_bloom_of(row as u32);

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -4981,19 +4981,28 @@ impl ElementFactStore {
     }
 
     pub fn set_parts(&mut self, node: StyleNodeID, parts: &[StyleAtomID], memory: &mut MemoryController) {
-        let previous = self.edit_staged_row(node, |facts| std::mem::replace(&mut facts.parts, parts.to_vec()));
+        let previous = self.staging.get(node).map_or_else(
+            || self.rows.row_of(node).map_or(&[][..], |row| self.rows.parts_of(row)),
+            |facts| facts.parts.as_slice(),
+        );
         for &part in previous.iter().filter(|part| !parts.contains(part)) {
             self.postings.remove(SelectorPostingKey::Part(part), node);
         }
         for &part in parts.iter().filter(|part| !previous.contains(part)) {
             self.postings.insert(SelectorPostingKey::Part(part), node, memory);
         }
+        self.edit_staged_row(node, |facts| parts.clone_into(&mut facts.parts));
     }
 
     pub fn set_custom_states(&mut self, node: StyleNodeID, states: &[StyleAtomID], memory: &mut MemoryController) {
-        let previous = self.edit_staged_row(node, |facts| {
-            std::mem::replace(&mut facts.custom_states, states.to_vec())
-        });
+        let previous = self.staging.get(node).map_or_else(
+            || {
+                self.rows
+                    .row_of(node)
+                    .map_or(&[][..], |row| self.rows.custom_states_of(row))
+            },
+            |facts| facts.custom_states.as_slice(),
+        );
         for &state in previous.iter().filter(|state| !states.contains(state)) {
             self.postings.remove(SelectorPostingKey::CustomState(state), node);
         }
@@ -5001,6 +5010,7 @@ impl ElementFactStore {
             self.postings
                 .insert(SelectorPostingKey::CustomState(state), node, memory);
         }
+        self.edit_staged_row(node, |facts| states.clone_into(&mut facts.custom_states));
     }
 
     pub fn forget(&mut self, node: StyleNodeID) {

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -1487,11 +1487,24 @@ impl Posting {
         let chunk_capacity_before = self.chunks[index].capacity();
         let moved = {
             let chunk = &mut self.chunks[index];
-            match chunk.binary_search(&node) {
-                Ok(_) => return None,
-                Err(position) => chunk.insert(position, node),
+            let Err(position) = chunk.binary_search(&node) else {
+                return None;
+            };
+            if chunk.len() == MAX_POSTING_CHUNK {
+                let middle = chunk.len() / 2;
+                let mut moved = Vec::with_capacity(chunk.len() - middle + 1);
+                moved.extend_from_slice(&chunk[middle..]);
+                chunk.truncate(middle);
+                if position < middle {
+                    chunk.insert(position, node);
+                } else {
+                    moved.insert(position - middle, node);
+                }
+                Some(moved)
+            } else {
+                chunk.insert(position, node);
+                None
             }
-            (chunk.len() > MAX_POSTING_CHUNK).then(|| chunk.split_off(chunk.len() / 2))
         };
         let mut added_bytes =
             ((self.chunks[index].capacity() - chunk_capacity_before) * size_of::<StyleNodeID>()) as u64;

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -4238,27 +4238,25 @@ impl ElementFactStore {
         self.metadata.get(node.element_index()? as usize)?.as_ref()
     }
 
-    fn snapshot_row(&self, node: StyleNodeID) -> StagedFactRow {
-        let Some(row) = self.rows.row_of(node) else {
-            return StagedFactRow::default();
-        };
+    fn staged_row_from_primary_snapshot(&self, snapshot: PrimaryFactSnapshot) -> StagedFactRow {
+        let rare_facts = snapshot.rare_facts.unwrap_or_default();
         StagedFactRow {
-            tag: self.rows.tag_of(row),
-            folded_tag: self.rows.folded_tag_of(row),
-            id: self.rows.id_of(row),
-            language: self.rows.language_of(row),
-            namespace: self.rows.namespace_of(row),
-            part_exposure: self.rows.part_exposure_of(row),
-            directionality: self.rows.directionality_of(row),
-            heading_level: self.rows.heading_level_of(row),
-            has_text_content: self.rows.has_text_content_of(row),
-            states: self.rows.states_of(row),
-            custom_states: self.rows.custom_states_of(row).to_vec(),
-            parts: self.rows.parts_of(row).to_vec(),
-            classes: self.rows.classes_of(row).to_vec(),
-            attributes: self
-                .rows
-                .attributes_of(row)
+            tag: snapshot.tag,
+            folded_tag: snapshot.folded_tag,
+            id: snapshot.id,
+            language: snapshot.language,
+            namespace: snapshot.namespace,
+            part_exposure: rare_facts.part_exposure,
+            directionality: snapshot.directionality,
+            heading_level: rare_facts.heading_level,
+            has_text_content: snapshot.has_text_content,
+            states: snapshot.states,
+            custom_states: rare_facts.custom_states.slice(&self.rows.custom_states).to_vec(),
+            parts: rare_facts.parts.slice(&self.rows.parts).to_vec(),
+            classes: snapshot.class_handle.slice(&self.rows.classes).to_vec(),
+            attributes: snapshot
+                .attribute_handle
+                .slice(&self.rows.attributes)
                 .iter()
                 .map(|attribute| (attribute.name, attribute.value))
                 .collect(),
@@ -4269,7 +4267,9 @@ impl ElementFactStore {
         self.memory_dirty = true;
         if !self.staging.contains(node) {
             let before = self.rows.row_of(node).map(|row| self.rows.primary_snapshot(row));
-            let row = self.snapshot_row(node);
+            let row = before.map_or_else(StagedFactRow::default, |snapshot| {
+                self.staged_row_from_primary_snapshot(snapshot)
+            });
             self.staging.insert(node, row, before);
         }
         self.staging.edit(node, edit).unwrap()

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -1221,8 +1221,11 @@ impl StyleNodeFacts {
             DispatchKey::Id(id) => self.id_of(row) == id,
             DispatchKey::Class(class) => self.classes_of(row).contains(&class),
             DispatchKey::AttributeName(name) => self.attributes_of(row).iter().any(|attribute| {
+                if attribute.name == name {
+                    return true;
+                }
                 let forms = self.attribute_name_forms(attribute.name);
-                attribute.name == name || forms.local == name || forms.folded_name == name || forms.folded_local == name
+                forms.local == name || forms.folded_name == name || forms.folded_local == name
             }),
             DispatchKey::TagName(tag) => self.tag_of(row) == tag || self.folded_tag_of(row) == tag,
             DispatchKey::Directionality(direction) => self.directionality_of(row) == direction,

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -3048,7 +3048,7 @@ impl RuleDispatch {
                 }
             });
         }
-        if descending_cascade_order {
+        if descending_cascade_order && workspace.candidates.len() > 1 {
             workspace.cascade_sort.extend(workspace.candidates.iter().map(|&id| {
                 let binding = self.entry_bindings[id.index()];
                 let cascade_order = if binding.cascade_order_index == u32::MAX {

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -3483,7 +3483,7 @@ pub struct ElementFactStore {
     element_declared_properties: ElementDeclarationRows,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 struct StagedFactRow {
     tag: StyleAtomID,
     /// The ASCII-lowercase folding of `tag`, held only when it differs from it. Type selectors
@@ -3717,17 +3717,14 @@ impl FactStaging {
             .filter_map(|&(node, entry)| (self.rows.get(Self::index(node)) == Some(entry)).then_some(node))
     }
 
-    fn dirty_rows(&self) -> Vec<(StyleNodeID, StagedFactRow)> {
-        self.dirty
-            .iter()
-            .filter_map(|&(node, entry)| {
-                if self.rows.get(Self::index(node)) != Some(entry) {
-                    return None;
-                }
-                let pair = self.entries.get(entry as usize)?.as_ref()?;
-                pair.dirty.then(|| (node, pair.after.clone()))
-            })
-            .collect()
+    fn dirty_rows(&self) -> impl Iterator<Item = (StyleNodeID, &StagedFactRow)> {
+        self.dirty.iter().filter_map(|&(node, entry)| {
+            if self.rows.get(Self::index(node)) != Some(entry) {
+                return None;
+            }
+            let pair = self.entries.get(entry as usize)?.as_ref()?;
+            pair.dirty.then_some((node, &pair.after))
+        })
     }
 
     fn mark_applied(&mut self) {
@@ -5312,8 +5309,8 @@ impl ElementFactStore {
             return;
         }
         self.sync_attribute_catalogs();
-        let staging = self.staging.dirty_rows();
-        for (node, facts) in staging {
+        let mut staging = std::mem::take(&mut self.staging);
+        for (node, facts) in staging.dirty_rows() {
             let previous = self.rows.row_of(node).map(|_| self.snapshot_row(node));
             let replaced_bytes = self
                 .rows
@@ -5326,11 +5323,11 @@ impl ElementFactStore {
             if let Some(previous) = &previous {
                 self.remove_row_catalog_references(previous);
             }
-            self.add_row_catalog_references(&facts);
+            self.add_row_catalog_references(facts);
             // A selector-free transaction may retain the active traversal's immutable primary
             // view. Preserve that view while advancing the authoritative rows for the next
             // transaction.
-            let stale_payload_bytes = Rc::make_mut(&mut self.rows).set_primary_row(node, &facts);
+            let stale_payload_bytes = Rc::make_mut(&mut self.rows).set_primary_row(node, facts);
             let row = self.rows.row_of(node).unwrap();
             let replacement_bytes = self.rows.logical_bytes_of_row(row);
             let replacement_payload_bytes = self.rows.payload_bytes_of_row(row);
@@ -5349,7 +5346,8 @@ impl ElementFactStore {
                 .checked_add(stale_payload_bytes)
                 .expect("primary stale fact payload byte count overflow");
         }
-        self.staging.mark_applied();
+        staging.mark_applied();
+        self.staging = staging;
         self.postings.update_selector_posting_limit(self.rows.live_row_count());
         let apply_capacity_bytes = self.apply_capacity_bytes();
         let current = self
@@ -6843,7 +6841,7 @@ mod tests {
         assert!(!rows.has_dirty());
         rows.insert(first, StagedFactRow::default(), None);
         assert_eq!(rows.keys().collect::<Vec<_>>(), vec![first]);
-        assert_eq!(rows.dirty_rows().len(), 1);
+        assert_eq!(rows.dirty_rows().count(), 1);
         assert_eq!(rows.capacity_bytes(), rows.recomputed_capacity_bytes());
 
         let directory_capacity = rows.rows.directory_capacity();

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -5015,8 +5015,41 @@ impl ElementFactStore {
         };
         let row_bytes = self.rows.logical_bytes_of_row(row);
         let payload_bytes = self.rows.payload_bytes_of_row(row);
-        let facts = self.snapshot_row(node);
         self.remove_row_catalog_references(row);
+        let tag = self.rows.tag_of(row);
+        if !tag.is_none() {
+            self.postings.remove(SelectorPostingKey::TagName(tag), node);
+        }
+        let folded_tag = self.rows.folded_tag_of(row);
+        if !folded_tag.is_none() {
+            self.postings.remove(SelectorPostingKey::TagName(folded_tag), node);
+        }
+        let id = self.rows.id_of(row);
+        if !id.is_none() {
+            self.postings.remove(SelectorPostingKey::Id(id), node);
+        }
+        let directionality = self.rows.directionality_of(row);
+        if !directionality.is_none() {
+            self.postings
+                .remove(SelectorPostingKey::Directionality(directionality), node);
+        }
+        for &class in self.rows.classes_of(row) {
+            self.postings.remove(SelectorPostingKey::Class(class), node);
+        }
+        for &part in self.rows.parts_of(row) {
+            self.postings.remove(SelectorPostingKey::Part(part), node);
+        }
+        for &state in self.rows.custom_states_of(row) {
+            self.postings.remove(SelectorPostingKey::CustomState(state), node);
+        }
+        for &AttributeFact { name, value, .. } in self.rows.attributes_of(row) {
+            for key in self.attribute_name_keys(name) {
+                self.postings.remove(SelectorPostingKey::AttributeName(key), node);
+            }
+            if !value.is_none() {
+                self.postings.remove(SelectorPostingKey::AttributeValue(value), node);
+            }
+        }
         Rc::get_mut(&mut self.rows)
             .expect("forgetting a fact row requires unique primary rows")
             .forget_row(node);
@@ -5032,37 +5065,6 @@ impl ElementFactStore {
             .primary_stale_payload_bytes
             .checked_add(payload_bytes)
             .expect("primary stale fact payload byte count overflow");
-        if !facts.tag.is_none() {
-            self.postings.remove(SelectorPostingKey::TagName(facts.tag), node);
-        }
-        if !facts.folded_tag.is_none() {
-            self.postings
-                .remove(SelectorPostingKey::TagName(facts.folded_tag), node);
-        }
-        if !facts.id.is_none() {
-            self.postings.remove(SelectorPostingKey::Id(facts.id), node);
-        }
-        if !facts.directionality.is_none() {
-            self.postings
-                .remove(SelectorPostingKey::Directionality(facts.directionality), node);
-        }
-        for class in facts.classes {
-            self.postings.remove(SelectorPostingKey::Class(class), node);
-        }
-        for part in facts.parts {
-            self.postings.remove(SelectorPostingKey::Part(part), node);
-        }
-        for state in facts.custom_states {
-            self.postings.remove(SelectorPostingKey::CustomState(state), node);
-        }
-        for (name, value) in facts.attributes {
-            for key in self.attribute_name_keys(name) {
-                self.postings.remove(SelectorPostingKey::AttributeName(key), node);
-            }
-            if !value.is_none() {
-                self.postings.remove(SelectorPostingKey::AttributeValue(value), node);
-            }
-        }
         if let Some(metadata) = node
             .element_index()
             .and_then(|index| self.metadata.get_mut(index as usize))

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -4725,49 +4725,27 @@ impl ElementFactStore {
         // foldings of both, which is how `[aB]` reaches an attribute written either way. The extra
         // names are postings rather than facts, so they say only that at least one attribute of the
         // element answers to them.
-        let keys = self.attribute_name_keys(name);
-        let old_value = if let Some(facts) = self.staging.get(node) {
-            facts
-                .attributes
-                .binary_search_by_key(&name, |entry| entry.0)
-                .ok()
-                .map(|index| facts.attributes[index].1)
-        } else if let Some(row) = self.rows.row_of(node) {
-            let attributes = self.rows.attributes_of(row);
-            attributes
-                .binary_search_by_key(&name, |entry| entry.name)
-                .ok()
-                .map(|index| attributes[index].value)
-        } else {
-            None
-        };
-        let changed = self.edit_staged_row(node, |facts| {
+        let (old_value, changed) = self.edit_staged_row(node, |facts| {
             let found = facts.attributes.binary_search_by_key(&name, |entry| entry.0);
             match (present, found) {
-                (true, Ok(index)) => {
-                    facts.attributes[index].1 = value;
-                    false
-                }
+                (true, Ok(index)) => (Some(std::mem::replace(&mut facts.attributes[index].1, value)), false),
                 (true, Err(index)) => {
                     facts.attributes.insert(index, (name, value));
-                    true
+                    (None, true)
                 }
-                (false, Ok(index)) => {
-                    facts.attributes.remove(index);
-                    true
-                }
-                (false, Err(_)) => false,
+                (false, Ok(index)) => (Some(facts.attributes.remove(index).1), true),
+                (false, Err(_)) => (None, false),
             }
         });
         if changed && present {
-            for key in keys {
+            for key in self.attribute_name_keys(name) {
                 self.postings
                     .insert(SelectorPostingKey::AttributeName(key), node, memory);
             }
         } else if changed {
             // A shared name stays true of the element while another of its attributes still
             // answers to it, so only the names nothing implies any more are dropped.
-            for key in keys {
+            for key in self.attribute_name_keys(name) {
                 if key == name || !self.node_answers_to_attribute_name(node, key) {
                     self.postings.remove(SelectorPostingKey::AttributeName(key), node);
                 }

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -3613,13 +3613,10 @@ impl FactStaging {
 
     fn edit<R>(&mut self, node: StyleNodeID, edit: impl FnOnce(&mut StagedFactRow) -> R) -> Option<R> {
         let entry = self.rows.get(Self::index(node))? as usize;
-        let is_dirty = self.entries.get(entry)?.as_ref()?.dirty;
-        if !is_dirty {
+        let pair = self.entries.get_mut(entry)?.as_mut()?;
+        if !pair.dirty {
             let previous_dirty_capacity = self.dirty.capacity();
-            self.entries[entry]
-                .as_mut()
-                .expect("mapped fact staging entry must be live")
-                .dirty = true;
+            pair.dirty = true;
             self.dirty_count += 1;
             self.dirty.push((node, entry as u32));
             self.capacity_bytes = self
@@ -3632,9 +3629,6 @@ impl FactStaging {
                 )
                 .expect("fact staging byte count overflow");
         }
-        let pair = self.entries[entry]
-            .as_mut()
-            .expect("mapped fact staging entry must be live");
         let previous_payload_bytes = pair.after.capacity_bytes();
         let result = edit(&mut pair.after);
         self.capacity_bytes = self

--- a/Libraries/LibWeb/Rust/src/css/style/input_routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/input_routing.rs
@@ -10,6 +10,8 @@
 //! normalized transaction input publishes the corresponding keys so planning can ask whether an
 //! attached selector observes that input.
 
+use smallvec::SmallVec;
+
 use super::index::FeatureValue;
 use super::index::LocalFeatureKey;
 use super::selector::RoutingKey;
@@ -19,10 +21,8 @@ use super::transaction::NormalizedInput;
 
 /// The routing keys one normalized input publishes.
 #[must_use]
-pub(super) fn routing_keys_for_input(input: &NormalizedInput) -> Vec<RoutingKey> {
-    let mut count = 0;
-    for_each_routing_key(input, |_| count += 1);
-    let mut keys = Vec::with_capacity(count);
+pub(super) fn routing_keys_for_input(input: &NormalizedInput) -> SmallVec<[RoutingKey; 4]> {
+    let mut keys = SmallVec::new();
     for_each_routing_key(input, |key| keys.push(key));
     keys
 }

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use smallvec::SmallVec;
+
 use super::*;
 
 impl StyleEngine {
@@ -1238,8 +1240,8 @@ impl StyleEngine {
     /// A fact is in the store by the time routing runs, so this is what the individual inputs would
     /// have published between them - a class each, the tag, the id, each attribute name.
     #[must_use]
-    pub(super) fn routing_keys_of_arriving_facts(&self, node: StyleNodeID) -> Vec<RoutingKey> {
-        let mut keys = Vec::new();
+    pub(super) fn routing_keys_of_arriving_facts(&self, node: StyleNodeID) -> SmallVec<[RoutingKey; 4]> {
+        let mut keys = SmallVec::new();
 
         let tag = self.facts.tag_of_node(node);
         if !tag.is_none() {

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -1398,7 +1398,6 @@ impl StyleEngine {
             return;
         }
         let staged_rows = self.tree_staging.dirty_rows();
-        let staged_first_children = self.tree_staging.dirty_first_children();
         // Depth changes only for arrivals and for nodes whose parent differs from the resident one,
         // read before installation: the frozen before-side parent misses a move that a mid-transaction
         // application already installed, and a sibling-only row must not count as a moved parent.
@@ -1426,8 +1425,8 @@ impl StyleEngine {
             self.tree
                 .set_assigned_slot(node, relations.assigned_slot, &mut self.memory);
         }
-        for (parent, _, child) in &staged_first_children {
-            self.tree.set_first_element_child(*parent, *child);
+        for (parent, _, child) in self.tree_staging.dirty_first_children() {
+            self.tree.set_first_element_child(parent, child);
         }
         for &(node, _, _) in &staged_rows {
             if !depth_recompute_nodes.contains(&node) {

--- a/Libraries/LibWeb/Rust/src/css/style/intern_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/intern_table.rs
@@ -94,7 +94,7 @@ impl<Identity: InternIdentity, Payload> InternTable<Identity, Payload> {
         self.entries.iter_mut()
     }
 
-    pub(super) fn live_identities(&self) -> impl Iterator<Item = Identity> + '_ {
+    pub(super) fn live_identities(&self) -> impl ExactSizeIterator<Item = Identity> + '_ {
         self.identities.iter().map(|candidate| candidate.identity)
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use smallvec::SmallVec;
+
 use super::batch_matcher::{append_selector_truth_matches, insert_scope_rule};
 use super::cascade::CascadeContinuationID;
 use super::selector::{AttributeCase, AttributeOperator};
@@ -3955,11 +3957,11 @@ impl StyleEngine {
             .tree
             .shadow_root_of(node)
             .and_then(|shadow_root| self.scope_by_root.get(shadow_root).filter(|&inner| inner != scope));
-        let slotted_scopes: Vec<_> = self
+        let slotted_scopes: SmallVec<[TreeScopeID; 1]> = self
             .scopes_slotted_into(node)
             .filter(|&slotted| slotted != scope && Some(slotted) != inner_scope)
             .collect();
-        let part_scopes: Vec<_> = self
+        let part_scopes: SmallVec<[TreeScopeID; 1]> = self
             .part_exposure_scopes(node)
             .filter(|&exposed| exposed != scope && Some(exposed) != inner_scope && !slotted_scopes.contains(&exposed))
             .collect();
@@ -4067,7 +4069,7 @@ impl StyleEngine {
         // that tree names it, so that tree's rules are asked of it as well. A slot is itself a
         // slottable, so an element can be re-slotted through several trees, and each of them names
         // it: what stands in the flat tree at the end of the chain is the element, not the slots.
-        let slotted_scopes: Vec<TreeScopeID> = self
+        let slotted_scopes: SmallVec<[TreeScopeID; 1]> = self
             .scopes_slotted_into(node)
             .filter(|&slotted| slotted != scope && Some(slotted) != inner_scope)
             .collect();
@@ -4075,7 +4077,7 @@ impl StyleEngine {
         // scope names it. `exportparts` forwards a name outwards one host at a time, and a rule in
         // every tree along that chain can address the element - under the name that level exposes it
         // by - so each of those scopes is asked, not only the outermost one the exposure names.
-        let part_scopes: Vec<TreeScopeID> = self
+        let part_scopes: SmallVec<[TreeScopeID; 1]> = self
             .part_exposure_scopes(node)
             .filter(|&exposed| exposed != scope && Some(exposed) != inner_scope && !slotted_scopes.contains(&exposed))
             .collect();

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -332,7 +332,7 @@ impl StyleEngine {
         let mut candidates: Vec<StyleNodeID> = Vec::new();
         for &key in &keys {
             match self.facts.postings().lookup(key) {
-                Lookup::Known(posting) => candidates.extend(posting.candidates()),
+                Lookup::Known(posting) => posting.append_candidates_to(&mut candidates),
                 Lookup::KnownAbsent => {}
                 Lookup::Missing(_) => return false,
             }
@@ -453,7 +453,7 @@ impl StyleEngine {
                     }
                     match self.facts.postings().lookup(key) {
                         Lookup::Known(posting) => {
-                            candidates.extend(posting.candidates());
+                            posting.append_candidates_to(&mut candidates);
                         }
                         Lookup::KnownAbsent => {}
                         Lookup::Missing(_) => {

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -297,7 +297,7 @@ impl StyleEngine {
     /// Refresh `query_sorted_candidates` for this program's subject keys under `root` — or report
     /// that postings can't name every entry's candidates, and the caller has to walk.
     fn ensure_sorted_query_candidates(&mut self, program: &SelectorProgram, root: StyleNodeID) -> bool {
-        let mut keys: Vec<DispatchKey> = Vec::new();
+        let mut keys: SmallVec<[DispatchKey; 1]> = SmallVec::new();
         for (entry_index, entry) in program.entries().iter().enumerate() {
             if entry.pseudo_element.is_some() {
                 continue;
@@ -322,7 +322,7 @@ impl StyleEngine {
         if let Some(stamp) = &self.query_sorted_candidates_stamp
             && stamp.generation == generation
             && stamp.root == root
-            && stamp.keys == keys
+            && stamp.keys == keys.as_slice()
         {
             return true;
         }
@@ -351,7 +351,11 @@ impl StyleEngine {
         self.query_sorted_candidates.clear();
         self.query_sorted_candidates
             .extend(ranked.into_iter().map(|(_, node)| node));
-        self.query_sorted_candidates_stamp = Some(QuerySortedCandidatesStamp { generation, root, keys });
+        self.query_sorted_candidates_stamp = Some(QuerySortedCandidatesStamp {
+            generation,
+            root,
+            keys: keys.into_vec(),
+        });
         true
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -441,7 +441,7 @@ impl StyleEngine {
             if let Some(values) = &cache.attribute_values[entry_index]
                 && let Some(value_candidates) = self.facts.attribute_value_candidates(values)
             {
-                candidates.extend(value_candidates);
+                candidates = value_candidates;
                 used_attribute_value_posting = true;
             }
             let mut use_all_nodes = !used_attribute_value_posting && dispatch_keys.is_empty();

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -3142,27 +3142,21 @@ impl StyleEngine {
         // Reuse the replacement allocation and append only old entries which survive into the
         // repaired answer. The compact retained slice is the old side for delta derivation below,
         // so no materialized old snapshot is needed.
-        // Both inputs are ordered by (rule, program), so count survivors with one merge walk.
+        // Both inputs are ordered by (rule, program), so find survivors with a merge walk.
         let mut affected_index = 0;
-        let unaffected_count = retained_base
-            .iter()
-            .filter(|entry| {
-                let key = (entry.rule, entry.program);
-                while affected_keys
-                    .get(affected_index)
-                    .is_some_and(|affected| *affected < key)
-                {
-                    affected_index += 1;
-                }
-                affected_keys.get(affected_index) != Some(&key)
-            })
-            .count();
-        let mut patched_answer = replacement;
-        patched_answer.reserve_exact(unaffected_count);
-        for &entry in retained_base {
-            if affected_keys.binary_search(&(entry.rule, entry.program)).is_ok() {
-                continue;
+        let unaffected = retained_base.iter().filter(move |entry| {
+            let key = (entry.rule, entry.program);
+            while affected_keys
+                .get(affected_index)
+                .is_some_and(|affected| *affected < key)
+            {
+                affected_index += 1;
             }
+            affected_keys.get(affected_index) != Some(&key)
+        });
+        let mut patched_answer = replacement;
+        patched_answer.reserve_exact(unaffected.clone().count());
+        for &entry in unaffected {
             let cascade_order = patch
                 .dispatch
                 .cascade_order_for_entry(entry.rule, entry.program, entry.entry)?;

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -347,7 +347,9 @@ impl StyleEngine {
             .filter_map(|node| ranks.get(&node).map(|&rank| (rank, node)))
             .collect();
         ranked.sort_unstable();
-        ranked.dedup();
+        if keys.len() > 1 {
+            ranked.dedup();
+        }
         self.query_sorted_candidates.clear();
         self.query_sorted_candidates
             .extend(ranked.into_iter().map(|(_, node)| node));

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -470,10 +470,11 @@ impl StyleEngine {
                         .preorder(context.root)
                         .filter(|&node| context.include_root || node != context.root),
                 );
+            } else {
+                candidates.retain(|&node| {
+                    (context.include_root || node != context.root) && self.tree.is_in_subtree_of(node, context.root)
+                });
             }
-            candidates.retain(|&node| {
-                (context.include_root || node != context.root) && self.tree.is_in_subtree_of(node, context.root)
-            });
             candidates.sort_unstable();
             candidates.dedup();
             self.counters.add(

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -4143,7 +4143,7 @@ impl StyleEngine {
             let all = match (result, deferred_prefix_matches) {
                 (Ok(()), Some(prefix_matches)) => {
                     if retained_match_answer_is_exact {
-                        retained_selector_truth = matches.prepared_selector_truth();
+                        retained_selector_truth = matches.take_prepared_selector_truth(&mut self.memory);
                     }
                     let (scope_program, dispatch) = self.ranked_scope_program(scope);
                     let non_prefix_matches = self.match_answers.intern(matches.as_slice());
@@ -4479,7 +4479,7 @@ impl StyleEngine {
                 (Ok(()), None) => {
                     if retained_match_answer_is_exact {
                         retained_match_answer = Some(prepare_retained_match_answer(matches.as_slice().iter().copied()));
-                        retained_selector_truth = matches.prepared_selector_truth();
+                        retained_selector_truth = matches.take_prepared_selector_truth(&mut self.memory);
                     }
                     if compact_for_cascade {
                         self.compact_matches_for_cascade_with_scratch(
@@ -4661,11 +4661,8 @@ impl StyleEngine {
                     if retained_match_answer_is_exact {
                         self.order_matches_in_cascade(matches.as_mut_vec(), can_have_scope_duplicates);
                         let retained = prepare_retained_match_answer(matches.as_slice().iter().copied());
-                        self.remember_prepared_retained_match_answer_with_truth(
-                            node,
-                            retained,
-                            matches.prepared_selector_truth(),
-                        );
+                        let truth = matches.take_prepared_selector_truth(&mut self.memory);
+                        self.remember_prepared_retained_match_answer_with_truth(node, retained, truth);
                     } else if compact_for_cascade {
                         // A cascade-only shortcut can answer the current style without proving the
                         // complete selector answer. Do not leave an older exact answer resident.

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -965,7 +965,7 @@ impl StyleEngine {
     #[must_use]
     pub(super) fn elements_under(&self, root: StyleNodeID) -> Vec<StyleNodeID> {
         let mut nodes: Vec<StyleNodeID> = Vec::new();
-        let mut roots = vec![root];
+        let mut roots = SmallVec::from_buf([root]);
         while let Some(next) = roots.pop() {
             for node in self.tree.preorder(next) {
                 if self.tree.host_of(node).is_none() {

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -844,6 +844,18 @@ impl StyleEngine {
                     continue;
                 }
                 if delta.change == SetChange::Removed
+                    && self
+                        .winner_groups
+                        .winner_in_state(previous, declared.property)
+                        .is_some_and(|winner| {
+                            winner.source != WinnerSource::Rule(delta.rule)
+                                && winner.source != WinnerSource::ExactCascade
+                                && winner.key.continuation == CascadeContinuationID::default()
+                        })
+                {
+                    continue;
+                }
+                if delta.change == SetChange::Removed
                     || matches!(
                         declared.operator,
                         CascadeOperator::Revert | CascadeOperator::RevertLayer

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -799,7 +799,7 @@ impl StyleEngine {
         deltas: &[SelectorTruthDelta],
         candidates: &mut Vec<OrderedCascadeCandidate>,
     ) -> bool {
-        let mut targets = Vec::new();
+        let mut targets: SmallVec<[Option<tree::PseudoElementTarget>; 3]> = SmallVec::new();
         for delta in deltas {
             let entry = self.programs.entry(delta.entry).1;
             if !targets.contains(&entry.pseudo_element) {

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -1116,6 +1116,9 @@ impl StyleEngine {
     }
 
     pub(super) fn cascade_context_scope(&self, rule: RuleID, tree_scope: TreeScopeID) -> TreeScopeID {
+        if tree_scope == TreeScopeID::DOCUMENT {
+            return tree_scope;
+        }
         let sheet = self.program.rule_sheet(rule);
         match self.program.attachment_in_scope(sheet, tree_scope).is_some() {
             true => tree_scope,

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -478,13 +478,16 @@ impl StyleEngine {
                 {
                     continue;
                 }
+                let mut priorities = [None; 2];
                 for &declared in declared_properties {
                     if !property_is_longhand(declared.property) {
                         continue;
                     }
+                    let priority = *priorities[declared.important as usize]
+                        .get_or_insert_with(|| self.element_cascade_priority(node, kind, declared.important));
                     element_top_1.consider(
                         declared.property,
-                        self.element_cascade_priority(node, kind, declared.important),
+                        priority,
                         CascadeCompactionCandidate::Element(kind, declared),
                     );
                 }

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -838,6 +838,7 @@ impl StyleEngine {
                 continue;
             }
             let mut matched_rule = None;
+            let mut priorities = [None; 2];
             for &declared in self.program.declared_properties_of(delta.rule) {
                 if !property_is_longhand(declared.property) {
                     continue;
@@ -865,13 +866,15 @@ impl StyleEngine {
                 let Some(matched) = matched_rule else {
                     return false;
                 };
-                let priority = self.cascade_priority_of(
-                    delta.rule,
-                    matched.tree_scope,
-                    entry.specificity,
-                    matched.scope_proximity,
-                    declared.important,
-                );
+                let priority = *priorities[declared.important as usize].get_or_insert_with(|| {
+                    self.cascade_priority_of(
+                        delta.rule,
+                        matched.tree_scope,
+                        entry.specificity,
+                        matched.scope_proximity,
+                        declared.important,
+                    )
+                });
                 if previous_winner.is_some_and(|winner| priority < winner.priority) {
                     continue;
                 }

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -502,7 +502,8 @@ impl StyleEngine {
         let mut scratch_bytes = 0;
 
         let published_winners = if let Some(node) = publish_winners_for {
-            let mut targets = vec![None];
+            let mut targets: SmallVec<[Option<tree::PseudoElementTarget>; 3]> = SmallVec::new();
+            targets.push(None);
             for target in all.iter().filter_map(|entry| entry.pseudo_element) {
                 if !targets.contains(&Some(target)) {
                     targets.push(Some(target));
@@ -524,7 +525,7 @@ impl StyleEngine {
                             let winners = self.resolved_cascade_winners_for_properties(node, all, target, None);
                             (target, winners)
                         })
-                        .collect::<Vec<_>>(),
+                        .collect::<SmallVec<[_; 3]>>(),
                 )
             } else {
                 Some(
@@ -575,7 +576,7 @@ impl StyleEngine {
                             };
                             (target, winners)
                         })
-                        .collect::<Vec<_>>(),
+                        .collect::<SmallVec<[_; 3]>>(),
                 )
             }
         } else {

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -1132,12 +1132,10 @@ impl StyleEngine {
     ) -> CascadePriority {
         let sheet = self.program.rule_sheet(rule);
         let version = self.program.rule_version(rule);
-        // A sheet the rule's own scope does not hold is one of the origins that decide everywhere,
-        // and those are attached to the document.
-        let attachment = self.program.attachment_in_scope(sheet, tree_scope);
         // A sheet the element's own scope does not hold is one of the origins that decide
         // everywhere, and those are attached to the document, which is the outermost context.
-        let context_scope = self.cascade_context_scope(rule, tree_scope);
+        let attachment = self.program.attachment_in_scope(sheet, tree_scope);
+        let context_scope = attachment.map_or(TreeScopeID::DOCUMENT, |attachment| attachment.tree_scope);
         let attachment = attachment.or_else(|| self.program.attachment_in_scope(sheet, TreeScopeID::DOCUMENT));
         CascadePriority::new(PriorityInputs {
             origin: self.program.sheet_origin(sheet),

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -431,30 +431,20 @@ impl StyleEngine {
                 continue;
             }
             let declared_properties = self.program.declared_properties_of(entry.rule);
-            let normal_priority = self.cascade_priority_of(
-                entry.rule,
-                entry.tree_scope,
-                entry.specificity,
-                entry.scope_proximity,
-                false,
-            );
-            let mut important_priority = None;
+            let mut priorities = [None; 2];
             for declared in declared_properties {
                 if !property_is_longhand(declared.property) {
                     continue;
                 }
-                let priority = match declared.important {
-                    true => *important_priority.get_or_insert_with(|| {
-                        self.cascade_priority_of(
-                            entry.rule,
-                            entry.tree_scope,
-                            entry.specificity,
-                            entry.scope_proximity,
-                            true,
-                        )
-                    }),
-                    false => normal_priority,
-                };
+                let priority = *priorities[declared.important as usize].get_or_insert_with(|| {
+                    self.cascade_priority_of(
+                        entry.rule,
+                        entry.tree_scope,
+                        entry.specificity,
+                        entry.scope_proximity,
+                        declared.important,
+                    )
+                });
                 match entry.pseudo_element {
                     Some(_) => top_1.consider(
                         (entry.pseudo_element, declared.property),

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use smallvec::SmallVec;
+
 use super::cascade::{CascadeAttachment, CascadeContinuationID, Top1Winner};
 use super::*;
 
@@ -622,8 +624,7 @@ impl StyleEngine {
             return;
         }
 
-        let compaction_scratch_bytes =
-            (all.len().div_ceil(8) + all.len() * size_of::<tree::PseudoElementTarget>()) as u64;
+        let compaction_scratch_bytes = (all.len() * size_of::<bool>()) as u64;
         self.memory
             .reserve_required(MemoryCategory::BatchScratch, compaction_scratch_bytes);
         scratch_bytes += compaction_scratch_bytes;
@@ -660,7 +661,7 @@ impl StyleEngine {
             }
         }
 
-        let mut retained_pseudo_targets = Vec::with_capacity(all.len());
+        let mut retained_pseudo_targets: SmallVec<[tree::PseudoElementTarget; 2]> = SmallVec::new();
         for (index, entry) in all.iter().enumerate() {
             if keep[index]
                 && let Some(target) = entry.pseudo_element
@@ -678,9 +679,12 @@ impl StyleEngine {
             }
         }
 
-        let actual_scratch_bytes = (keep.capacity().div_ceil(8)
-            + retained_pseudo_targets.capacity() * size_of::<tree::PseudoElementTarget>())
-            as u64;
+        let pseudo_target_scratch_bytes = if retained_pseudo_targets.spilled() {
+            retained_pseudo_targets.capacity() * size_of::<tree::PseudoElementTarget>()
+        } else {
+            0
+        };
+        let actual_scratch_bytes = (keep.capacity() * size_of::<bool>() + pseudo_target_scratch_bytes) as u64;
         if actual_scratch_bytes > scratch_bytes {
             self.memory
                 .reserve_required(MemoryCategory::BatchScratch, actual_scratch_bytes - scratch_bytes);

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -238,19 +238,26 @@ impl StyleEngine {
         let wants = |property| properties.is_none_or(|properties| properties.binary_search(&property).is_ok());
         candidates.clear();
         for entry in matches.iter().filter(|entry| entry.pseudo_element == pseudo) {
+            let mut priority_and_stratum_by_importance = [None; 2];
             for &declared in self.program.declared_properties_of(entry.rule) {
                 // A shorthand written with a substitution is declared whole beside the longhands
                 // it pends; the longhands are the winners, the shorthand names no column.
                 if !wants(declared.property) || !property_is_longhand(declared.property) {
                     continue;
                 }
-                let priority = self.cascade_priority_of(
-                    entry.rule,
-                    entry.tree_scope,
-                    entry.specificity,
-                    entry.scope_proximity,
-                    declared.important,
-                );
+                let (priority, stratum) = *priority_and_stratum_by_importance[declared.important as usize]
+                    .get_or_insert_with(|| {
+                        (
+                            self.cascade_priority_of(
+                                entry.rule,
+                                entry.tree_scope,
+                                entry.specificity,
+                                entry.scope_proximity,
+                                declared.important,
+                            ),
+                            self.cascade_stratum_of(entry.rule, entry.tree_scope, declared.important),
+                        )
+                    });
                 candidates.push(OrderedCascadeCandidate {
                     winner: PropertyWinner {
                         property: declared.property,
@@ -259,7 +266,7 @@ impl StyleEngine {
                         priority,
                         source: WinnerSource::Rule(entry.rule),
                     },
-                    stratum: self.cascade_stratum_of(entry.rule, entry.tree_scope, declared.important),
+                    stratum,
                 });
             }
         }
@@ -274,11 +281,18 @@ impl StyleEngine {
                 {
                     continue;
                 }
+                let mut priority_and_stratum_by_importance = [None; 2];
                 for &declared in declared_properties {
                     if !wants(declared.property) || !property_is_longhand(declared.property) {
                         continue;
                     }
-                    let priority = self.element_cascade_priority(node, kind, declared.important);
+                    let (priority, stratum) = *priority_and_stratum_by_importance[declared.important as usize]
+                        .get_or_insert_with(|| {
+                            (
+                                self.element_cascade_priority(node, kind, declared.important),
+                                self.element_cascade_stratum(node, kind, declared.important),
+                            )
+                        });
                     candidates.push(OrderedCascadeCandidate {
                         winner: PropertyWinner {
                             property: declared.property,
@@ -287,7 +301,7 @@ impl StyleEngine {
                             priority,
                             source: WinnerSource::Element(kind),
                         },
-                        stratum: self.element_cascade_stratum(node, kind, declared.important),
+                        stratum,
                     });
                 }
             }

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -633,12 +633,12 @@ impl StyleEngine {
                 keep[index] = true;
             }
         }
-        for winner in top_1.winners() {
+        for winner in top_1.unordered_winners() {
             if let CascadeCompactionCandidate::Rule(match_index) = winner.payload {
                 keep[match_index] = true;
             }
         }
-        for winner in element_top_1.winners() {
+        for winner in &element_top_1.winners {
             if let CascadeCompactionCandidate::Rule(match_index) = winner.payload {
                 keep[match_index] = true;
             }

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -3674,6 +3674,9 @@ impl PrefixStates {
     }
 
     fn intern_result(&mut self, matches: PrefixMatchSetID, truth: PrefixTruthSetID) -> PrefixResultID {
+        if matches == PrefixMatchSetID(0) && truth == PrefixTruthSetID(0) {
+            return PrefixResultID(0);
+        }
         let hash = super::intern_table::content_hash((matches, truth));
         if let Some(result) = self.result_ids.find(hash, |_result, candidate| {
             candidate.matches == matches && candidate.truth == truth

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -3631,6 +3631,9 @@ impl PrefixStates {
     }
 
     fn intern_output_matches(&mut self) -> PrefixMatchSetID {
+        if self.output_matches.is_empty() {
+            return PrefixMatchSetID(0);
+        }
         let hash = super::intern_table::content_hash(&self.output_matches);
         if let Some(candidate) = self
             .match_sets_by_hash
@@ -3650,6 +3653,9 @@ impl PrefixStates {
     }
 
     fn intern_output_truth(&mut self) -> PrefixTruthSetID {
+        if self.output_matched_steps.is_empty() {
+            return PrefixTruthSetID(0);
+        }
         let hash = super::intern_table::content_hash(&self.output_matched_steps);
         if let Some(candidate) = self.truth_sets_by_hash.find(hash, |candidate, ()| {
             self.truth_in(candidate) == self.output_matched_steps

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -4551,17 +4551,20 @@ fn matches_feature(facts: &StyleNodeFacts, row: u32, feature: FeatureTest) -> bo
         FeatureTest::Attribute(test) => {
             let folds = !test.fold_in_namespace.is_none() && facts.namespace_of(row) == test.fold_in_namespace;
             facts.attributes_of(row).iter().any(|attribute| {
+                let value_matches = match test.operator {
+                    AttributeOperator::Presence => true,
+                    AttributeOperator::Exact => attribute.value == test.value_atom,
+                    _ => unreachable!("only atom-answerable features are canonicalized"),
+                };
+                if !value_matches {
+                    return false;
+                }
                 let forms = facts.attribute_name_forms(attribute.name);
                 let (written, folded) = match test.any_namespace {
                     true => (forms.local, forms.folded_local),
                     false => (attribute.name, forms.folded_name),
                 };
-                (written == test.name || (folds && folded == test.folded))
-                    && match test.operator {
-                        AttributeOperator::Presence => true,
-                        AttributeOperator::Exact => attribute.value == test.value_atom,
-                        _ => unreachable!("only atom-answerable features are canonicalized"),
-                    }
+                written == test.name || (folds && folded == test.folded)
             })
         }
     }

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -4568,6 +4568,14 @@ fn matches_feature(facts: &StyleNodeFacts, row: u32, feature: FeatureTest) -> bo
                 if !value_matches {
                     return false;
                 }
+                if !test.any_namespace {
+                    if attribute.name == test.name {
+                        return true;
+                    }
+                    if !folds {
+                        return false;
+                    }
+                }
                 let forms = facts.attribute_name_forms(attribute.name);
                 let (written, folded) = match test.any_namespace {
                     true => (forms.local, forms.folded_local),

--- a/Libraries/LibWeb/Rust/src/css/style/program.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/program.rs
@@ -1070,12 +1070,15 @@ impl StyleSheetProgram {
     /// name sort after every named layer in the scope.
     #[must_use]
     pub fn layer_index(&self, scope: TreeScopeID, layer: CascadeLayerID) -> u32 {
-        let ranks = self.layer_ranks.get(scope.0 as usize).and_then(Option::as_ref);
-        ranks.and_then(|ranks| ranks.get(&layer).copied()).unwrap_or_else(|| {
-            ranks.map_or(0, |ranks| {
-                u32::try_from(ranks.len()).expect("cascade layer count exhausted")
-            })
-        })
+        let Some(ranks) = self.layer_ranks.get(scope.0 as usize).and_then(Option::as_ref) else {
+            return 0;
+        };
+        if layer != CascadeLayerID::UNLAYERED
+            && let Some(&rank) = ranks.get(&layer)
+        {
+            return rank;
+        }
+        u32::try_from(ranks.len()).expect("cascade layer count exhausted")
     }
 
     #[must_use]

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -1433,16 +1433,18 @@ impl StyleEngine {
             STYLE_GROUP_INDEX_INHERITED_SVG, STYLE_GROUP_INDEX_INHERITED_TEXT, STYLE_GROUP_INDEX_INHERITED_UI,
         };
         use crate::css::property_metadata::{property_id as prop, property_style_group_index};
-        self.winner_groups.winners_in_state(state).fold(0_u32, |mask, winner| {
-            let mask = mask | property_style_group_index(winner.property).map_or(0, |group| 1 << group);
-            if winner.property == prop::COLOR {
-                mask | (1 << STYLE_GROUP_INDEX_INHERITED_UI)
-                    | (1 << STYLE_GROUP_INDEX_INHERITED_SVG)
-                    | (1 << STYLE_GROUP_INDEX_INHERITED_TEXT)
-            } else {
-                mask
-            }
-        })
+        self.winner_groups
+            .properties_in_state(state)
+            .fold(0_u32, |mask, property| {
+                let mask = mask | property_style_group_index(property).map_or(0, |group| 1 << group);
+                if property == prop::COLOR {
+                    mask | (1 << STYLE_GROUP_INDEX_INHERITED_UI)
+                        | (1 << STYLE_GROUP_INDEX_INHERITED_SVG)
+                        | (1 << STYLE_GROUP_INDEX_INHERITED_TEXT)
+                } else {
+                    mask
+                }
+            })
     }
 
     /// The document element's record settled: the root font metrics the drives after it resolve

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -825,8 +825,7 @@ impl StyleEngine {
                 environment: parent_environment,
                 font_environment_generation: inputs.font_environment_generation,
             });
-        let delta = self.winner_groups.semantic_delta(None, state);
-        let delta_property_count = delta.properties().len() as u64;
+        let delta_property_count = self.winner_groups.winner_count_in_state(state) as u64;
         if !self.node_declares_custom_properties(node)
             && let Some(delta) = self.assign_cached_cold_record(
                 node,
@@ -846,7 +845,7 @@ impl StyleEngine {
         // full drive resolves the font and rebuilds every group from it. The other font-phase
         // longhands without a group carry feature and variation data the resolution does not
         // pass on yet.
-        for &property in delta.properties() {
+        for property in self.winner_groups.semantic_delta_properties(None, state) {
             if property_starts_animation_or_counter_environment(property)
                 || (computed_group_dependency_mask(property).is_none() && !font_resolution_selects_by(property))
             {

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -1420,9 +1420,9 @@ impl StyleEngine {
             && self
                 .computed_group_sets
                 .custom_property_environment_identity(node)
-                .is_some()
-            && self.computed_group_sets.custom_property_environment_identity(node)
-                == self.computed_group_sets.custom_property_environment_identity(parent)
+                .is_some_and(|environment| {
+                    self.computed_group_sets.custom_property_environment_identity(parent) == Some(environment)
+                })
     }
 
     /// The inherited groups a state's winners rebuild for their element: the groups its

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -235,18 +235,14 @@ impl StyleEngine {
             self.abandon_engine_computed_record(node, scratch);
             return None;
         }
-        let element_uses_substitution = self.nodes_with_substituted_records.contains(&node);
-        let pseudo_states: Vec<_> = self
-            .winner_groups
-            .pseudo_states(node)
-            .filter_map(|(_, version, state, priority_current)| {
-                (version == self.program.version() && priority_current).then_some(state)
-            })
-            .collect();
-        let pseudo_uses_substitution = pseudo_states
-            .into_iter()
-            .any(|state| self.state_has_substitutions(node, state));
-        if element_uses_substitution || pseudo_uses_substitution {
+        let uses_substitution = self.nodes_with_substituted_records.contains(&node)
+            || self
+                .winner_groups
+                .pseudo_states(node)
+                .any(|(_, version, state, priority_current)| {
+                    version == self.program.version() && priority_current && self.state_has_substitutions(node, state)
+                });
+        if uses_substitution {
             self.nodes_with_substituted_records.insert(node);
         } else {
             self.nodes_with_substituted_records.remove(&node);

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -4191,7 +4191,7 @@ impl StyleEngine {
     ) -> Result<Vec<StyleNodeID>, PostingKey> {
         let mut nodes = self.facts.custom_property_candidates(name)?;
         match self.facts.postings().lookup(DependencyPostingKey::AnyCustomProperty) {
-            Lookup::Known(posting) => nodes.extend(posting.candidates()),
+            Lookup::Known(posting) => posting.append_candidates_to(&mut nodes),
             Lookup::KnownAbsent => {}
             Lookup::Missing(gap) => return Err(gap),
         }

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -100,7 +100,6 @@ impl StyleEngine {
         sequences: &mut SequenceChanges,
         regions: &mut ImpactRegions,
     ) {
-        let routing = Rc::clone(&self.routing);
         // A declaration sourced from the element changes what wins on that element and nothing
         // else. There is no selector to transpose: the region is the element itself.
         if let InputKey::ElementDeclaration(node, _) = input.key {
@@ -160,6 +159,10 @@ impl StyleEngine {
             }
             _ => routing_keys_for_input(input),
         };
+        if keys.is_empty() {
+            return;
+        }
+        let routing = Rc::clone(&self.routing);
         let route_liveness = routing.route_liveness(&self.program, &self.programs);
         for key in keys {
             // A maintained relation already accounts for these selectors' complete changes.

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -5484,18 +5484,14 @@ impl<'a> MatchEvaluator<'a> {
         self.matches_node(program, id, node, counters)
     }
 
-    fn matches_transitive_relation(
+    fn matches_descendant_relation(
         &self,
         program: &SelectorProgram,
         relation: SelectorNodeID,
         inner: SelectorNodeID,
         node: StyleNodeID,
-        preceding_sibling: bool,
         counters: &mut Counters,
     ) -> Result<bool, Incomplete> {
-        if preceding_sibling {
-            return self.matches_preceding_sibling_prefix(program, relation, inner, node, counters);
-        }
         let (workspace, side) = self.match_workspace.unwrap();
         let cache = workspace.relations(side);
         let program_id = self.transitive_relation_program.get().unwrap();
@@ -5510,11 +5506,7 @@ impl<'a> MatchEvaluator<'a> {
         let mut incomplete = None;
         let answer = loop {
             traversed.push(current);
-            let adjacent = match preceding_sibling {
-                true => self.previous_sibling_of(current),
-                false => self.parent_of(current),
-            };
-            let Some(adjacent) = adjacent else {
+            let Some(adjacent) = self.parent_of(current) else {
                 break false;
             };
             counters.bump(Counter::CombinatorSteps);
@@ -5758,7 +5750,7 @@ impl<'a> MatchEvaluator<'a> {
                     && self.relative_anchor.get().is_none()
                     && self.scope_shadow_root.is_none()
                 {
-                    return self.matches_transitive_relation(program, id, inner, node, false, counters);
+                    return self.matches_descendant_relation(program, id, inner, node, counters);
                 }
                 let mut ancestor = self.parent_of(node);
                 while let Some(current) = ancestor {
@@ -5786,7 +5778,7 @@ impl<'a> MatchEvaluator<'a> {
                     && self.relative_anchor.get().is_none()
                     && self.scope_shadow_root.is_none()
                 {
-                    return self.matches_transitive_relation(program, id, inner, node, true, counters);
+                    return self.matches_preceding_sibling_prefix(program, id, inner, node, counters);
                 }
                 let Some(parent) = self.parent_of(node) else {
                     return Ok(false);

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -40,6 +40,7 @@ use super::index::StyleNodeFacts;
 use super::index::dispatch_bloom_bit;
 use super::instrumentation::Counter;
 use super::instrumentation::Counters;
+use smallvec::SmallVec;
 use std::cell::Cell;
 use std::cell::Ref;
 use std::cell::RefCell;
@@ -5621,12 +5622,12 @@ impl<'a> MatchEvaluator<'a> {
     /// One per level of `exportparts` forwarding. An element that carries a part name and is
     /// forwarded nowhere has no recorded pairing at all, so the host of the tree it stands in is the
     /// only level it has - which is every part in a document using no `exportparts`.
-    fn part_exposure_hosts(&self, node: StyleNodeID) -> Vec<StyleNodeID> {
+    fn part_exposure_hosts(&self, node: StyleNodeID) -> SmallVec<[StyleNodeID; 1]> {
         let pairs = self.tree.part_hosts_of(node);
         if pairs.is_empty() {
             return self.tree.shadow_host_of(node).into_iter().collect();
         }
-        let mut hosts: Vec<StyleNodeID> = Vec::with_capacity(pairs.len());
+        let mut hosts = SmallVec::new();
         for &(_, host) in pairs {
             if !hosts.contains(&host) {
                 hosts.push(host);

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -6213,8 +6213,8 @@ impl<'a> MatchEvaluator<'a> {
             AttributeOperator::DashMatch => {
                 equals(value, literal, insensitive)
                     || (value.len() > literal.len()
-                        && starts_with(value, literal, insensitive)
-                        && value[literal.len()] == u16::from(b'-'))
+                        && value[literal.len()] == u16::from(b'-')
+                        && starts_with(value, literal, insensitive))
             }
             AttributeOperator::Prefix => !literal.is_empty() && starts_with(value, literal, insensitive),
             AttributeOperator::Suffix => {

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -5506,7 +5506,7 @@ impl<'a> MatchEvaluator<'a> {
         }
 
         let mut current = node;
-        let mut traversed = Vec::new();
+        let mut traversed: SmallVec<[StyleNodeID; 8]> = SmallVec::new();
         let mut incomplete = None;
         let answer = loop {
             traversed.push(current);

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -3212,12 +3212,12 @@ impl SelectorProgram {
             walk.origin_required
                 .sort_unstable_by_key(|&key| dispatch_selectivity(key));
             walk.origin_required.truncate(MAX_REQUIRED_DISPATCH_KEYS);
-            let mut parent_dispatch = Vec::new();
+            walk.parent_dispatch.clear();
             self.dispatch_analysis(
                 enclosing,
                 DispatchRelation::Parent,
                 DispatchQuery::Alternatives,
-                &mut parent_dispatch,
+                &mut walk.parent_dispatch,
             );
             // Steps taken inside a relative argument lead from the anchor to a possible witness,
             // not from the anchor to the entry's subjects. Only the steps already on the stack when
@@ -3259,7 +3259,7 @@ impl SelectorProgram {
                 anchor,
                 origin_dispatch: &walk.origin_dispatch,
                 origin_required: &walk.origin_required,
-                parent_dispatch: &parent_dispatch,
+                parent_dispatch: &walk.parent_dispatch,
                 waypoints: &walk.applied_waypoints,
             });
         };
@@ -3480,6 +3480,7 @@ struct TransposeWalk {
     applied_waypoints: Vec<DispatchKey>,
     origin_dispatch: Vec<DispatchKey>,
     origin_required: Vec<DispatchKey>,
+    parent_dispatch: Vec<DispatchKey>,
 }
 
 /// One semantic input a selector entry mentions, with everything routing needs to transpose it.

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -5559,10 +5559,9 @@ impl<'a> MatchEvaluator<'a> {
         let Some(parent) = self.parent_of(node) else {
             return Ok(false);
         };
-        let first = self.children_of(parent).next();
         let (parent_id, cached_prefix) = cache.preceding_sibling_prefix(program_id, relation, parent);
-        let mut prefix = cached_prefix.unwrap_or(PrecedingSiblingPrefix {
-            next: first,
+        let mut prefix = cached_prefix.unwrap_or_else(|| PrecedingSiblingPrefix {
+            next: self.children_of(parent).next(),
             answer: false,
         });
         let mut retried_from_start = false;
@@ -5585,7 +5584,7 @@ impl<'a> MatchEvaluator<'a> {
                     return Ok(false);
                 }
                 prefix = PrecedingSiblingPrefix {
-                    next: first,
+                    next: self.children_of(parent).next(),
                     answer: false,
                 };
                 incomplete = None;

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -5552,6 +5552,11 @@ impl<'a> MatchEvaluator<'a> {
             return Ok(false);
         };
         let (parent_id, cached_prefix) = cache.preceding_sibling_prefix(program_id, relation, parent);
+        if let Some(prefix) = cached_prefix
+            && prefix.next == Some(node)
+        {
+            return Ok(prefix.answer);
+        }
         let mut prefix = cached_prefix.unwrap_or_else(|| PrecedingSiblingPrefix {
             next: self.children_of(parent).next(),
             answer: false,

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -6476,19 +6476,22 @@ fn matches_an_plus_b(step: i32, offset: i32, index: i64) -> bool {
     difference % step == 0 && difference / step >= 0
 }
 
-fn fold(unit: u16, insensitive: bool) -> u16 {
-    if insensitive && (u16::from(b'A')..=u16::from(b'Z')).contains(&unit) {
+fn fold(unit: u16) -> u16 {
+    if (u16::from(b'A')..=u16::from(b'Z')).contains(&unit) {
         return unit + u16::from(b'a' - b'A');
     }
     unit
 }
 
 fn equals(value: &[u16], literal: &[u16], insensitive: bool) -> bool {
+    if !insensitive {
+        return value == literal;
+    }
     value.len() == literal.len()
         && value
             .iter()
             .zip(literal)
-            .all(|(&left, &right)| fold(left, insensitive) == fold(right, insensitive))
+            .all(|(&left, &right)| fold(left) == fold(right))
 }
 
 fn starts_with(value: &[u16], literal: &[u16], insensitive: bool) -> bool {

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -6174,6 +6174,14 @@ impl<'a> MatchEvaluator<'a> {
             .iter()
             .copied()
             .filter(move |attribute| {
+                if !test.any_namespace {
+                    if attribute.name == test.name {
+                        return true;
+                    }
+                    if !folds {
+                        return false;
+                    }
+                }
                 let forms = row.facts.attribute_name_forms(attribute.name);
                 let (written, folded) = match test.any_namespace {
                     true => (forms.local, forms.folded_local),

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -3457,11 +3457,12 @@ impl SelectorProgram {
         // The compound being stepped away from is what a subject reached through this step had to
         // satisfy at this point of the selector. A compound whose set is not a single key describes
         // no requirement that a subject's ancestor walk can check one lookup at a time.
-        let mut keys = Vec::new();
-        let waypoint = match self.dispatch_keys_of(enclosing, &mut keys) && keys.len() == 1 {
-            true => Some(keys[0]),
-            false => None,
-        };
+        walk.origin_dispatch.clear();
+        let waypoint =
+            match self.dispatch_keys_of(enclosing, &mut walk.origin_dispatch) && walk.origin_dispatch.len() == 1 {
+                true => Some(walk.origin_dispatch[0]),
+                false => None,
+            };
         walk.path.push(step);
         walk.waypoints.push(waypoint);
         self.walk_transpose(inner, inner, anchor, walk, visit);

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -4969,16 +4969,6 @@ impl MatchEvaluationWorkspace {
         }
     }
 
-    fn insert_type_position(&self, node: StyleNodeID, side: MatchEvaluationSide, position: SiblingPositions) -> bool {
-        self.type_positions_by_evaluation_side[side as usize]
-            .borrow_mut()
-            .insert(
-                node.element_index().expect("only elements have sibling positions") as usize,
-                position,
-            )
-            .1
-    }
-
     /// A workspace for the candidates of one selector query: sibling geometry is shared, final
     /// answers are not memoized.
     pub(super) fn for_selector_query() -> Self {
@@ -6409,10 +6399,14 @@ impl<'a> MatchEvaluator<'a> {
                 sibling_types.push(type_id);
                 type_positions[type_id as usize].from_end += 1;
             }
+            let mut positions = workspace.type_positions_by_evaluation_side[side as usize].borrow_mut();
             for (&sibling, type_id) in siblings.iter().zip(sibling_types) {
                 let position = &mut type_positions[type_id as usize];
                 position.from_start += 1;
-                workspace.insert_type_position(sibling, side, *position);
+                positions.insert(
+                    sibling.element_index().expect("only elements have sibling positions") as usize,
+                    *position,
+                );
                 position.from_end -= 1;
             }
         }
@@ -6604,9 +6598,13 @@ mod tests {
             2
         );
 
-        cache.insert_type_position(node, MatchEvaluationSide::Current, position);
+        cache.type_positions_by_evaluation_side[MatchEvaluationSide::Current as usize]
+            .borrow_mut()
+            .insert(node.element_index().unwrap() as usize, position);
         assert_eq!(cache.sibling_position(node, MatchEvaluationSide::OldFacts, true), None);
-        cache.insert_type_position(node, MatchEvaluationSide::OldFacts, position);
+        cache.type_positions_by_evaluation_side[MatchEvaluationSide::OldFacts as usize]
+            .borrow_mut()
+            .insert(node.element_index().unwrap() as usize, position);
         cache.retain_current_for_matching();
         assert_eq!(
             cache.sibling_position(node, MatchEvaluationSide::Current, true),

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -6374,7 +6374,7 @@ impl<'a> MatchEvaluator<'a> {
         if position.of_type {
             let mut type_ids = HashMap::default();
             let mut sibling_types = Vec::with_capacity(siblings.len());
-            let mut type_positions = Vec::<SiblingPositions>::new();
+            let mut type_positions: SmallVec<[SiblingPositions; 1]> = SmallVec::new();
             for &sibling in siblings.iter() {
                 let row = match self.row_of(sibling) {
                     Ok(row) => row,

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -25,6 +25,7 @@
 //! arrives with the semantics it needs rather than as a placeholder that would have to be guessed
 //! at now.
 
+use super::capacity::ShallowCapacityBytes;
 use super::capacity::capacity_bytes;
 use super::column::BitColumn;
 use super::column::Column;
@@ -4777,6 +4778,7 @@ pub struct MatchEvaluationWorkspace {
 #[derive(Default)]
 struct PositionalAnswers {
     by_test: Vec<(NthPosition, HashMap<StyleNodeID, bool>)>,
+    answer_capacity_bytes: u64,
 }
 
 impl PositionalAnswers {
@@ -4792,10 +4794,14 @@ impl PositionalAnswers {
     fn insert(&mut self, position: NthPosition, node: StyleNodeID, answer: bool) {
         match self.by_test.iter_mut().find(|(candidate, _)| *candidate == position) {
             Some((_, answers)) => {
+                let previous_bytes = answers.shallow_capacity_bytes();
                 answers.insert(node, answer);
+                self.answer_capacity_bytes += answers.shallow_capacity_bytes() - previous_bytes;
             }
             None => {
-                self.by_test.push((position, HashMap::from_iter([(node, answer)])));
+                let answers = HashMap::from_iter([(node, answer)]);
+                self.answer_capacity_bytes += answers.shallow_capacity_bytes();
+                self.by_test.push((position, answers));
             }
         }
     }
@@ -4803,15 +4809,8 @@ impl PositionalAnswers {
     fn capacity_bytes(&self) -> usize {
         (capacity_bytes! {
             shallow [self.by_test];
-            cached [];
-            nested [self.by_test.iter().map(|(_, answers)| {
-                capacity_bytes! {
-                    shallow [*answers];
-                    cached [];
-                    nested [];
-                    skip [];
-                }
-            }).sum::<u64>()];
+            cached [self.answer_capacity_bytes];
+            nested [];
             skip [];
         }) as usize
     }

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -6376,7 +6376,7 @@ impl<'a> MatchEvaluator<'a> {
         if position.of_type {
             let mut type_ids = HashMap::default();
             let mut sibling_types = Vec::with_capacity(siblings.len());
-            let mut totals = Vec::<u32>::new();
+            let mut type_positions = Vec::<SiblingPositions>::new();
             for &sibling in siblings.iter() {
                 let row = match self.row_of(sibling) {
                     Ok(row) => row,
@@ -6389,27 +6389,22 @@ impl<'a> MatchEvaluator<'a> {
                     Err(incomplete) => return Err(incomplete),
                 };
                 let sibling_type = (row.facts.tag_of(row.row), row.facts.namespace_of(row.row));
-                let next_type_id = u32::try_from(totals.len()).expect("sibling type space exhausted");
+                let next_type_id = u32::try_from(type_positions.len()).expect("sibling type space exhausted");
                 let type_id = *type_ids.entry(sibling_type).or_insert_with(|| {
-                    totals.push(0);
+                    type_positions.push(SiblingPositions {
+                        from_start: 0,
+                        from_end: 0,
+                    });
                     next_type_id
                 });
                 sibling_types.push(type_id);
-                totals[type_id as usize] += 1;
+                type_positions[type_id as usize].from_end += 1;
             }
-            let mut seen = vec![0_u32; totals.len()];
             for (&sibling, type_id) in siblings.iter().zip(sibling_types) {
-                let type_index = type_id as usize;
-                let from_start = &mut seen[type_index];
-                *from_start += 1;
-                workspace.insert_type_position(
-                    sibling,
-                    side,
-                    SiblingPositions {
-                        from_start: *from_start,
-                        from_end: totals[type_index] - *from_start + 1,
-                    },
-                );
+                let position = &mut type_positions[type_id as usize];
+                position.from_start += 1;
+                workspace.insert_type_position(sibling, side, *position);
+                position.from_end -= 1;
             }
         }
 

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -359,14 +359,20 @@ fn attribute_changes_publish_one_name_route() {
         new: InputValue::Feature(FeatureValue::Atom(new_value)),
     };
 
-    assert_eq!(routing_keys_for_input(&changed), [RoutingKey::AttributeName(name)]);
+    assert_eq!(
+        routing_keys_for_input(&changed).as_slice(),
+        [RoutingKey::AttributeName(name)]
+    );
 
     let added = NormalizedInput {
         old: InputValue::Feature(FeatureValue::Absent),
         new: InputValue::Feature(FeatureValue::Atom(new_value)),
         ..changed
     };
-    assert_eq!(routing_keys_for_input(&added), [RoutingKey::AttributeName(name)]);
+    assert_eq!(
+        routing_keys_for_input(&added).as_slice(),
+        [RoutingKey::AttributeName(name)]
+    );
 }
 
 #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/transaction_view.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/transaction_view.rs
@@ -38,15 +38,12 @@ impl FeatureFluxColumn {
     pub(super) fn from_entries(mut entries: Vec<(StyleNodeID, DispatchKey)>) -> Self {
         entries.sort_unstable();
         entries.dedup();
-        let mut nodes_by_key: Vec<_> = entries.iter().map(|&(node, key)| (key, node)).collect();
-        nodes_by_key.sort_unstable();
-        let mut features = Self {
-            nodes_by_key,
-            ..Self::default()
-        };
+        let mut features = Self::default();
         for entries in entries.chunk_by(|left, right| left.0 == right.0) {
             features.push_node(entries[0].0, entries.iter().map(|&(_, key)| key));
         }
+        features.nodes_by_key = entries.into_iter().map(|(node, key)| (key, node)).collect();
+        features.nodes_by_key.sort_unstable();
         features
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/tree.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tree.rs
@@ -184,7 +184,6 @@ pub(super) struct TreeRelationStaging {
 }
 
 type StagedTreeRows = Vec<(StyleNodeID, Option<TreeRelations>, Option<TreeRelations>)>;
-type StagedFirstChildren = Vec<(StyleNodeID, Option<StyleNodeID>, Option<StyleNodeID>)>;
 
 fn radix_sort_style_node_ids(mut nodes: Vec<StyleNodeID>) -> Vec<StyleNodeID> {
     if nodes.is_sorted() {
@@ -314,18 +313,16 @@ impl TreeRelationStaging {
             .collect()
     }
 
-    pub(super) fn dirty_first_children(&self) -> StagedFirstChildren {
-        self.dirty_first_children
-            .iter()
-            .copied()
-            .map(|parent| {
-                let pair = self
-                    .first_children
-                    .get(parent)
-                    .expect("dirty first-child row must be staged");
-                (parent, pair.before, pair.after)
-            })
-            .collect()
+    pub(super) fn dirty_first_children(
+        &self,
+    ) -> impl Iterator<Item = (StyleNodeID, Option<StyleNodeID>, Option<StyleNodeID>)> + '_ {
+        self.dirty_first_children.iter().copied().map(|parent| {
+            let pair = self
+                .first_children
+                .get(parent)
+                .expect("dirty first-child row must be staged");
+            (parent, pair.before, pair.after)
+        })
     }
 
     pub(super) fn before_relations(&self, node: StyleNodeID, resident: Option<TreeRelations>) -> Option<TreeRelations> {
@@ -1245,7 +1242,7 @@ mod tests {
         staging.stage_first_child(parent, None, Some(node));
         staging.mark_applied();
         assert!(staging.dirty_rows().is_empty());
-        assert!(staging.dirty_first_children().is_empty());
+        assert!(staging.dirty_first_children().next().is_none());
         staging.stage_row(node, Some(first_after), Some(final_after));
         staging.stage_first_child(parent, Some(node), Some(final_first_child));
 

--- a/Libraries/LibWeb/Rust/src/css/style/tree.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tree.rs
@@ -187,7 +187,7 @@ type StagedTreeRows = Vec<(StyleNodeID, Option<TreeRelations>, Option<TreeRelati
 type StagedFirstChildren = Vec<(StyleNodeID, Option<StyleNodeID>, Option<StyleNodeID>)>;
 
 fn radix_sort_style_node_ids(mut nodes: Vec<StyleNodeID>) -> Vec<StyleNodeID> {
-    if nodes.len() < 2 {
+    if nodes.is_sorted() {
         return nodes;
     }
     let mut scratch = vec![nodes[0]; nodes.len()];


### PR DESCRIPTION
Collect performance cleanups across selector matching, fact updates, cascade resolution, and computed-style reuse.

- Borrow or move existing data instead of cloning temporary vectors, and keep small scratch lists inline.
- Reuse cascade priorities and cached identities, and skip redundant sorting, lookups, and repairs.
- Replace repeated searches with linear merges and maintain memory accounting incrementally.
- Reserve posting storage up front and avoid growing full chunks before splitting them.

These target common style recalculation paths, including workloads exercised by StyleBench.
