### PR TITLE
Move layout-pass bookkeeping into the Rust arena

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -951,7 +951,7 @@ AnimationUpdateContext::~AnimationUpdateContext()
         }
 
         if (invalidation.changes_containing_block_establishment)
-            target->document().partial_relayout_invalidation().record_escape(DOM::PartialRelayoutEscapeReason::ContainingBlockEstablishmentChangedByKeyframeEffect);
+            target->document().record_partial_relayout_escape(DOM::PartialRelayoutEscapeReason::ContainingBlockEstablishmentChangedByKeyframeEffect);
 
         if (invalidation.needs_relayout())
             target->set_needs_layout_update(DOM::SetNeedsLayoutReason::KeyframeEffect);

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -58,7 +58,7 @@ static void apply_element_style_invalidation_after_style_change(DOM::Element& el
         element.document().schedule_scroll_container_resnap();
 
     if (invalidation.changes_containing_block_establishment)
-        element.document().partial_relayout_invalidation().record_escape(DOM::PartialRelayoutEscapeReason::ContainingBlockEstablishmentChangedByStyleChange);
+        element.document().record_partial_relayout_escape(DOM::PartialRelayoutEscapeReason::ContainingBlockEstablishmentChangedByStyleChange);
 
     if (invalidation.needs_relayout()) {
         // A relayout-only style change on an absolutely positioned partial relayout boundary

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1915,144 +1915,6 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, Layout
     m_document->set_needs_repaint();
 }
 
-static void propagate_scrollbar_width_to_viewport(Element& root_element, Layout::Viewport& viewport)
-{
-    // https://drafts.csswg.org/css-scrollbars/#scrollbar-width
-    // UAs must apply the scrollbar-color value set on the root element to the viewport.
-    // NB: Called during layout tree construction.
-    auto scrollbar_width = root_element.unsafe_layout_node()->scrollbar_width();
-    viewport.modify_computed_values([&](auto& values) {
-        values.set_scrollbar_width(scrollbar_width);
-    });
-}
-
-// https://drafts.csswg.org/css-writing-modes-4/#principal-flow
-static void propagate_principal_writing_mode_to_viewport(Element& root_element, Layout::Viewport& viewport)
-{
-    // The principal writing mode of the document is determined by the used writing-mode, direction, and
-    // text-orientation values of the root element.
-    auto const* root_inherited_box_values = root_element.style_group<CSS::ComputedValues::InheritedBoxValues>();
-    VERIFY(root_inherited_box_values);
-    auto writing_mode = static_cast<CSS::WritingMode>(root_inherited_box_values->writing_mode);
-    auto direction = static_cast<CSS::Direction>(root_inherited_box_values->direction);
-
-    // As a special case for handling HTML documents, if the root element has a body child element [HTML] whose
-    // display value is not none, the used value of the of writing-mode and direction properties on root element
-    // are taken from the computed writing-mode and direction of the first such child element instead of from the
-    // root element's own values.
-    // NOTE: Using containment disables this special handling of the HTML body element.
-    auto* body_element = root_element.first_child_of_type<HTML::HTMLBodyElement>();
-    auto const* root_box_values = root_element.style_group<CSS::ComputedValues::BoxValues>();
-    VERIFY(root_box_values);
-    auto const* body_box_values = body_element ? body_element->style_group<CSS::ComputedValues::BoxValues>() : nullptr;
-    auto const* body_inherited_box_values = body_element ? body_element->style_group<CSS::ComputedValues::InheritedBoxValues>() : nullptr;
-    auto has_containment = [](CSS::ComputedValues::BoxValues const& values) {
-        return values.size_containment || values.inline_size_containment || values.layout_containment || values.style_containment || values.paint_containment;
-    };
-    bool propagation_is_disabled_by_containment = has_containment(*root_box_values)
-        || (body_box_values && has_containment(*body_box_values));
-    if (root_element.is_html_html_element() && !propagation_is_disabled_by_containment
-        && body_box_values && body_inherited_box_values && !CSS::display_from_ffi_display(body_box_values->display).is_none()) {
-        writing_mode = static_cast<CSS::WritingMode>(body_inherited_box_values->writing_mode);
-        direction = static_cast<CSS::Direction>(body_inherited_box_values->direction);
-    }
-    root_element.unsafe_layout_node()->modify_computed_values([&](auto& values) {
-        values.set_writing_mode(writing_mode);
-        values.set_direction(direction);
-    });
-
-    // https://drafts.csswg.org/css-writing-modes-4/#icb
-    // The principal writing mode is propagated to the initial containing block and to the viewport, thereby
-    // affecting the layout of the root element and the scrolling direction of the viewport.
-    viewport.modify_computed_values([&](auto& values) {
-        values.set_writing_mode(writing_mode);
-        values.set_direction(direction);
-    });
-}
-
-// https://drafts.csswg.org/css-overflow-3/#overflow-propagation
-static void propagate_overflow_to_viewport(Element& root_element, Layout::Viewport& viewport)
-{
-    // https://drafts.csswg.org/css-contain-2/#contain-property
-    // Additionally, when any containments are active on either the HTML <html> or <body> elements, propagation of
-    // properties from the <body> element to the initial containing block, the viewport, or the canvas background, is
-    // disabled. Notably, this affects:
-    // - 'overflow' and its longhands (see CSS Overflow 3 § 3.3 Overflow Viewport Propagation)
-    auto* body_element = root_element.first_child_of_type<HTML::HTMLBodyElement>();
-    auto const* root_box_values = root_element.style_group<CSS::ComputedValues::BoxValues>();
-    VERIFY(root_box_values);
-    auto has_containment = [](CSS::ComputedValues::BoxValues const& values) {
-        return values.size_containment || values.inline_size_containment || values.layout_containment || values.style_containment || values.paint_containment;
-    };
-    auto const* body_box_values = body_element ? body_element->style_group<CSS::ComputedValues::BoxValues>() : nullptr;
-    bool body_element_can_propagate_overflow = body_element
-        && body_box_values
-        && !CSS::display_from_ffi_display(body_box_values->display).is_none()
-        && body_element->unsafe_layout_node();
-    bool body_propagation_is_disabled_by_containment = root_element.is_html_html_element() && has_containment(*root_box_values);
-    if (body_box_values && has_containment(*body_box_values))
-        body_propagation_is_disabled_by_containment = true;
-
-    // UAs must apply the overflow-* values set on the root element to the viewport
-    // when the root element’s display value is not none.
-    auto root_element_layout_node = root_element.unsafe_layout_node();
-    auto root_overflow_x = static_cast<CSS::Overflow>(root_box_values->overflow_x);
-    auto root_overflow_y = static_cast<CSS::Overflow>(root_box_values->overflow_y);
-
-    Element* overflow_origin_element = &root_element;
-
-    // However, when the root element is an [HTML] html element (including XML syntax for HTML)
-    // whose overflow value is visible (in both axes), and that element has as a child
-    // a body element whose display value is also not none,
-    // user agents must instead apply the overflow-* values of the first such child element to the viewport.
-    if (root_element.is_html_html_element() && !body_propagation_is_disabled_by_containment) {
-        if (root_overflow_x == CSS::Overflow::Visible && root_overflow_y == CSS::Overflow::Visible) {
-            if (body_element_can_propagate_overflow)
-                overflow_origin_element = body_element;
-        }
-    }
-
-    // If 'visible' is applied to the viewport, it must be interpreted as 'auto'. If 'clip' is applied to the viewport, it must be interpreted as 'hidden'.
-    auto const* overflow_origin_box_values = overflow_origin_element == &root_element ? root_box_values : body_box_values;
-    auto overflow_x_to_apply = static_cast<CSS::Overflow>(overflow_origin_box_values->overflow_x);
-    if (overflow_x_to_apply == CSS::Overflow::Visible) {
-        overflow_x_to_apply = CSS::Overflow::Auto;
-    } else if (overflow_x_to_apply == CSS::Overflow::Clip) {
-        overflow_x_to_apply = CSS::Overflow::Hidden;
-    }
-    auto overflow_y_to_apply = static_cast<CSS::Overflow>(overflow_origin_box_values->overflow_y);
-    if (overflow_y_to_apply == CSS::Overflow::Visible) {
-        overflow_y_to_apply = CSS::Overflow::Auto;
-    } else if (overflow_y_to_apply == CSS::Overflow::Clip) {
-        overflow_y_to_apply = CSS::Overflow::Hidden;
-    }
-    // Every node receives its final values exactly once: a steady-state pass then leaves
-    // every style group payload untouched instead of oscillating values within the pass.
-    viewport.modify_computed_values([&](auto& values) {
-        values.set_overflow_x(overflow_x_to_apply);
-        values.set_overflow_y(overflow_y_to_apply);
-    });
-
-    // UAs must apply the overflow-* values set on the root element to the viewport
-    // when the root element's display value is not none.
-    // The element from which the value is propagated must then have a used overflow value of visible.
-    // FIXME: Apply this to the used values, not the computed ones.
-    bool root_element_is_overflow_origin = overflow_origin_element == &root_element;
-    root_element_layout_node->modify_computed_values([&](auto& values) {
-        values.set_overflow_x(root_element_is_overflow_origin ? CSS::Overflow::Visible : root_overflow_x);
-        values.set_overflow_y(root_element_is_overflow_origin ? CSS::Overflow::Visible : root_overflow_y);
-    });
-    if (body_element_can_propagate_overflow) {
-        bool body_element_is_overflow_origin = overflow_origin_element == body_element;
-        auto body_overflow_x = static_cast<CSS::Overflow>(body_box_values->overflow_x);
-        auto body_overflow_y = static_cast<CSS::Overflow>(body_box_values->overflow_y);
-        body_element->unsafe_layout_node()->modify_computed_values([&](auto& values) {
-            values.set_overflow_x(body_element_is_overflow_origin ? CSS::Overflow::Visible : body_overflow_x);
-            values.set_overflow_y(body_element_is_overflow_origin ? CSS::Overflow::Visible : body_overflow_y);
-        });
-    }
-}
-
 void Document::update_layout_if_needed_for_node(Node const& node, UpdateLayoutReason reason)
 {
     if (!node.is_connected())
@@ -2371,7 +2233,6 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
             break;
         }
 
-        auto* document_element = this->document_element();
         auto viewport_rect = navigable->viewport_rect();
 
         auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
@@ -2380,10 +2241,6 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
             auto tree_build_result = Layout::build_layout_tree(*this);
             set_layout_root(*tree_build_result.root);
             record_layout_tree_build(tree_build_result.rebuilt_subtree_roots.size(), tree_build_result.layout_tree_update_escaped_rebuild_roots);
-
-            // NB: Called during layout update.
-            if (document_element && document_element->unsafe_layout_node())
-                propagate_scrollbar_width_to_viewport(*document_element, *m_layout_root);
 
             if (tree_build_result.needs_another_build_pass)
                 continue;
@@ -2398,17 +2255,6 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
                 continue;
         }
 
-        if (document_element && document_element->unsafe_layout_node()) {
-            propagate_principal_writing_mode_to_viewport(*document_element, *m_layout_root);
-            propagate_overflow_to_viewport(*document_element, *m_layout_root);
-        } else {
-            m_layout_root->modify_computed_values([](auto& values) {
-                values.set_overflow_x(CSS::Overflow::Auto);
-                values.set_overflow_y(CSS::Overflow::Auto);
-            });
-        }
-
-        layout_node_arena().sync_enrolled_content_for_layout();
         Layout::LayoutRustBridge bridge;
         bridge.run_root_layout(
             *m_layout_root,

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1879,9 +1879,6 @@ static void relayout_subtree(Layout::Box& subtree_root)
     } else {
         bridge.compute_subtree_layout(subtree_root);
     }
-
-    Layout::RustFFI::layout_arena_reset_layout_update_flags_in_subtree(
-        subtree_root.arena_handle(), Layout::Node::slot_id(&subtree_root));
 }
 
 // Recomputes containing blocks and derives the abspos escape flags for the inclusive subtree
@@ -2316,12 +2313,8 @@ Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::Ru
         recompute_containing_blocks_in_inclusive_subtree(layout_node_arena(), *root);
 
     layout_node_arena().sync_enrolled_content_for_layout();
-    for (auto* root : partial_relayout_roots) {
+    for (auto* root : partial_relayout_roots)
         relayout_subtree(*root);
-        // NB: The subtree commit reset the root's descendant rows, and the subtree's
-        //     new size may change ancestor scrollable overflow; scheduling the root covers both.
-        schedule_scrollable_overflow_recalculation(*root);
-    }
 
     ++m_partial_layout_count;
 
@@ -2462,18 +2455,11 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
             viewport_rect.width(),
             viewport_rect.height(),
             should_collect_devtools_layout_data);
-        Layout::RustFFI::layout_arena_rebuild_scrollable_overflow_contained_boxes(layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root));
 
         style_invalidation_counters().relayouts_performed++;
-
-        Layout::RustFFI::layout_arena_set_needs_full_scrollable_overflow_recalculation(layout_node_arena().handle());
-
         ++m_full_layout_count;
 
         after_layout_commit(LayoutTreeChanged::Yes, LayoutCommitScope::Full);
-
-        Layout::RustFFI::layout_arena_reset_layout_update_flags_in_subtree(
-            layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root));
 
         if constexpr (UPDATE_LAYOUT_DEBUG) {
             dbgln("LAYOUT {} {} µs", to_string(reason), timer.elapsed_time().to_microseconds());

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1770,17 +1770,13 @@ void Document::invalidate_layout_tree(InvalidateLayoutTreeReason reason)
     tear_down_layout_tree();
 }
 
-void Document::PartialRelayoutInvalidation::record_escape(PartialRelayoutEscapeReason reason)
+void Document::record_partial_relayout_escape(PartialRelayoutEscapeReason reason)
 {
     dbgln_if(UPDATE_LAYOUT_DEBUG, "Pending updates escape partial relayout boundaries ({})", to_string(reason));
-    m_escapes = true;
-}
-
-void Document::PartialRelayoutInvalidation::clear_escape(PartialRelayoutEscapeClearReason reason)
-{
-    if (m_escapes)
-        dbgln_if(UPDATE_LAYOUT_DEBUG, "Pending updates no longer escape partial relayout boundaries ({})", to_string(reason));
-    m_escapes = false;
+    // A document without an arena has no layout root either, and the full pass that builds one
+    // clears the bit before any boundary can be registered.
+    if (m_layout_node_arena)
+        Layout::RustFFI::layout_arena_record_partial_relayout_escape(m_layout_node_arena->handle());
 }
 
 // Anchor names publish geometry that anchor() functions on positioned boxes anywhere in the
@@ -2240,18 +2236,20 @@ bool Document::needs_style_update_after_layout()
 // the full layout path without rebuilding again.
 Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::RustFFI::NodeSlotId> registered_partial_relayout_root_slots, bool& needs_layout_tree_rebuild, bool should_collect_devtools_layout_data)
 {
-    if (!m_layout_root
-        || needs_full_layout_tree_update()
-        || m_partial_relayout_invalidation.escapes()
-        || registered_partial_relayout_root_slots.is_empty()
-        || m_layout_root->needs_layout_update()
-        || !m_query_containers_needing_container_query_evaluation_after_layout.is_empty()
-        || should_collect_devtools_layout_data
-        || any_anchor_names_are_registered())
+    Layout::RustFFI::FfiPartialRelayoutHostFacts host_facts {
+        .document_needs_full_layout_tree_update = needs_full_layout_tree_update(),
+        .container_query_evaluation_is_pending = !m_query_containers_needing_container_query_evaluation_after_layout.is_empty(),
+        .should_collect_devtools_layout_data = should_collect_devtools_layout_data,
+        .any_anchor_names_are_registered = any_anchor_names_are_registered(),
+    };
+    if (!Layout::RustFFI::layout_arena_partial_relayout_may_be_attempted(
+            layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root),
+            registered_partial_relayout_root_slots.data(), registered_partial_relayout_root_slots.size(),
+            host_facts))
         return PartialRelayoutResult::NotEligible;
 
     bool layout_tree_was_built_in_partial_branch = false;
-    bool pending_updates_escaped_during_partial_build = false;
+    bool layout_tree_update_escaped_rebuild_roots = false;
     Vector<Layout::Node*> rebuilt_subtree_roots;
     if (needs_layout_tree_rebuild) {
         auto tree_build_timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
@@ -2262,24 +2260,19 @@ Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::Ru
         if (reconcile_stale_list_item_counters_after_tree_build(tree_build_result.rebuilt_subtree_roots) || tree_build_result.needs_another_build_pass)
             return PartialRelayoutResult::NeedsAnotherLayoutPass;
         layout_tree_was_built_in_partial_branch = true;
-        pending_updates_escaped_during_partial_build = m_partial_relayout_invalidation.escapes()
-            || tree_build_result.layout_tree_update_escaped_rebuild_roots;
-        m_partial_relayout_invalidation.clear_escape(PartialRelayoutEscapeClearReason::PartialLayoutTreeBuild);
+        layout_tree_update_escaped_rebuild_roots = tree_build_result.layout_tree_update_escaped_rebuild_roots;
         rebuilt_subtree_roots = move(tree_build_result.rebuilt_subtree_roots);
+
+        // Nodes created by the incremental build have no containing blocks assigned yet, and the
+        // mutation may have moved where existing out-of-flow descendants belong; recompute both so
+        // boundary qualification below reads facts matching the just-built tree.
+        for (auto* rebuilt_root : rebuilt_subtree_roots)
+            recompute_containing_blocks_in_inclusive_subtree(layout_node_arena(), *rebuilt_root);
 
         if constexpr (UPDATE_LAYOUT_DEBUG) {
             dbgln("TREEBUILD {} µs", tree_build_timer.elapsed_time().to_microseconds());
         }
     }
-
-    if (m_layout_root->needs_layout_update() || pending_updates_escaped_during_partial_build)
-        return PartialRelayoutResult::NotEligible;
-
-    // Nodes created by the incremental build have no containing blocks assigned yet, and the
-    // mutation may have moved where existing out-of-flow descendants belong; recompute both so
-    // boundary qualification below reads facts matching the just-built tree.
-    for (auto* rebuilt_root : rebuilt_subtree_roots)
-        recompute_containing_blocks_in_inclusive_subtree(layout_node_arena(), *rebuilt_root);
 
     Vector<Layout::RustFFI::NodeSlotId> rebuilt_subtree_root_slots;
     rebuilt_subtree_root_slots.ensure_capacity(rebuilt_subtree_roots.size());
@@ -2287,10 +2280,11 @@ Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::Ru
         rebuilt_subtree_root_slots.unchecked_append(Layout::Node::slot_id(rebuilt_root));
 
     Vector<Layout::RustFFI::NodeSlotId> partial_relayout_root_slots;
-    bool boundary_set_supports_partial_relayout = Layout::RustFFI::layout_arena_collect_partial_relayout_roots(
-        layout_node_arena().handle(),
+    bool boundary_set_supports_partial_relayout = Layout::RustFFI::layout_arena_plan_partial_relayout(
+        layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root),
         registered_partial_relayout_root_slots.data(), registered_partial_relayout_root_slots.size(),
         rebuilt_subtree_root_slots.data(), rebuilt_subtree_root_slots.size(),
+        layout_tree_update_escaped_rebuild_roots,
         &partial_relayout_root_slots,
         [](void* context, Layout::RustFFI::NodeSlotId root) {
             static_cast<Vector<Layout::RustFFI::NodeSlotId>*>(context)->append(root);
@@ -2443,10 +2437,6 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
         }
 
         recompute_containing_blocks_in_inclusive_subtree(layout_node_arena(), *m_layout_root);
-
-        // The walk above re-derived every fact partial relayout boundary qualification depends
-        // on, so pending changes that escaped classification are accounted for from here on.
-        m_partial_relayout_invalidation.clear_escape(PartialRelayoutEscapeClearReason::FullLayoutPass);
 
         layout_node_arena().sync_enrolled_content_for_layout();
         Layout::LayoutRustBridge bridge;
@@ -11344,18 +11334,6 @@ Utf16View to_string(PartialRelayoutEscapeReason reason)
         return #e##sv;
         ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_REASONS(ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_REASON)
 #undef ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_REASON
-    }
-    VERIFY_NOT_REACHED();
-}
-
-Utf16View to_string(PartialRelayoutEscapeClearReason reason)
-{
-    switch (reason) {
-#define ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_CLEAR_REASON(e) \
-    case PartialRelayoutEscapeClearReason::e:             \
-        return #e##sv;
-        ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_CLEAR_REASONS(ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_CLEAR_REASON)
-#undef ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_CLEAR_REASON
     }
     VERIFY_NOT_REACHED();
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1869,26 +1869,11 @@ static void relayout_subtree(Layout::Box& subtree_root)
     // the previous commit. The commit sink resolves the committed row to splice out in either
     // path.
     if (subtree_root.is_absolutely_positioned()) {
-        VERIFY(subtree_root.containing_block());
         VERIFY(subtree_root.has_saved_abspos_layout_inputs());
         bridge.replay_saved_abspos_layout(subtree_root);
     } else {
         bridge.compute_subtree_layout(subtree_root);
     }
-}
-
-// Recomputes containing blocks and derives the abspos escape flags for the inclusive subtree
-// inside the Rust arena; the DOM-ancestry half of the inline containing-block workaround stays
-// on the C++ side as the callback.
-static void recompute_containing_blocks_in_inclusive_subtree(Layout::NodeArena& arena, Layout::Node& subtree_root)
-{
-    Layout::RustFFI::layout_arena_recompute_containing_blocks(
-        arena.handle(), Layout::Node::slot_id(&subtree_root),
-        [](void* node_shell, void* containing_block_shell) -> Layout::RustFFI::NodeSlotId {
-            auto const& node = *static_cast<Layout::Node const*>(node_shell);
-            auto const& containing_block = *static_cast<Layout::Box const*>(containing_block_shell);
-            return Layout::Node::slot_id(node.find_inline_containing_block(containing_block));
-        });
 }
 
 // Refreshes every structure derived from committed layout results, shared by the partial and
@@ -2263,12 +2248,6 @@ Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::Ru
         layout_tree_update_escaped_rebuild_roots = tree_build_result.layout_tree_update_escaped_rebuild_roots;
         rebuilt_subtree_roots = move(tree_build_result.rebuilt_subtree_roots);
 
-        // Nodes created by the incremental build have no containing blocks assigned yet, and the
-        // mutation may have moved where existing out-of-flow descendants belong; recompute both so
-        // boundary qualification below reads facts matching the just-built tree.
-        for (auto* rebuilt_root : rebuilt_subtree_roots)
-            recompute_containing_blocks_in_inclusive_subtree(layout_node_arena(), *rebuilt_root);
-
         if constexpr (UPDATE_LAYOUT_DEBUG) {
             dbgln("TREEBUILD {} µs", tree_build_timer.elapsed_time().to_microseconds());
         }
@@ -2298,13 +2277,6 @@ Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::Ru
         auto* root = static_cast<Layout::Node*>(Layout::RustFFI::layout_arena_node_shell_if_live(layout_node_arena().handle(), slot));
         partial_relayout_roots.unchecked_append(&as<Layout::Box>(*root));
     }
-
-    // The final boundary can be wider than the rebuilt roots that led us to it. Replaying such a
-    // boundary may re-enter intrinsic sizing for descendants outside those rebuilt roots, including
-    // anonymous layout nodes created during the incremental tree build, so refresh the metadata for
-    // the whole subtree that is about to be laid out.
-    for (auto* root : partial_relayout_roots)
-        recompute_containing_blocks_in_inclusive_subtree(layout_node_arena(), *root);
 
     layout_node_arena().sync_enrolled_content_for_layout();
     for (auto* root : partial_relayout_roots)
@@ -2435,8 +2407,6 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
                 values.set_overflow_y(CSS::Overflow::Auto);
             });
         }
-
-        recompute_containing_blocks_in_inclusive_subtree(layout_node_arena(), *m_layout_root);
 
         layout_node_arena().sync_enrolled_content_for_layout();
         Layout::LayoutRustBridge bridge;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -186,8 +186,7 @@ enum class UpdateLayoutReason {
     X(AnchorNamesUnregisteredByElementRemoval)             \
     X(AnchorNamesUnregisteredByStyleChange)                \
     X(ContainingBlockEstablishmentChangedByKeyframeEffect) \
-    X(ContainingBlockEstablishmentChangedByStyleChange)    \
-    X(DirtyDomNodeHasDetachedLayoutNode)
+    X(ContainingBlockEstablishmentChangedByStyleChange)
 
 enum class PartialRelayoutEscapeReason {
 #define ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_REASON(e) e,
@@ -196,18 +195,6 @@ enum class PartialRelayoutEscapeReason {
 };
 
 [[nodiscard]] Utf16View to_string(PartialRelayoutEscapeReason);
-
-#define ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_CLEAR_REASONS(X) \
-    X(FullLayoutPass)                                      \
-    X(PartialLayoutTreeBuild)
-
-enum class PartialRelayoutEscapeClearReason {
-#define ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_CLEAR_REASON(e) e,
-    ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_CLEAR_REASONS(ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_CLEAR_REASON)
-#undef ENUMERATE_PARTIAL_RELAYOUT_ESCAPE_CLEAR_REASON
-};
-
-[[nodiscard]] Utf16View to_string(PartialRelayoutEscapeClearReason);
 
 // https://html.spec.whatwg.org/multipage/dom.html#document-load-timing-info
 struct DocumentLoadTimingInfo {
@@ -843,21 +830,9 @@ public:
     Painting::ChromeWidgetRegistry& chrome_widget_registry() { return *m_chrome_widget_registry; }
     Painting::ChromeWidgetRegistry const& chrome_widget_registry() const { return *m_chrome_widget_registry; }
 
-    // Attribution of pending updates for partial relayout. Invariant: every update recorded
-    // since the last layout pass is either attributed to a boundary in the root set the
-    // layout node arena keeps, or the escape bit is set. The dispatch may only run partial
-    // relayout while the escape bit is clear; a full layout pass re-derives every fact
-    // boundary qualification depends on, so it clears the bit.
-    class PartialRelayoutInvalidation {
-    public:
-        void record_escape(PartialRelayoutEscapeReason);
-        void clear_escape(PartialRelayoutEscapeClearReason);
-        [[nodiscard]] bool escapes() const { return m_escapes; }
-
-    private:
-        bool m_escapes { false };
-    };
-    [[nodiscard]] PartialRelayoutInvalidation& partial_relayout_invalidation() { return m_partial_relayout_invalidation; }
+    // Records that a pending update cannot be attributed to any boundary in the partial relayout
+    // root set; the layout node arena keeps the escape bit next to those roots.
+    void record_partial_relayout_escape(PartialRelayoutEscapeReason);
 
     void set_needs_to_refresh_scroll_state(bool b);
 
@@ -1734,8 +1709,6 @@ private:
     bool m_is_decoded_svg { false };
 
     bool m_is_running_update_layout { false };
-
-    PartialRelayoutInvalidation m_partial_relayout_invalidation;
 
     u64 m_partial_layout_count { 0 };
     u64 m_full_layout_count { 0 };

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2414,7 +2414,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
         // live anchor-name maps, while positioned boxes anywhere may hold geometry resolved
         // against them; names still registered keep that check refusing partial relayout.
         if (element_had_registered_anchor_names && !element_has_anchor_names)
-            document().partial_relayout_invalidation().record_escape(PartialRelayoutEscapeReason::AnchorNamesUnregisteredByStyleChange);
+            document().record_partial_relayout_escape(PartialRelayoutEscapeReason::AnchorNamesUnregisteredByStyleChange);
     }
 
     // Which animations an element references is an index StyleEngine keeps, in the same shape as the
@@ -2513,7 +2513,7 @@ void Element::clear_computed_styles_from_display_none_descendants()
         // Anchor names are registered outside the style record, so unregister them before discarding the only record
         // that identifies them. Rematerializing the element's style will register its current names again.
         if (element->is_connected() && unregister_current_anchor_names(*element, element->root()))
-            element->document().partial_relayout_invalidation().record_escape(PartialRelayoutEscapeReason::AnchorNamesUnregisteredByStyleChange);
+            element->document().record_partial_relayout_escape(PartialRelayoutEscapeReason::AnchorNamesUnregisteredByStyleChange);
 
         // The layout tree is torn down after the style transaction. Keep its style alive until then without
         // retaining the record as the descendant's current computed style.
@@ -3197,7 +3197,7 @@ void Element::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, No
         if (unregister_current_anchor_names(*this, old_root)) {
             // Positioned boxes anywhere may hold geometry resolved against these names, which
             // the dispatch-time check of the live anchor-name maps can no longer see.
-            document().partial_relayout_invalidation().record_escape(PartialRelayoutEscapeReason::AnchorNamesUnregisteredByElementRemoval);
+            document().record_partial_relayout_escape(PartialRelayoutEscapeReason::AnchorNamesUnregisteredByElementRemoval);
         }
     }
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2342,9 +2342,6 @@ void Node::set_needs_layout_tree_update(bool value, SetNeedsLayoutTreeUpdateReas
                 layout_node->arena_handle(), Layout::Node::slot_id(layout_node),
                 is_structural_boundary_self_rebuild_reason(reason));
 
-            if (classification.layout_node_is_detached_from_tree)
-                document().partial_relayout_invalidation().record_escape(PartialRelayoutEscapeReason::DirtyDomNodeHasDetachedLayoutNode);
-
             layout_node->set_needs_layout_update(SetNeedsLayoutReason::LayoutTreeUpdate,
                 classification.marks_partial_relayout_boundary_self_only
                     ? Layout::LayoutUpdatePropagation::BoundarySelfOnly

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -31,6 +31,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/AttributeNames.h>
+#include <LibWeb/HTML/HTMLBodyElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/DominantBaseline.h>
@@ -441,6 +442,49 @@ LayoutRustBridge::LayoutRustBridge() = default;
 
 LayoutRustBridge::~LayoutRustBridge() = default;
 
+static bool style_has_any_containment(CSS::ComputedValues::BoxValues const& values)
+{
+    return values.size_containment || values.inline_size_containment || values.layout_containment || values.style_containment || values.paint_containment;
+}
+
+// The inputs of the principal writing mode and viewport overflow propagation. They are read from
+// the elements' own style records: the previous pass already rewrote their boxes' values, and a
+// display:none body has style but no box.
+static RustFFI::FfiViewportPropagationFacts viewport_propagation_facts(DOM::Document& document)
+{
+    RustFFI::FfiViewportPropagationFacts facts {};
+    facts.root_layout_node = RustFFI::NodeSlotId_INVALID;
+    facts.body_layout_node = RustFFI::NodeSlotId_INVALID;
+    auto* root_element = document.document_element();
+    if (!root_element || !root_element->unsafe_layout_node())
+        return facts;
+    auto const* root_box_values = root_element->style_group<CSS::ComputedValues::BoxValues>();
+    auto const* root_inherited_box_values = root_element->style_group<CSS::ComputedValues::InheritedBoxValues>();
+    VERIFY(root_box_values && root_inherited_box_values);
+    facts.root_layout_node = Node::slot_id(root_element->unsafe_layout_node());
+    facts.root_is_html_html_element = root_element->is_html_html_element();
+    facts.root_overflow_x = root_box_values->overflow_x;
+    facts.root_overflow_y = root_box_values->overflow_y;
+    facts.root_writing_mode = root_inherited_box_values->writing_mode;
+    facts.root_direction = root_inherited_box_values->direction;
+    facts.root_has_containment = style_has_any_containment(*root_box_values);
+
+    auto* body_element = root_element->first_child_of_type<HTML::HTMLBodyElement>();
+    auto const* body_box_values = body_element ? body_element->style_group<CSS::ComputedValues::BoxValues>() : nullptr;
+    auto const* body_inherited_box_values = body_element ? body_element->style_group<CSS::ComputedValues::InheritedBoxValues>() : nullptr;
+    if (!body_box_values || !body_inherited_box_values)
+        return facts;
+    facts.has_styled_body = true;
+    facts.body_layout_node = Node::slot_id(body_element->unsafe_layout_node());
+    facts.body_display_is_none = CSS::display_from_ffi_display(body_box_values->display).is_none();
+    facts.body_overflow_x = body_box_values->overflow_x;
+    facts.body_overflow_y = body_box_values->overflow_y;
+    facts.body_writing_mode = body_inherited_box_values->writing_mode;
+    facts.body_direction = body_inherited_box_values->direction;
+    facts.body_has_containment = style_has_any_containment(*body_box_values);
+    return facts;
+}
+
 void LayoutRustBridge::run_root_layout(Box& viewport, CSSPixels viewport_inline_size, CSSPixels viewport_block_size, bool should_collect_devtools_layout_data)
 {
     VERIFY(!m_commit_root);
@@ -448,6 +492,25 @@ void LayoutRustBridge::run_root_layout(Box& viewport, CSSPixels viewport_inline_
     ScopeGuard clear_commit_root = [&] {
         m_commit_root = nullptr;
     };
+
+    static_assert(to_underlying(CSS::Overflow::Auto) == 0);
+    static_assert(to_underlying(CSS::Overflow::Clip) == 1);
+    static_assert(to_underlying(CSS::Overflow::Hidden) == 2);
+    static_assert(to_underlying(CSS::Overflow::Visible) == 4);
+    auto facts = viewport_propagation_facts(viewport.document());
+    RustFFI::FfiViewportPropagationApplyCallbacks apply_callbacks {
+        .context = nullptr,
+        .apply_overflow = [](void*, void* shell, u8 overflow_x, u8 overflow_y) {
+            auto& node = as<NodeWithStyle>(*static_cast<Node*>(shell));
+            node.set_overflow(static_cast<CSS::Overflow>(overflow_x), static_cast<CSS::Overflow>(overflow_y)); },
+        .apply_writing_mode_and_direction = [](void*, void* shell, u8 writing_mode, u8 direction) {
+            auto& node = as<NodeWithStyle>(*static_cast<Node*>(shell));
+            node.set_writing_mode_and_direction(static_cast<CSS::WritingMode>(writing_mode), static_cast<CSS::Direction>(direction)); },
+    };
+    // The style rewrites enroll the affected boxes' text children for content sync, so the sync
+    // follows them, and both precede the pass, which caches decoded style.
+    RustFFI::rust_layout_propagate_root_styles_to_viewport(viewport.arena_handle(), Node::slot_id(&viewport), &facts, &apply_callbacks);
+    viewport.node_arena().sync_enrolled_content_for_layout();
 
     auto callbacks = formatting_context_callbacks();
     auto sink = commit_sink();

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -621,6 +621,7 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
             auto const* dom_node = static_cast<Box const*>(node)->dom_node();
             return dom_node ? dom_node->unique_id().value() : -1;
         },
+        .inline_containing_block_lookup = Node::inline_containing_block_lookup_for_arena,
     };
 }
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -878,6 +878,21 @@ void NodeWithStyle::set_overflow(CSS::Overflow overflow_x, CSS::Overflow overflo
     });
 }
 
+void NodeWithStyle::set_writing_mode_and_direction(CSS::WritingMode writing_mode, CSS::Direction direction)
+{
+    modify_computed_values([&](auto& values) {
+        values.set_writing_mode(writing_mode);
+        values.set_direction(direction);
+    });
+}
+
+void NodeWithStyle::set_scrollbar_width(CSS::ScrollbarWidth scrollbar_width)
+{
+    modify_computed_values([&](auto& values) {
+        values.set_scrollbar_width(scrollbar_width);
+    });
+}
+
 void NodeWithStyle::reset_table_box_computed_values_used_by_wrapper_to_init_values()
 {
     VERIFY(this->display().is_table_inside());

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -280,6 +280,13 @@ NodeWithStyle const* Node::find_inline_containing_block(Box const& containing_bl
     return nullptr;
 }
 
+RustFFI::NodeSlotId Node::inline_containing_block_lookup_for_arena(void* node_shell, void* containing_block_shell)
+{
+    auto const& node = *static_cast<Node const*>(node_shell);
+    auto const& containing_block = *static_cast<Box const*>(containing_block_shell);
+    return slot_id(node.find_inline_containing_block(containing_block));
+}
+
 GC::Ptr<HTML::LocalNavigable> Node::navigable() const
 {
     return document().navigable();

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -697,6 +697,8 @@ public:
     void set_display(CSS::Display);
     void set_content(CSS::ContentData const&);
     void set_overflow(CSS::Overflow overflow_x, CSS::Overflow overflow_y);
+    void set_writing_mode_and_direction(CSS::WritingMode, CSS::Direction);
+    void set_scrollbar_width(CSS::ScrollbarWidth);
 
 private:
     CSS::ComputedStyleRecordView computed_style_record_view() const;

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -282,9 +282,10 @@ public:
 
     bool is_flex_item() const { return has_flag(RustFFI::NodeFlag::IsFlexItem); }
 
-    // The containing block is computed inside the Rust arena
-    // (layout_arena_recompute_containing_blocks); the stored slot is always a Box or invalid.
-    // The tolerant resolution yields null when the containing block's slot has been freed.
+    // The containing block is computed inside the Rust arena, by the tree builder for rebuilt
+    // subtrees and by the layout entries for the subtree they lay out; the stored slot is always
+    // a Box or invalid. The tolerant resolution yields null when the containing block's slot has
+    // been freed.
     [[nodiscard]] Box const* containing_block() const;
     [[nodiscard]] Box* containing_block();
 
@@ -293,6 +294,9 @@ public:
     // walking the DOM tree. Invoked from the Rust containing-block recomputation, which owns
     // the layout-tree half of the walk but cannot see DOM ancestry.
     [[nodiscard]] NodeWithStyle const* find_inline_containing_block(Box const& containing_block) const;
+    // The same, in the shape the arena walk calls it with: both arguments are layout node shells.
+    // Shared by the layout and tree builder callback tables.
+    [[nodiscard]] static RustFFI::NodeSlotId inline_containing_block_lookup_for_arena(void* node_shell, void* containing_block_shell);
 
     Gfx::Font const& first_available_font() const;
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1290,6 +1290,14 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(document_pointer);
             // NB: Called during layout tree construction.
             return Node::slot_id(static_cast<DOM::Document*>(document_pointer)->unsafe_layout_node()); },
+        .document_element_layout_node = [](void* document_pointer) -> RustFFI::NodeSlotId {
+            VERIFY(document_pointer);
+            // NB: Called during layout tree construction.
+            auto* document_element = static_cast<DOM::Document*>(document_pointer)->document_element();
+            return Node::slot_id(document_element ? document_element->unsafe_layout_node() : nullptr); },
+        .apply_viewport_scrollbar_width = [](void* viewport_shell, u8 scrollbar_width) {
+            VERIFY(viewport_shell);
+            as<Viewport>(*static_cast<Node*>(viewport_shell)).set_scrollbar_width(static_cast<CSS::ScrollbarWidth>(scrollbar_width)); },
         .report_rebuild_outcome = [](void* builder_pointer, void* const* rebuilt_root_pointers, size_t rebuilt_root_count, bool layout_tree_update_escaped_rebuild_roots) {
             VERIFY(builder_pointer);
             VERIFY(rebuilt_root_pointers || rebuilt_root_count == 0);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1367,6 +1367,7 @@ RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_ca
         .prepare_subtree_for_detach = [](void*, void* layout_node_pointer) {
             VERIFY(layout_node_pointer);
             static_cast<Node*>(layout_node_pointer)->prepare_subtree_for_detach_from_layout_tree(); },
+        .inline_containing_block_lookup = Node::inline_containing_block_lookup_for_arena,
     };
 }
 

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -3092,6 +3092,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             manifest_dir.join("src/css/computed_value_types.rs"),
             manifest_dir.join("src/css/display.rs"),
             manifest_dir.join("src/layout/formatting_context.rs"),
+            manifest_dir.join("src/layout/viewport_propagation.rs"),
             manifest_dir.join("src/layout/flex_formatting_context.rs"),
             manifest_dir.join("src/layout/grid_formatting_context.rs"),
             manifest_dir.join("src/layout/svg_formatting_context.rs"),

--- a/Libraries/LibWeb/Rust/src/css/computed_value_views.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_value_views.rs
@@ -641,7 +641,6 @@ impl<'a> ComputedValuesView<'a> {
     }
 
     #[inline]
-    #[allow(dead_code)]
     pub(crate) fn misc_reset(self) -> &'a MiscResetValues {
         self.native_group(STYLE_GROUP_INDEX_MISC_RESET)
     }

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -2055,6 +2055,9 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
     // SAFETY: The host keeps the document's layout inputs alive and unchanged
     // while computing fragments. Nested measurements only mutate side caches.
     let arena = unsafe { LayoutNodeArena::from_handle(host.arena) };
+    // A full pass re-derives every fact partial relayout boundary qualification depends on, so
+    // pending changes that escaped classification are accounted for from here on.
+    arena.clear_partial_relayout_escape();
     let callbacks = LayoutPass::new(arena, host);
     let sink = unsafe { &*sink };
     let viewport_inline_size = CssPixels::from_raw(viewport_inline_size_raw);

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -893,6 +893,10 @@ pub struct FfiLayoutFcCallbacks {
         unsafe extern "C" fn(*mut c_void, *mut c_void, CssPixels, CssPixels) -> svg_formatting_context::FfiFloatRect,
     pub anchor_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, *const *mut c_void, usize) -> NodeSlotId,
     pub node_unique_id: unsafe extern "C" fn(*mut c_void) -> i64,
+    /// The DOM-ancestry half of containing-block recomputation: receives the shells of an
+    /// absolutely positioned node and its containing block, must not mutate the layout tree or
+    /// its styles, and returns the slot of the intervening inline containing block, if any.
+    pub inline_containing_block_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
 }
 
 pub(crate) struct FormattingContextRun<'pass> {
@@ -2055,8 +2059,11 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
     // SAFETY: The host keeps the document's layout inputs alive and unchanged
     // while computing fragments. Nested measurements only mutate side caches.
     let arena = unsafe { LayoutNodeArena::from_handle(host.arena) };
-    // A full pass re-derives every fact partial relayout boundary qualification depends on, so
-    // pending changes that escaped classification are accounted for from here on.
+    // Containing blocks follow style facts a layout invalidation can change without a tree
+    // update, so a full pass re-derives them for the whole tree. That walk re-derives every fact
+    // partial relayout boundary qualification depends on, so pending changes that escaped
+    // classification are accounted for from here on.
+    arena.recompute_containing_blocks_in_subtree(root, host.inline_containing_block_lookup);
     arena.clear_partial_relayout_escape();
     let callbacks = LayoutPass::new(arena, host);
     let sink = unsafe { &*sink };
@@ -2218,6 +2225,10 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
     let arena = unsafe { LayoutNodeArena::from_handle(host.arena) };
     let callbacks = LayoutPass::new(arena, host);
     let sink = unsafe { &*sink };
+    // The boundary can be wider than the rebuilt roots that led to it, and laying it out may
+    // re-enter intrinsic sizing for descendants outside those roots, including anonymous boxes
+    // the incremental tree build created; refresh the containing blocks of the whole subtree.
+    arena.recompute_containing_blocks_in_subtree(root, host.inline_containing_block_lookup);
 
     let pass_fragments = RunRecords::with_unrooted(arena, root, |entry_records| {
         let root_used = used_values::used_values_from_committed_fragment_link(&callbacks, root)
@@ -2314,6 +2325,8 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
     let arena = unsafe { LayoutNodeArena::from_handle(host.arena) };
     let callbacks = LayoutPass::new(arena, host);
     let sink = unsafe { &*sink };
+    // As for a subtree layout: the replayed box's own subtree is what is about to be laid out.
+    arena.recompute_containing_blocks_in_subtree(box_, host.inline_containing_block_lookup);
     let containing_block = callbacks.containing_block(box_);
     assert!(!containing_block.is_invalid());
     let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -2123,16 +2123,11 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
         )
     });
     // SAFETY: Computation has finished and its input borrows are no longer used.
-    // Commit performs no host callbacks while it borrows the arena exclusively.
-    let notifications = commit::commit_replacing(
-        root,
-        unsafe { LayoutNodeArena::from_handle_mut(host.arena) },
-        &pass_fragments,
-    );
-    // SAFETY: The host and shells remain live, and commit's mutable borrow has ended.
-    unsafe { notifications.notify_host(sink) };
-    // SAFETY: Host callbacks have returned; borrow the arena again for cache maintenance.
-    unsafe { LayoutNodeArena::from_handle(host.arena) }.sweep_stale_fc_run_cache_entries();
+    let arena = unsafe { commit_entry_pass(host, root, &pass_fragments, sink) };
+    // The full scrollable overflow update measures eagerly and returns without refilling the
+    // contained-boxes index, so the index is rebuilt here from the freshly committed rows.
+    arena.rebuild_scrollable_overflow_contained_boxes(root);
+    arena.set_needs_full_scrollable_overflow_recalculation();
 }
 
 fn finish_entry_pass(
@@ -2153,6 +2148,48 @@ fn finish_entry_pass(
         "an entry pass always produces the entry root's fragment"
     );
     pass_fragments
+}
+
+/// Commits the finished entry pass rooted at `commit_root` and settles the arena-local
+/// bookkeeping every layout entry owes its caller: host notifications, cache maintenance, and
+/// the reset of the update flags the committed subtree satisfied. Returns the arena re-borrowed
+/// after commit for entry-specific epilogues.
+///
+/// # Safety
+///
+/// `host.arena` must be the live arena the pass computed against, `sink` must remain valid for
+/// the call, and no borrow taken during the pass may still be live.
+unsafe fn commit_entry_pass<'a>(
+    host: &'a FfiLayoutFcCallbacks,
+    commit_root: NodeSlotId,
+    pass_fragments: &fragment_tree::CompletedPassFragments,
+    sink: &commit::FfiCommitSink,
+) -> &'a LayoutNodeArena {
+    // SAFETY: Computation has finished and its input borrows are no longer used.
+    // Commit performs no host callbacks while it borrows the arena exclusively.
+    let notifications = commit::commit_replacing(
+        commit_root,
+        unsafe { LayoutNodeArena::from_handle_mut(host.arena) },
+        pass_fragments,
+    );
+    // SAFETY: The host and shells remain live, and commit's mutable borrow has ended.
+    unsafe { notifications.notify_host(sink) };
+    // SAFETY: Host callbacks have returned; borrow the arena again for the epilogue, which
+    // performs no host callbacks.
+    let arena = unsafe { LayoutNodeArena::from_handle(host.arena) };
+    arena.sweep_stale_fc_run_cache_entries();
+    arena.reset_layout_update_flags_in_subtree(commit_root);
+    arena
+}
+
+/// The subtree commit reset the root's descendant rows, and the subtree's new size may change
+/// ancestor scrollable overflow; scheduling the root covers both.
+fn schedule_scrollable_overflow_recalculation_for_relaid_out_root(arena: &LayoutNodeArena, root: NodeSlotId) {
+    // A partial relayout root is an SVG viewport or an absolutely positioned box, never an SVG
+    // content box, so the host's rule of re-laying out SVG content instead of scheduling does not
+    // apply here.
+    debug_assert!(!node_facts::kind_is_svg_box(arena.data(root).kind.get()));
+    arena.schedule_scrollable_overflow_recalculation(root);
 }
 
 /// # Safety
@@ -2250,16 +2287,8 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         finish_entry_pass(entry_records, &entry_fragments, &callbacks, false)
     });
     // SAFETY: Computation has finished and its input borrows are no longer used.
-    // Commit performs no host callbacks while it borrows the arena exclusively.
-    let notifications = commit::commit_replacing(
-        root,
-        unsafe { LayoutNodeArena::from_handle_mut(host.arena) },
-        &pass_fragments,
-    );
-    // SAFETY: The host and shells remain live, and commit's mutable borrow has ended.
-    unsafe { notifications.notify_host(sink) };
-    // SAFETY: Host callbacks have returned; borrow the arena again for cache maintenance.
-    unsafe { LayoutNodeArena::from_handle(host.arena) }.sweep_stale_fc_run_cache_entries();
+    let arena = unsafe { commit_entry_pass(host, root, &pass_fragments, sink) };
+    schedule_scrollable_overflow_recalculation_for_relaid_out_root(arena, root);
 }
 
 /// # Safety
@@ -2303,14 +2332,6 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
         finish_entry_pass(entry_records, &entry_fragments, &callbacks, false)
     });
     // SAFETY: Computation has finished and its input borrows are no longer used.
-    // Commit performs no host callbacks while it borrows the arena exclusively.
-    let notifications = commit::commit_replacing(
-        box_,
-        unsafe { LayoutNodeArena::from_handle_mut(host.arena) },
-        &pass_fragments,
-    );
-    // SAFETY: The host and shells remain live, and commit's mutable borrow has ended.
-    unsafe { notifications.notify_host(sink) };
-    // SAFETY: Host callbacks have returned; borrow the arena again for cache maintenance.
-    unsafe { LayoutNodeArena::from_handle(host.arena) }.sweep_stale_fc_run_cache_entries();
+    let arena = unsafe { commit_entry_pass(host, box_, &pass_fragments, sink) };
+    schedule_scrollable_overflow_recalculation_for_relaid_out_root(arena, box_);
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -2746,16 +2746,6 @@ pub unsafe extern "C" fn layout_arena_pre_order_relabel_count(arena: *mut c_void
 /// # Safety
 ///
 /// The arena must remain valid for the duration of the call, and `root` must
-/// name the root of a live subtree in this arena.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_reset_layout_update_flags_in_subtree(arena: *mut c_void, root: NodeSlotId) {
-    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-    unsafe { LayoutNodeArena::from_handle(arena) }.reset_layout_update_flags_in_subtree(root);
-}
-
-/// # Safety
-///
-/// The arena must remain valid for the duration of the call, and `root` must
 /// name the root of a live subtree in this arena. `inline_cb_lookup` is invoked
 /// for each absolutely positioned node with a resolved containing block; it
 /// receives the two nodes' shell pointers, must not mutate the layout tree or

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -545,6 +545,11 @@ pub(crate) struct LayoutNodeArena {
     paint_state: RefCell<crate::painting::paint_state::PaintState>,
     svg_pattern_referencing_nodes: RefCell<Vec<NodeSlotId>>,
     pub(crate) partial_relayout_boundary_roots: RefCell<Vec<NodeSlotId>>,
+    /// Attribution of pending updates for partial relayout. Invariant: every update recorded
+    /// since the last layout pass is either attributed to a boundary in the root set above, or
+    /// this escape bit is set. Partial relayout may only run while the bit is clear; a full
+    /// layout pass re-derives every fact boundary qualification depends on, so it clears the bit.
+    pub(crate) pending_updates_escape_partial_relayout: Cell<bool>,
     pub(crate) boxes_needing_scrollable_overflow_recalculation: RefCell<Vec<NodeSlotId>>,
     pub(crate) needs_full_scrollable_overflow_recalculation: Cell<bool>,
     text_nodes_enrolled_for_content_sync: RefCell<HashSet<NodeSlotId>>,
@@ -586,6 +591,7 @@ impl LayoutNodeArena {
             paint_state: RefCell::new(crate::painting::paint_state::PaintState::default()),
             svg_pattern_referencing_nodes: RefCell::new(Vec::new()),
             partial_relayout_boundary_roots: RefCell::new(Vec::new()),
+            pending_updates_escape_partial_relayout: Cell::new(false),
             boxes_needing_scrollable_overflow_recalculation: RefCell::new(Vec::new()),
             needs_full_scrollable_overflow_recalculation: Cell::new(false),
             text_nodes_enrolled_for_content_sync: RefCell::new(HashSet::default()),

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -2751,24 +2751,6 @@ pub unsafe extern "C" fn layout_arena_pre_order_relabel_count(arena: *mut c_void
 
 /// # Safety
 ///
-/// The arena must remain valid for the duration of the call, and `root` must
-/// name the root of a live subtree in this arena. `inline_cb_lookup` is invoked
-/// for each absolutely positioned node with a resolved containing block; it
-/// receives the two nodes' shell pointers, must not mutate the layout tree or
-/// its styles, and must return the slot of the intervening inline containing
-/// block or the invalid slot id.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_recompute_containing_blocks(
-    arena: *mut c_void,
-    root: NodeSlotId,
-    inline_cb_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
-) {
-    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-    unsafe { LayoutNodeArena::from_handle(arena) }.recompute_containing_blocks_in_subtree(root, inline_cb_lookup);
-}
-
-/// # Safety
-///
 /// The arena must remain valid for the duration of the call. `id` may be
 /// invalid or stale; null is returned in that case.
 #[unsafe(no_mangle)]

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -46,6 +46,7 @@ mod text_transform;
 mod tree_builder;
 mod tree_mutation;
 pub mod used_values;
+mod viewport_propagation;
 
 use crate::css::style::fast_hash::FastMap as HashMap;
 use crate::css::style::fast_hash::FastSet as HashSet;

--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -12,7 +12,6 @@ use std::ffi::c_void;
 
 #[repr(C)]
 pub struct FfiLayoutTreeUpdateClassification {
-    pub layout_node_is_detached_from_tree: bool,
     pub marks_partial_relayout_boundary_self_only: bool,
     pub nearest_non_anonymous_ancestor_when_parent_is_anonymous: NodeSlotId,
 }
@@ -31,6 +30,12 @@ impl LayoutNodeArena {
     ) -> FfiLayoutTreeUpdateClassification {
         let data = self.data(node);
         let (kind, parent) = (data.kind.get(), data.parent.get());
+
+        // A dirty DOM node whose box is outside the layout tree cannot attribute its update to
+        // any boundary.
+        if parent.is_invalid() && kind != NodeKind::Viewport {
+            self.record_partial_relayout_escape();
+        }
 
         let marks_boundary_self_only = node_facts::kind_is_box(kind)
             && reason_is_structural_boundary_self_rebuild
@@ -57,7 +62,6 @@ impl LayoutNodeArena {
         }
 
         FfiLayoutTreeUpdateClassification {
-            layout_node_is_detached_from_tree: parent.is_invalid() && kind != NodeKind::Viewport,
             marks_partial_relayout_boundary_self_only: marks_boundary_self_only,
             nearest_non_anonymous_ancestor_when_parent_is_anonymous: nearest_non_anonymous_ancestor,
         }
@@ -166,6 +170,55 @@ impl LayoutNodeArena {
 
     pub(crate) fn take_partial_relayout_boundary_roots(&self) -> Vec<NodeSlotId> {
         std::mem::take(&mut *self.partial_relayout_boundary_roots.borrow_mut())
+    }
+
+    pub(crate) fn record_partial_relayout_escape(&self) {
+        self.pending_updates_escape_partial_relayout.set(true);
+    }
+
+    pub(crate) fn clear_partial_relayout_escape(&self) {
+        self.pending_updates_escape_partial_relayout.set(false);
+    }
+
+    fn node_needs_layout_update(&self, node: NodeSlotId) -> bool {
+        node_facts::has_flag(self.data(node), NodeFlag::NeedsLayoutUpdate)
+    }
+
+    /// Whether the pending update may be satisfied by re-laying out only registered boundary
+    /// subtrees. Decided before the layout tree build, so an ineligible update takes the full
+    /// layout path's build instead. `root` may be the invalid slot when no tree exists yet.
+    pub(crate) fn partial_relayout_may_be_attempted(
+        &self,
+        root: NodeSlotId,
+        registered_root_slots: &[NodeSlotId],
+        facts: FfiPartialRelayoutHostFacts,
+    ) -> bool {
+        !(root.is_invalid()
+            || facts.document_needs_full_layout_tree_update
+            || self.pending_updates_escape_partial_relayout.get()
+            || registered_root_slots.is_empty()
+            || self.node_needs_layout_update(root)
+            || facts.container_query_evaluation_is_pending
+            || facts.should_collect_devtools_layout_data
+            || facts.any_anchor_names_are_registered)
+    }
+
+    /// Selects the boundary subtrees to relay out after the layout tree build. Consumes the
+    /// escape bit either way: a refusal here is followed by a full layout pass in the same
+    /// update, which re-derives every fact the bit stands in for.
+    pub(crate) fn plan_partial_relayout(
+        &self,
+        root: NodeSlotId,
+        registered_root_slots: &[NodeSlotId],
+        rebuilt_subtree_root_slots: &[NodeSlotId],
+        layout_tree_update_escaped_rebuild_roots: bool,
+    ) -> Option<Vec<NodeSlotId>> {
+        let pending_updates_escaped =
+            self.pending_updates_escape_partial_relayout.replace(false) || layout_tree_update_escaped_rebuild_roots;
+        if self.node_needs_layout_update(root) || pending_updates_escaped {
+            return None;
+        }
+        self.collect_partial_relayout_roots(registered_root_slots, rebuilt_subtree_root_slots)
     }
 
     fn nearest_inclusive_partial_relayout_boundary(&self, node: NodeSlotId) -> Option<NodeSlotId> {
@@ -455,36 +508,77 @@ pub unsafe extern "C" fn layout_arena_take_partial_relayout_boundary_roots(
     }
 }
 
+/// The facts the host owns that take an update off the partial relayout path.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPartialRelayoutHostFacts {
+    pub document_needs_full_layout_tree_update: bool,
+    pub container_query_evaluation_is_pending: bool,
+    pub should_collect_devtools_layout_data: bool,
+    pub any_anchor_names_are_registered: bool,
+}
+
+/// # Safety
+///
+/// `slots` must be valid for `count` elements whenever `count` is nonzero.
+unsafe fn slot_slice<'a>(slots: *const NodeSlotId, count: usize) -> &'a [NodeSlotId] {
+    if count == 0 {
+        &[]
+    } else {
+        // SAFETY: A nonzero count implies a valid array of that length.
+        unsafe { std::slice::from_raw_parts(slots, count) }
+    }
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_record_partial_relayout_escape(arena: *mut c_void) {
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.record_partial_relayout_escape();
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and the slot array must be valid
+/// for its count; its slots may be stale. `root` may be the invalid slot id.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_partial_relayout_may_be_attempted(
+    arena: *mut c_void,
+    root: NodeSlotId,
+    registered_root_slots: *const NodeSlotId,
+    registered_root_count: usize,
+    facts: FfiPartialRelayoutHostFacts,
+) -> bool {
+    // SAFETY: The C++ caller keeps the arena and the slot array alive for this call.
+    let arena = unsafe { LayoutNodeArena::from_handle(arena) };
+    let registered = unsafe { slot_slice(registered_root_slots, registered_root_count) };
+    arena.partial_relayout_may_be_attempted(root, registered, facts)
+}
+
 /// # Safety
 ///
 /// The arena must remain valid for the duration of the call, and both slot arrays must be
 /// valid for their counts. Slots in `registered_root_slots` may be stale; slots in
-/// `rebuilt_subtree_root_slots` must name live nodes in this arena.
+/// `rebuilt_subtree_root_slots` and `root` must name live nodes in this arena.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_collect_partial_relayout_roots(
+pub unsafe extern "C" fn layout_arena_plan_partial_relayout(
     arena: *mut c_void,
+    root: NodeSlotId,
     registered_root_slots: *const NodeSlotId,
     registered_root_count: usize,
     rebuilt_subtree_root_slots: *const NodeSlotId,
     rebuilt_subtree_root_count: usize,
+    layout_tree_update_escaped_rebuild_roots: bool,
     context: *mut c_void,
     push_root: unsafe extern "C" fn(*mut c_void, NodeSlotId),
 ) -> bool {
     // SAFETY: The C++ caller keeps the arena and both slot arrays alive for this call.
     let arena = unsafe { LayoutNodeArena::from_handle(arena) };
-    let registered = if registered_root_count == 0 {
-        &[]
-    } else {
-        // SAFETY: A nonzero count implies a valid array of that length.
-        unsafe { std::slice::from_raw_parts(registered_root_slots, registered_root_count) }
-    };
-    let rebuilt = if rebuilt_subtree_root_count == 0 {
-        &[]
-    } else {
-        // SAFETY: A nonzero count implies a valid array of that length.
-        unsafe { std::slice::from_raw_parts(rebuilt_subtree_root_slots, rebuilt_subtree_root_count) }
-    };
-    match arena.collect_partial_relayout_roots(registered, rebuilt) {
+    let registered = unsafe { slot_slice(registered_root_slots, registered_root_count) };
+    let rebuilt = unsafe { slot_slice(rebuilt_subtree_root_slots, rebuilt_subtree_root_count) };
+    match arena.plan_partial_relayout(root, registered, rebuilt, layout_tree_update_escaped_rebuild_roots) {
         Some(roots) => {
             for root in roots {
                 // SAFETY: The C++ callback appends the slot id to a caller-owned collection.
@@ -540,6 +634,7 @@ pub unsafe extern "C" fn layout_arena_set_needs_layout_update(
 
 #[cfg(test)]
 mod tests {
+    use super::FfiPartialRelayoutHostFacts;
     use crate::layout::layout_node_arena::{LayoutNodeArena, NodeAllocation};
     use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
 
@@ -726,7 +821,7 @@ mod tests {
         arena.insert_child(anonymous_parent.slot, child.slot, NodeSlotId::INVALID);
 
         let classification = arena.classify_layout_tree_update(child.slot, false);
-        assert!(!classification.layout_node_is_detached_from_tree);
+        assert!(!arena.pending_updates_escape_partial_relayout.get());
         assert!(!classification.marks_partial_relayout_boundary_self_only);
         assert_eq!(
             classification.nearest_non_anonymous_ancestor_when_parent_is_anonymous,
@@ -739,9 +834,98 @@ mod tests {
             NodeSlotId::INVALID
         );
 
-        let detached_classification = arena.classify_layout_tree_update(grandparent.slot, false);
-        assert!(detached_classification.layout_node_is_detached_from_tree);
+        arena.classify_layout_tree_update(grandparent.slot, false);
+        assert!(arena.pending_updates_escape_partial_relayout.get());
         free_node(&mut arena, &grandparent);
+    }
+
+    fn host_facts_permitting_partial_relayout() -> FfiPartialRelayoutHostFacts {
+        FfiPartialRelayoutHostFacts {
+            document_needs_full_layout_tree_update: false,
+            container_query_evaluation_is_pending: false,
+            should_collect_devtools_layout_data: false,
+            any_anchor_names_are_registered: false,
+        }
+    }
+
+    // A parent box with one child registered as a boundary root, drained like a pass would.
+    fn arena_with_a_registered_child_root() -> (LayoutNodeArena, NodeAllocation, Vec<NodeSlotId>) {
+        let mut arena = LayoutNodeArena::new();
+        let parent = allocate_box_with_a_dummy_shell(&mut arena);
+        let child = allocate_box_with_a_dummy_shell(&mut arena);
+        arena.insert_child(parent.slot, child.slot, NodeSlotId::INVALID);
+        arena.set_needs_layout_update(child.slot, false);
+        let registered = arena.take_partial_relayout_boundary_roots();
+        assert_eq!(registered, vec![child.slot]);
+        (arena, parent, registered)
+    }
+
+    #[test]
+    fn a_recorded_escape_refuses_the_precheck_until_a_plan_consumes_it() {
+        let (mut arena, parent, registered) = arena_with_a_registered_child_root();
+        let facts = host_facts_permitting_partial_relayout();
+
+        assert!(arena.partial_relayout_may_be_attempted(parent.slot, &registered, facts));
+        arena.record_partial_relayout_escape();
+        assert!(!arena.partial_relayout_may_be_attempted(parent.slot, &registered, facts));
+
+        assert_eq!(arena.plan_partial_relayout(parent.slot, &registered, &[], false), None);
+        assert!(!arena.pending_updates_escape_partial_relayout.get());
+        assert!(arena.partial_relayout_may_be_attempted(parent.slot, &registered, facts));
+        free_node(&mut arena, &parent);
+    }
+
+    #[test]
+    fn planning_refuses_when_the_build_escaped_its_rebuild_roots() {
+        let (mut arena, parent, registered) = arena_with_a_registered_child_root();
+        assert_eq!(arena.plan_partial_relayout(parent.slot, &registered, &[], true), None);
+        assert!(!arena.pending_updates_escape_partial_relayout.get());
+        free_node(&mut arena, &parent);
+    }
+
+    #[test]
+    fn a_dirty_root_refuses_both_the_precheck_and_the_plan() {
+        let (mut arena, parent, registered) = arena_with_a_registered_child_root();
+        arena.set_node_flag(parent.slot, NodeFlag::NeedsLayoutUpdate, true);
+        assert!(!arena.partial_relayout_may_be_attempted(
+            parent.slot,
+            &registered,
+            host_facts_permitting_partial_relayout()
+        ));
+        assert_eq!(arena.plan_partial_relayout(parent.slot, &registered, &[], false), None);
+        free_node(&mut arena, &parent);
+    }
+
+    #[test]
+    fn the_precheck_refuses_a_missing_root_an_empty_root_set_and_every_host_fact() {
+        let (mut arena, parent, registered) = arena_with_a_registered_child_root();
+        let permitted = host_facts_permitting_partial_relayout();
+
+        assert!(!arena.partial_relayout_may_be_attempted(NodeSlotId::INVALID, &registered, permitted));
+        assert!(!arena.partial_relayout_may_be_attempted(parent.slot, &[], permitted));
+
+        let refusing_facts = [
+            FfiPartialRelayoutHostFacts {
+                document_needs_full_layout_tree_update: true,
+                ..permitted
+            },
+            FfiPartialRelayoutHostFacts {
+                container_query_evaluation_is_pending: true,
+                ..permitted
+            },
+            FfiPartialRelayoutHostFacts {
+                should_collect_devtools_layout_data: true,
+                ..permitted
+            },
+            FfiPartialRelayoutHostFacts {
+                any_anchor_names_are_registered: true,
+                ..permitted
+            },
+        ];
+        for facts in refusing_facts {
+            assert!(!arena.partial_relayout_may_be_attempted(parent.slot, &registered, facts));
+        }
+        free_node(&mut arena, &parent);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -1805,26 +1805,44 @@ pub unsafe extern "C" fn rust_build_layout_tree(
     // NB: Called during layout tree construction.
     // SAFETY: The document remains live and any attached layout root is owned by it and the builder.
     let document_layout_node = unsafe { (host.callbacks.document_layout_node)(document) };
+    let rebuilt_subtrees_were_updated_individually = !document_layout_node.is_invalid()
+        && !(entry_facts.document_needs_full_layout_tree_update
+            || !entry_facts.has_layout_node
+            || state.layout_tree_update_escaped_rebuild_roots);
     if !document_layout_node.is_invalid() {
         let layout_host = host.layout();
-        if entry_facts.document_needs_full_layout_tree_update
-            || !entry_facts.has_layout_node
-            || state.layout_tree_update_escaped_rebuild_roots
-        {
-            fixup_tables(&layout_host, document_layout_node);
-        } else {
+        if rebuilt_subtrees_were_updated_individually {
             fixup_tables_in_rebuilt_subtrees(
                 &layout_host,
                 &state.rebuilt_subtree_roots,
                 &state.reused_child_list_update_roots,
                 &state.additional_table_fixup_roots,
             );
+        } else {
+            fixup_tables(&layout_host, document_layout_node);
         }
     }
 
     for &element in &state.layout_tree_rebuild_requests {
         // SAFETY: The builder remains live, and the walk that could clear DOM update flags is complete.
         unsafe { (host.callbacks.request_layout_tree_rebuild)(host.callbacks.builder, element) };
+    }
+
+    if rebuilt_subtrees_were_updated_individually {
+        // Nodes created by the incremental build have no containing blocks assigned yet, and the
+        // mutation may have moved where existing out-of-flow descendants belong; recompute both so
+        // partial relayout boundary qualification reads facts matching the just-built tree. A full
+        // layout pass re-derives them for the whole tree instead.
+        let layout_host = host.layout();
+        for &root in &state.rebuilt_subtree_roots {
+            // A later mutation in the same build can have replaced a rebuilt root's box.
+            if layout_host.arena().node_data_if_live(root).is_none() {
+                continue;
+            }
+            layout_host
+                .arena()
+                .recompute_containing_blocks_in_subtree(root, layout_host.callbacks.inline_containing_block_lookup);
+        }
     }
 
     // SAFETY: The builder remains live and copies the reported shell pointers before returning.
@@ -2254,6 +2272,8 @@ pub struct FfiTreeBuilderCallbacks {
     pub take_fieldset_overflow_for_content_wrapper:
         unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiAnonymousStyleOverrides,
     pub prepare_subtree_for_detach: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    /// The DOM-ancestry half of containing-block recomputation; see the layout callback table.
+    pub inline_containing_block_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -125,6 +125,9 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
     pub set_layout_root: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
+    pub document_element_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
+    /// Sets `scrollbar-width` on the viewport box's computed style.
+    pub apply_viewport_scrollbar_width: unsafe extern "C" fn(*mut c_void, u8),
     pub report_rebuild_outcome: unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize, bool),
     pub layout: FfiTreeBuilderCallbacks,
     pub pseudo: FfiPseudoTreeBuilderCallbacks,
@@ -1820,6 +1823,26 @@ pub unsafe extern "C" fn rust_build_layout_tree(
             );
         } else {
             fixup_tables(&layout_host, document_layout_node);
+        }
+
+        // https://drafts.csswg.org/css-scrollbars/#scrollbar-width
+        // UAs must apply the scrollbar-color value set on the root element to the viewport.
+        // NB: Called during layout tree construction.
+        // SAFETY: The document remains live throughout the build.
+        let root_layout_node = unsafe { (host.callbacks.document_element_layout_node)(document) };
+        if !root_layout_node.is_invalid() {
+            let scrollbar_width = layout_host
+                .style(root_layout_node)
+                .expect("the document element's box publishes its style during the build")
+                .misc_reset()
+                .scrollbar_width;
+            // SAFETY: The viewport shell is live, and the build runs outside any layout pass.
+            unsafe {
+                (host.callbacks.apply_viewport_scrollbar_width)(
+                    layout_host.shell(document_layout_node),
+                    scrollbar_width,
+                );
+            }
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/viewport_propagation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/viewport_propagation.rs
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Propagation of the root element's and its body's style to the viewport: the principal
+//! writing mode and the viewport's overflow. The host reads the inputs from the elements' own
+//! style records rather than from their boxes, since the previous pass rewrote the boxes'
+//! values and a `display: none` body has style but no box, and applies the results through
+//! the boxes' style setters outside any layout pass.
+
+use crate::css::css_enums::overflow;
+use crate::layout::LayoutNodeArena;
+use crate::layout::node_data::NodeSlotId;
+use std::ffi::c_void;
+
+/// What the host knows about the document element and its first HTML body child element.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiViewportPropagationFacts {
+    /// Invalid when there is no document element or it has no box.
+    pub root_layout_node: NodeSlotId,
+    pub root_is_html_html_element: bool,
+    pub root_overflow_x: u8,
+    pub root_overflow_y: u8,
+    pub root_writing_mode: u8,
+    pub root_direction: u8,
+    /// Any of size, inline-size, layout, style or paint containment.
+    pub root_has_containment: bool,
+    /// The root element has an HTML body child element with computed style.
+    pub has_styled_body: bool,
+    /// Invalid when the body has no box.
+    pub body_layout_node: NodeSlotId,
+    pub body_display_is_none: bool,
+    pub body_overflow_x: u8,
+    pub body_overflow_y: u8,
+    pub body_writing_mode: u8,
+    pub body_direction: u8,
+    pub body_has_containment: bool,
+}
+
+/// Each callback receives a layout node shell and the values to set on its computed style.
+#[repr(C)]
+pub struct FfiViewportPropagationApplyCallbacks {
+    pub context: *mut c_void,
+    pub apply_overflow: unsafe extern "C" fn(*mut c_void, *mut c_void, u8, u8),
+    pub apply_writing_mode_and_direction: unsafe extern "C" fn(*mut c_void, *mut c_void, u8, u8),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PropagatedViewportStyles {
+    pub(crate) writing_mode: u8,
+    pub(crate) direction: u8,
+    pub(crate) viewport_overflow: (u8, u8),
+    pub(crate) root_overflow: (u8, u8),
+    /// Present when the body has a box that takes part in overflow propagation.
+    pub(crate) body_overflow: Option<(u8, u8)>,
+}
+
+// https://drafts.csswg.org/css-overflow-3/#overflow-propagation
+// If 'visible' is applied to the viewport, it must be interpreted as 'auto'. If 'clip' is applied
+// to the viewport, it must be interpreted as 'hidden'.
+fn overflow_as_applied_to_viewport(value: u8) -> u8 {
+    match value {
+        overflow::VISIBLE => overflow::AUTO,
+        overflow::CLIP => overflow::HIDDEN,
+        other => other,
+    }
+}
+
+/// `None` when the document element has no box; the viewport then only gets `overflow: auto`.
+pub(crate) fn decide_viewport_propagation(facts: &FfiViewportPropagationFacts) -> Option<PropagatedViewportStyles> {
+    if facts.root_layout_node.is_invalid() {
+        return None;
+    }
+    let body_is_styled = facts.has_styled_body;
+    let body_is_rendered = body_is_styled && !facts.body_display_is_none;
+
+    // https://drafts.csswg.org/css-writing-modes-4/#principal-flow
+    // The principal writing mode of the document is determined by the used writing-mode,
+    // direction, and text-orientation values of the root element. As a special case for handling
+    // HTML documents, if the root element has a body child element whose display value is not
+    // none, the used value of the writing-mode and direction properties on the root element are
+    // taken from the computed writing-mode and direction of the first such child element instead
+    // of from the root element's own values.
+    // NOTE: Using containment disables this special handling of the HTML body element.
+    let mut writing_mode = facts.root_writing_mode;
+    let mut direction = facts.root_direction;
+    let propagation_is_disabled_by_containment =
+        facts.root_has_containment || (body_is_styled && facts.body_has_containment);
+    if facts.root_is_html_html_element && !propagation_is_disabled_by_containment && body_is_rendered {
+        writing_mode = facts.body_writing_mode;
+        direction = facts.body_direction;
+    }
+
+    // https://drafts.csswg.org/css-contain-2/#contain-property
+    // Additionally, when any containments are active on either the HTML <html> or <body>
+    // elements, propagation of properties from the <body> element to the initial containing
+    // block, the viewport, or the canvas background, is disabled. Notably, this affects:
+    // - 'overflow' and its longhands (see CSS Overflow 3 § 3.3 Overflow Viewport Propagation)
+    let body_can_propagate_overflow = body_is_rendered && !facts.body_layout_node.is_invalid();
+    let body_propagation_is_disabled_by_containment = (facts.root_is_html_html_element && facts.root_has_containment)
+        || (body_is_styled && facts.body_has_containment);
+
+    // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
+    // UAs must apply the overflow-* values set on the root element to the viewport when the
+    // root element's display value is not none. However, when the root element is an [HTML]
+    // html element (including XML syntax for HTML) whose overflow value is visible (in both
+    // axes), and that element has as a child a body element whose display value is also not
+    // none, user agents must instead apply the overflow-* values of the first such child element
+    // to the viewport.
+    let root_overflow = (facts.root_overflow_x, facts.root_overflow_y);
+    let body_overflow = (facts.body_overflow_x, facts.body_overflow_y);
+    let body_is_overflow_origin = facts.root_is_html_html_element
+        && !body_propagation_is_disabled_by_containment
+        && root_overflow == (overflow::VISIBLE, overflow::VISIBLE)
+        && body_can_propagate_overflow;
+    let origin_overflow = if body_is_overflow_origin {
+        body_overflow
+    } else {
+        root_overflow
+    };
+
+    // The element from which the value is propagated must then have a used overflow value of
+    // visible.
+    // FIXME: Apply this to the used values, not the computed ones.
+    let visible = (overflow::VISIBLE, overflow::VISIBLE);
+    Some(PropagatedViewportStyles {
+        writing_mode,
+        direction,
+        viewport_overflow: (
+            overflow_as_applied_to_viewport(origin_overflow.0),
+            overflow_as_applied_to_viewport(origin_overflow.1),
+        ),
+        root_overflow: if body_is_overflow_origin {
+            root_overflow
+        } else {
+            visible
+        },
+        body_overflow: body_can_propagate_overflow.then_some(if body_is_overflow_origin {
+            visible
+        } else {
+            body_overflow
+        }),
+    })
+}
+
+/// Applies the propagation in the order the boxes were always rewritten in: the root's writing
+/// mode and direction, the viewport's, then the viewport's, the root's and the body's overflow.
+/// Every box receives its final values exactly once, so a steady-state pass leaves every style
+/// record untouched instead of oscillating values within the pass.
+///
+/// # Safety
+///
+/// The arena, `facts` and `callbacks` must remain valid for the duration of the call, `viewport`
+/// and the boxes named by the facts must be live, and the call must be made outside any layout
+/// pass: the apply callbacks replace computed values.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_layout_propagate_root_styles_to_viewport(
+    arena: *mut c_void,
+    viewport: NodeSlotId,
+    facts: *const FfiViewportPropagationFacts,
+    callbacks: *const FfiViewportPropagationApplyCallbacks,
+) {
+    assert!(!viewport.is_invalid());
+    assert!(!facts.is_null());
+    assert!(!callbacks.is_null());
+    // SAFETY: The C++ caller keeps the arena, the facts and the callback table alive for this
+    // synchronous call.
+    let arena = unsafe { LayoutNodeArena::from_handle(arena) };
+    let facts = unsafe { &*facts };
+    let callbacks = unsafe { &*callbacks };
+    let apply_overflow = |node: NodeSlotId, (overflow_x, overflow_y): (u8, u8)| {
+        // SAFETY: The node is live, and the host applies the values synchronously.
+        unsafe { (callbacks.apply_overflow)(callbacks.context, arena.node_shell(node), overflow_x, overflow_y) };
+    };
+    let apply_writing_mode_and_direction = |node: NodeSlotId, writing_mode: u8, direction: u8| {
+        // SAFETY: As above.
+        unsafe {
+            (callbacks.apply_writing_mode_and_direction)(
+                callbacks.context,
+                arena.node_shell(node),
+                writing_mode,
+                direction,
+            );
+        }
+    };
+
+    let Some(styles) = decide_viewport_propagation(facts) else {
+        apply_overflow(viewport, (overflow::AUTO, overflow::AUTO));
+        return;
+    };
+    let root = facts.root_layout_node;
+    apply_writing_mode_and_direction(root, styles.writing_mode, styles.direction);
+    // https://drafts.csswg.org/css-writing-modes-4/#icb
+    // The principal writing mode is propagated to the initial containing block and to the
+    // viewport, thereby affecting the layout of the root element and the scrolling direction of
+    // the viewport.
+    apply_writing_mode_and_direction(viewport, styles.writing_mode, styles.direction);
+    apply_overflow(viewport, styles.viewport_overflow);
+    apply_overflow(root, styles.root_overflow);
+    if let Some(body_overflow) = styles.body_overflow {
+        apply_overflow(facts.body_layout_node, body_overflow);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::css::css_enums::{direction, writing_mode};
+
+    fn html_document_facts() -> FfiViewportPropagationFacts {
+        FfiViewportPropagationFacts {
+            root_layout_node: NodeSlotId::new(1, 1),
+            root_is_html_html_element: true,
+            root_overflow_x: overflow::VISIBLE,
+            root_overflow_y: overflow::VISIBLE,
+            root_writing_mode: writing_mode::HORIZONTAL_TB,
+            root_direction: direction::LTR,
+            root_has_containment: false,
+            has_styled_body: true,
+            body_layout_node: NodeSlotId::new(2, 1),
+            body_display_is_none: false,
+            body_overflow_x: overflow::SCROLL,
+            body_overflow_y: overflow::HIDDEN,
+            body_writing_mode: writing_mode::VERTICAL_RL,
+            body_direction: direction::RTL,
+            body_has_containment: false,
+        }
+    }
+
+    const VISIBLE: (u8, u8) = (overflow::VISIBLE, overflow::VISIBLE);
+
+    #[test]
+    fn a_visible_html_root_hands_propagation_to_its_body() {
+        let styles = decide_viewport_propagation(&html_document_facts()).unwrap();
+        assert_eq!(styles.writing_mode, writing_mode::VERTICAL_RL);
+        assert_eq!(styles.direction, direction::RTL);
+        assert_eq!(styles.viewport_overflow, (overflow::SCROLL, overflow::HIDDEN));
+        assert_eq!(styles.root_overflow, VISIBLE);
+        assert_eq!(styles.body_overflow, Some(VISIBLE));
+    }
+
+    #[test]
+    fn a_root_with_its_own_overflow_stays_the_origin_and_maps_the_viewport_keywords() {
+        let mut facts = html_document_facts();
+        facts.root_overflow_x = overflow::CLIP;
+        let styles = decide_viewport_propagation(&facts).unwrap();
+        assert_eq!(styles.viewport_overflow, (overflow::HIDDEN, overflow::AUTO));
+        assert_eq!(styles.root_overflow, VISIBLE);
+        assert_eq!(styles.body_overflow, Some((overflow::SCROLL, overflow::HIDDEN)));
+        assert_eq!(styles.writing_mode, writing_mode::VERTICAL_RL);
+    }
+
+    #[test]
+    fn a_body_without_a_box_still_supplies_the_writing_mode_but_no_overflow() {
+        let mut facts = html_document_facts();
+        facts.body_layout_node = NodeSlotId::INVALID;
+        let styles = decide_viewport_propagation(&facts).unwrap();
+        assert_eq!(styles.writing_mode, writing_mode::VERTICAL_RL);
+        assert_eq!(styles.viewport_overflow, (overflow::AUTO, overflow::AUTO));
+        assert_eq!(styles.root_overflow, VISIBLE);
+        assert_eq!(styles.body_overflow, None);
+    }
+
+    #[test]
+    fn a_display_none_body_takes_no_part_in_either_propagation() {
+        let mut facts = html_document_facts();
+        facts.body_layout_node = NodeSlotId::INVALID;
+        facts.body_display_is_none = true;
+        let styles = decide_viewport_propagation(&facts).unwrap();
+        assert_eq!(styles.writing_mode, writing_mode::HORIZONTAL_TB);
+        assert_eq!(styles.direction, direction::LTR);
+        assert_eq!(styles.viewport_overflow, (overflow::AUTO, overflow::AUTO));
+        assert_eq!(styles.body_overflow, None);
+    }
+
+    #[test]
+    fn containment_on_either_element_disables_both_body_special_cases() {
+        for containment_is_on_root in [true, false] {
+            let mut facts = html_document_facts();
+            facts.root_has_containment = containment_is_on_root;
+            facts.body_has_containment = !containment_is_on_root;
+            let styles = decide_viewport_propagation(&facts).unwrap();
+            assert_eq!(styles.writing_mode, writing_mode::HORIZONTAL_TB);
+            assert_eq!(styles.viewport_overflow, (overflow::AUTO, overflow::AUTO));
+            assert_eq!(styles.root_overflow, VISIBLE);
+            assert_eq!(styles.body_overflow, Some((overflow::SCROLL, overflow::HIDDEN)));
+        }
+    }
+
+    #[test]
+    fn a_root_that_is_not_an_html_element_ignores_its_body_child() {
+        let mut facts = html_document_facts();
+        facts.root_is_html_html_element = false;
+        let styles = decide_viewport_propagation(&facts).unwrap();
+        assert_eq!(styles.writing_mode, writing_mode::HORIZONTAL_TB);
+        assert_eq!(styles.viewport_overflow, (overflow::AUTO, overflow::AUTO));
+        assert_eq!(styles.root_overflow, VISIBLE);
+        assert_eq!(styles.body_overflow, Some((overflow::SCROLL, overflow::HIDDEN)));
+    }
+
+    #[test]
+    fn a_missing_root_box_leaves_only_the_viewport_default() {
+        let mut facts = html_document_facts();
+        facts.root_layout_node = NodeSlotId::INVALID;
+        assert_eq!(decide_viewport_propagation(&facts), None);
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -430,15 +430,6 @@ pub unsafe extern "C" fn layout_arena_needs_full_scrollable_overflow_recalculati
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_set_needs_full_scrollable_overflow_recalculation(arena: *mut c_void) {
-    let arena = unsafe { arena_from_handle(arena) };
-    arena.needs_full_scrollable_overflow_recalculation.set(true);
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 /// The drained slot ids may name freed slots; the caller resolves liveness before
 /// dereferencing anything.
 #[unsafe(no_mangle)]
@@ -1231,13 +1222,7 @@ pub unsafe extern "C" fn layout_arena_rebuild_scrollable_overflow_contained_boxe
     root: NodeSlotId,
 ) {
     let arena = unsafe { arena_from_handle(arena) };
-    let paintable_rows = arena.paintable_rows();
-    let mut paint_state = arena.paint_state().borrow_mut();
-    crate::painting::scrollable_overflow::refill_contained_boxes_index(
-        &paintable_rows,
-        root,
-        &mut paint_state.scrollable_overflow_contained_boxes,
-    );
+    arena.rebuild_scrollable_overflow_contained_boxes(root);
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -535,6 +535,21 @@ impl LayoutNodeArena {
         }
     }
 
+    pub(crate) fn set_needs_full_scrollable_overflow_recalculation(&self) {
+        self.needs_full_scrollable_overflow_recalculation.set(true);
+    }
+
+    /// Rebuilds the contained-boxes index from the committed rows under `root`.
+    pub(crate) fn rebuild_scrollable_overflow_contained_boxes(&self, root: NodeSlotId) {
+        let paintable_rows = self.paintable_rows();
+        let mut paint_state = self.paint_state().borrow_mut();
+        crate::painting::scrollable_overflow::refill_contained_boxes_index(
+            &paintable_rows,
+            root,
+            &mut paint_state.scrollable_overflow_contained_boxes,
+        );
+    }
+
     pub(crate) fn take_scrollable_overflow_recalculation_state(&self) -> (Vec<NodeSlotId>, bool) {
         (
             std::mem::take(&mut *self.boxes_needing_scrollable_overflow_recalculation.borrow_mut()),

--- a/Tests/LibWeb/Text/expected/css/viewport-overflow-frameset-child.txt
+++ b/Tests/LibWeb/Text/expected/css/viewport-overflow-frameset-child.txt
@@ -1,0 +1,1 @@
+Viewport overflow with a frameset child: auto

--- a/Tests/LibWeb/Text/input/css/viewport-overflow-frameset-child.html
+++ b/Tests/LibWeb/Text/input/css/viewport-overflow-frameset-child.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../include.js"></script>
+    <script>
+        // A frameset is the document's body in the DOM sense, but overflow propagates to the
+        // viewport only from a body *element*, so the root element stays the origin here.
+        promiseTest(async () => {
+            await animationFrame();
+            println(`Viewport overflow with a frameset child: ${internals.viewportOverflowX()}`);
+        });
+    </script>
+</head>
+<frameset style="overflow: scroll"></frameset>
+</html>


### PR DESCRIPTION
`Document::update_layout()` replayed facts the Rust layout arena already owned. This moves them to the side that owns the state, one fold per commit, with no intended behaviour change:

1. Reset update flags and scrollable-overflow bookkeeping inside the Rust layout entries.
2. Keep the partial relayout escape bit in the arena; the dispatch now asks it whether a partial pass may be attempted and which boundary subtrees to relay out.
3. Recompute containing blocks inside the tree builder (rebuilt roots) and the layout entries (the subtree being laid out), with one shared inline-containing-block lookup callback.
4. Decide viewport overflow / writing-mode / scrollbar-width propagation on the Rust side from a facts struct C++ fills from the root and body elements' style records; C++ applies through style setters before the pass.