### PR TITLE
LibWeb: Fix stale state in style, layout, and compositor animation updates

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8091,6 +8091,11 @@ void Document::fire_compositor_animation_wakeup_for_testing(Badge<Internals::Int
     service_compositor_animation_wakeup(relevant_settings_object().time_origin() + frame_time_ms);
 }
 
+void Document::force_visual_context_tree_rebuild_on_next_compositor_animation_update_for_testing(Badge<Internals::Internals>)
+{
+    m_force_visual_context_tree_rebuild_on_next_compositor_animation_update_for_testing = true;
+}
+
 void Document::update_compositor_animations()
 {
     struct CompetingPropertyEffects {
@@ -8652,6 +8657,19 @@ void Document::update_compositor_animations()
         CSS::RequiredInvalidationAfterStyleChange invalidation;
         invalidation.ensure_at_least(CSS::InvalidationLevel::Repaint);
         Painting::repaint_after_style_change(*layout_node, invalidation);
+    }
+
+    if (m_force_visual_context_tree_rebuild_on_next_compositor_animation_update_for_testing) {
+        m_force_visual_context_tree_rebuild_on_next_compositor_animation_update_for_testing = false;
+        schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::ForcedForTesting);
+    }
+
+    // A descriptor must target the tree it is published with. The selection pass above can force
+    // or release animation-only visual context nodes, so redo it after applying those updates.
+    if (m_needs_accumulated_visual_contexts_update) {
+        paint_state().set_visual_animations(*this, {});
+        update_compositor_animations();
+        return;
     }
 
     paint_state().set_visual_animations(*this, move(visual_animations));

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -470,6 +470,7 @@ public:
     void stop_compositor_animation_timers();
     void arm_compositor_animation_timers_for_testing(Badge<Internals::Internals>);
     void fire_compositor_animation_wakeup_for_testing(Badge<Internals::Internals>, double frame_time_ms);
+    void force_visual_context_tree_rebuild_on_next_compositor_animation_update_for_testing(Badge<Internals::Internals>);
     void request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const&);
     bool run_empty_animation_style_update_for_testing(Badge<Internals::Internals>);
     bool compositor_animation_wakeup_timer_is_active() const;
@@ -1861,6 +1862,7 @@ private:
     RefPtr<Core::Timer> m_compositor_animation_wakeup_timer;
     Optional<MonotonicTime> m_compositor_animation_wakeup_deadline;
     RefPtr<Core::Timer> m_compositor_animation_observation_timer;
+    bool m_force_visual_context_tree_rebuild_on_next_compositor_animation_update_for_testing { false };
     Vector<WeakPtr<Layout::Node>> m_layout_nodes_with_forced_compositor_effects_layer;
     Vector<WeakPtr<Layout::Node>> m_layout_nodes_with_forced_compositor_background_color_frame;
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1416,6 +1416,11 @@ void Internals::fire_compositor_animation_wakeup_for_testing(double frame_time_m
     window().associated_document().fire_compositor_animation_wakeup_for_testing({}, frame_time_ms);
 }
 
+void Internals::force_visual_context_tree_rebuild_on_next_compositor_animation_update_for_testing()
+{
+    window().associated_document().force_visual_context_tree_rebuild_on_next_compositor_animation_update_for_testing({});
+}
+
 void Internals::request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node> node)
 {
     window().associated_document().request_reentrant_animation_style_flush_for_testing({}, node);
@@ -2022,6 +2027,7 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     size_t compositor_visual_animation_count = 0;
     Optional<double> compositor_visual_animation_local_time_at_anchor;
     bool compositor_visual_animations_share_timing_anchor = true;
+    bool compositor_visual_animation_targets_are_valid = true;
     if (document.has_committed_viewport_box() && document.paint_state().has_visual_context_tree()) {
         auto visual_context_tree = document.paint_state().visual_context_tree(document);
         auto visual_animations = visual_context_tree.visual_animations();
@@ -2032,11 +2038,15 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
                 return animation.monotonic_time_at_anchor_ns == visual_animations.first().monotonic_time_at_anchor_ns
                     && animation.local_time_at_anchor_ms == visual_animations.first().local_time_at_anchor_ms;
             });
+            compositor_visual_animation_targets_are_valid = all_of(visual_animations, [&](auto const& animation) {
+                return visual_context_tree.visual_animation_targets_are_valid(animation);
+            });
         }
     }
     object->define_direct_property("compositorVisualAnimations"_utf16_fly_string, JS::Value(compositor_visual_animation_count), JS::default_attributes);
     object->define_direct_property("compositorVisualAnimationLocalTimeAtAnchor"_utf16_fly_string, compositor_visual_animation_local_time_at_anchor.has_value() ? JS::Value(*compositor_visual_animation_local_time_at_anchor) : JS::js_null(), JS::default_attributes);
     object->define_direct_property("compositorVisualAnimationsShareTimingAnchor"_utf16_fly_string, JS::Value(compositor_visual_animations_share_timing_anchor), JS::default_attributes);
+    object->define_direct_property("compositorVisualAnimationTargetsAreValid"_utf16_fly_string, JS::Value(compositor_visual_animation_targets_are_valid), JS::default_attributes);
     auto document_timeline_current_time = document.timeline()->current_time();
     object->define_direct_property("documentTimelineCurrentTime"_utf16_fly_string, document_timeline_current_time.has_value() ? JS::Value(document_timeline_current_time->value) : JS::js_null(), JS::default_attributes);
     object->define_direct_property("compositorAnimationWakeupTimerActive"_utf16_fly_string, JS::Value(document.compositor_animation_wakeup_timer_is_active()), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -207,6 +207,7 @@ public:
     bool run_empty_animation_style_update_for_testing();
     void arm_compositor_animation_timers_for_testing();
     void fire_compositor_animation_wakeup_for_testing(double frame_time_ms);
+    void force_visual_context_tree_rebuild_on_next_compositor_animation_update_for_testing();
     void request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node>);
     GC::Ref<JS::Object> layout_tree_build_stats();
     GC::Ref<JS::Object> compare_layout_tree_with_full_rebuild();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -195,6 +195,7 @@ interface Internals {
     boolean runEmptyAnimationStyleUpdateForTesting();
     undefined armCompositorAnimationTimersForTesting();
     undefined fireCompositorAnimationWakeupForTesting(double frameTimeMs);
+    undefined forceVisualContextTreeRebuildOnNextCompositorAnimationUpdateForTesting();
     undefined requestReentrantAnimationStyleFlushForTesting(Node node);
     // Returns the confinement report of the most recent layout tree build for the current
     // document. Keys: builds (cumulative build count), lastBuildRebuiltSubtreeRoots (number of

--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -14,6 +14,10 @@ impl StyleEngine {
         root: StyleNodeID,
         mut emit: impl FnMut(StyleTransactionVersion, ProgramVersion, &[PublishedStyleDeltaRecord]),
     ) -> bool {
+        // The previous transaction's uninstalled records can no longer be consumed. Revert
+        // them before this transaction publishes anything: a later C++ computation can install
+        // the same record, which must not then be mistaken for an unconsumed derivation.
+        self.discard_engine_computed_records();
         self.reclaim_computed_memory_if_needed();
         self.sync_tier3_benefit_observations();
         let tier3_evictions = self.memory.finish_tier3_quota_period();

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -1891,6 +1891,9 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn clear_committed_fragment_link(&self, id: NodeSlotId) {
+        // Cached runs may reuse the committed paintable subtree without replaying its fragments.
+        // Once that subtree is cleared, a later layout must rebuild it instead.
+        self.fc_run_cache_store.remove_entry(id.slot_index());
         drop(self.take_committed_fragment_link(self.data(id)));
     }
 

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-forced-effects-frame-removal.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-forced-effects-frame-removal.txt
@@ -1,0 +1,4 @@
+stale animation creates a forced effects frame: true
+stale forced effects frame is removed: true
+target background-color animation remains published: true
+published animation targets match the rebuilt visual tree: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/hidden-style-record-republication.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/hidden-style-record-republication.txt
@@ -1,0 +1,6 @@
+visible opacity: 1
+hidden opacity: 0.5
+color scheme: dark
+visible opacity: 1
+hidden opacity: 0.5
+color scheme: light

--- a/Tests/LibWeb/Text/expected/layout-run-cache-line-clamp.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-line-clamp.txt
@@ -1,0 +1,5 @@
+viewport 400: target 50, child 50
+viewport 80: target 0, child 0
+viewport 400: target 50, child 50
+viewport 80: target 0, child 0
+viewport 400: target 50, child 50

--- a/Tests/LibWeb/Text/input/css/compositor-animation-forced-effects-frame-removal.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-forced-effects-frame-removal.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .box {
+        width: 20px;
+        height: 20px;
+    }
+</style>
+<div class="box" id="stale"></div>
+<script>
+    asyncTest(async done => {
+        const stale = document.getElementById("stale");
+        const nextFrame = () => new Promise(requestAnimationFrame);
+
+        for (let i = 0; i < 1051; ++i) {
+            const child = document.createElement("div");
+            child.className = "box";
+            stale.append(child);
+        }
+        const dummy = document.createElement("div");
+        dummy.className = "box";
+        stale.append(dummy);
+        document.elementFromPoint(0, 0);
+
+        const target = stale.children[stale.children.length - 2];
+        const staleChildren = [...stale.children].filter(child => child !== target && child !== dummy);
+        const staleAnimations = staleChildren.map(child => child.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 100000 }));
+        target.animate([{ backgroundColor: "rgb(255, 0, 0)" }, { backgroundColor: "rgb(0, 0, 255)" }], { duration: 100000 });
+
+        await nextFrame();
+        internals.updateCompositorAnimations();
+        document.elementFromPoint(0, 0);
+        internals.updateCompositorAnimations();
+        document.elementFromPoint(0, 0);
+
+        const staleForcedEffectsFrame = staleChildren.every(child => internals.visualContextNodeIndices(child).needsCompositorEffectsLayer);
+        for (const animation of staleAnimations)
+            animation.cancel();
+        internals.resetStyleInvalidationCounters();
+        internals.forceVisualContextTreeRebuildOnNextCompositorAnimationUpdateForTesting();
+        internals.updateCompositorAnimations();
+
+        const counters = internals.getStyleInvalidationCounters();
+        const staleForcedEffectsFrameRemoved = staleChildren.every(child => !internals.visualContextNodeIndices(child).needsCompositorEffectsLayer);
+
+        println(`stale animation creates a forced effects frame: ${staleForcedEffectsFrame}`);
+        println(`stale forced effects frame is removed: ${staleForcedEffectsFrameRemoved}`);
+        println(`target background-color animation remains published: ${counters.compositorVisualAnimations === 1}`);
+        println(`published animation targets match the rebuilt visual tree: ${counters.compositorVisualAnimationTargetsAreValid}`);
+
+        for (const animation of document.getAnimations())
+            animation.cancel();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/hidden-style-record-republication.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/hidden-style-record-republication.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .hidden { display: none; }
+    .changed #target { opacity: 0.5; }
+</style>
+<div id="ancestor"><div><div id="target">target</div></div></div>
+<script>
+    test(() => {
+        // Hiding the ancestor skips the target's engine-computed record. The intervening
+        // element is rematerialized and schedules the target in a later transaction.
+        // Repeat with warm records so that rematerialization reuses the skipped record.
+        for (let i = 0; i < 2; ++i) {
+            ancestor.className = "";
+            println(`visible opacity: ${getComputedStyle(target).opacity}`);
+            ancestor.className = "hidden changed";
+            println(`hidden opacity: ${getComputedStyle(target).opacity}`);
+            ancestor.style.colorScheme = i % 2 ? "light" : "dark";
+            println(`color scheme: ${getComputedStyle(target).colorScheme}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-run-cache-line-clamp.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-line-clamp.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<iframe id="frame" width="400" srcdoc="
+    <style>
+        body { margin: 0; }
+        #clamped {
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 1;
+            overflow: hidden;
+            font: 20px/20px monospace;
+        }
+        #target { display: inline-block; width: 50px; height: 20px; }
+        #child { display: flow-root; width: 50px; }
+    </style>
+    <div id='clamped'>text text text text <span id='target'><span id='child'>child</span></span></div>
+"></iframe>
+<script>
+    asyncTest(done => {
+        frame.onload = async () => {
+            // Narrowing the viewport clamps away the inline subtree and clears its paintables.
+            // Widening it must rebuild them even when the nested formatting context's inputs match.
+            for (const width of [400, 80, 400, 80, 400]) {
+                frame.width = width;
+                document.body.offsetWidth;
+                await animationFrame();
+                const target = frame.contentDocument.getElementById("target");
+                const child = frame.contentDocument.getElementById("child");
+                println(`viewport ${width}: target ${target.getBoundingClientRect().width}, child ${child.getBoundingClientRect().width}`);
+            }
+            done();
+        };
+    });
+</script>


### PR DESCRIPTION
Rebuild compositor animation targets when selection changes the visual context tree, so published descriptors reference the current tree.

Retire uninstalled style records before the next transaction, preventing cleanup from rolling back a subsequently installed record. This fixes a crash when scrolling YouTube video previews.

Invalidate cached layout runs when their committed fragments are cleared. This fixes a crash when resizing a window causes line-clamped content to disappear and reappear.

Add regression coverage for all three cases.
