### PR TITLE
LibWeb: Port more navigable algorithms away from LocalNavigable

### DIFF
--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/FrameAncestorsDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/FrameAncestorsDirective.cpp
@@ -46,16 +46,14 @@ Directive::Result FrameAncestorsDirective::navigation_response_check(GC::Ref<Fet
         return Result::Allowed;
 
     // 5. Let current be target.
-    auto current = target;
-
     // 6. While current is a child navigable:
-    while (current->parent()) {
-        // 1. Let document be current’s container document.
-        auto document = current->container_document();
-        VERIFY(document);
-
+    //     1. Let document be current’s container document.
+    //     4. Set current to document’s node navigable.
+    // NB: Each container document is the next parent navigable's active document, and a parent navigable answers
+    //     for a document hosted in another process.
+    for (auto current = target->parent(); current; current = current->parent()) {
         // 2. Let origin be the result of executing the URL parser on the ASCII serialization of document’s origin.
-        auto serialized_origin = document->origin().serialize();
+        auto serialized_origin = current->active_document_origin()->serialize();
         auto origin = DOMURL::parse_from_byte_string(serialized_origin.bytes_as_string_view());
 
         // AD-HOC: If the origin is opaque, serialization produces "null" which fails URL parsing.
@@ -67,10 +65,6 @@ Directive::Result FrameAncestorsDirective::navigation_response_check(GC::Ref<Fet
         //    executed upon origin, this directive’s value, policy’s self-origin, and 0, return "Blocked".
         if (does_url_match_source_list_in_origin_with_redirect_count(origin.value(), value(), policy->self_origin(), 0) == MatchResult::DoesNotMatch)
             return Result::Blocked;
-
-        // 4. Set current to document’s node navigable.
-        VERIFY(document->navigable());
-        current = *document->navigable();
     }
 
     // 7. Return "Allowed".

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4434,7 +4434,7 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
             if (!is_decoded_svg()) {
                 HTML::HTMLLinkElement::load_fallback_favicon_if_needed(*this);
             }
-            navigable->traversable_navigable()->page().client().page_did_finish_loading(m_navigation_id, url());
+            navigable->page().client().page_did_finish_loading(m_navigation_id, url());
         } else {
             m_needs_to_call_page_did_load = true;
         }
@@ -4732,8 +4732,7 @@ bool Document::is_fully_active() const
     if (!navigable)
         return false;
 
-    auto traversable = navigable->traversable_navigable();
-    if (navigable == traversable && traversable->is_top_level_traversable())
+    if (navigable->is_top_level_traversable())
         return true;
 
     auto container_document = navigable->container_document();
@@ -4977,12 +4976,12 @@ bool Document::has_focus() const
     if (!navigable)
         return false;
 
-    auto traversable = navigable->traversable_navigable();
-    if (!traversable || !traversable->is_focused())
+    auto& traversable = as<HTML::LocalTraversableNavigable>(*navigable->traversable_navigable());
+    if (!traversable.is_focused())
         return false;
 
     // 2. Let candidate be target's node navigable's top-level traversable's active document.
-    auto candidate = traversable->active_document();
+    auto candidate = traversable.active_document();
 
     // 3. While true:
     while (candidate) {
@@ -5291,7 +5290,7 @@ void Document::check_favicon_after_loading_link_resource()
 
     if (largest_icon) {
         if (auto navigable = this->navigable(); navigable && navigable->is_traversable())
-            navigable->traversable_navigable()->page().client().page_did_change_favicon(*largest_icon);
+            navigable->page().client().page_did_change_favicon(*largest_icon);
     } else {
         dbgln_if(SPAM_DEBUG, "No favicon found to be used");
     }
@@ -6191,7 +6190,7 @@ void Document::make_active()
     HTML::relevant_settings_object(window).execution_ready = true;
 
     if (m_needs_to_call_page_did_load) {
-        navigable()->traversable_navigable()->page().client().page_did_finish_loading(m_navigation_id, url());
+        navigable()->page().client().page_did_finish_loading(m_navigation_id, url());
         m_needs_to_call_page_did_load = false;
     }
 
@@ -10160,17 +10159,14 @@ void Document::set_navigable(GC::Ptr<HTML::LocalNavigable> navigable)
     if (m_navigable == navigable)
         return;
 
-    auto previous_traversable = m_navigable ? m_navigable->traversable_navigable() : nullptr;
+    GC::Ptr<Page> previous_page = m_navigable ? &m_navigable->page() : nullptr;
     m_navigable = navigable.ptr();
     HTML::main_thread_event_loop().document_navigable_did_change({});
 
-    if (previous_traversable)
-        previous_traversable->page().update_needs_beforeunload_check();
-    if (navigable) {
-        auto new_traversable = navigable->traversable_navigable();
-        if (new_traversable && new_traversable != previous_traversable)
-            new_traversable->page().update_needs_beforeunload_check();
-    }
+    if (previous_page)
+        previous_page->update_needs_beforeunload_check();
+    if (navigable && &navigable->page() != previous_page.ptr())
+        navigable->page().update_needs_beforeunload_check();
 }
 
 void Document::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4735,11 +4735,10 @@ bool Document::is_fully_active() const
     if (navigable->is_top_level_traversable())
         return true;
 
-    auto container_document = navigable->container_document();
-    if (container_document && container_document.ptr() != this && container_document->is_fully_active())
-        return true;
-
-    return false;
+    // NB: The container document is the parent navigable's active document. Asking the parent navigable lets a parent
+    //     hosted in another process answer from its replicated state.
+    auto parent = navigable->parent();
+    return parent && parent->active_document_is_fully_active();
 }
 
 bool Document::is_active() const

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -339,8 +339,7 @@ static void update_needs_beforeunload_check(EventTarget& event_target, DOMEventL
     if (!navigable)
         return;
 
-    if (auto traversable = navigable->traversable_navigable())
-        traversable->page().update_needs_beforeunload_check();
+    navigable->page().update_needs_beforeunload_check();
 }
 
 // https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -376,7 +376,7 @@ void populate_request_from_client(Infrastructure::Request& request)
             //    user prompts to global’s navigable’s traversable navigable.
             if (auto const* window = HTML::window_from_global_object(global)) {
                 if (window->navigable())
-                    request.set_traversable_for_user_prompts(window->navigable()->traversable_navigable());
+                    request.set_traversable_for_user_prompts(GC::Ptr<HTML::Navigable> { window->navigable()->traversable_navigable() });
             }
         }
     }
@@ -2017,7 +2017,7 @@ GC::Ref<PendingResponse> http_network_or_cache_fetch(JS::Realm& realm, Infrastru
         if (response->status() == 401
             && http_request->response_tainting() != Infrastructure::Request::ResponseTainting::CORS
             && include_credentials == HTTP::Cookie::IncludeCredentials::Yes
-            && request->traversable_for_user_prompts().has<GC::Ptr<HTML::LocalTraversableNavigable>>()
+            && request->traversable_for_user_prompts().has<GC::Ptr<HTML::Navigable>>()
             && www_authenticate_has_credential_based_scheme()) {
             // 1. Needs testing: multiple `WWW-Authenticate` headers, missing, parsing issues.
             // (Red box in the spec, no-op)

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -166,7 +166,7 @@ public:
     using PolicyContainerType = Variant<PolicyContainer, GC::Ref<HTML::PolicyContainer>>;
     using ReferrerType = Variant<Referrer, URL::URL>;
     using ReservedClientType = GC::Ptr<HTML::Environment>;
-    using TraversableForUserPromptsType = Variant<TraversableForUserPrompts, GC::Ptr<HTML::EnvironmentSettingsObject>, GC::Ptr<HTML::LocalTraversableNavigable>>;
+    using TraversableForUserPromptsType = Variant<TraversableForUserPrompts, GC::Ptr<HTML::EnvironmentSettingsObject>, GC::Ptr<HTML::Navigable>>;
 
     [[nodiscard]] static GC::Ref<Request> create();
     [[nodiscard]] static GC::Ref<Request> create(JS::VM&);

--- a/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Libraries/LibWeb/HTML/Focus.cpp
@@ -608,7 +608,7 @@ void run_unfocusing_steps(GC::Ptr<DOM::Node> old_focus_target)
     auto& top_document = as<DOM::Document>(*old_chain.last());
 
     // 8. If topDocument's node navigable has system focus, then run the focusing steps for topDocument's viewport.
-    if (top_document.navigable()->traversable_navigable()->is_focused()) {
+    if (as<LocalTraversableNavigable>(*top_document.navigable()->traversable_navigable()).is_focused()) {
 
         // AD-HOC: Remove top_document from old_chain so step 1 in run_focus_update_steps doesn't cancel the blur.
         auto without_viewport_surrogate = old_chain;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -450,7 +450,7 @@ static void show_the_picker_if_applicable(HTMLInputElement& element)
             auto weak_element = GC::Weak<HTMLInputElement> { element };
 
             element.set_is_open(true);
-            element.document().browsing_context()->top_level_browsing_context()->page().did_request_file_picker(weak_element, accepted_file_types, allow_multiple_files);
+            element.document().page().did_request_file_picker(weak_element, accepted_file_types, allow_multiple_files);
         }
         // 4. If dismissed is true or if the user dismissed the prompt without changing their selection,
         //    then queue an element task on the user interaction task source given element to fire an event named cancel at element,
@@ -473,7 +473,7 @@ static void show_the_picker_if_applicable(HTMLInputElement& element)
         if (element.type_state() == HTMLInputElement::TypeAttributeState::Color) {
             auto weak_element = GC::Weak<HTMLInputElement> { element };
             element.set_is_open(true);
-            element.document().browsing_context()->top_level_browsing_context()->page().did_request_color_picker(weak_element, Color::from_utf16_string(element.value()).value_or(Color(0, 0, 0)));
+            element.document().page().did_request_color_picker(weak_element, Color::from_utf16_string(element.value()).value_or(Color(0, 0, 0)));
         }
     }
 }

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -1226,7 +1226,7 @@ void HTMLLinkElement::load_fallback_favicon_if_needed(GC::Ref<DOM::Document> doc
             decode_favicon(body, request->url(), document)
                 ->when_resolved(GC::weak_callback(*document, [](DOM::Document& document, NonnullRefPtr<Gfx::Bitmap const>& favicon) {
                     if (auto navigable = document.navigable(); navigable && navigable->is_traversable())
-                        navigable->traversable_navigable()->page().client().page_did_change_favicon(*favicon);
+                        navigable->page().client().page_did_change_favicon(*favicon);
                 }));
         });
         auto process_body_error = GC::create_function(GC::Heap::the(), [](JS::Value) {

--- a/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
@@ -25,7 +25,7 @@ void HTMLTitleElement::children_changed(ChildrenChangedMetadata const& metadata)
     HTMLElement::children_changed(metadata);
     auto navigable = this->navigable();
     if (navigable && navigable->is_traversable()) {
-        navigable->traversable_navigable()->page().client().page_did_change_title(document().title());
+        navigable->page().client().page_did_change_title(document().title());
     }
 }
 

--- a/Libraries/LibWeb/HTML/History.cpp
+++ b/Libraries/LibWeb/HTML/History.cpp
@@ -252,7 +252,7 @@ WebIDL::ExceptionOr<void> History::set_scroll_restoration(Bindings::ScrollRestor
     auto active_session_history_entry = navigable->active_session_history_entry();
     active_session_history_entry->set_scroll_restoration_mode(scroll_restoration == Bindings::ScrollRestoration::Auto ? ScrollRestorationMode::Auto : ScrollRestorationMode::Manual);
 
-    navigable->traversable_navigable()->page().client().page_did_update_session_history_entry_scroll_restoration_mode(navigable->id(), session_history_entry_identity(*active_session_history_entry), active_session_history_entry->scroll_restoration_mode());
+    navigable->page().client().page_did_update_session_history_entry_scroll_restoration_mode(navigable->id(), session_history_entry_identity(*active_session_history_entry), active_session_history_entry->scroll_restoration_mode());
 
     return {};
 }

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1356,6 +1356,11 @@ Optional<URL::Origin> LocalNavigable::active_document_origin() const
     return m_active_document->origin();
 }
 
+bool LocalNavigable::active_document_is_fully_active() const
+{
+    return m_active_document && m_active_document->is_fully_active();
+}
+
 ReplicatedNavigableState LocalNavigable::replicated_state() const
 {
     VERIFY(m_active_document);

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -785,6 +785,24 @@ bool LocalNavigable::is_script_closable()
         || as<LocalTraversableNavigable>(this)->session_history_entry_count() == 1;
 }
 
+// https://html.spec.whatwg.org/multipage/iframe-embed-object.html#potentially-delays-the-load-event
+bool LocalNavigable::delays_the_load_event_of_its_container() const
+{
+    // - element's content navigable's active document is not ready for post-load tasks;
+    if (!active_document()->ready_for_post_load_tasks())
+        return true;
+
+    // - element's content navigable's is delaying load events is true; or
+    if (is_delaying_load_events())
+        return true;
+
+    // - anything is delaying the load event of element's content navigable's active document.
+    if (active_document()->anything_is_delaying_the_load_event())
+        return true;
+
+    return false;
+}
+
 void LocalNavigable::set_delaying_load_events(bool value)
 {
     if (value) {

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1075,7 +1075,7 @@ Vector<NonnullRefPtr<SessionHistoryEntry>> LocalNavigable::session_history_entri
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#initialize-the-navigable
-void LocalNavigable::initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<LocalNavigable> parent, GC::Ref<DOM::Document> document, VisibilityState system_visibility_state)
+void LocalNavigable::initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<Navigable> parent, GC::Ref<DOM::Document> document, VisibilityState system_visibility_state)
 {
     set_id(page().client().allocate_navigable_id());
 
@@ -1100,19 +1100,23 @@ void LocalNavigable::initialize_navigable(NonnullRefPtr<DocumentState> document_
 
     // 5. Set navigable's parent to parent.
     set_parent(parent);
-    if (parent) {
-        m_should_show_line_box_borders = parent->m_should_show_line_box_borders;
-        m_force_dark_enabled = parent->m_force_dark_enabled;
-        m_force_dark_foreground_threshold = parent->m_force_dark_foreground_threshold;
-        m_force_dark_background_threshold = parent->m_force_dark_background_threshold;
-        m_should_show_caret_hit_test_debug_overlay = parent->m_should_show_caret_hit_test_debug_overlay;
-    }
-    if (parent && !m_is_svg_page && has_compositor_context() && parent->has_compositor_context()) {
-        compositor_context().set_parent_context(parent->compositor_context().id());
-    }
 
     // 6. Set the initial visibility state of documentState's document to navigable's traversable navigable's system visibility state.
     document->set_initial_visibility_state(system_visibility_state);
+}
+
+// AD-HOC: The debug settings and the compositor tree are per page, so a child navigable starts from its parent's. A
+//         navigable that roots a page receives both from the page host instead.
+void LocalNavigable::inherit_page_state_from(LocalNavigable const& parent)
+{
+    m_should_show_line_box_borders = parent.m_should_show_line_box_borders;
+    m_force_dark_enabled = parent.m_force_dark_enabled;
+    m_force_dark_foreground_threshold = parent.m_force_dark_foreground_threshold;
+    m_force_dark_background_threshold = parent.m_force_dark_background_threshold;
+    m_should_show_caret_hit_test_debug_overlay = parent.m_should_show_caret_hit_test_debug_overlay;
+
+    if (!m_is_svg_page && has_compositor_context() && parent.has_compositor_context())
+        compositor_context().set_parent_context(parent.compositor_context().id());
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#activate-history-entry
@@ -5900,7 +5904,7 @@ void LocalNavigable::repaint_after_compositor_process_reconnect()
     resolve_all_pending_async_scroll_operations();
 
     if (has_compositor_context()) {
-        if (auto parent = this->parent()) {
+        if (auto parent = this->parent(); parent && !is_local_root()) {
             auto& local_parent = as<LocalNavigable>(*parent);
             if (local_parent.has_compositor_context())
                 compositor_context().set_parent_context(local_parent.compositor_context().id());

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -788,8 +788,15 @@ bool LocalNavigable::is_script_closable()
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#potentially-delays-the-load-event
 bool LocalNavigable::delays_the_load_event_of_its_container() const
 {
+    // AD-HOC: A destroyed document leaves its navigable without an active document until the next one is activated
+    //         or the navigable itself goes away, which the specification has no state for. A document that does not
+    //         exist is not ready for post-load tasks.
+    auto document = active_document();
+    if (!document)
+        return true;
+
     // - element's content navigable's active document is not ready for post-load tasks;
-    if (!active_document()->ready_for_post_load_tasks())
+    if (!document->ready_for_post_load_tasks())
         return true;
 
     // - element's content navigable's is delaying load events is true; or
@@ -797,7 +804,7 @@ bool LocalNavigable::delays_the_load_event_of_its_container() const
         return true;
 
     // - anything is delaying the load event of element's content navigable's active document.
-    if (active_document()->anything_is_delaying_the_load_event())
+    if (document->anything_is_delaying_the_load_event())
         return true;
 
     return false;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -805,13 +805,20 @@ bool LocalNavigable::delays_the_load_event_of_its_container() const
 
 void LocalNavigable::set_delaying_load_events(bool value)
 {
-    if (value) {
-        auto document = container_document();
-        VERIFY(document);
-        m_delaying_the_load_event.emplace(*document);
-    } else {
-        m_delaying_the_load_event.clear();
+    m_is_delaying_load_events = value;
+
+    // The container document's load event waits on this flag where that document lives.
+    // FIXME: A container document hosted in another process does not wait yet. Its process needs the loading state
+    //        replicated for the remote navigable that stands in for this one.
+    if (!value) {
+        m_container_document_load_event_delayer.clear();
+        return;
     }
+    if (auto document = container_document()) {
+        m_container_document_load_event_delayer.emplace(*document);
+        return;
+    }
+    VERIFY(parent() && !is<LocalNavigable>(*parent()));
 }
 
 void LocalNavigable::set_navigation_load_event_guard(DOM::Document& parent_doc)

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1451,20 +1451,6 @@ GC::Ptr<DOM::Document> LocalNavigable::container_document() const
     return container->document();
 }
 
-// https://html.spec.whatwg.org/multipage/document-sequences.html#nav-traversable
-GC::Ptr<LocalTraversableNavigable> LocalNavigable::traversable_navigable() const
-{
-    // 1. Let navigable be inputNavigable.
-    GC::Ptr<Navigable> navigable = const_cast<LocalNavigable*>(this);
-
-    // 2. While navigable is not a traversable navigable, set navigable to navigable's parent.
-    while (navigable && !is<LocalTraversableNavigable>(*navigable))
-        navigable = navigable->parent();
-
-    // 3. Return navigable.
-    return navigable ? &as<LocalTraversableNavigable>(*navigable) : nullptr;
-}
-
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#set-the-ongoing-navigation
 void LocalNavigable::set_ongoing_navigation(Variant<Empty, Traversal, Utf16String> ongoing_navigation)
 {
@@ -1672,19 +1658,19 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
 
         auto request_new_web_view = [&] {
             TokenizedFeature::Map empty_window_features;
-            auto hints = WebViewHints::from_tokenised_features(window_features.has_value() ? *window_features : empty_window_features, traversable_navigable()->page());
+            auto hints = WebViewHints::from_tokenised_features(window_features.has_value() ? *window_features : empty_window_features, page());
             Optional<CrossProcessId> opener_navigable_id;
             Optional<URL::URL> opener_base_url;
             if (new_no_opener == TokenizedFeature::NoOpener::No) {
                 opener_navigable_id = id();
                 opener_base_url = active_document()->base_url();
             }
-            return traversable_navigable()->page().client().page_did_request_new_web_view(activate_tab, hints, opener_navigable_id, move(opener_base_url), new_target_name);
+            return page().client().page_did_request_new_web_view(activate_tab, hints, opener_navigable_id, move(opener_base_url), new_target_name);
         };
 
         // --> If currentNavigable's active window does not have transient activation and the user agent has been configured to
         //     not show popups (i.e., the user agent has a "popup blocker" enabled)
-        if (active_window() && !active_window()->has_transient_activation() && traversable_navigable()->page().should_block_pop_ups()) {
+        if (active_window() && !active_window()->has_transient_activation() && page().should_block_pop_ups()) {
             // FIXME: The user agent may inform the user that a popup has been blocked.
             dbgln("Pop-up blocked!");
         }

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -261,8 +261,9 @@ public:
     // https://drafts.csswg.org/css-view-transitions-1/#snapshot-containing-block-size
     CSSPixelSize snapshot_containing_block_size();
 
-    bool has_session_history_entry_and_ready_for_navigation() const { return m_has_session_history_entry_and_ready_for_navigation; }
+    virtual bool has_session_history_entry_and_ready_for_navigation() const override { return m_has_session_history_entry_and_ready_for_navigation; }
     void set_has_session_history_entry_and_ready_for_navigation();
+    virtual bool delays_the_load_event_of_its_container() const override;
 
     void inform_the_navigation_api_about_child_navigable_destruction();
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -128,6 +128,7 @@ public:
 
     virtual Optional<URL::URL> active_document_url() const override;
     virtual Optional<URL::Origin> active_document_origin() const override;
+    virtual bool active_document_is_fully_active() const override;
     ReplicatedNavigableState replicated_state() const;
 
     void save_persisted_state_to_active_session_history_entry();

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -78,8 +78,6 @@ public:
 
     Vector<GC::Root<LocalNavigable>> child_navigables() const;
 
-    virtual bool is_traversable() const { return false; }
-
     bool is_local_root() const;
 
     bool is_closing() const { return m_closing; }
@@ -143,8 +141,6 @@ public:
     GC::Ptr<NavigableContainer> container() const;
     void set_container(Badge<NavigableContainer>, GC::Ptr<NavigableContainer> container) { m_container = container; }
     GC::Ptr<DOM::Document> container_document() const;
-
-    GC::Ptr<LocalTraversableNavigable> traversable_navigable() const;
 
     [[nodiscard]] bool is_focused() const;
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -88,7 +88,7 @@ public:
     void stop_loading();
 
     void set_delaying_load_events(bool value);
-    bool is_delaying_load_events() const { return m_delaying_the_load_event.has_value(); }
+    bool is_delaying_load_events() const { return m_is_delaying_load_events; }
 
     void set_navigation_load_event_guard(DOM::Document& parent_doc);
     void clear_navigation_load_event_guard();
@@ -516,7 +516,8 @@ private:
     bool m_closing { false };
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#delaying-load-events-mode
-    Optional<DOM::DocumentLoadEventDelayer> m_delaying_the_load_event;
+    bool m_is_delaying_load_events { false };
+    Optional<DOM::DocumentLoadEventDelayer> m_container_document_load_event_delayer;
 
     // AD-HOC: Guards the parent document's load event delay count during cross-document navigation.
     Optional<DOM::DocumentLoadEventDelayer> m_navigation_load_event_guard;

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -70,7 +70,8 @@ public:
     using NullOrError = NavigationParamsNullOrError;
     using NavigationParamsVariant = HTML::NavigationParamsVariant;
 
-    void initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<LocalNavigable> parent, GC::Ref<DOM::Document> document, VisibilityState system_visibility_state);
+    void initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<Navigable> parent, GC::Ref<DOM::Document> document, VisibilityState system_visibility_state);
+    void inherit_page_state_from(LocalNavigable const& parent);
     void set_id_for_session_history_reconstruction(CrossProcessId id) { set_id(id); }
 
     void register_navigation_observer(Badge<NavigationObserver>, NavigationObserver&);

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -32,6 +32,20 @@ bool Navigable::is_ancestor_of(Navigable const& other) const
     return false;
 }
 
+// https://html.spec.whatwg.org/multipage/document-sequences.html#nav-traversable
+GC::Ref<Navigable> Navigable::traversable_navigable()
+{
+    // 1. Let navigable be inputNavigable.
+    GC::Ref<Navigable> navigable = *this;
+
+    // 2. While navigable is not a traversable navigable, set navigable to navigable's parent.
+    while (!navigable->is_traversable())
+        navigable = *navigable->parent();
+
+    // 3. Return navigable.
+    return navigable;
+}
+
 // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-top
 GC::Ref<Navigable> Navigable::top_level_traversable()
 {

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -41,6 +41,7 @@ public:
     virtual bool is_top_level_traversable() const { return false; }
     virtual Optional<URL::URL> active_document_url() const = 0;
     virtual Optional<URL::Origin> active_document_origin() const = 0;
+    virtual bool active_document_is_fully_active() const = 0;
 
     WebIDL::ExceptionOr<void> navigate(NavigateParams);
 

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -35,6 +35,8 @@ public:
 
     virtual GC::Ptr<WindowProxy> active_window_proxy() = 0;
     virtual Utf16String const& target_name() const = 0;
+    virtual bool is_traversable() const { return false; }
+    GC::Ref<Navigable> traversable_navigable();
     GC::Ref<Navigable> top_level_traversable();
     virtual bool is_top_level_traversable() const { return false; }
     virtual Optional<URL::URL> active_document_url() const = 0;

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -43,6 +43,9 @@ public:
     virtual Optional<URL::Origin> active_document_origin() const = 0;
     virtual bool active_document_is_fully_active() const = 0;
 
+    virtual bool has_session_history_entry_and_ready_for_navigation() const = 0;
+    virtual bool delays_the_load_event_of_its_container() const = 0;
+
     WebIDL::ExceptionOr<void> navigate(NavigateParams);
 
     bool allowed_by_sandboxing_to_navigate(Navigable const& target, SourceSnapshotParams const&) const;

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -149,7 +149,8 @@ void NavigableContainer::create_new_child_navigable()
             .on_complete = GC::create_function(heap(), [this, navigable](HistoryStepResult) {
                 if (navigable->has_been_destroyed() || content_navigable() != navigable)
                     return;
-                set_content_navigable_has_session_history_entry_and_ready_for_navigation();
+                navigable->set_has_session_history_entry_and_ready_for_navigation();
+                this->document().schedule_html_parser_end_check();
             }),
         });
 }
@@ -237,22 +238,20 @@ Optional<URL::URL> NavigableContainer::shared_attribute_processing_steps_for_ifr
             return {};
     }
 
-    // AD-HOC: If the content navigable already has a navigation in progress or pending, skip the initial
-    //         about:blank URL update. Without this, the URL update creates a state machine that clobbers the
-    //         navigable's ongoing_navigation, causing the real navigation to be dropped when its populate completion
-    //         callback checks ongoing_navigation != navigation_id. Non-blank src navigations must still be processed
-    //         here, and will be queued by LocalNavigable::navigate() until the child navigable is ready for navigation.
-    auto& local_navigable = as<LocalNavigable>(*m_content_navigable);
-
-    if (url_matches_about_blank(url) && initial_insertion == InitialInsertion::Yes
-        && (local_navigable.has_pending_navigations() || !local_navigable.ongoing_navigation().has<Empty>())) {
-        return {};
-    }
-
     // 4. If url matches about:blank and initialInsertion is true, then perform the URL and history update steps given element's content navigable's active document and url.
     if (url_matches_about_blank(url) && initial_insertion == InitialInsertion::Yes) {
-        auto& document = *local_navigable.active_document();
-        perform_url_and_history_update_steps(document, url);
+        // NB: A newly inserted element's content navigable was created in this process.
+        auto& local_navigable = as<LocalNavigable>(*m_content_navigable);
+
+        // AD-HOC: If the content navigable already has a navigation in progress or pending, skip the initial
+        //         about:blank URL update. Without this, the URL update creates a state machine that clobbers the
+        //         navigable's ongoing_navigation, causing the real navigation to be dropped when its populate completion
+        //         callback checks ongoing_navigation != navigation_id. Non-blank src navigations must still be processed
+        //         here, and will be queued by LocalNavigable::navigate() until the child navigable is ready for navigation.
+        if (local_navigable.has_pending_navigations() || !local_navigable.ongoing_navigation().has<Empty>())
+            return {};
+
+        perform_url_and_history_update_steps(*local_navigable.active_document(), url);
     }
 
     // 5. Return url.
@@ -270,6 +269,7 @@ void NavigableContainer::navigate_an_iframe_or_frame(URL::URL url, ReferrerPolic
     //         the previous document may have parsed and run scripts but not yet fired its load event;
     //         forcing "replace" in that case would incorrectly discard the history entry.
     if (initial_insertion == InitialInsertion::Yes) {
+        // NB: A newly inserted element's content navigable was created in this process.
         auto active_document = as<LocalNavigable>(*m_content_navigable).active_document();
         if (active_document && !active_document->is_completely_loaded())
             history_handling = NavigationHistoryBehavior::Replace;
@@ -408,28 +408,14 @@ bool NavigableContainer::currently_delays_the_load_event() const
     if (!m_content_navigable)
         return false;
 
-    // - element's content navigable's active document is not ready for post-load tasks;
-    auto& local_navigable = as<LocalNavigable>(*m_content_navigable);
-
-    if (!local_navigable.active_document()->ready_for_post_load_tasks())
-        return true;
-
-    // - element's content navigable's is delaying load events is true; or
-    if (local_navigable.is_delaying_load_events())
-        return true;
-
-    // - anything is delaying the load event of element's content navigable's active document.
-    if (local_navigable.active_document()->anything_is_delaying_the_load_event())
-        return true;
-
-    return false;
+    return m_content_navigable->delays_the_load_event_of_its_container();
 }
 
 bool NavigableContainer::content_navigable_has_session_history_entry_and_ready_for_navigation() const
 {
     if (!content_navigable())
         return false;
-    return as<LocalNavigable>(*m_content_navigable).has_session_history_entry_and_ready_for_navigation();
+    return m_content_navigable->has_session_history_entry_and_ready_for_navigation();
 }
 
 void NavigableContainer::set_potentially_delays_the_load_event(bool value)
@@ -437,15 +423,6 @@ void NavigableContainer::set_potentially_delays_the_load_event(bool value)
     m_potentially_delays_the_load_event = value;
     if (!value)
         document().schedule_html_parser_end_check();
-}
-
-void NavigableContainer::set_content_navigable_has_session_history_entry_and_ready_for_navigation()
-{
-    auto content_navigable = this->content_navigable();
-    if (!content_navigable)
-        return;
-    as<LocalNavigable>(*content_navigable).set_has_session_history_entry_and_ready_for_navigation();
-    document().schedule_html_parser_end_check();
 }
 
 }

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -103,6 +103,7 @@ void NavigableContainer::create_new_child_navigable()
 
     // 8. Initialize the navigable navigable given documentState and parentNavigable.
     navigable->initialize_navigable(document_state, parent_navigable, *document, parent_navigable->active_document()->visibility_state());
+    navigable->inherit_page_state_from(*parent_navigable);
 
     // 9. Set element's content navigable to navigable.
     m_content_navigable = navigable;

--- a/Libraries/LibWeb/HTML/NavigableContainer.h
+++ b/Libraries/LibWeb/HTML/NavigableContainer.h
@@ -72,8 +72,6 @@ protected:
 
     void set_potentially_delays_the_load_event(bool value);
 
-    void set_content_navigable_has_session_history_entry_and_ready_for_navigation();
-
 private:
     virtual bool is_navigable_container() const override { return true; }
 

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -59,8 +59,7 @@ static void report_navigation_api_state_update(DOM::Document& document, SessionH
     if (!navigable)
         return;
 
-    auto traversable = navigable->traversable_navigable();
-    traversable->page().client().page_did_update_session_history_entry_navigation_api_state(navigable->id(), session_history_entry_identity(entry), entry.navigation_api_state());
+    navigable->page().client().page_did_update_session_history_entry_navigation_api_state(navigable->id(), session_history_entry_identity(entry), entry.navigation_api_state());
 }
 
 NavigationAPIMethodTracker::NavigationAPIMethodTracker(GC::Ref<Navigation> navigation,

--- a/Libraries/LibWeb/HTML/NavigationParams.cpp
+++ b/Libraries/LibWeb/HTML/NavigationParams.cpp
@@ -98,17 +98,14 @@ bool check_a_navigation_responses_adherence_to_x_frame_options(GC::Ptr<Fetch::In
     // 9. If xFrameOptions[0] is "sameorigin", then:
     if (!x_frame_options.is_empty() && first_x_frame_option->equals_ignoring_ascii_case("sameorigin"sv)) {
         // 1. Let containerDocument be navigable's container document.
-        auto container_document = navigable->container_document();
-
         // 2. While containerDocument is not null:
-        while (container_document) {
-            // 1. If containerDocument's origin is not same origin with destinationOrigin, then return false.
-            if (!container_document->origin().is_same_origin(destination_origin)) {
+        //     1. If containerDocument's origin is not same origin with destinationOrigin, then return false.
+        //     2. Set containerDocument to containerDocument's container document.
+        // NB: Each container document is the next parent navigable's active document, and a parent navigable
+        //     answers for a document hosted in another process.
+        for (auto ancestor = navigable->parent(); ancestor; ancestor = ancestor->parent()) {
+            if (!ancestor->active_document_origin()->is_same_origin(destination_origin))
                 return false;
-            }
-
-            // 2. Set containerDocument to containerDocument's container document.
-            container_document = container_document->container_document();
         }
     }
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1067,10 +1067,6 @@ Utf16String Internals::dump_session_history()
     if (!navigable)
         return "(no navigable)"_utf16;
 
-    auto traversable = navigable->traversable_navigable();
-    if (!traversable)
-        return "(no traversable)"_utf16;
-
     auto serialized_history = document.page().client().page_did_request_ui_process_session_history_for_testing();
     auto parsed_history = JsonValue::from_string(serialized_history);
     if (parsed_history.is_error() || !parsed_history.value().is_object())
@@ -1094,7 +1090,7 @@ Utf16String Internals::dump_session_history()
     }
 
     auto const* entries = &*top_level_entries;
-    if (navigable.ptr() != traversable.ptr()) {
+    if (!navigable->is_traversable()) {
         auto navigable_id = MUST(String::formatted("{}", navigable->id()));
         Function<JsonArray const*(JsonArray const&)> find_entries =
             [&](JsonArray const& candidate_entries) -> JsonArray const* {

--- a/Libraries/LibWeb/StorageAPI/StorageBottle.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageBottle.cpp
@@ -61,7 +61,9 @@ GC::Ptr<StorageBottle> obtain_a_storage_bottle_map(StorageType type, HTML::Envir
         VERIFY(type == StorageType::Session);
 
         // 2. Set shed to environment’s global object’s associated Document’s node navigable’s traversable navigable’s storage shed.
-        shed = &HTML::relevant_window(environment.global_object()).associated_document().navigable()->traversable_navigable()->storage_shed();
+        // FIXME: A traversable hosted by another process keeps its shed there. Session storage for documents whose
+        //        traversable is remote needs that shed instead of a local one.
+        shed = &as<HTML::LocalTraversableNavigable>(*HTML::relevant_window(environment.global_object()).associated_document().navigable()->traversable_navigable()).storage_shed();
     }
 
     // 4. Let shelf be the result of running obtain a storage shelf, with shed, environment, and type.

--- a/Libraries/LibWeb/WebDriver/Contexts.cpp
+++ b/Libraries/LibWeb/WebDriver/Contexts.cpp
@@ -42,7 +42,7 @@ JsonObject window_proxy_reference_object(HTML::WindowProxy const& window)
 
     // identifier
     //    Associated window handle of the window’s browsing context.
-    object.set(MUST(identifier.as_string().view().to_utf8()), navigable->traversable_navigable()->window_handle().to_utf8());
+    object.set(MUST(identifier.as_string().view().to_utf8()), as<HTML::LocalTraversableNavigable>(*navigable->traversable_navigable()).window_handle().to_utf8());
 
     return object;
 }
@@ -53,7 +53,7 @@ static GC::Ptr<HTML::LocalNavigable> find_navigable_with_handle(Utf16View handle
         if (navigable->is_top_level_traversable() != should_be_top_level)
             continue;
 
-        if (navigable->traversable_navigable()->window_handle() == handle)
+        if (as<HTML::LocalTraversableNavigable>(*navigable->traversable_navigable()).window_handle() == handle)
             return navigable;
     }
 

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -558,7 +558,7 @@ Web::WebDriver::Response WebDriverConnection::new_window(JsonValue payload)
         auto [target_navigable, no_opener, window_type] = MUST(active_window->window_open_steps_internal("about:blank"sv, ""sv, "noopener"sv));
 
         // 6. Let handle be the associated window handle of the newly created window.
-        auto handle = as<Web::HTML::LocalNavigable>(*target_navigable).traversable_navigable()->window_handle().to_utf8();
+        auto handle = as<Web::HTML::LocalTraversableNavigable>(*target_navigable->traversable_navigable()).window_handle().to_utf8();
 
         // 7. Let type be "tab" if the newly created window shares an OS-level window with the current browsing context, or "window" otherwise.
         auto type = "tab"sv;


### PR DESCRIPTION
Continue moving navigable using algorithms off the assumption that a navigable's parent,
traversable and content navigable are local, preparing for RemoteNavigable to be added
to the Navigable tree.

Slowly whittling them down!