### PR TITLE
Resolve per-document paint facts once per displaylist recording

### DIFF
--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -13,9 +13,13 @@
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/HTML/HTMLImageElement.h>
+#include <LibWeb/HTML/HTMLMapElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/Node.h>
@@ -431,30 +435,6 @@ SelectionStyle selection_style(Layout::Node const& node)
     return selection_style_for_node(node, node.dom_node());
 }
 
-bool should_paint_cursor(Layout::Node const& node)
-{
-    if (!has_committed_box(node))
-        return false;
-
-    auto const& document = node.document();
-    if (!document.navigable()->is_focused())
-        return false;
-
-    auto cursor_position = document.cursor_position();
-    if (!cursor_position)
-        return false;
-
-    if (auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(document.focused_area().ptr());
-        text_control && text_control->text_control_to_html_element().is_mutable()) {
-        return true;
-    }
-
-    // The editable element may sit anywhere between the cursor and this box (e.g. a
-    // contenteditable inline box), so editability is the cursor node's, not this box's.
-    auto const* editable_node = cursor_position->node().ptr();
-    return editable_node && editable_node->is_editable_or_editing_host();
-}
-
 static bool has_content(Layout::Node const& node)
 {
     // Interrupting block-in-inline children produce only placeholder pieces, so any child
@@ -534,86 +514,151 @@ CSSPixelRect caret_rect_for_child_offset(Layout::Node const& block, size_t offse
     return rect;
 }
 
-Optional<CaretPaint> resolve_caret_paint(Layout::Node const& block, Layout::Node const* owner_inline)
+Layout::RustFFI::FfiCaretPaint resolve_document_caret_paint(DOM::Document& document)
 {
-    if (!should_paint_cursor(block))
-        return {};
-    auto const& styled_block = as<Layout::NodeWithStyle>(block);
+    Layout::RustFFI::FfiCaretPaint caret {};
+    Layout::RustFFI::NodeSlotId const no_slot { Layout::RustFFI::INVALID_NODE_SLOT_INDEX };
+    caret.kind = Layout::RustFFI::FfiCaretPaintKind::None;
+    caret.block = no_slot;
+    caret.owner = no_slot;
 
-    auto cursor_position = block.document().cursor_position();
-    VERIFY(cursor_position);
+    auto cursor_position = document.cursor_position();
+    if (!cursor_position)
+        return caret;
+    // The caret paints only while the window has focus and the cursor node is editable (or a mutable text
+    // control has focus); every candidate box below has a committed box.
+    auto navigable = document.navigable();
+    if (!navigable || !navigable->is_focused())
+        return caret;
+    auto const* cursor_node = cursor_position->node().ptr();
+    if (!cursor_node)
+        return caret;
+    bool cursor_is_editable = false;
+    if (auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(document.focused_area().ptr()); text_control && text_control->text_control_to_html_element().is_mutable())
+        cursor_is_editable = true;
+    else
+        cursor_is_editable = cursor_node->is_editable_or_editing_host();
+    if (!cursor_is_editable)
+        return caret;
 
-    auto const* dom_node = block.dom_node();
+    auto fill = [&](Layout::RustFFI::FfiCaretPaintKind kind, Layout::RustFFI::NodeSlotId block, Layout::RustFFI::NodeSlotId owner, CSSPixelRect rect, Color color) {
+        caret.kind = kind;
+        caret.block = block;
+        caret.owner = owner;
+        caret.rect = rect;
+        caret.color = color;
+        caret.blink_cycle_start_time_ns = document.cursor_blink_cycle_start_time_ns();
+        caret.should_blink = !HTML::Window::in_test_mode();
+    };
 
-    Layout::Node const* text_layout_node = nullptr;
-    if (auto const* text = as_if<DOM::Text>(cursor_position->node().ptr()))
-        text_layout_node = text->unsafe_layout_node();
-
-    if (text_layout_node) {
+    if (auto const* text = as_if<DOM::Text>(cursor_node)) {
+        auto const* text_layout_node = text->unsafe_layout_node();
+        if (!text_layout_node)
+            return caret;
+        auto* arena = text_layout_node->arena_handle();
         auto result = Layout::RustFFI::layout_arena_text_caret_rect_for_position(
-            block.arena_handle(), Layout::Node::slot_id(text_layout_node), cursor_position->offset(),
+            arena, Layout::Node::slot_id(text_layout_node), cursor_position->offset(),
             cursor_position->affinity() == TextAffinity::Downstream);
-        if (result.found && result.owner_paintable.index == committed_row_slot(block).index) {
-            auto owner_slot = owner_inline ? committed_row_slot(*owner_inline)
-                                           : Layout::RustFFI::NodeSlotId { Layout::RustFFI::INVALID_NODE_SLOT_INDEX };
-            if (result.nearest_self_painting_inline.index != owner_slot.index)
-                return {};
-            auto const* style_source = static_cast<Layout::NodeWithStyle const*>(result.style_source);
-            if (!style_source || !layout_node_is_visible(*style_source))
-                return {};
-            return CaretPaint { result.rect, style_source->caret_color() };
-        }
         if (result.found) {
-            return {};
+            auto const* style_source = static_cast<Layout::NodeWithStyle const*>(result.style_source);
+            if (style_source && layout_node_is_visible(*style_source))
+                fill(Layout::RustFFI::FfiCaretPaintKind::InBlock, result.owner_paintable, result.nearest_self_painting_inline, result.rect, style_source->caret_color());
+            return caret;
         }
-    }
-
-    if (owner_inline) {
-        // Blank lines and empty editable elements are handled by the block / the box itself.
-        return {};
-    }
-    if (!is_visible(block)) {
-        // Blank-line and empty-element carets belong to this block itself.
-        return {};
-    }
-
-    if (text_layout_node) {
-        auto empty_line = Layout::RustFFI::layout_arena_paintable_empty_line_caret_rect(
-            block.arena_handle(), committed_row_slot(block), Layout::Node::slot_id(text_layout_node), cursor_position->offset());
-        if (empty_line.has_value) {
+        // No fragment holds the position: the caret sits on an empty line of the block that lays the text out.
+        for (auto const* block = text_layout_node->parent(); block; block = block->parent()) {
+            if (!has_committed_box(*block) || !is_visible(*block))
+                continue;
+            auto empty_line = Layout::RustFFI::layout_arena_paintable_empty_line_caret_rect(
+                arena, committed_row_slot(*block), Layout::Node::slot_id(text_layout_node), cursor_position->offset());
+            if (!empty_line.has_value)
+                continue;
             auto const* style_source = static_cast<Layout::NodeWithStyle const*>(empty_line.style_source);
             if (!style_source)
-                return {};
+                return caret;
             auto empty_line_rect = empty_line.rect;
-            CSSPixelRect cursor_rect { empty_line_rect.x(), empty_line_rect.y(), 1, empty_line_rect.height() };
-            return CaretPaint { cursor_rect, style_source->caret_color() };
+            fill(Layout::RustFFI::FfiCaretPaintKind::InBlock, committed_row_slot(*block), no_slot, CSSPixelRect { empty_line_rect.x(), empty_line_rect.y(), 1, empty_line_rect.height() }, style_source->caret_color());
+            return caret;
         }
+        return caret;
     }
 
-    if (cursor_position->node() != GC::Ptr { dom_node })
-        return {};
-
-    return CaretPaint { caret_rect_for_child_offset(block, cursor_position->offset()), styled_block.caret_color() };
+    // The cursor is parked on an element: its own box paints the caret at the child offset, or, for an
+    // empty editable inline, at the box's position.
+    auto const* layout_node = cursor_node->layout_node();
+    if (!layout_node || !has_committed_box(*layout_node))
+        return caret;
+    auto const& styled_node = as<Layout::NodeWithStyle>(*layout_node);
+    if (is_inline_paintable(*layout_node)) {
+        if (has_content(*layout_node))
+            return caret;
+        auto position = box_type_agnostic_position(*layout_node);
+        fill(Layout::RustFFI::FfiCaretPaintKind::EmptyInline, committed_row_slot(*layout_node), no_slot, CSSPixelRect { position.x(), position.y(), 1, styled_node.line_height() }, styled_node.caret_color());
+        return caret;
+    }
+    if (!is_visible(*layout_node))
+        return caret;
+    fill(Layout::RustFFI::FfiCaretPaintKind::InBlock, committed_row_slot(*layout_node), no_slot, caret_rect_for_child_offset(*layout_node, cursor_position->offset()), styled_node.caret_color());
+    return caret;
 }
 
-Optional<CaretPaint> resolve_empty_editable_caret_paint(Layout::Node const& node)
+Layout::RustFFI::FfiFocusedTextControlSelection resolve_focused_text_control_selection(DOM::Document const& document)
 {
-    if (!should_paint_cursor(node) || has_content(node))
-        return {};
-    auto const& styled_node = as<Layout::NodeWithStyle>(node);
+    Layout::RustFFI::FfiFocusedTextControlSelection selection {};
+    auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(document.focused_area().ptr());
+    if (!text_control)
+        return selection;
+    auto text_node = text_control->form_associated_element_to_text_node();
+    if (!text_node)
+        return selection;
+    auto selection_start = text_control->selection_start();
+    auto selection_end = text_control->selection_end();
+    if (selection_start == selection_end)
+        return selection;
+    auto const* text_layout_node = text_node->unsafe_layout_node();
+    if (!text_layout_node)
+        return selection;
+    selection.text_node = Layout::Node::slot_id(text_layout_node);
+    selection.start = selection_start;
+    selection.end = selection_end;
+    return selection;
+}
 
-    auto cursor_position = node.document().cursor_position();
-    VERIFY(cursor_position);
-
-    auto const* dom_node = node.dom_node();
-    if (!dom_node || cursor_position->node() != GC::Ptr { dom_node })
-        return {};
-
-    auto position = box_type_agnostic_position(node);
-    return CaretPaint {
-        .rect = { position.x(), position.y(), 1, styled_node.line_height() },
-        .color = styled_node.caret_color(),
-    };
+Layout::RustFFI::FfiFocusedAreaOutline resolve_focused_area_outline(DOM::Document const& document, Vector<u8>& path_bytes)
+{
+    // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
+    // The shapes of area elements in an image map associated with an img element that is being rendered and is not
+    // inert. Focused area elements have no box of their own, so the image whose rendering makes the area's shape a
+    // focusable area paints the focus outline along that shape.
+    Layout::RustFFI::FfiFocusedAreaOutline outline {};
+    auto const* area_element = as_if<HTML::HTMLAreaElement>(document.focused_area().ptr());
+    if (!area_element)
+        return outline;
+    auto const* map_element = area_element->first_ancestor_of_type<HTML::HTMLMapElement>();
+    if (!map_element)
+        return outline;
+    auto image_element = map_element->first_painted_image_with_focusable_shapes();
+    if (!image_element)
+        return outline;
+    auto const* layout_node = image_element->layout_node();
+    if (!layout_node || !has_committed_box(*layout_node))
+        return outline;
+    auto area_computed_values = area_element->computed_style();
+    if (!area_computed_values || area_computed_values->outline_style() != CSS::OutlineStyle::Auto)
+        return outline;
+    auto outline_data = Painting::outline_data(*layout_node, *area_computed_values);
+    if (!outline_data.has_value())
+        return outline;
+    auto path = area_element->shape_path(absolute_rect(*layout_node).size());
+    if (!path.has_value())
+        return outline;
+    path_bytes = path->serialize_to_bytes();
+    outline.image = committed_row_slot(*layout_node);
+    outline.path_bytes = path_bytes.data();
+    outline.path_byte_count = path_bytes.size();
+    outline.color = outline_data->color;
+    outline.width = outline_data->width;
+    return outline;
 }
 
 static Optional<CSS::BorderData> border_data_for_outline(Layout::Node const& layout_node, Color outline_color, CSS::OutlineStyle outline_style, CSSPixels outline_width)

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -18,11 +18,6 @@
 
 namespace Web::Painting {
 
-struct CaretPaint {
-    CSSPixelRect rect;
-    Color color;
-};
-
 WEB_API void set_paint_viewport_scrollbars(bool enabled);
 bool should_paint_viewport_scrollbars();
 
@@ -100,10 +95,12 @@ WEB_API Optional<String> grid_layout_json(Layout::Node const&, UniqueNodeID);
 WEB_API Optional<String> flex_layout_json(Layout::Node const&, UniqueNodeID);
 
 WEB_API CSSPixelPoint box_type_agnostic_position(Layout::Node const&);
-WEB_API bool should_paint_cursor(Layout::Node const&);
 WEB_API CSSPixelRect caret_rect_for_child_offset(Layout::Node const&, size_t offset);
-WEB_API Optional<CaretPaint> resolve_caret_paint(Layout::Node const& block, Layout::Node const* owner_inline);
-WEB_API Optional<CaretPaint> resolve_empty_editable_caret_paint(Layout::Node const&);
+
+// Per-document paint facts the recording inputs carry, resolved once per recording.
+WEB_API Layout::RustFFI::FfiCaretPaint resolve_document_caret_paint(DOM::Document&);
+WEB_API Layout::RustFFI::FfiFocusedTextControlSelection resolve_focused_text_control_selection(DOM::Document const&);
+WEB_API Layout::RustFFI::FfiFocusedAreaOutline resolve_focused_area_outline(DOM::Document const&, Vector<u8>& path_bytes);
 WEB_API SelectionStyle selection_style(Layout::Node const&);
 WEB_API SelectionStyle selection_style_for_node(Layout::Node const&, GC::Ptr<DOM::Node const>);
 

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -24,17 +24,13 @@
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
-#include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
-#include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
-#include <LibWeb/HTML/HTMLMapElement.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/NavigableContainer.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/ImageProvider.h>
 #include <LibWeb/Layout/LayoutRustFFI.h>
@@ -866,27 +862,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             }
             return facts;
         },
-        .outline_facts = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiOutlineFacts {
-            auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
-            Layout::RustFFI::FfiOutlineFacts facts {};
-            if (auto const* area_element = as_if<HTML::HTMLAreaElement>(layout_node.document().focused_area().ptr())) {
-                auto const* map_element = area_element->first_ancestor_of_type<HTML::HTMLMapElement>();
-                auto const* image_element = as_if<HTML::HTMLImageElement>(layout_node.dom_node());
-                if (map_element && image_element && map_element->first_painted_image_with_focusable_shapes().ptr() == image_element) {
-                    if (auto area_computed_values = area_element->computed_style(); area_computed_values && area_computed_values->outline_style() == CSS::OutlineStyle::Auto) {
-                        if (auto outline_data = Painting::outline_data(layout_node, *area_computed_values); outline_data.has_value()) {
-                            if (auto path = area_element->shape_path(absolute_rect(layout_node).size()); path.has_value()) {
-                                facts.paints_focused_area_outline = true;
-                                facts.focused_area_path = new Gfx::Path(path.release_value());
-                                facts.focused_area_color = outline_data->color;
-                                facts.focused_area_width = outline_data->width;
-                            }
-                        }
-                    }
-                }
-            }
-            return facts;
-        },
         .image_intrinsic_facts = [](void*, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index) -> Layout::RustFFI::FfiImageIntrinsicFacts {
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             Layout::RustFFI::FfiImageIntrinsicFacts facts {};
@@ -911,25 +886,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 }
             }
             return facts;
-        },
-        .text_control_selection = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiTextControlSelection {
-            Layout::RustFFI::FfiTextControlSelection result {};
-            auto const* layout_node = static_cast<Layout::Node const*>(layout_node_shell);
-            if (!layout_node)
-                return result;
-            auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(layout_node->document().focused_area().ptr());
-            if (!text_control)
-                return result;
-            if (GC::Ptr { layout_node->dom_node() } != text_control->form_associated_element_to_text_node())
-                return result;
-            auto selection_start = text_control->selection_start();
-            auto selection_end = text_control->selection_end();
-            if (selection_start == selection_end)
-                return result;
-            result.has_selection = true;
-            result.start = selection_start;
-            result.end = selection_end;
-            return result;
         },
         .selection_style_facts = [](void*, void* layout_node_shell, void* shadow_sink) -> Layout::RustFFI::FfiSelectionStyleFacts {
             Layout::RustFFI::FfiSelectionStyleFacts facts {};
@@ -957,27 +913,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
         .register_font = [](void* context_pointer, void const* font) -> u64 {
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             return context.resource_storage.add_font(*static_cast<Gfx::Font const*>(font)).value();
-        },
-        .cursor_facts = [](void*, void* layout_node_shell, void* owner_layout_node_shell) -> Layout::RustFFI::FfiCursorFacts {
-            auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
-            Layout::RustFFI::FfiCursorFacts facts {};
-            if (!layout_node.document().cursor_position())
-                return facts;
-            auto const* owner_layout_node = static_cast<Layout::Node const*>(owner_layout_node_shell);
-            Optional<CaretPaint> caret;
-            if (is_inline_paintable(layout_node)) {
-                caret = resolve_empty_editable_caret_paint(layout_node);
-            } else {
-                caret = resolve_caret_paint(layout_node, owner_layout_node);
-            }
-            if (!caret.has_value())
-                return facts;
-            facts.paints = true;
-            facts.rect = caret->rect;
-            facts.color = caret->color;
-            facts.blink_cycle_start_time_ns = layout_node.document().cursor_blink_cycle_start_time_ns();
-            facts.should_blink = !HTML::Window::in_test_mode();
-            return facts;
         },
         .layer_image_prepare = [](void*, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index) -> Layout::RustFFI::FfiLayerImagePrepareFacts {
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
@@ -1225,22 +1160,26 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             auto visual_context_tree = AccumulatedVisualContextTree::adopt_rust_handle(retained_tree);
             return context.resource_storage.add_display_list(display_list_from_rust_recording(visual_context_tree, recorded), visual_context_tree).value();
         },
-        .overlay_label_font = [](void*, float point_size) -> void const* {
-            auto font = Platform::FontPlugin::the().default_font(point_size);
-            VERIFY(font);
-            // The platform font caches keep the font alive; the caller retains
-            // it within the synchronous call.
-            return font.ptr();
-        },
-        .overlay_node_label_text = [](void*, void* layout_node_shell, void* label_sink) {
-            auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
-            auto border_rect = absolute_border_box_rect(layout_node);
-            StringBuilder builder;
-            builder.appendff("{}", layout_node.debug_description());
-            builder.appendff(" {}x{} @ {},{}", border_rect.width(), border_rect.height(), border_rect.x(), border_rect.y());
-            auto bytes = builder.string_view().bytes();
-            Layout::RustFFI::layout_arena_paint_push_bytes(label_sink, bytes.data(), bytes.size()); },
     };
+}
+
+// The platform default font at an overlay label's CSS size and at that size in device pixels, kept alive for the
+// recording call.
+struct OverlayLabelFonts {
+    RefPtr<Gfx::Font> css_font;
+    RefPtr<Gfx::Font> device_font;
+
+    Layout::RustFFI::FfiOverlayLabelFonts ffi() const { return { .css_font = css_font.ptr(), .device_font = device_font.ptr() }; }
+};
+
+static OverlayLabelFonts overlay_label_fonts(float css_size, double device_pixels_per_css_pixel)
+{
+    OverlayLabelFonts fonts {
+        .css_font = Platform::FontPlugin::the().default_font(css_size),
+        .device_font = Platform::FontPlugin::the().default_font(css_size * static_cast<float>(device_pixels_per_css_pixel)),
+    };
+    VERIFY(fonts.css_font && fonts.device_font);
+    return fonts;
 }
 
 }
@@ -1262,15 +1201,17 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
     inputs.tooltip_text_color = overlay_inputs.tooltip_text_color;
     inputs.tooltip_border_color = overlay_inputs.tooltip_border_color;
     Vector<Layout::RustFFI::FfiGridOverlayInput> ffi_grid_overlays;
-    auto grid_label_css_pixel_size = overlay_inputs.grid_highlights.is_empty()
-        ? 0.0f
-        : Platform::FontPlugin::the().default_font(10)->pixel_size();
+    OverlayLabelFonts grid_label_fonts;
+    if (!overlay_inputs.grid_highlights.is_empty()) {
+        grid_label_fonts = overlay_label_fonts(10.0f, device_pixels_per_css_pixel);
+        inputs.grid_label_fonts = grid_label_fonts.ffi();
+    }
     for (auto const& highlight : overlay_inputs.grid_highlights) {
         ffi_grid_overlays.append({
             .paintable = committed_row_slot(*highlight.layout_node),
             .color = highlight.options.color,
             .label_foreground_color = highlight.options.color.with_alpha(235).suggested_foreground_color(),
-            .label_css_pixel_size = grid_label_css_pixel_size,
+            .label_css_pixel_size = grid_label_fonts.css_font->pixel_size(),
             .show_area_names = highlight.options.show_area_names,
             .show_line_numbers = highlight.options.show_line_numbers,
             .show_track_sizes = highlight.options.show_track_sizes,
@@ -1289,6 +1230,19 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
     inputs.flex_overlays = ffi_flex_overlays.data();
     inputs.flex_overlay_count = ffi_flex_overlays.size();
     inputs.caret_debug_rect = overlay_inputs.caret_debug_rect;
+    ByteString inspector_highlight_label_text;
+    OverlayLabelFonts inspector_label_fonts;
+    if (overlay_inputs.highlighted_layout_node) {
+        auto const& layout_node = *overlay_inputs.highlighted_layout_node;
+        auto border_rect = absolute_border_box_rect(layout_node);
+        inspector_highlight_label_text = ByteString::formatted("{} {}x{} @ {},{}", layout_node.debug_description(), border_rect.width(), border_rect.height(), border_rect.x(), border_rect.y());
+        inspector_label_fonts = overlay_label_fonts(12.0f, device_pixels_per_css_pixel);
+        inputs.inspector_highlight_label = {
+            .fonts = inspector_label_fonts.ffi(),
+            .text = inspector_highlight_label_text.bytes().data(),
+            .text_byte_count = inspector_highlight_label_text.length(),
+        };
+    }
     inputs.device_viewport_rect = device_viewport_rect.to_type<int>();
     if (auto navigable = document.navigable())
         inputs.css_viewport_rect = navigable->viewport_rect();
@@ -1316,6 +1270,10 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
         inputs.window_is_focused = navigable && navigable->is_focused();
         inputs.outline_auto_color = CSS::SystemColor::accent_color(CSS::PreferredColorScheme::Auto);
     }
+    inputs.caret = resolve_document_caret_paint(document);
+    inputs.focused_text_control = resolve_focused_text_control_selection(document);
+    Vector<u8> focused_area_path_bytes;
+    inputs.focused_area_outline = resolve_focused_area_outline(document, focused_area_path_bytes);
     {
         auto color_scheme = document.canvas_color_scheme();
         bool opaque_canvas = false;

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -50,6 +50,77 @@ pub struct FfiRecordingInputs {
     pub flex_overlays: *const FfiFlexOverlayInput,
     pub flex_overlay_count: usize,
     pub caret_debug_rect: used_values::OptionalCssPixelRect,
+    // Per-document facts the host resolves once per recording.
+    pub caret: FfiCaretPaint,
+    pub focused_text_control: FfiFocusedTextControlSelection,
+    pub focused_area_outline: FfiFocusedAreaOutline,
+    pub inspector_highlight_label: FfiInspectorHighlightLabel,
+    pub grid_label_fonts: FfiOverlayLabelFonts,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiCaretPaintKind {
+    None,
+    /// `block` paints the caret, in the fragment run owned by the self-painting inline `owner`
+    /// (`INVALID` when the block itself owns it).
+    InBlock,
+    /// The empty editable inline `block` paints the caret at its own position.
+    EmptyInline,
+}
+
+/// Where the document's caret paints, resolved once per recording by the host.
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct FfiCaretPaint {
+    pub kind: FfiCaretPaintKind,
+    pub block: crate::layout::node_data::NodeSlotId,
+    pub owner: crate::layout::node_data::NodeSlotId,
+    pub rect: used_values::FfiCssPixelRect,
+    pub color: Color,
+    pub blink_cycle_start_time_ns: i64,
+    pub should_blink: bool,
+}
+
+/// The focused text control's selection, keyed by its primary layout text node. Equal start
+/// and end offsets mean no selection.
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct FfiFocusedTextControlSelection {
+    pub text_node: crate::layout::node_data::NodeSlotId,
+    pub start: usize,
+    pub end: usize,
+}
+
+/// The focus ring of a focused image-map area, painted by the image whose rendering makes the
+/// area's shape focusable. No path bytes means no focus ring.
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct FfiFocusedAreaOutline {
+    pub image: crate::layout::node_data::NodeSlotId,
+    /// A serialised `Gfx::Path` in the image's own coordinate space, live for the recording call.
+    pub path_bytes: *const u8,
+    pub path_byte_count: usize,
+    pub color: Color,
+    pub width: crate::css::css_pixels::CssPixels,
+}
+
+/// The platform default font at an overlay label's CSS size and at that size in device pixels.
+/// Both are null unless the recording paints the overlay they belong to.
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct FfiOverlayLabelFonts {
+    pub css_font: *const c_void,
+    pub device_font: *const c_void,
+}
+
+/// The inspector's box-model label for the highlighted node: UTF-8 text live for the recording call.
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct FfiInspectorHighlightLabel {
+    pub fonts: FfiOverlayLabelFonts,
+    pub text: *const u8,
+    pub text_byte_count: usize,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -243,23 +314,6 @@ pub struct FfiAsyncScrollFacts {
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
-pub struct FfiOutlineFacts {
-    pub paints_focused_area_outline: bool,
-    pub focused_area_path: *mut c_void,
-    pub focused_area_color: Color,
-    pub focused_area_width: crate::css::css_pixels::CssPixels,
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-#[repr(C)]
-pub struct FfiTextControlSelection {
-    pub has_selection: bool,
-    pub start: usize,
-    pub end: usize,
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-#[repr(C)]
 pub struct FfiSelectionStyleFacts {
     pub background_color: Color,
     pub text_color: OptionalColor,
@@ -269,16 +323,6 @@ pub struct FfiSelectionStyleFacts {
     pub text_decoration_line_count: u32,
     pub text_decoration_style: u8,
     pub text_decoration_color: Color,
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-#[repr(C)]
-pub struct FfiCursorFacts {
-    pub paints: bool,
-    pub rect: used_values::FfiCssPixelRect,
-    pub color: Color,
-    pub blink_cycle_start_time_ns: i64,
-    pub should_blink: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -405,13 +449,10 @@ impl From<&RecordedDisplayList> for FfiRecordedDisplayList {
 pub struct FfiPaintHostCallbacks {
     pub context: *mut c_void,
     pub async_scroll_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiAsyncScrollFacts,
-    pub outline_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiOutlineFacts,
     pub image_intrinsic_facts:
         unsafe extern "C" fn(*mut c_void, *mut c_void, FfiLayerImageList, u32) -> FfiImageIntrinsicFacts,
-    pub text_control_selection: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiTextControlSelection,
     pub selection_style_facts: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiSelectionStyleFacts,
     pub register_font: unsafe extern "C" fn(*mut c_void, *const c_void) -> u64,
-    pub cursor_facts: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiCursorFacts,
     pub layer_image_prepare:
         unsafe extern "C" fn(*mut c_void, *mut c_void, FfiLayerImageList, u32) -> FfiLayerImagePrepareFacts,
     pub layer_image_nested_display_list: unsafe extern "C" fn(
@@ -446,8 +487,6 @@ pub struct FfiPaintHostCallbacks {
         *mut c_void,
     ) -> FfiSvgPaintStyle,
     pub nested_display_list_from_tree: unsafe extern "C" fn(*mut c_void, FfiRecordedDisplayList, *const c_void) -> u64,
-    pub overlay_label_font: unsafe extern "C" fn(*mut c_void, f32) -> *const c_void,
-    pub overlay_node_label_text: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
 }
 
 #[derive(Default)]
@@ -457,33 +496,11 @@ pub struct ColorStopSink {
 }
 
 impl FfiPaintHostCallbacks {
-    pub(crate) fn outline_facts(&self, layout_node_shell: *mut c_void) -> FfiOutlineFacts {
-        // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe { (self.outline_facts)(self.context, layout_node_shell) }
-    }
     pub(crate) fn async_scroll_facts(&self, layout_node_shell: *mut c_void) -> FfiAsyncScrollFacts {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe { (self.async_scroll_facts)(self.context, layout_node_shell) }
     }
-    /// Resolves the platform default UI font at `point_size`. The returned
-    /// `Gfx::Font` pointer is borrowed; the platform font caches keep it live
-    /// for the synchronous window in which the caller retains it.
-    pub(crate) fn overlay_label_font(&self, point_size: f32) -> *const c_void {
-        // SAFETY: The C++ host answers synchronously.
-        unsafe { (self.overlay_label_font)(self.context, point_size) }
-    }
 
-    pub(crate) fn overlay_node_label_text(&self, layout_node_shell: *mut c_void) -> Vec<u16> {
-        let mut label = Vec::new();
-        // SAFETY: The C++ host fills the label sink synchronously through the exported push
-        // function.
-        unsafe { (self.overlay_node_label_text)(self.context, layout_node_shell, (&raw mut label).cast()) };
-        String::from_utf8_lossy(&label).encode_utf16().collect()
-    }
-    pub(crate) fn text_control_selection(&self, layout_node_shell: *mut c_void) -> FfiTextControlSelection {
-        // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe { (self.text_control_selection)(self.context, layout_node_shell) }
-    }
     pub(crate) fn selection_style_facts(
         &self,
         layout_node_shell: *mut c_void,
@@ -501,14 +518,6 @@ impl FfiPaintHostCallbacks {
         // SAFETY: The C++ host registers the live font in the recording's
         // resource table synchronously.
         unsafe { (self.register_font)(self.context, font) }
-    }
-    pub(crate) fn cursor_facts(
-        &self,
-        layout_node_shell: *mut c_void,
-        owner_layout_node_shell: *mut c_void,
-    ) -> FfiCursorFacts {
-        // SAFETY: The C++ host answers synchronously from live layout node shells.
-        unsafe { (self.cursor_facts)(self.context, layout_node_shell, owner_layout_node_shell) }
     }
     pub(crate) fn layer_image_prepare(
         &self,

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -148,7 +148,6 @@ pub struct PaintRecorder<'a> {
     pub(crate) all_descendant_subtree_caches_dirty: bool,
     text_node_facts_cache: HashMap<u32, FfiHitTestTextNodeFacts>,
     font_resource_id_cache: HashMap<usize, u64>,
-    text_control_selection_cache: HashMap<u32, crate::painting::host::FfiTextControlSelection>,
     selection_style_cache: HashMap<u32, Rc<paint::text::SelectionStyleAnswer>>,
     pub(crate) wheel_hit_test_target_cache: HashMap<NodeSlotId, SpatialNodeIndex>,
 }
@@ -203,19 +202,18 @@ impl<'a> PaintRecorder<'a> {
         font_id
     }
 
-    pub(crate) fn text_control_selection(
-        &mut self,
-        node: crate::layout::node_data::NodeSlotId,
-    ) -> crate::painting::host::FfiTextControlSelection {
-        let key = node.index;
-        if let Some(facts) = self.text_control_selection_cache.get(&key) {
-            return *facts;
+    /// The focused text control's selection as `(start, end)` when `node` is one of its text
+    /// node's committed rows.
+    pub(crate) fn text_control_selection(&self, node: NodeSlotId) -> Option<(usize, usize)> {
+        let control = &self.inputs.focused_text_control;
+        if control.start == control.end {
+            return None;
         }
-        let facts = self
-            .paint_host
-            .text_control_selection(self.layout_arena.shell_if_live(node));
-        self.text_control_selection_cache.insert(key, facts);
-        facts
+        self.layout_arena
+            .text_fragments(control.text_node)
+            .as_slice()
+            .contains(&node)
+            .then_some((control.start, control.end))
     }
 
     pub(crate) fn selection_style(
@@ -272,7 +270,6 @@ impl<'a> PaintRecorder<'a> {
             all_descendant_subtree_caches_dirty: self.all_descendant_subtree_caches_dirty,
             text_node_facts_cache: HashMap::new(),
             font_resource_id_cache: HashMap::new(),
-            text_control_selection_cache: HashMap::new(),
             selection_style_cache: HashMap::new(),
             wheel_hit_test_target_cache: HashMap::new(),
         }

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
@@ -132,16 +132,13 @@ pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, pha
             text::paint_cursor(recorder, root, Some(paintable));
         }
         if facts.is_visible {
-            let cursor = recorder.paint_host.cursor_facts(
-                recorder.layout_node_shell(paintable),
-                recorder.layout_node_shell(paintable),
-            );
-            if cursor.paints {
-                let color = cursor.color;
+            let caret = recorder.inputs.caret;
+            if caret.kind == crate::painting::host::FfiCaretPaintKind::EmptyInline && caret.block == paintable {
+                let color = caret.color;
                 if color.alpha() != 0 {
                     let rect = recorder
                         .converter
-                        .rounded_device_rect(crate::css::css_pixels::CssPixelRect::from(cursor.rect));
+                        .rounded_device_rect(crate::css::css_pixels::CssPixelRect::from(caret.rect));
                     recorder.recorder.fill_rect(rect, color, ForceDarkRole::Foreground);
                 }
             }

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
@@ -12,7 +12,7 @@ use crate::layout::node_data::NodeSlotId;
 use crate::painting::display_list::commands::{ContextRef, DisplayListGlyph, FontResourceId};
 use crate::painting::display_list::recorder::GlyphRunForRecording;
 use crate::painting::force_dark::ForceDarkRole;
-use crate::painting::host::{FfiFlexOverlayInput, FfiGridOverlayInput};
+use crate::painting::host::{FfiFlexOverlayInput, FfiGridOverlayInput, FfiOverlayLabelFonts};
 use crate::painting::paintable_geometry;
 use crate::painting::record::PaintRecorder;
 use libgfx_rust::{Color, FloatPoint, IntPoint, IntRect, LineStyle, Orientation};
@@ -95,10 +95,11 @@ fn paint_box_model_highlight(recorder: &mut PaintRecorder<'_>, paintable: NodeSl
     paint_inspector_rect(recorder, border_rect, Color::from_rgb(0, 255, 0));
     paint_inspector_rect(recorder, content_rect, Color::from_rgb(255, 0, 255));
 
-    let text = recorder
-        .paint_host
-        .overlay_node_label_text(recorder.layout_node_shell(paintable));
-    let label = shape_overlay_label(recorder, &text, 12.0);
+    let label_input = recorder.inputs.inspector_highlight_label;
+    // SAFETY: The host keeps the label bytes live for the recording call.
+    let label_bytes = unsafe { crate::painting::ffi::ffi_slice(label_input.text, label_input.text_byte_count) };
+    let text: Vec<u16> = String::from_utf8_lossy(label_bytes).encode_utf16().collect();
+    let label = shape_overlay_label(recorder, &text, label_input.fonts);
     let mut size_text_rect = border_rect;
     size_text_rect.y = border_rect.y + border_rect.height;
     size_text_rect.width = CssPixels::nearest_value_for_f32(label.css_width) + CssPixels::from_integer(4);
@@ -274,7 +275,7 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
             .fill_rect(converter.enclosing_device_rect(rect), rect_color, ForceDarkRole::None);
     };
     let paint_label = |recorder: &mut PaintRecorder<'_>, top_left: CssPixelPoint, text: &[u16]| {
-        let label = shape_overlay_label(recorder, text, 10.0);
+        let label = shape_overlay_label(recorder, text, recorder.inputs.grid_label_fonts);
         let label_width = label_width_for(&label);
         let label_rect = CssPixelRect {
             x: top_left.x,
@@ -293,7 +294,7 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
         draw_label(recorder, &label, label_device_rect, input.label_foreground_color);
     };
     let paint_centered_label = |recorder: &mut PaintRecorder<'_>, rect: CssPixelRect, text: &[u16]| {
-        let label = shape_overlay_label(recorder, text, 10.0);
+        let label = shape_overlay_label(recorder, text, recorder.inputs.grid_label_fonts);
         let label_width = label_width_for(&label);
         let top_left = CssPixelPoint {
             x: rect.center().x - label_width.div_as_fraction(two),
@@ -468,17 +469,12 @@ struct OverlayLabel {
     glyphs: Vec<DisplayListGlyph>,
 }
 
-fn shape_overlay_label(recorder: &mut PaintRecorder<'_>, text: &[u16], css_font_size: f32) -> OverlayLabel {
-    let device_scale = recorder.inputs.device_pixels_per_css_pixel as f32;
-    // SAFETY: The host resolves the fonts from the platform font caches, which
-    // keep them live through this synchronous call; retaining them here keeps
-    // them alive for the rest of the recording.
-    let css_font =
-        unsafe { libgfx_rust::font::RetainedFont::retain(recorder.paint_host.overlay_label_font(css_font_size)) };
+fn shape_overlay_label(recorder: &mut PaintRecorder<'_>, text: &[u16], fonts: FfiOverlayLabelFonts) -> OverlayLabel {
+    // SAFETY: The host resolves both fonts from the platform font caches, which keep them live
+    // through the recording call; retaining them here keeps them alive for the rest of it.
+    let css_font = unsafe { libgfx_rust::font::RetainedFont::retain(fonts.css_font) };
     // SAFETY: See above.
-    let device_font = unsafe {
-        libgfx_rust::font::RetainedFont::retain(recorder.paint_host.overlay_label_font(css_font_size * device_scale))
-    };
+    let device_font = unsafe { libgfx_rust::font::RetainedFont::retain(fonts.device_font) };
     // SAFETY: The RetainedFont handles keep both fonts live for these borrows.
     let css_font_ref = unsafe { libgfx_rust::font::FontRef::from_raw(css_font.as_raw()) };
     // SAFETY: See above.

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/outline.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/outline.rs
@@ -29,8 +29,7 @@ pub(crate) fn paint_outline_phase(recorder: &mut PaintRecorder<'_>, paintable: N
         let border_radii = recorder.border_radii(paintable);
         paint_outline(recorder, outline, outline_offset, border_box_rect, border_radii);
     }
-    let facts = recorder.paint_host.outline_facts(recorder.layout_node_shell(paintable));
-    paint_focused_area_outline(recorder, paintable, &facts);
+    paint_focused_area_outline(recorder, paintable);
 }
 
 pub(crate) fn outline_border_geometry(
@@ -119,21 +118,19 @@ pub(crate) fn paint_outline(
     );
 }
 
-fn paint_focused_area_outline(
-    recorder: &mut PaintRecorder<'_>,
-    paintable: NodeSlotId,
-    facts: &crate::painting::host::FfiOutlineFacts,
-) {
+fn paint_focused_area_outline(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId) {
     // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
     // The shapes of area elements in an image map associated with an img element that is being rendered and is not
     // inert.
     // NB: Focused area elements have no paintable of their own, so the image whose rendering makes the area's shape a
     // focusable area paints the focus outline along that shape.
-    if !facts.paints_focused_area_outline || facts.focused_area_path.is_null() {
+    let outline = recorder.inputs.focused_area_outline;
+    // SAFETY: The host keeps the serialised path bytes live for the recording call.
+    let path_bytes = unsafe { crate::painting::ffi::ffi_slice(outline.path_bytes, outline.path_byte_count) };
+    if path_bytes.is_empty() || outline.image != paintable {
         return;
     }
-    // SAFETY: The host hands out a heap-allocated Gfx::Path the receiver owns.
-    let path = unsafe { libgfx_rust::path::OwnedPath::adopt(facts.focused_area_path) };
+    let path = libgfx_rust::path::OwnedPath::from_serialized_bytes(path_bytes);
     let converter = recorder.converter;
     let image_rect = paintable_geometry::absolute_rect(recorder.layout_arena, paintable);
     let scale = recorder.inputs.device_pixels_per_css_pixel as f32;
@@ -155,8 +152,8 @@ fn paint_focused_area_outline(
                 dash_offset: 0.0,
                 path: &transformed,
                 opacity: 1.0,
-                paint_style_or_color: PaintStyleOrColor::Color(facts.focused_area_color),
-                thickness: facts.focused_area_width.to_double() as f32 * scale,
+                paint_style_or_color: PaintStyleOrColor::Color(outline.color),
+                thickness: outline.width.to_double() as f32 * scale,
                 should_anti_alias: ShouldAntiAlias::Yes,
             });
         });

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
@@ -9,6 +9,7 @@ use crate::layout::node_data::{NodeFlag, NodeSlotId};
 use crate::painting::display_list::commands::{DisplayListGlyph, FontResourceId};
 use crate::painting::display_list::recorder::GlyphRunForRecording;
 use crate::painting::force_dark::ForceDarkRole;
+use crate::painting::host::FfiCaretPaintKind;
 use crate::painting::paintable_data::{FragmentRecord, SELECTION_STATE_START_AND_END};
 use crate::painting::record::PaintRecorder;
 use crate::painting::text_fragment::{self, SelectionOffsets};
@@ -50,14 +51,13 @@ fn selection_offsets_for_fragment(
     fragment: &FragmentRecord,
 ) -> Option<SelectionOffsets> {
     let drop_degenerate = |offsets: Option<SelectionOffsets>| offsets.filter(|offsets| offsets.start != offsets.end);
-    let control = recorder.text_control_selection(fragment.layout_node);
-    if control.has_selection {
+    if let Some((start, end)) = recorder.text_control_selection(fragment.layout_node) {
         return drop_degenerate(text_fragment::compute_selection_offsets(
             recorder.layout_arena,
             fragment,
             SELECTION_STATE_START_AND_END,
-            control.start,
-            control.end,
+            start,
+            end,
         ));
     }
     let range = recorder.paint_state.selection.as_ref()?;
@@ -482,22 +482,22 @@ fn paint_text_fragment(
 // Paints the caret when it sits in a fragment owned by `owner`; the block itself
 // (owner == None) also handles blank lines and empty editable elements.
 pub(crate) fn paint_cursor(recorder: &mut PaintRecorder<'_>, block: NodeSlotId, owner: Option<NodeSlotId>) {
-    let owner_shell = owner.map_or(std::ptr::null_mut(), |owner| recorder.layout_node_shell(owner));
-    let facts = recorder
-        .paint_host
-        .cursor_facts(recorder.layout_node_shell(block), owner_shell);
-    if !facts.paints {
+    let caret = recorder.inputs.caret;
+    if caret.kind != FfiCaretPaintKind::InBlock
+        || caret.block != block
+        || caret.owner != owner.unwrap_or(NodeSlotId::INVALID)
+    {
         return;
     }
-    let color = facts.color;
+    let color = caret.color;
     if color.alpha() == 0 {
         return;
     }
     let converter = recorder.converter;
     recorder.recorder.paint_caret(
-        converter.rounded_device_rect(CssPixelRect::from(facts.rect)),
+        converter.rounded_device_rect(CssPixelRect::from(caret.rect)),
         color,
-        facts.blink_cycle_start_time_ns,
-        facts.should_blink,
+        caret.blink_cycle_start_time_ns,
+        caret.should_blink,
     );
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -126,7 +126,6 @@ pub(crate) fn record_display_list(
         all_descendant_subtree_caches_dirty: layout_arena.all_descendant_subtree_caches_dirty(),
         text_node_facts_cache: HashMap::new(),
         font_resource_id_cache: HashMap::new(),
-        text_control_selection_cache: HashMap::new(),
         selection_style_cache: HashMap::new(),
         wheel_hit_test_target_cache: HashMap::new(),
     };


### PR DESCRIPTION
The caret, the focused text control's selection, the focused image-map area's focus ring and the inspector overlay's label and fonts are facts of the document, not of a box, yet the recorder asked the host for them box by box through five callbacks that reached into the Document, the focused area and the platform font cache.

record_rust_display_list now resolves each of them once into FfiRecordingInputs: resolve_document_caret_paint() walks the same cases the per-box caret helpers did, from the cursor node outwards, and names the one box that paints the caret; the text control selection identifies its primary layout text node, whose committed rows are resolved by the Rust arena; the focused area's outline carries its serialised path; the overlays carry their fonts and the highlight label. The recorder compares slots against those snapshots. This removes the cursor_facts, text_control_selection, outline_facts, overlay_label_font and overlay_node_label_text host callbacks.