### PR TITLE
UI/Qt+AppKit: Report every select dropdown close to WebContent (and make Expedia.com actually usable)

### DIFF
--- a/Tests/UI/AppKit/CMakeLists.txt
+++ b/Tests/UI/AppKit/CMakeLists.txt
@@ -22,3 +22,12 @@ ladybird_test("TestClipboardTypes.mm" UI/AppKit NAME TestAppKitClipboardTypes LI
 target_sources(TestAppKitClipboardTypes PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit/Application/ClipboardTypes.mm")
 target_include_directories(TestAppKitClipboardTypes PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit")
 target_link_libraries(TestAppKitClipboardTypes PRIVATE "-framework Cocoa")
+
+ladybird_test("TestSelectDropdown.mm" UI/AppKit NAME TestAppKitSelectDropdown LIBS LibWeb LibGfx LibIPC LibURL)
+target_sources(TestAppKitSelectDropdown PRIVATE
+    "${LADYBIRD_SOURCE_DIR}/UI/AppKit/Interface/SelectDropdown.mm"
+    "${LADYBIRD_SOURCE_DIR}/UI/AppKit/Utilities/Conversions.mm"
+)
+target_include_directories(TestAppKitSelectDropdown PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit")
+target_compile_options(TestAppKitSelectDropdown PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fobjc-arc>)
+target_link_libraries(TestAppKitSelectDropdown PRIVATE "-framework Cocoa")

--- a/Tests/UI/AppKit/TestSelectDropdown.mm
+++ b/Tests/UI/AppKit/TestSelectDropdown.mm
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <LibTest/TestCase.h>
+
+#import <Interface/SelectDropdown.h>
+
+// These tests pop up a real menu and drive it with key events posted to the application's event queue. The menu's
+// tracking loop takes those like hardware ones — with the application inactive, the window never shown, and no
+// application run loop, as under ctest. But a tracking menu also follows the real pointer, whichever application is
+// active: a move clears the menu's keyboard highlight, and a click dismisses the menu. So a run whose highlight or
+// menu the pointer took away is run again, up to three times in all, rather than failed on the spot.
+
+namespace {
+
+struct Report {
+    int calls { 0 };
+    Optional<u32> selected_item_id;
+};
+
+// The state of one run of steps against one menu.
+struct Run {
+    size_t next_step { 0 };
+    bool lost_to_the_pointer { false };
+};
+
+// A step runs on every tick, 50ms apart, until it returns true.
+using Step = Function<bool()>;
+
+void record_reports(SelectDropdown* dropdown, Report& report)
+{
+    [dropdown setOnClosed:[&report](Optional<u32> const& selected_item_id) {
+        ++report.calls;
+        report.selected_item_id = selected_item_id;
+    }];
+}
+
+Vector<Web::HTML::SelectItem> three_options()
+{
+    Vector<Web::HTML::SelectItem> items;
+    items.append(Web::HTML::SelectItemOption { .id = 1, .selected = true, .label = "Alpha"_utf16 });
+    items.append(Web::HTML::SelectItemOption { .id = 2, .label = "Bravo"_utf16 });
+    items.append(Web::HTML::SelectItemOption { .id = 3, .label = "Charlie"_utf16 });
+    return items;
+}
+
+// The window the menu pops up for. It's never shown; the menu doesn't need it to be. The test binary has no
+// application object of its own, and the menu's tracking loop and the posted key events need one.
+NSWindow* make_window()
+{
+    [NSApplication sharedApplication];
+    auto* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
+                                               styleMask:NSWindowStyleMaskTitled
+                                                 backing:NSBackingStoreBuffered
+                                                   defer:NO];
+    window.releasedWhenClosed = NO;
+    return window;
+}
+
+enum class PostAt {
+    Back,
+    Front,
+};
+
+// A key that acts on the highlighted item goes to the front of the queue: A pointer move already queued behind it
+// can't clear the highlight first.
+void post_key(NSWindow* window, unsigned short key_code, NSString* characters, PostAt post_at = PostAt::Back)
+{
+    auto make_event = [&](NSEventType type) {
+        return [NSEvent keyEventWithType:type
+                                location:NSZeroPoint
+                           modifierFlags:0
+                               timestamp:[[NSProcessInfo processInfo] systemUptime]
+                            windowNumber:window.windowNumber
+                                 context:nil
+                              characters:characters
+             charactersIgnoringModifiers:characters
+                               isARepeat:NO
+                                 keyCode:key_code];
+    };
+    [NSApp postEvent:make_event(NSEventTypeKeyDown) atStart:post_at == PostAt::Front];
+    [NSApp postEvent:make_event(NSEventTypeKeyUp) atStart:NO];
+}
+
+void press_down(NSWindow* window)
+{
+    post_key(window, 125, [NSString stringWithFormat:@"%C", static_cast<unichar>(NSDownArrowFunctionKey)]);
+}
+
+void press_return(NSWindow* window)
+{
+    post_key(window, 36, @"\r", PostAt::Front);
+}
+
+void press_escape(NSWindow* window)
+{
+    post_key(window, 53, @"\x1b", PostAt::Front);
+}
+
+Step close_without_reporting(SelectDropdown* dropdown)
+{
+    return [dropdown] {
+        [dropdown closeWithoutReporting];
+        return true;
+    };
+}
+
+// Escape with nothing highlighted. The pointer hovering over the menu would highlight an item; the dismissal is then
+// still checked, just without that precondition.
+Step escape_with_nothing_highlighted(SelectDropdown* dropdown, NSWindow* window)
+{
+    return [=] {
+        if (dropdown.menu.highlightedItem != nil)
+            warnln("An item is highlighted (is the pointer over the menu?); checking the dismissal anyway");
+        press_escape(window);
+        return true;
+    };
+}
+
+// Presses Down until an item is highlighted — the one at the index, or any item when none is given — and then runs
+// `then` on that same tick, before anything else can move the highlight. The menu acts on a key well within a tick,
+// so once the highlight has moved, the next press goes out; a highlight that hasn't moved in four ticks is taken as
+// cleared by the pointer, and Down goes out again — the menu then starts over from the top. After two seconds of
+// that, a run that wanted a particular item gives up, to be retried; one that wanted any item carries on without the
+// highlight, since what it checks is the dismissal, which doesn't depend on it.
+Step highlight_then(SelectDropdown* dropdown, NSWindow* window, Optional<NSInteger> index, Run& run, Function<void()> then)
+{
+    struct State {
+        int ticks { 0 };
+        int ticks_since_press { 0 };
+        NSMenuItem* highlighted_at_press { nil };
+    };
+    auto* run_pointer = &run;
+    return [=, then = move(then), state = State {}]() mutable {
+        auto* highlighted = dropdown.menu.highlightedItem;
+        auto* wanted = index.has_value() ? [dropdown.menu itemAtIndex:index.value()] : highlighted;
+        if (highlighted != nil && highlighted == wanted) {
+            then();
+            return true;
+        }
+        if (++state.ticks > 40) {
+            if (index.has_value()) {
+                run_pointer->lost_to_the_pointer = true;
+                [dropdown.menu cancelTracking];
+            } else {
+                warnln("No item stayed highlighted for two seconds (is the pointer moving?); checking the dismissal without one");
+                then();
+            }
+            return true;
+        }
+        bool press_was_taken = state.ticks_since_press > 0 && highlighted != state.highlighted_at_press;
+        if (state.ticks_since_press == 0 || press_was_taken || state.ticks_since_press >= 4) {
+            state.highlighted_at_press = highlighted;
+            press_down(window);
+            state.ticks_since_press = 0;
+        }
+        ++state.ticks_since_press;
+        return false;
+    };
+}
+
+Step highlight_any_item_then_escape(SelectDropdown* dropdown, NSWindow* window, Run& run)
+{
+    return highlight_then(dropdown, window, {}, run, [window] { press_escape(window); });
+}
+
+Step highlight_any_item_then_cancel_tracking(SelectDropdown* dropdown, NSWindow* window, Run& run)
+{
+    return highlight_then(dropdown, window, {}, run, [dropdown] { [dropdown.menu cancelTracking]; });
+}
+
+Step choose_item(SelectDropdown* dropdown, NSWindow* window, NSInteger index, Run& run)
+{
+    return highlight_then(dropdown, window, index, run, [window] { press_return(window); });
+}
+
+// Pops the menu up for the window's content view, and runs the steps from a timer in the tracking loop's mode until
+// the menu closes. Returns false when the run was lost to the pointer, or the menu went away before the steps were
+// done.
+bool open_and_interact(SelectDropdown* dropdown, NSWindow* window, Vector<Web::HTML::SelectItem> const& items, Vector<Step>& steps, Run& run)
+{
+    run = {};
+    int idle_ticks = 0;
+    auto tick = [&] {
+        if (run.lost_to_the_pointer)
+            return;
+        if (run.next_step < steps.size()) {
+            if (steps[run.next_step]())
+                ++run.next_step;
+            return;
+        }
+        // Every step is done and the menu is still up: Three seconds of that is a failure, not a retry.
+        if (++idle_ticks == 60) {
+            FAIL("The menu is still open three seconds after the last step");
+            [dropdown.menu cancelTracking];
+        }
+    };
+    auto* timer = [NSTimer timerWithTimeInterval:0.05 repeats:YES block:^(NSTimer*) { tick(); }];
+    [[NSRunLoop currentRunLoop] addTimer:timer forMode:NSEventTrackingRunLoopMode];
+    [[NSRunLoop currentRunLoop] addTimer:timer forMode:NSDefaultRunLoopMode];
+
+    auto* event = [NSEvent mouseEventWithType:NSEventTypeRightMouseUp
+                                     location:NSMakePoint(10, 10)
+                                modifierFlags:0
+                                    timestamp:0
+                                 windowNumber:window.windowNumber
+                                      context:nil
+                                  eventNumber:0
+                                   clickCount:1
+                                     pressure:1.0];
+    [dropdown openWithEvent:event forView:window.contentView minimumWidth:100 items:items];
+    [timer invalidate];
+
+    // A key the menu never got to would otherwise land in the next menu's tracking loop.
+    [NSApp discardEventsMatchingMask:NSEventMaskAny beforeEvent:nil];
+
+    return !run.lost_to_the_pointer && run.next_step == steps.size();
+}
+
+enum class Expecting {
+    NoChoice,
+    AChoice,
+};
+
+// Runs the steps against a fresh menu — and again, three attempts in all, whenever the pointer got in the way: a run
+// lost to it, or a menu that closed without the expected choice because the pointer cleared the highlight just before
+// Return landed.
+template<typename MakeSteps>
+bool run_settling(SelectDropdown* dropdown, NSWindow* window, Vector<Web::HTML::SelectItem> const& items, Report& report, Expecting expecting, MakeSteps make_steps)
+{
+    for (int attempt = 1; attempt <= 3; ++attempt) {
+        report = {};
+        Run run;
+        auto steps = make_steps(run);
+        bool completed = open_and_interact(dropdown, window, items, steps, run);
+        if (completed && (expecting == Expecting::NoChoice || report.selected_item_id.has_value()))
+            return true;
+        warnln("Attempt {}: the pointer took the menu or its highlight away; trying again", attempt);
+    }
+    return false;
+}
+
+}
+
+TEST_CASE(escape_with_an_item_highlighted_reports_no_choice)
+{
+    auto* window = make_window();
+    auto* dropdown = [[SelectDropdown alloc] init];
+    Report report;
+    record_reports(dropdown, report);
+
+    EXPECT(run_settling(dropdown, window, three_options(), report, Expecting::NoChoice, [&](Run& run) {
+        Vector<Step> steps;
+        steps.append(highlight_any_item_then_escape(dropdown, window, run));
+        return steps;
+    }));
+
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(!report.selected_item_id.has_value());
+}
+
+TEST_CASE(escape_with_nothing_highlighted_reports_no_choice)
+{
+    auto* window = make_window();
+    auto* dropdown = [[SelectDropdown alloc] init];
+    Report report;
+    record_reports(dropdown, report);
+
+    EXPECT(run_settling(dropdown, window, three_options(), report, Expecting::NoChoice, [&](Run&) {
+        Vector<Step> steps;
+        steps.append(escape_with_nothing_highlighted(dropdown, window));
+        return steps;
+    }));
+
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(!report.selected_item_id.has_value());
+}
+
+TEST_CASE(canceling_tracking_with_an_item_highlighted_reports_no_choice)
+{
+    auto* window = make_window();
+    auto* dropdown = [[SelectDropdown alloc] init];
+    Report report;
+    record_reports(dropdown, report);
+
+    // The application deactivating is one of the ways a menu goes away from the outside; cancelTracking stands in for
+    // all of them.
+    EXPECT(run_settling(dropdown, window, three_options(), report, Expecting::NoChoice, [&](Run& run) {
+        Vector<Step> steps;
+        steps.append(highlight_any_item_then_cancel_tracking(dropdown, window, run));
+        return steps;
+    }));
+
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(!report.selected_item_id.has_value());
+}
+
+TEST_CASE(choosing_an_item_reports_its_id)
+{
+    auto* window = make_window();
+    auto* dropdown = [[SelectDropdown alloc] init];
+    Report report;
+    record_reports(dropdown, report);
+
+    EXPECT(run_settling(dropdown, window, three_options(), report, Expecting::AChoice, [&](Run& run) {
+        Vector<Step> steps;
+        steps.append(choose_item(dropdown, window, 2, run));
+        return steps;
+    }));
+
+    EXPECT_EQ(report.calls, 1);
+    EXPECT_EQ(report.selected_item_id.value_or(0), 3u);
+}
+
+TEST_CASE(choosing_an_item_inside_a_group_reports_its_id)
+{
+    auto* window = make_window();
+    auto* dropdown = [[SelectDropdown alloc] init];
+    Report report;
+    record_reports(dropdown, report);
+
+    Vector<Web::HTML::SelectItem> items;
+    items.append(Web::HTML::SelectItemOption { .id = 1, .selected = true, .label = "Top"_utf16 });
+    items.append(Web::HTML::SelectItemSeparator {});
+    Vector<Web::HTML::SelectItemOption> grouped_options;
+    grouped_options.append(Web::HTML::SelectItemOption { .id = 2, .label = "First"_utf16 });
+    grouped_options.append(Web::HTML::SelectItemOption { .id = 3, .label = "Second"_utf16 });
+    items.append(Web::HTML::SelectItemOptionGroup { .label = "Group"_utf16, .items = move(grouped_options) });
+
+    // The menu holds: Top, a separator, the group's disabled title, First, Second.
+    EXPECT(run_settling(dropdown, window, items, report, Expecting::AChoice, [&](Run& run) {
+        Vector<Step> steps;
+        steps.append(choose_item(dropdown, window, 4, run));
+        return steps;
+    }));
+
+    EXPECT_EQ(static_cast<int>(dropdown.menu.numberOfItems), 5);
+    EXPECT_EQ(report.calls, 1);
+    EXPECT_EQ(report.selected_item_id.value_or(0), 3u);
+}
+
+TEST_CASE(closing_without_reporting_reports_nothing)
+{
+    auto* window = make_window();
+    auto* dropdown = [[SelectDropdown alloc] init];
+    Report report;
+    record_reports(dropdown, report);
+
+    EXPECT(run_settling(dropdown, window, three_options(), report, Expecting::NoChoice, [&](Run&) {
+        Vector<Step> steps;
+        steps.append(close_without_reporting(dropdown));
+        return steps;
+    }));
+    EXPECT_EQ(report.calls, 0);
+
+    // The next menu reports again as normal.
+    EXPECT(run_settling(dropdown, window, three_options(), report, Expecting::NoChoice, [&](Run&) {
+        Vector<Step> steps;
+        steps.append([window] {
+            press_escape(window);
+            return true;
+        });
+        return steps;
+    }));
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(!report.selected_item_id.has_value());
+}

--- a/Tests/UI/Qt/CMakeLists.txt
+++ b/Tests/UI/Qt/CMakeLists.txt
@@ -57,6 +57,16 @@ ladybird_test("TestHiddenPageSizing.cpp" UI/Qt
 target_sources(TestHiddenPageSizing PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/HiddenPageSizing.cpp")
 deploy_qt_offscreen_platform_plugin(TestHiddenPageSizing)
 
+ladybird_test("TestSelectDropdown.cpp" UI/Qt
+    CUSTOM_MAIN "$<TARGET_OBJECTS:QtTestMain>"
+    LIBS LibWeb LibGfx LibIPC LibURL Qt::Core Qt::Gui Qt::Widgets
+)
+target_sources(TestSelectDropdown PRIVATE
+    "${LADYBIRD_SOURCE_DIR}/UI/Qt/SelectDropdown.cpp"
+    "${LADYBIRD_SOURCE_DIR}/UI/Qt/StringUtils.cpp"
+)
+deploy_qt_offscreen_platform_plugin(TestSelectDropdown)
+
 if (NOT LINUX)
     return()
 endif()

--- a/Tests/UI/Qt/TestSelectDropdown.cpp
+++ b/Tests/UI/Qt/TestSelectDropdown.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <UI/Qt/SelectDropdown.h>
+
+#include <QApplication>
+#include <QKeyEvent>
+#include <QTimer>
+#include <QWidget>
+
+namespace {
+
+struct Report {
+    int calls { 0 };
+    Optional<u32> selected_item_id;
+};
+
+void record_reports(Ladybird::SelectDropdown& dropdown, Report& report)
+{
+    dropdown.on_closed = [&report](Optional<u32> const& selected_item_id) {
+        ++report.calls;
+        report.selected_item_id = selected_item_id;
+    };
+}
+
+Vector<Web::HTML::SelectItem> three_options()
+{
+    Vector<Web::HTML::SelectItem> items;
+    items.append(Web::HTML::SelectItemOption { .id = 1, .selected = true, .label = "Alpha"_utf16 });
+    items.append(Web::HTML::SelectItemOption { .id = 2, .label = "Bravo"_utf16 });
+    items.append(Web::HTML::SelectItemOption { .id = 3, .label = "Charlie"_utf16 });
+    return items;
+}
+
+void send_key(QWidget& widget, int key)
+{
+    QKeyEvent press { QEvent::KeyPress, key, Qt::NoModifier };
+    QApplication::sendEvent(&widget, &press);
+    QKeyEvent release { QEvent::KeyRelease, key, Qt::NoModifier };
+    QApplication::sendEvent(&widget, &release);
+    QApplication::processEvents();
+}
+
+// open() runs the menu's own event loop until the menu closes, so the interaction is queued before the call and runs
+// from inside that loop.
+template<typename Interaction>
+void open_and_interact(Ladybird::SelectDropdown& dropdown, Vector<Web::HTML::SelectItem> const& items, Interaction interaction)
+{
+    bool interacted = false;
+    QTimer::singleShot(0, &dropdown, [&] {
+        interacted = true;
+        EXPECT(dropdown.isVisible());
+        interaction();
+    });
+    dropdown.open(QPoint { 10, 10 }, 100, items);
+    EXPECT(interacted);
+    EXPECT(!dropdown.isVisible());
+}
+
+}
+
+TEST_CASE(escape_with_an_item_highlighted_reports_no_choice)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.show();
+
+    Ladybird::SelectDropdown dropdown(&web_view);
+    Report report;
+    record_reports(dropdown, report);
+
+    open_and_interact(dropdown, three_options(), [&] {
+        send_key(dropdown, Qt::Key_Down);
+        EXPECT(dropdown.activeAction());
+        send_key(dropdown, Qt::Key_Escape);
+    });
+
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(!report.selected_item_id.has_value());
+}
+
+TEST_CASE(escape_with_nothing_highlighted_reports_no_choice)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.show();
+
+    Ladybird::SelectDropdown dropdown(&web_view);
+    Report report;
+    record_reports(dropdown, report);
+
+    open_and_interact(dropdown, three_options(), [&] {
+        EXPECT(!dropdown.activeAction());
+        send_key(dropdown, Qt::Key_Escape);
+    });
+
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(!report.selected_item_id.has_value());
+}
+
+TEST_CASE(hiding_the_menu_with_an_item_highlighted_reports_no_choice)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.show();
+
+    Ladybird::SelectDropdown dropdown(&web_view);
+    Report report;
+    record_reports(dropdown, report);
+
+    // The window deactivating is one of the ways a menu goes away from the outside; hide() stands in for all of them.
+    open_and_interact(dropdown, three_options(), [&] {
+        dropdown.setActiveAction(dropdown.actions()[1]);
+        dropdown.hide();
+    });
+
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(!report.selected_item_id.has_value());
+}
+
+TEST_CASE(choosing_an_item_reports_its_id)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.show();
+
+    Ladybird::SelectDropdown dropdown(&web_view);
+    Report report;
+    record_reports(dropdown, report);
+
+    open_and_interact(dropdown, three_options(), [&] {
+        dropdown.setActiveAction(dropdown.actions()[2]);
+        send_key(dropdown, Qt::Key_Return);
+    });
+
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(report.selected_item_id.has_value());
+    EXPECT_EQ(report.selected_item_id.value(), 3u);
+}
+
+TEST_CASE(choosing_an_item_inside_a_group_reports_its_id)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.show();
+
+    Ladybird::SelectDropdown dropdown(&web_view);
+    Report report;
+    record_reports(dropdown, report);
+
+    Vector<Web::HTML::SelectItem> items;
+    items.append(Web::HTML::SelectItemOption { .id = 1, .selected = true, .label = "Top"_utf16 });
+    items.append(Web::HTML::SelectItemSeparator {});
+    Vector<Web::HTML::SelectItemOption> grouped_options;
+    grouped_options.append(Web::HTML::SelectItemOption { .id = 2, .label = "First"_utf16 });
+    grouped_options.append(Web::HTML::SelectItemOption { .id = 3, .label = "Second"_utf16 });
+    items.append(Web::HTML::SelectItemOptionGroup { .label = "Group"_utf16, .items = move(grouped_options) });
+
+    open_and_interact(dropdown, items, [&] {
+        // The menu holds: Top, a separator, the group's disabled title, First, Second.
+        auto actions = dropdown.actions();
+        EXPECT(actions.size() == 5);
+        dropdown.setActiveAction(actions[4]);
+        send_key(dropdown, Qt::Key_Return);
+    });
+
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(report.selected_item_id.has_value());
+    EXPECT_EQ(report.selected_item_id.value(), 3u);
+}
+
+TEST_CASE(closing_without_reporting_reports_nothing)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.show();
+
+    Ladybird::SelectDropdown dropdown(&web_view);
+    Report report;
+    record_reports(dropdown, report);
+
+    open_and_interact(dropdown, three_options(), [&] {
+        dropdown.setActiveAction(dropdown.actions()[0]);
+        dropdown.close_without_reporting();
+    });
+    EXPECT_EQ(report.calls, 0);
+
+    // The next menu reports again as normal.
+    open_and_interact(dropdown, three_options(), [&] {
+        send_key(dropdown, Qt::Key_Escape);
+    });
+    EXPECT_EQ(report.calls, 1);
+    EXPECT(!report.selected_item_id.has_value());
+}

--- a/UI/AppKit/CMakeLists.txt
+++ b/UI/AppKit/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(ladybird_impl STATIC
     Interface/Menu.mm
     Interface/Palette.mm
     Interface/SearchPanel.mm
+    Interface/SelectDropdown.mm
     Interface/Tab.mm
     Interface/TabController.mm
     Utilities/ApplicationIcon.mm

--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -43,7 +43,7 @@
 
 @end
 
-@interface LadybirdWebView : NSView <NSMenuDelegate, NSTextInputClient>
+@interface LadybirdWebView : NSView <NSTextInputClient>
 
 - (instancetype)init:(id<LadybirdWebViewObserver>)observer
            isPrivate:(WebView::IsPrivate)is_private;

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -20,6 +20,7 @@
 #import <Interface/Event.h>
 #import <Interface/LadybirdWebView.h>
 #import <Interface/Menu.h>
+#import <Interface/SelectDropdown.h>
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
@@ -139,7 +140,7 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 @property (nonatomic, strong) NSMenu* selected_text_link_context_menu;
 @property (nonatomic, strong) NSMenu* image_context_menu;
 @property (nonatomic, strong) NSMenu* media_context_menu;
-@property (nonatomic, strong) NSMenu* select_dropdown;
+@property (nonatomic, strong) SelectDropdown* select_dropdown;
 @property (nonatomic, strong) NSTextField* status_label;
 @property (nonatomic, strong) NSBox* crash_overlay;
 @property (nonatomic, strong) NSTextField* crash_overlay_url;
@@ -147,7 +148,6 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 @property (nonatomic, strong) NSAlert* external_url_confirmation_dialog;
 @property (nonatomic, strong) NSOpenPanel* file_picker;
 @property (nonatomic, strong) NSMagnificationGestureRecognizer* pinch_recognizer;
-@property (nonatomic, assign) BOOL suppress_select_dropdown_close;
 
 // NSEvent does not provide a way to mark whether it has been handled, nor can we attach user data to the event. So
 // when we dispatch the event for a second time after WebContent has had a chance to handle it, we must track that
@@ -473,10 +473,7 @@ static __weak LadybirdWebView* s_color_panel_owner;
             //     complete the pending external URL request.
             [[self window] endSheet:[self.external_url_confirmation_dialog window] returnCode:NSModalResponseCancel];
         }
-        if (self.select_dropdown != nil) {
-            self.suppress_select_dropdown_close = YES;
-            [self.select_dropdown cancelTracking];
-        }
+        [self.select_dropdown closeWithoutReporting];
 
         auto* color_panel = [NSColorPanel sharedColorPanel];
         [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillCloseNotification object:color_panel];
@@ -986,51 +983,22 @@ static __weak LadybirdWebView* s_color_panel_owner;
                       }];
     };
 
-    self.select_dropdown = [[NSMenu alloc] initWithTitle:@"Select Dropdown"];
-    [self.select_dropdown setDelegate:self];
+    self.select_dropdown = [[SelectDropdown alloc] init];
+    [self.select_dropdown setOnClosed:[weak_self](Optional<u32> const& selected_item_id) {
+        LadybirdWebView* self = weak_self;
+        if (self == nil) {
+            return;
+        }
+        m_web_view_bridge->select_dropdown_closed(selected_item_id);
+    }];
 
     m_web_view_bridge->on_request_select_dropdown = [weak_self](Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
             return;
         }
-        self.suppress_select_dropdown_close = NO;
-        [self.select_dropdown removeAllItems];
-        self.select_dropdown.minimumWidth = minimum_width;
-
-        auto add_menu_item = [self](Web::HTML::SelectItemOption const& item_option, bool in_option_group) {
-            auto label = in_option_group ? Utf16String::formatted("    {}", item_option.label) : item_option.label;
-            NSMenuItem* menuItem = [[NSMenuItem alloc]
-                initWithTitle:Ladybird::utf16_string_to_ns_string(label)
-                       action:item_option.disabled ? nil : @selector(selectDropdownAction:)
-                keyEquivalent:@""];
-            menuItem.representedObject = [NSNumber numberWithUnsignedInt:item_option.id];
-            menuItem.state = item_option.selected ? NSControlStateValueOn : NSControlStateValueOff;
-            [self.select_dropdown addItem:menuItem];
-        };
-
-        for (auto const& item : items) {
-            if (item.has<Web::HTML::SelectItemOptionGroup>()) {
-                auto const& item_option_group = item.get<Web::HTML::SelectItemOptionGroup>();
-                NSMenuItem* subtitle = [[NSMenuItem alloc]
-                    initWithTitle:Ladybird::utf16_string_to_ns_string(item_option_group.label)
-                           action:nil
-                    keyEquivalent:@""];
-                [self.select_dropdown addItem:subtitle];
-
-                for (auto const& item_option : item_option_group.items)
-                    add_menu_item(item_option, true);
-            }
-
-            if (item.has<Web::HTML::SelectItemOption>())
-                add_menu_item(item.get<Web::HTML::SelectItemOption>(), false);
-
-            if (item.has<Web::HTML::SelectItemSeparator>())
-                [self.select_dropdown addItem:[NSMenuItem separatorItem]];
-        }
-
         auto* event = Ladybird::create_context_menu_mouse_event(self, content_position);
-        [NSMenu popUpContextMenu:self.select_dropdown withEvent:event forView:self];
+        [self.select_dropdown openWithEvent:event forView:self minimumWidth:minimum_width items:items];
     };
 
     m_web_view_bridge->on_restore_window = [weak_self]() {
@@ -1159,22 +1127,6 @@ static __weak LadybirdWebView* s_color_panel_owner;
     m_web_view_bridge->enqueue_input_event(move(key_event));
 
     self.current_key_down_event = nil;
-}
-
-- (void)selectDropdownAction:(NSMenuItem*)menuItem
-{
-    NSNumber* data = [menuItem representedObject];
-    m_web_view_bridge->select_dropdown_closed([data unsignedIntValue]);
-}
-
-- (void)menuDidClose:(NSMenu*)menu
-{
-    if (self.suppress_select_dropdown_close) {
-        self.suppress_select_dropdown_close = NO;
-        return;
-    }
-    if (!menu.highlightedItem)
-        m_web_view_bridge->select_dropdown_closed({});
 }
 
 - (void)colorPickerUpdate:(NSColorPanel*)colorPanel

--- a/UI/AppKit/Interface/SelectDropdown.h
+++ b/UI/AppKit/Interface/SelectDropdown.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Optional.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <LibWeb/HTML/SelectItem.h>
+
+#import <Cocoa/Cocoa.h>
+
+// The popup menu for a <select> element. Every -openWithEvent:forView:minimumWidth:items: ends in exactly one closed
+// report — carrying the chosen item's id, or nothing when the menu went away without a choice — unless
+// -closeWithoutReporting took the menu down.
+@interface SelectDropdown : NSObject
+
+- (instancetype)init;
+
+// Pops the menu up for the view at the event's location, and returns once the menu has closed.
+- (void)openWithEvent:(NSEvent*)event forView:(NSView*)view minimumWidth:(CGFloat)minimumWidth items:(Vector<Web::HTML::SelectItem> const&)items;
+- (void)closeWithoutReporting;
+
+- (void)setOnClosed:(Function<void(Optional<u32> const& selectedItemId)>)onClosed;
+
+@property (nonatomic, readonly) NSMenu* menu;
+
+@end

--- a/UI/AppKit/Interface/SelectDropdown.mm
+++ b/UI/AppKit/Interface/SelectDropdown.mm
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#import <Interface/SelectDropdown.h>
+#import <Utilities/Conversions.h>
+
+@interface SelectDropdown ()
+{
+    Function<void(Optional<u32> const&)> m_on_closed;
+}
+
+@property (nonatomic, strong, readwrite) NSMenu* menu;
+@property (nonatomic, strong) NSMenuItem* chosen_item;
+@property (nonatomic, assign) BOOL tracking;
+@property (nonatomic, assign) BOOL suppress_close_report;
+
+@end
+
+@implementation SelectDropdown
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        self.menu = [[NSMenu alloc] initWithTitle:@"Select Dropdown"];
+    }
+
+    return self;
+}
+
+- (void)setOnClosed:(Function<void(Optional<u32> const&)>)onClosed
+{
+    m_on_closed = move(onClosed);
+}
+
+- (void)openWithEvent:(NSEvent*)event forView:(NSView*)view minimumWidth:(CGFloat)minimumWidth items:(Vector<Web::HTML::SelectItem> const&)items
+{
+    self.chosen_item = nil;
+    self.suppress_close_report = NO;
+    [self.menu removeAllItems];
+    self.menu.minimumWidth = minimumWidth;
+
+    auto add_menu_item = [self](Web::HTML::SelectItemOption const& item_option, bool in_option_group) {
+        auto label = in_option_group ? Utf16String::formatted("    {}", item_option.label) : item_option.label;
+        NSMenuItem* menuItem = [[NSMenuItem alloc]
+            initWithTitle:Ladybird::utf16_string_to_ns_string(label)
+                   action:item_option.disabled ? nil : @selector(itemChosen:)
+            keyEquivalent:@""];
+        menuItem.target = self;
+        menuItem.representedObject = [NSNumber numberWithUnsignedInt:item_option.id];
+        menuItem.state = item_option.selected ? NSControlStateValueOn : NSControlStateValueOff;
+        [self.menu addItem:menuItem];
+    };
+
+    for (auto const& item : items) {
+        if (item.has<Web::HTML::SelectItemOptionGroup>()) {
+            auto const& item_option_group = item.get<Web::HTML::SelectItemOptionGroup>();
+            NSMenuItem* subtitle = [[NSMenuItem alloc]
+                initWithTitle:Ladybird::utf16_string_to_ns_string(item_option_group.label)
+                       action:nil
+                keyEquivalent:@""];
+            [self.menu addItem:subtitle];
+
+            for (auto const& item_option : item_option_group.items)
+                add_menu_item(item_option, true);
+        }
+
+        if (item.has<Web::HTML::SelectItemOption>())
+            add_menu_item(item.get<Web::HTML::SelectItemOption>(), false);
+
+        if (item.has<Web::HTML::SelectItemSeparator>())
+            [self.menu addItem:[NSMenuItem separatorItem]];
+    }
+
+    // NB: This returns once the menu has closed and the chosen item's action (if any) has run — so this is the one
+    //     place that sees every way the menu can go away. menuDidClose: can't tell a cancel from a choice: It fires
+    //     before the action, with the highlighted item still set either way.
+    self.tracking = YES;
+    [NSMenu popUpContextMenu:self.menu withEvent:event forView:view];
+    self.tracking = NO;
+
+    if (self.suppress_close_report) {
+        self.suppress_close_report = NO;
+        return;
+    }
+
+    if (!m_on_closed)
+        return;
+
+    if (self.chosen_item != nil)
+        m_on_closed([[self.chosen_item representedObject] unsignedIntValue]);
+    else
+        m_on_closed({});
+}
+
+- (void)closeWithoutReporting
+{
+    if (!self.tracking)
+        return;
+
+    self.suppress_close_report = YES;
+    [self.menu cancelTracking];
+}
+
+- (void)itemChosen:(NSMenuItem*)menuItem
+{
+    self.chosen_item = menuItem;
+}
+
+@end

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(ladybird PRIVATE
     LocationEdit.cpp
     Menu.cpp
     NativeWindowContainer.cpp
+    SelectDropdown.cpp
     Settings.cpp
     StringUtils.cpp
     Tab.cpp

--- a/UI/Qt/SelectDropdown.cpp
+++ b/UI/Qt/SelectDropdown.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StdLibExtras.h>
+#include <UI/Qt/SelectDropdown.h>
+#include <UI/Qt/StringUtils.h>
+
+#include <QAction>
+#include <QVariant>
+
+namespace Ladybird {
+
+SelectDropdown::SelectDropdown(QWidget* parent)
+    : QMenu("Select Dropdown", parent)
+{
+}
+
+void SelectDropdown::open(QPoint const& global_position, int minimum_width, Vector<Web::HTML::SelectItem> const& items)
+{
+    m_suppress_close_report = false;
+    clear();
+    setMinimumWidth(minimum_width);
+
+    auto add_menu_item = [this](Web::HTML::SelectItemOption const& item_option, bool in_option_group) {
+        auto label = in_option_group ? qformatted("    {}", item_option.label) : qstring_from_utf16_string(item_option.label);
+
+        QAction* action = new QAction(label, this);
+        action->setCheckable(true);
+        action->setChecked(item_option.selected);
+        action->setDisabled(item_option.disabled);
+        action->setData(QVariant(static_cast<uint>(item_option.id)));
+        addAction(action);
+    };
+
+    for (auto const& item : items) {
+        if (item.has<Web::HTML::SelectItemOptionGroup>()) {
+            auto const& item_option_group = item.get<Web::HTML::SelectItemOptionGroup>();
+            QAction* subtitle = new QAction(qstring_from_utf16_string(item_option_group.label), this);
+            subtitle->setDisabled(true);
+            addAction(subtitle);
+
+            for (auto const& item_option : item_option_group.items)
+                add_menu_item(item_option, true);
+        }
+
+        if (item.has<Web::HTML::SelectItemOption>())
+            add_menu_item(item.get<Web::HTML::SelectItemOption>(), false);
+
+        if (item.has<Web::HTML::SelectItemSeparator>())
+            addSeparator();
+    }
+
+    // NB: exec() returns the action the user chose, or null when the menu went away without a choice — and that covers
+    //     every way a QMenu can close: Escape, a click elsewhere, the window deactivating. The aboutToHide signal can't
+    //     tell those apart from a choice; Qt emits it with the highlighted action still current, before triggered()
+    //     would fire, so a cancel with an item highlighted looks just like a choice there.
+    auto* chosen_action = exec(global_position);
+
+    if (exchange(m_suppress_close_report, false))
+        return;
+    if (!on_closed)
+        return;
+
+    if (chosen_action)
+        on_closed(chosen_action->data().value<uint>());
+    else
+        on_closed({});
+}
+
+void SelectDropdown::close_without_reporting()
+{
+    if (!isVisible())
+        return;
+    m_suppress_close_report = true;
+    close();
+}
+
+}

--- a/UI/Qt/SelectDropdown.h
+++ b/UI/Qt/SelectDropdown.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Optional.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <LibWeb/HTML/SelectItem.h>
+
+#include <QMenu>
+#include <QPoint>
+
+namespace Ladybird {
+
+// The popup menu for a <select> element. Every open() ends in exactly one on_closed() call — carrying the chosen item's
+// id, or nothing when the menu went away without a choice — unless close_without_reporting() took the menu down.
+class SelectDropdown final : public QMenu {
+public:
+    explicit SelectDropdown(QWidget* parent);
+
+    void open(QPoint const& global_position, int minimum_width, Vector<Web::HTML::SelectItem> const&);
+    void close_without_reporting();
+
+    Function<void(Optional<u32> const& selected_item_id)> on_closed;
+
+private:
+    bool m_suppress_close_report { false };
+};
+
+}

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -32,6 +32,7 @@
 #    include <UI/Qt/MacWindow.h>
 #endif
 #include <UI/Qt/InputMethodUtils.h>
+#include <UI/Qt/SelectDropdown.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/WebContentView.h>
 
@@ -206,50 +207,13 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
         finish_handling_drag_event(event);
     };
 
-    m_select_dropdown = new QMenu("Select Dropdown", this);
-    QObject::connect(m_select_dropdown, &QMenu::aboutToHide, this, [this]() {
-        if (exchange(m_suppress_select_dropdown_close, false))
-            return;
-        if (!m_select_dropdown->activeAction())
-            select_dropdown_closed({});
-    });
+    m_select_dropdown = new SelectDropdown(this);
+    m_select_dropdown->on_closed = [this](Optional<u32> const& selected_item_id) {
+        select_dropdown_closed(selected_item_id);
+    };
 
     on_request_select_dropdown = [this](Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) {
-        m_suppress_select_dropdown_close = false;
-        m_select_dropdown->clear();
-        m_select_dropdown->setMinimumWidth(minimum_width);
-
-        auto add_menu_item = [this](Web::HTML::SelectItemOption const& item_option, bool in_option_group) {
-            auto label = in_option_group ? qformatted("    {}", item_option.label) : qstring_from_utf16_string(item_option.label);
-
-            QAction* action = new QAction(label, this);
-            action->setCheckable(true);
-            action->setChecked(item_option.selected);
-            action->setDisabled(item_option.disabled);
-            action->setData(QVariant(static_cast<uint>(item_option.id)));
-            QObject::connect(action, &QAction::triggered, this, &WebContentView::select_dropdown_action);
-            m_select_dropdown->addAction(action);
-        };
-
-        for (auto const& item : items) {
-            if (item.has<Web::HTML::SelectItemOptionGroup>()) {
-                auto const& item_option_group = item.get<Web::HTML::SelectItemOptionGroup>();
-                QAction* subtitle = new QAction(qstring_from_utf16_string(item_option_group.label), this);
-                subtitle->setDisabled(true);
-                m_select_dropdown->addAction(subtitle);
-
-                for (auto const& item_option : item_option_group.items)
-                    add_menu_item(item_option, true);
-            }
-
-            if (item.has<Web::HTML::SelectItemOption>())
-                add_menu_item(item.get<Web::HTML::SelectItemOption>(), false);
-
-            if (item.has<Web::HTML::SelectItemSeparator>())
-                m_select_dropdown->addSeparator();
-        }
-
-        m_select_dropdown->exec(map_point_to_global_position(content_position));
+        m_select_dropdown->open(map_point_to_global_position(content_position), minimum_width, items);
     };
 }
 
@@ -280,12 +244,6 @@ void WebContentView::finish_window_move()
     create();
     show();
 #endif
-}
-
-void WebContentView::select_dropdown_action()
-{
-    QAction* action = qobject_cast<QAction*>(sender());
-    select_dropdown_closed(action->data().value<uint>());
 }
 
 static Web::UIEvents::MouseButton get_button_from_qt_mouse_button(Qt::MouseButton button)
@@ -1044,10 +1002,7 @@ private:
 
 void WebContentView::close_select_dropdown_after_crash()
 {
-    if (!m_select_dropdown->isVisible())
-        return;
-    m_suppress_select_dropdown_close = true;
-    m_select_dropdown->close();
+    m_select_dropdown->close_without_reporting();
 }
 
 void WebContentView::set_crash_overlay_visible(bool visible)

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -20,7 +20,6 @@
 #include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/ViewImplementation.h>
 
-#include <QMenu>
 #include <QPixmap>
 #include <QTimer>
 #include <QUrl>
@@ -66,6 +65,7 @@ using WebContentViewBase = QWidget;
 #endif
 
 class CrashOverlayUrlLabel;
+class SelectDropdown;
 
 struct WebContentViewInitialState {
     WebView::IsPrivate is_private { WebView::IsPrivate::No };
@@ -128,9 +128,6 @@ public:
 
     QPoint map_point_to_global_position(Gfx::IntPoint) const;
 
-public slots:
-    void select_dropdown_action();
-
 signals:
     void urls_dropped(QList<QUrl> const&);
 
@@ -190,8 +187,7 @@ private:
     QPointF m_last_click_position;
     int m_click_count { 0 };
 
-    QMenu* m_select_dropdown { nullptr };
-    bool m_suppress_select_dropdown_close { false };
+    SelectDropdown* m_select_dropdown { nullptr };
 
     QWidget* m_crash_overlay { nullptr };
     CrashOverlayUrlLabel* m_crash_overlay_url { nullptr };


### PR DESCRIPTION
On the https://expedia.co.jp checkout page (and almost certainly on other localized Expedia sites — since they use the same form/UI code), **the Country/State/Province select stopped opening: clicking it did nothing,** and neither did any other select in the tab; a reload didn’t bring them back, only a new tab did. 

The menu had been dismissed with an item highlighted (Esc after arrowing/hovering onto an entry), and the UI never told WebContent the picker was gone. `Page` keeps one pending non-blocking dialog at a time and drops every picker request if one is set — so from then on, **every select, color picker, and file picker in that tab got silently swallowed.**

Both the Qt port and AppKit port UI code decided whether the user had chosen something from a close notification that fires **before the outcome is known** — Qt’s `aboutToHide` still has the highlighted action current, and AppKit’s `menuDidClose:` fires before the item’s action with `highlightedItem` set either way — and left the choice itself to a signal that only a real activation fires. So a cancel with an item highlighted reported nothing at all.

**Fix:** The Qt port and AppKit port both now keep the menu in a `SelectDropdown` class that reports exactly once — from the one place that sees the menu’s whole outcome:

- Qt: the value `QMenu::exec()` returns — the chosen action, or null for any dismissal (Escape, a click elsewhere, the window deactivating).
- AppKit: the return of `popUpContextMenu:withEvent:forView:`, by which time the menu has closed and the chosen item’s action, if any, has already run and recorded the item.

---

> [!NOTE]
> `Page::did_request_select_dropdown` still drops a picker request while another is pending, unchanged: With both UIs now answering every menu, nothing stays pending — and letting a second menu through while one is up would nest one menu’s event loop inside another’s.
