### PR TITLE
 LibWeb: Cut the per-element fixed cost of style recomputation

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -221,6 +221,38 @@ impl ComputedLonghandTable {
         self.mark_evaluated(index, source_slot);
     }
 
+    /// A slot that already holds an equal value keeps it, and so its identity: an unchanged longhand
+    /// then costs no allocation, no hash and no deep comparison when the table is published.
+    pub(crate) fn set_computed(&mut self, property_id: u16, value: StyleValueData, source_slot: i64) {
+        assert!(
+            !self.frozen,
+            "the computed longhand table is immutable once its style is created"
+        );
+        let index = Self::slot_index(property_id);
+        if self.storage.slots[index]
+            .as_ref()
+            .is_none_or(|existing| *existing.data() != value)
+        {
+            self.replace_slot_value(index, RetainedStyleValueData::from_owned(value));
+        }
+        self.mark_evaluated(index, source_slot);
+    }
+
+    pub(crate) fn set_or_keep_equal(&mut self, property_id: u16, value: RetainedStyleValueData, source_slot: i64) {
+        assert!(
+            !self.frozen,
+            "the computed longhand table is immutable once its style is created"
+        );
+        let index = Self::slot_index(property_id);
+        let equal_to_existing = self.storage.slots[index].as_ref().is_some_and(|existing| unsafe {
+            crate::css::style_value::rust_style_value_equals(existing.pointer(), value.pointer())
+        });
+        if !equal_to_existing {
+            self.replace_slot_value(index, value);
+        }
+        self.mark_evaluated(index, source_slot);
+    }
+
     fn replace_slot_value(&mut self, index: usize, value: RetainedStyleValueData) {
         let pointer = value.pointer().cast();
         let previous = self.storage.value_view[index];
@@ -458,7 +490,9 @@ impl ComputedLonghandTable {
             let Some(value) = inherited_source.storage.slots[index].clone() else {
                 continue;
             };
-            table.set(property_id, value, -1);
+            // An inherited value equal to the one already held keeps that one, so a swap that
+            // changes nothing leaves the table equal to its source slot for slot.
+            table.set_or_keep_equal(property_id, value, -1);
         }
         table.metadata.effective_color_scheme = inherited_source.metadata.effective_color_scheme;
         // A value reading `currentcolor` - the keyword itself, or a color function of it - is
@@ -1258,5 +1292,35 @@ mod tests {
         let mut copied = ComputedLonghandTable::new();
         copied.copy_from_values(source.value_pointers());
         assert_eq!(copied.slot_hash_sum(), source.slot_hash_sum());
+    }
+
+    #[test]
+    fn set_computed_keeps_an_equal_value_and_replaces_a_different_one() {
+        let mut table = ComputedLonghandTable::new();
+        table.set(property_id::OPACITY, retained_number(0.5), 7);
+        let original = table.get(property_id::OPACITY).unwrap().pointer();
+
+        table.set_computed(property_id::OPACITY, StyleValueData::Number { value: 0.5 }, -1);
+        assert_eq!(table.get(property_id::OPACITY).unwrap().pointer(), original);
+        assert_eq!(table.source_slot(property_id::OPACITY), None);
+
+        table.set_computed(property_id::OPACITY, StyleValueData::Number { value: 0.75 }, -1);
+        assert_ne!(table.get(property_id::OPACITY).unwrap().pointer(), original);
+        assert_eq!(table.slot_hash_sum(), table.recomputed_slot_hash_sum());
+    }
+
+    #[test]
+    fn set_or_keep_equal_keeps_the_existing_allocation() {
+        let mut table = ComputedLonghandTable::new();
+        table.set(property_id::OPACITY, retained_number(0.5), -1);
+        let original = table.get(property_id::OPACITY).unwrap().pointer();
+        let equal = retained_number(0.5);
+        assert_ne!(equal.pointer(), original);
+        table.set_or_keep_equal(property_id::OPACITY, equal, -1);
+        assert_eq!(table.get(property_id::OPACITY).unwrap().pointer(), original);
+        let different = retained_number(1.0);
+        let different_pointer = different.pointer();
+        table.set_or_keep_equal(property_id::OPACITY, different, -1);
+        assert_eq!(table.get(property_id::OPACITY).unwrap().pointer(), different_pointer);
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -22,11 +22,13 @@
 //! by reference count with every `ComputedValues` built from those
 //! properties and with the style record publication that interns it.
 
+use std::cell::Cell;
 use std::ffi::c_void;
 use std::sync::Arc;
 
 use crate::css::animated_overlay::AnimatedOverlay;
 use crate::css::animated_overlay::overlay_wins;
+use crate::css::ffi_stats::{self, FfiOp};
 use crate::css::property_metadata::{
     FIRST_LONGHAND_PROPERTY_ID, LAST_LONGHAND_PROPERTY_ID, property_id, property_is_inherited,
 };
@@ -36,6 +38,23 @@ use crate::css::style_value::{RetainedStyleValueData, StyleValueData};
 pub(crate) const LONGHAND_COUNT: usize = (LAST_LONGHAND_PROPERTY_ID - FIRST_LONGHAND_PROPERTY_ID + 1) as usize;
 
 pub(crate) const LONGHAND_BITMAP_BYTES: usize = LONGHAND_COUNT.div_ceil(8);
+
+/// Mixes one slot's value content hash with the slot index, so that a sum over the slots is
+/// order-sensitive while any one slot's share can still be subtracted and replaced.
+const fn mix_slot_hash(slot: usize, content: u64) -> u64 {
+    (content ^ (slot as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15))
+        .wrapping_mul(0x2545_F491_4F6C_DD1D)
+        .rotate_left((slot as u32) & 63)
+}
+
+pub(crate) fn longhand_slot_hash(slot: usize, value: *const c_void) -> u64 {
+    if value.is_null() {
+        return mix_slot_hash(slot, 0);
+    }
+    ffi_stats::bump(FfiOp::LonghandTableSlotHash);
+    let content = unsafe { crate::css::style_value::style_value_content_hash(value.cast()) };
+    mix_slot_hash(slot, content)
+}
 
 /// One sparse inheritance-dependent specified value, exposed to C++ as the
 /// borrowed span behind a style's inheritance-dependent value view.
@@ -142,6 +161,11 @@ pub struct ComputedLonghandTable {
     /// Values before automatic post-compute adjustments, retained only while
     /// animation processing may need to restore them.
     post_compute_restore_values: Option<Box<PostComputeRestoreValues>>,
+    /// The sum of every slot's `longhand_slot_hash`, once known. A table seeded from a published
+    /// table inherits its sum and adjusts it on each slot write, so publishing hashes only the
+    /// values the drive changed; a table that starts empty computes the sum once, when it is
+    /// first published.
+    slot_hash_sum: Cell<Option<u64>>,
     frozen: bool,
 }
 
@@ -174,6 +198,7 @@ impl ComputedLonghandTable {
                 in_display_none_subtree: false,
             },
             post_compute_restore_values: None,
+            slot_hash_sum: Cell::new(None),
             frozen: false,
         }
     }
@@ -191,10 +216,53 @@ impl ComputedLonghandTable {
             !self.frozen,
             "the computed longhand table is immutable once its style is created"
         );
-        self.storage.value_view[Self::slot_index(property_id)] = value.pointer().cast();
-        self.storage.slots[Self::slot_index(property_id)] = Some(value);
-        set_bitmap_bit(&mut self.evaluated_bits, Self::slot_index(property_id), true);
-        self.storage.source_slots[Self::slot_index(property_id)] = i32::try_from(source_slot).unwrap_or(-1);
+        let index = Self::slot_index(property_id);
+        self.replace_slot_value(index, value);
+        self.mark_evaluated(index, source_slot);
+    }
+
+    fn replace_slot_value(&mut self, index: usize, value: RetainedStyleValueData) {
+        let pointer = value.pointer().cast();
+        let previous = self.storage.value_view[index];
+        if previous != pointer {
+            self.adjust_slot_hash_sum(index, previous, pointer);
+        }
+        self.storage.value_view[index] = pointer;
+        self.storage.slots[index] = Some(value);
+    }
+
+    fn mark_evaluated(&mut self, index: usize, source_slot: i64) {
+        set_bitmap_bit(&mut self.evaluated_bits, index, true);
+        self.storage.source_slots[index] = i32::try_from(source_slot).unwrap_or(-1);
+    }
+
+    fn adjust_slot_hash_sum(&mut self, index: usize, previous: *const c_void, replacement: *const c_void) {
+        if let Some(sum) = self.slot_hash_sum.get() {
+            self.slot_hash_sum.set(Some(
+                sum.wrapping_sub(longhand_slot_hash(index, previous))
+                    .wrapping_add(longhand_slot_hash(index, replacement)),
+            ));
+        }
+    }
+
+    pub(crate) fn slot_hash_sum(&self) -> u64 {
+        if let Some(sum) = self.slot_hash_sum.get() {
+            return sum;
+        }
+        ffi_stats::bump(FfiOp::LonghandTableFullHash);
+        let sum = self.recomputed_slot_hash_sum();
+        self.slot_hash_sum.set(Some(sum));
+        sum
+    }
+
+    pub(crate) fn recomputed_slot_hash_sum(&self) -> u64 {
+        self.storage
+            .value_view
+            .iter()
+            .enumerate()
+            .fold(0_u64, |sum, (slot, &value)| {
+                sum.wrapping_add(longhand_slot_hash(slot, value))
+            })
     }
 
     pub(crate) fn set_important(&mut self, property_id: u16, important: bool) {
@@ -311,8 +379,10 @@ impl ComputedLonghandTable {
             !self.frozen,
             "the computed longhand table is immutable once its style is created"
         );
+        ffi_stats::bump(FfiOp::LonghandTableClone);
         self.storage.slots.clone_from(&source.storage.slots);
         self.storage.value_view.clone_from(&source.storage.value_view);
+        self.slot_hash_sum.set(source.slot_hash_sum.get());
         self.storage.source_slots.clone_from(&source.storage.source_slots);
         self.important_bits = source.important_bits;
         self.inherited_bits = source.inherited_bits;
@@ -335,6 +405,9 @@ impl ComputedLonghandTable {
             "the computed longhand table is immutable once its style is created"
         );
         let slot = Self::slot_index(property_id);
+        if self.storage.value_view[slot] != source.storage.value_view[slot] {
+            self.adjust_slot_hash_sum(slot, self.storage.value_view[slot], source.storage.value_view[slot]);
+        }
         self.storage.slots[slot].clone_from(&source.storage.slots[slot]);
         self.storage.value_view[slot] = source.storage.value_view[slot];
         self.storage.source_slots[slot] = source.storage.source_slots[slot];
@@ -417,6 +490,7 @@ impl ComputedLonghandTable {
             });
             self.storage.value_view[index] = value;
         }
+        self.slot_hash_sum.set(None);
         self.storage.source_slots.fill(-1);
         self.important_bits = [0; LONGHAND_BITMAP_BYTES];
         self.inherited_bits = [0; LONGHAND_BITMAP_BYTES];
@@ -1161,5 +1235,28 @@ mod tests {
 
         copy.merge_dependency_flags(false, true);
         assert_eq!(copy.dependency_flags(), 3);
+    }
+
+    #[test]
+    fn slot_hash_sum_follows_every_slot_write() {
+        let mut source = ComputedLonghandTable::new();
+        source.set(property_id::OPACITY, retained_number(1.0), -1);
+        assert_eq!(source.slot_hash_sum(), source.recomputed_slot_hash_sum());
+        source.set(property_id::OPACITY, retained_number(0.5), -1);
+        source.set(property_id::Z_INDEX, retained_number(3.0), -1);
+        source.set(property_id::OPACITY, retained_number(0.25), -1);
+        assert_eq!(source.slot_hash_sum(), source.recomputed_slot_hash_sum());
+
+        let mut seeded = ComputedLonghandTable::copied_for_partial_drive(&source);
+        assert_eq!(seeded.slot_hash_sum(), source.slot_hash_sum());
+        seeded.set(property_id::Z_INDEX, retained_number(4.0), -1);
+        assert_ne!(seeded.slot_hash_sum(), source.slot_hash_sum());
+        assert_eq!(seeded.slot_hash_sum(), seeded.recomputed_slot_hash_sum());
+        seeded.copy_slot_from(&source, property_id::Z_INDEX);
+        assert_eq!(seeded.slot_hash_sum(), source.slot_hash_sum());
+
+        let mut copied = ComputedLonghandTable::new();
+        copied.copy_from_values(source.value_pointers());
+        assert_eq!(copied.slot_hash_sum(), source.slot_hash_sum());
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -22,7 +22,7 @@
 //! by reference count with every `ComputedValues` built from those
 //! properties and with the style record publication that interns it.
 
-use std::cell::Cell;
+use std::cell::{Cell, OnceCell};
 use std::ffi::c_void;
 use std::sync::Arc;
 
@@ -166,6 +166,9 @@ pub struct ComputedLonghandTable {
     /// values the drive changed; a table that starts empty computes the sum once, when it is
     /// first published.
     slot_hash_sum: Cell<Option<u64>>,
+    /// The longhands the table's `transition-*` values make transitionable, resolved once per
+    /// frozen table because every drive seeded from it asks for them.
+    frozen_transition_longhands: OnceCell<Box<[u16]>>,
     frozen: bool,
 }
 
@@ -199,6 +202,7 @@ impl ComputedLonghandTable {
             },
             post_compute_restore_values: None,
             slot_hash_sum: Cell::new(None),
+            frozen_transition_longhands: OnceCell::new(),
             frozen: false,
         }
     }
@@ -295,6 +299,13 @@ impl ComputedLonghandTable {
             .fold(0_u64, |sum, (slot, &value)| {
                 sum.wrapping_add(longhand_slot_hash(slot, value))
             })
+    }
+
+    pub(crate) fn frozen_transition_longhands(&self, compute: impl FnOnce(&Self) -> Box<[u16]>) -> Option<&[u16]> {
+        if !self.frozen {
+            return None;
+        }
+        Some(self.frozen_transition_longhands.get_or_init(|| compute(self)))
     }
 
     pub(crate) fn set_important(&mut self, property_id: u16, important: bool) {
@@ -1345,5 +1356,26 @@ mod tests {
         assert!(table.is_inherited(property_id::Z_INDEX));
         assert!(!table.is_important(property_id::OPACITY));
         assert!(!table.is_inherited(property_id::OPACITY));
+    }
+
+    #[test]
+    fn frozen_transition_longhands_resolve_once() {
+        let mut table = ComputedLonghandTable::new();
+        let mut resolutions = 0;
+        let mut resolve = |_: &ComputedLonghandTable| {
+            resolutions += 1;
+            Box::from([property_id::OPACITY])
+        };
+        assert!(table.frozen_transition_longhands(&mut resolve).is_none());
+        table.freeze();
+        assert_eq!(
+            table.frozen_transition_longhands(&mut resolve),
+            Some(&[property_id::OPACITY][..])
+        );
+        assert_eq!(
+            table.frozen_transition_longhands(&mut resolve),
+            Some(&[property_id::OPACITY][..])
+        );
+        assert_eq!(resolutions, 1);
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -469,6 +469,17 @@ impl ComputedLonghandTable {
         self.metadata.effective_color_scheme
     }
 
+    /// Only the values and their hash sum carry over from `source`; flags, provenance, metadata and
+    /// the inheritance-dependent records start fresh, as for a drive from an empty table.
+    pub(crate) fn seeded_with_values_from(source: &ComputedLonghandTable) -> Self {
+        ffi_stats::bump(FfiOp::LonghandTableClone);
+        let mut table = Self::new();
+        table.storage.slots.clone_from(&source.storage.slots);
+        table.storage.value_view.clone_from(&source.storage.value_view);
+        table.slot_hash_sum.set(source.slot_hash_sum.get());
+        table
+    }
+
     pub(crate) fn copied_for_drive(source: &ComputedLonghandTable) -> Self {
         let mut table = Self::new();
         table.copy_values_and_metadata_from(source);
@@ -1377,5 +1388,21 @@ mod tests {
             Some(&[property_id::OPACITY][..])
         );
         assert_eq!(resolutions, 1);
+    }
+
+    #[test]
+    fn seeded_table_carries_only_the_source_values() {
+        let mut source = ComputedLonghandTable::new();
+        source.set(property_id::OPACITY, retained_number(0.5), 7);
+        source.set_important(property_id::OPACITY, true);
+        let seeded = ComputedLonghandTable::seeded_with_values_from(&source);
+        assert_eq!(
+            seeded.get(property_id::OPACITY).unwrap().pointer(),
+            source.get(property_id::OPACITY).unwrap().pointer()
+        );
+        assert_eq!(seeded.slot_hash_sum(), source.slot_hash_sum());
+        assert_eq!(seeded.source_slot(property_id::OPACITY), None);
+        assert!(!seeded.is_important(property_id::OPACITY));
+        assert!(seeded.evaluated_bits().iter().all(|&bits| bits == 0));
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -326,20 +326,26 @@ impl ComputedLonghandTable {
         assert!(important_words.len() * 64 >= LONGHAND_COUNT);
         assert_eq!(inherited_words.len(), important_words.len());
         assert_eq!(evaluated_words.len(), important_words.len());
-        for index in 0..LONGHAND_COUNT {
-            if evaluated_words[index / 64] & (1 << (index % 64)) == 0 {
-                continue;
+        for (word_index, &evaluated_word) in evaluated_words.iter().enumerate() {
+            let mut remaining = evaluated_word;
+            while remaining != 0 {
+                let bit = remaining.trailing_zeros() as usize;
+                remaining &= remaining - 1;
+                let index = word_index * 64 + bit;
+                if index >= LONGHAND_COUNT {
+                    break;
+                }
+                set_bitmap_bit(
+                    &mut self.important_bits,
+                    index,
+                    important_words[word_index] & (1 << bit) != 0,
+                );
+                set_bitmap_bit(
+                    &mut self.inherited_bits,
+                    index,
+                    inherited_words[word_index] & (1 << bit) != 0,
+                );
             }
-            set_bitmap_bit(
-                &mut self.important_bits,
-                index,
-                important_words[index / 64] & (1 << (index % 64)) != 0,
-            );
-            set_bitmap_bit(
-                &mut self.inherited_bits,
-                index,
-                inherited_words[index / 64] & (1 << (index % 64)) != 0,
-            );
         }
     }
 
@@ -1322,5 +1328,22 @@ mod tests {
         let different_pointer = different.pointer();
         table.set_or_keep_equal(property_id::OPACITY, different, -1);
         assert_eq!(table.get(property_id::OPACITY).unwrap().pointer(), different_pointer);
+    }
+
+    #[test]
+    fn merge_driver_flags_touches_only_evaluated_slots() {
+        let mut table = ComputedLonghandTable::new();
+        let words = LONGHAND_COUNT.div_ceil(64);
+        let mut important = vec![u64::MAX; words];
+        let inherited = vec![u64::MAX; words];
+        let mut evaluated = vec![0_u64; words];
+        let z_index = ComputedLonghandTable::slot_index(property_id::Z_INDEX);
+        evaluated[z_index / 64] |= 1 << (z_index % 64);
+        important[z_index / 64] &= !(1 << (z_index % 64));
+        table.merge_driver_flags(&important, &inherited, &evaluated);
+        assert!(!table.is_important(property_id::Z_INDEX));
+        assert!(table.is_inherited(property_id::Z_INDEX));
+        assert!(!table.is_important(property_id::OPACITY));
+        assert!(!table.is_inherited(property_id::OPACITY));
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -79,7 +79,9 @@ fn set_bitmap_bit(bits: &mut [u8; LONGHAND_BITMAP_BYTES], index: usize, value: b
     }
 }
 
-pub struct ComputedLonghandTable {
+/// The per-slot arrays, kept on the heap so that a table moves as a handful of words rather than
+/// as the several kilobytes the slots occupy.
+struct SlotStorage {
     slots: [Option<RetainedStyleValueData>; LONGHAND_COUNT],
     /// The raw data pointer of every slot, null where the slot is empty, so a
     /// borrower can read the whole table as one span without FFI calls.
@@ -89,6 +91,32 @@ pub struct ComputedLonghandTable {
     /// overwrites the sidecar, so sparse lookup would make a full drive
     /// quadratic in the number of context-bearing declarations.
     source_slots: [i32; LONGHAND_COUNT],
+}
+
+impl SlotStorage {
+    fn new_boxed() -> Box<Self> {
+        let mut storage = Box::<Self>::new_uninit();
+        let pointer = storage.as_mut_ptr();
+        // SAFETY: Every field is initialized in place below, so the box holds a complete value
+        // when it is assumed initialized; nothing is moved through the stack.
+        unsafe {
+            let slots = std::ptr::addr_of_mut!((*pointer).slots).cast::<Option<RetainedStyleValueData>>();
+            for index in 0..LONGHAND_COUNT {
+                slots.add(index).write(None);
+            }
+            std::ptr::addr_of_mut!((*pointer).value_view)
+                .cast::<*const c_void>()
+                .write_bytes(0, LONGHAND_COUNT);
+            std::ptr::addr_of_mut!((*pointer).source_slots)
+                .cast::<i32>()
+                .write_bytes(u8::MAX, LONGHAND_COUNT);
+            storage.assume_init()
+        }
+    }
+}
+
+pub struct ComputedLonghandTable {
+    storage: Box<SlotStorage>,
     /// Whether the longhand's winning declaration was `!important`, in the
     /// byte layout of the C++ `FixedBitmap` (bit `i` is byte `i / 8`, bit
     /// `i % 8`), so whole bitmaps copy across the FFI without translation.
@@ -130,9 +158,7 @@ pub struct FfiComputedStyleMetadata {
 impl ComputedLonghandTable {
     pub(crate) fn new() -> Self {
         Self {
-            slots: std::array::from_fn(|_| None),
-            value_view: [std::ptr::null(); LONGHAND_COUNT],
-            source_slots: [-1; LONGHAND_COUNT],
+            storage: SlotStorage::new_boxed(),
             important_bits: [0; LONGHAND_BITMAP_BYTES],
             inherited_bits: [0; LONGHAND_BITMAP_BYTES],
             evaluated_bits: [0; LONGHAND_BITMAP_BYTES],
@@ -165,10 +191,10 @@ impl ComputedLonghandTable {
             !self.frozen,
             "the computed longhand table is immutable once its style is created"
         );
-        self.value_view[Self::slot_index(property_id)] = value.pointer().cast();
-        self.slots[Self::slot_index(property_id)] = Some(value);
+        self.storage.value_view[Self::slot_index(property_id)] = value.pointer().cast();
+        self.storage.slots[Self::slot_index(property_id)] = Some(value);
         set_bitmap_bit(&mut self.evaluated_bits, Self::slot_index(property_id), true);
-        self.source_slots[Self::slot_index(property_id)] = i32::try_from(source_slot).unwrap_or(-1);
+        self.storage.source_slots[Self::slot_index(property_id)] = i32::try_from(source_slot).unwrap_or(-1);
     }
 
     pub(crate) fn set_important(&mut self, property_id: u16, important: bool) {
@@ -285,9 +311,9 @@ impl ComputedLonghandTable {
             !self.frozen,
             "the computed longhand table is immutable once its style is created"
         );
-        self.slots.clone_from(&source.slots);
-        self.value_view.clone_from(&source.value_view);
-        self.source_slots.clone_from(&source.source_slots);
+        self.storage.slots.clone_from(&source.storage.slots);
+        self.storage.value_view.clone_from(&source.storage.value_view);
+        self.storage.source_slots.clone_from(&source.storage.source_slots);
         self.important_bits = source.important_bits;
         self.inherited_bits = source.inherited_bits;
         self.evaluated_bits = source.evaluated_bits;
@@ -309,9 +335,9 @@ impl ComputedLonghandTable {
             "the computed longhand table is immutable once its style is created"
         );
         let slot = Self::slot_index(property_id);
-        self.slots[slot].clone_from(&source.slots[slot]);
-        self.value_view[slot] = source.value_view[slot];
-        self.source_slots[slot] = source.source_slots[slot];
+        self.storage.slots[slot].clone_from(&source.storage.slots[slot]);
+        self.storage.value_view[slot] = source.storage.value_view[slot];
+        self.storage.source_slots[slot] = source.storage.source_slots[slot];
         set_bitmap_bit(&mut self.important_bits, slot, bitmap_bit(&source.important_bits, slot));
         set_bitmap_bit(&mut self.inherited_bits, slot, bitmap_bit(&source.inherited_bits, slot));
         set_bitmap_bit(&mut self.evaluated_bits, slot, bitmap_bit(&source.evaluated_bits, slot));
@@ -356,7 +382,7 @@ impl ComputedLonghandTable {
                 continue;
             }
             let index = Self::slot_index(property_id);
-            let Some(value) = inherited_source.slots[index].clone() else {
+            let Some(value) = inherited_source.storage.slots[index].clone() else {
                 continue;
             };
             table.set(property_id, value, -1);
@@ -386,12 +412,12 @@ impl ComputedLonghandTable {
         );
         assert_eq!(values.len(), LONGHAND_COUNT);
         for (index, &value) in values.iter().enumerate() {
-            self.slots[index] = (!value.is_null()).then(|| unsafe {
+            self.storage.slots[index] = (!value.is_null()).then(|| unsafe {
                 RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(value.cast()))
             });
-            self.value_view[index] = value;
+            self.storage.value_view[index] = value;
         }
-        self.source_slots.fill(-1);
+        self.storage.source_slots.fill(-1);
         self.important_bits = [0; LONGHAND_BITMAP_BYTES];
         self.inherited_bits = [0; LONGHAND_BITMAP_BYTES];
         self.evaluated_bits = [0; LONGHAND_BITMAP_BYTES];
@@ -572,9 +598,10 @@ impl ComputedLonghandTable {
             && self.pseudo_element_styles() == other.pseudo_element_styles()
             && self.inheritance_dependent.len() == other.inheritance_dependent.len()
             && self
+                .storage
                 .value_view
                 .iter()
-                .zip(&other.value_view)
+                .zip(&other.storage.value_view)
                 .all(|(&first, &second)| values_equal(first, second))
             && values_equal(self.raw_cascaded_font_size(), other.raw_cascaded_font_size())
             && self.inheritance_dependent.iter().all(|(property, value)| {
@@ -627,7 +654,7 @@ impl ComputedLonghandTable {
             };
         }
         FfiEffectiveLonghandValue {
-            value: self.value_view[Self::slot_index(property_id)],
+            value: self.storage.value_view[Self::slot_index(property_id)],
             source: EFFECTIVE_LONGHAND_SOURCE_TABLE,
         }
     }
@@ -679,19 +706,19 @@ impl ComputedLonghandTable {
 
     /// The stored value for a longhand, when the drive stored one.
     pub(crate) fn get(&self, property_id: u16) -> Option<&RetainedStyleValueData> {
-        self.slots[Self::slot_index(property_id)].as_ref()
+        self.storage.slots[Self::slot_index(property_id)].as_ref()
     }
 
     /// The cascade source slot of the declaration a longhand's value came
     /// from, recorded only when that declaration carries style sheet context.
     pub(crate) fn source_slot(&self, property_id: u16) -> Option<u32> {
-        u32::try_from(self.source_slots[Self::slot_index(property_id)]).ok()
+        u32::try_from(self.storage.source_slots[Self::slot_index(property_id)]).ok()
     }
 
     /// One raw data pointer per longhand slot, null where the drive stored no
     /// value. The span is stable for the table's lifetime once frozen.
     pub(crate) fn value_pointers(&self) -> &[*const c_void] {
-        &self.value_view
+        &self.storage.value_view
     }
 
     pub(crate) fn is_frozen(&self) -> bool {
@@ -809,7 +836,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_values(
 ) -> *const *const c_void {
     let table = unsafe { &*table };
     debug_assert!(table.frozen, "only frozen tables hand out their value span");
-    table.value_view.as_ptr()
+    table.storage.value_view.as_ptr()
 }
 
 /// Whether two frozen tables have equal values and publication metadata.

--- a/Libraries/LibWeb/Rust/src/css/ffi_stats.rs
+++ b/Libraries/LibWeb/Rust/src/css/ffi_stats.rs
@@ -59,6 +59,10 @@ define_ffi_ops! {
     AnimationKeyframeLonghandEntry => "animationKeyframeLonghandEntries",
     AnimationEvaluationEntry => "animationEvaluationEntries",
     TransitionDecisionEntry => "transitionDecisionEntries",
+    // Computed longhand table passes whose cost follows the table's width rather than a change.
+    LonghandTableClone => "longhandTableClones",
+    LonghandTableFullHash => "longhandTableFullHashes",
+    LonghandTableSlotHash => "longhandTableSlotHashes",
     SubstitutionCallbackFreeParse => "substitutionCallbackFreeParses",
     SubstitutionCallbackParseRequest => "substitutionCallbackParseRequests",
     SizesAttributeParseEntry => "sizesAttributeParseEntries",

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -35,7 +35,7 @@ use super::memory::MemoryLease;
 use super::tree::PseudoElementKind;
 use super::tree::PseudoElementTarget;
 use super::tree::StyleNodeID;
-use crate::css::computed_longhand_table::ComputedLonghandTable;
+use crate::css::computed_longhand_table::{ComputedLonghandTable, longhand_slot_hash};
 use crate::css::computed_values::computed_group_output_mask;
 use crate::css::computed_values::release_group_payload;
 use crate::css::computed_values::replay_style_group_identity;
@@ -152,9 +152,6 @@ struct ComputedFixedMetadata {
 /// the source-slot sidecar is per-drive and does not participate in identity.
 struct RetainedLonghandTable {
     table: *const ComputedLonghandTable,
-    /// The order-sensitive sum of the table's per-slot value hashes: the part of the table's
-    /// publication hash a patched copy can adjust slot by slot instead of rehashing every value.
-    slot_hash_sum: u64,
 }
 
 impl RetainedLonghandTable {
@@ -1024,7 +1021,9 @@ impl ComputedGroupSets {
 
     /// Interns one frozen computed longhand table. Values and publication
     /// metadata participate in identity; the per-drive provenance sidecar
-    /// does not.
+    /// does not. A candidate found equal by comparison is reused before the
+    /// table's hash is asked for, so a table that starts empty and computes
+    /// to a published state never hashes its values.
     fn intern_longhand_table(
         &mut self,
         table: &ComputedLonghandTable,
@@ -1040,19 +1039,7 @@ impl ComputedGroupSets {
                 return candidate;
             }
         }
-        self.intern_longhand_table_with_slot_hash_sum(table, longhand_table_slot_hash_sum(table))
-    }
-
-    /// Intern a frozen table whose per-slot hash sum the caller already knows, from the table it
-    /// was patched from.
-    fn intern_longhand_table_with_slot_hash_sum(
-        &mut self,
-        table: &ComputedLonghandTable,
-        slot_hash_sum: u64,
-    ) -> ComputedLonghandTableID {
-        debug_assert!(table.is_frozen(), "only frozen longhand tables are published");
-        debug_assert_eq!(slot_hash_sum, longhand_table_slot_hash_sum(table));
-        let hash = longhand_table_hash_with_slot_hash_sum(table, slot_hash_sum);
+        let hash = longhand_table_hash(table);
         if let Some(identity) = self
             .computed_longhand_tables
             .find(hash, |_identity, candidate| candidate.table().publication_equals(table))
@@ -1068,14 +1055,8 @@ impl ComputedGroupSets {
         let retained = unsafe { crate::css::computed_longhand_table::rust_computed_longhand_table_retain(table) };
         self.longhand_table_nested_memory
             .grow_committed(size_of_val(table.value_pointers()) as u64);
-        self.computed_longhand_tables.insert(
-            hash,
-            identity,
-            RetainedLonghandTable {
-                table: retained,
-                slot_hash_sum,
-            },
-        );
+        self.computed_longhand_tables
+            .insert(hash, identity, RetainedLonghandTable { table: retained });
         identity
     }
 
@@ -1392,26 +1373,12 @@ impl ComputedGroupSets {
             let source_slot = table.source_slot(property).map_or(-1, i64::from);
             table.set(property, resolved, source_slot);
         }
-        let (table, slot_hash_sum) = {
-            let retained = &self.computed_longhand_tables[old_table];
-            let source = retained.table();
-            let mut slot_hash_sum = retained.slot_hash_sum;
-            let old_values = source.value_pointers();
-            let new_values = table.value_pointers();
-            for slot in 0..old_values.len() {
-                if old_values[slot] != new_values[slot] {
-                    slot_hash_sum = slot_hash_sum
-                        .wrapping_sub(longhand_slot_hash(slot, old_values[slot]))
-                        .wrapping_add(longhand_slot_hash(slot, new_values[slot]));
-                }
-            }
-            // The flag is the parent's and the driven display's, the way a fresh computation
-            // sets it, not what the old table held.
-            let display_is_none = crate::css::style_compute::effective_display(&table, None).is_none();
-            table.set_in_display_none_subtree(parent_in_display_none_subtree || display_is_none);
-            table.freeze();
-            (table.into_raw_shared(), slot_hash_sum)
-        };
+        // The flag is the parent's and the driven display's, the way a fresh computation sets
+        // it, not what the old table held.
+        let display_is_none = crate::css::style_compute::effective_display(&table, None).is_none();
+        table.set_in_display_none_subtree(parent_in_display_none_subtree || display_is_none);
+        table.freeze();
+        let table = table.into_raw_shared();
         let release_table = |table: *const ComputedLonghandTable| unsafe {
             crate::css::computed_longhand_table::rust_computed_longhand_table_release(table.cast_mut());
         };
@@ -1477,7 +1444,7 @@ impl ComputedGroupSets {
             })
             .0
         };
-        let longhand_table = self.intern_longhand_table_with_slot_hash_sum(unsafe { &*table }, slot_hash_sum);
+        let longhand_table = self.intern_longhand_table(unsafe { &*table }, Some(old_table), None);
         release_table(table);
         // The environment moves with the record when the node's custom declarations resolved to
         // another; a record keeps its environment otherwise.
@@ -3046,13 +3013,11 @@ impl ComputedGroupSets {
             .filter(|identity| !reachable.longhand_tables[identity.index()])
             .collect::<Vec<_>>()
         {
-            let retained = &self.computed_longhand_tables[identity];
-            let hash = longhand_table_hash_with_slot_hash_sum(retained.table(), retained.slot_hash_sum);
+            let hash = longhand_table_hash(self.computed_longhand_tables[identity].table());
             let table = std::mem::replace(
                 self.computed_longhand_tables.get_mut(identity),
                 RetainedLonghandTable {
                     table: std::ptr::null(),
-                    slot_hash_sum: 0,
                 },
             );
             self.longhand_table_nested_memory
@@ -3529,33 +3494,10 @@ fn content_hash(content: impl Hash) -> u64 {
     hasher.finish()
 }
 
-/// One slot's contribution to a table's slot hash sum: the value's content hash mixed with the
-/// slot, so the sum is order-sensitive while any slot's share can be subtracted and replaced.
-fn longhand_slot_hash(slot: usize, value: *const c_void) -> u64 {
-    let content = unsafe { crate::css::style_value::style_value_content_hash(value.cast()) };
-    (content ^ (slot as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15))
-        .wrapping_mul(0x2545_F491_4F6C_DD1D)
-        .rotate_left((slot as u32) & 63)
-}
-
-fn longhand_table_slot_hash_sum(table: &ComputedLonghandTable) -> u64 {
-    table
-        .value_pointers()
-        .iter()
-        .enumerate()
-        .fold(0_u64, |sum, (slot, &value)| {
-            sum.wrapping_add(longhand_slot_hash(slot, value))
-        })
-}
-
-#[cfg(test)]
 fn longhand_table_hash(table: &ComputedLonghandTable) -> u64 {
-    longhand_table_hash_with_slot_hash_sum(table, longhand_table_slot_hash_sum(table))
-}
-
-fn longhand_table_hash_with_slot_hash_sum(table: &ComputedLonghandTable, slot_hash_sum: u64) -> u64 {
+    debug_assert_eq!(table.slot_hash_sum(), table.recomputed_slot_hash_sum());
     let mut hasher = fast_hasher();
-    slot_hash_sum.hash(&mut hasher);
+    table.slot_hash_sum().hash(&mut hasher);
     table.evaluated_bits().hash(&mut hasher);
     table.importance_bits().hash(&mut hasher);
     table.inheritance_bits().hash(&mut hasher);

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -196,6 +196,10 @@ impl StyleRecordView<'_> {
         };
         ComputedLonghandTable::copied_for_partial_drive(source)
     }
+
+    pub(crate) fn longhand_table_seeded_with_values(&self) -> Option<ComputedLonghandTable> {
+        unsafe { self.longhand_table.as_ref() }.map(ComputedLonghandTable::seeded_with_values_from)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -4698,7 +4698,10 @@ fn append_transition_longhands(
 ) {
     use crate::css::property_metadata::{longhand_is_logical_alias, property_id as prop};
 
-    if property_is_shorthand(property) {
+    if property == prop::ALL {
+        let (writing_mode, direction) = writing_mode_and_direction();
+        properties.extend_from_slice(all_transition_longhands(writing_mode, direction));
+    } else if property_is_shorthand(property) {
         for &longhand in longhands_for_shorthand(property) {
             append_transition_longhands(properties, longhand, writing_mode_and_direction);
         }
@@ -4710,6 +4713,24 @@ fn append_transition_longhands(
             property
         });
     }
+}
+
+/// The physical longhands `transition-property: all` names under one writing mode and direction,
+/// expanded once per pair: `all` is the initial value, so nearly every table carries it.
+fn all_transition_longhands(writing_mode: u8, direction: u8) -> &'static [u16] {
+    const WRITING_MODE_COUNT: usize = 5;
+    const DIRECTION_COUNT: usize = 2;
+    static LONGHANDS: [OnceLock<Box<[u16]>>; WRITING_MODE_COUNT * DIRECTION_COUNT] =
+        [const { OnceLock::new() }; WRITING_MODE_COUNT * DIRECTION_COUNT];
+
+    let index = usize::from(writing_mode) * DIRECTION_COUNT + usize::from(direction);
+    LONGHANDS[index].get_or_init(|| {
+        let mut properties = Vec::new();
+        for &longhand in longhands_for_shorthand(crate::css::property_metadata::property_id::ALL) {
+            append_transition_longhands(&mut properties, longhand, &mut || (writing_mode, direction));
+        }
+        properties.into_boxed_slice()
+    })
 }
 
 fn computed_writing_mode_and_direction(table: &ComputedLonghandTable) -> (u8, u8) {

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -5064,7 +5064,12 @@ pub unsafe extern "C" fn rust_compute_properties(input: *const FfiComputePropert
             .expect("a partial style drive must have a previous style record");
         previous_style.longhand_table_for_partial_drive()
     } else {
-        ComputedLonghandTable::new()
+        // An element that already has a style starts from that style's values, so a longhand
+        // computing to the same value keeps it instead of allocating and hashing a fresh copy.
+        previous_style
+            .as_ref()
+            .and_then(|view| view.longhand_table_seeded_with_values())
+            .unwrap_or_else(ComputedLonghandTable::new)
     };
     unsafe {
         (input.prepare_longhand_drive)(

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -15,6 +15,7 @@
 //! Element-bound inputs, such as container sizes and tree positions, are
 //! snapshotted by C++ before entering the Rust computation drive.
 
+use std::borrow::Cow;
 use std::ffi::c_void;
 use std::sync::{Arc, OnceLock};
 
@@ -4689,15 +4690,21 @@ fn time_value_to_milliseconds(value: &StyleValueData) -> f64 {
     crate::css::calc::time_to_milliseconds(*value, *unit)
 }
 
-fn append_transition_longhands(properties: &mut Vec<u16>, property: u16, writing_mode: u8, direction: u8) {
+/// The axes are read only when a logical alias needs mapping.
+fn append_transition_longhands(
+    properties: &mut Vec<u16>,
+    property: u16,
+    writing_mode_and_direction: &mut impl FnMut() -> (u8, u8),
+) {
     use crate::css::property_metadata::{longhand_is_logical_alias, property_id as prop};
 
     if property_is_shorthand(property) {
         for &longhand in longhands_for_shorthand(property) {
-            append_transition_longhands(properties, longhand, writing_mode, direction);
+            append_transition_longhands(properties, longhand, writing_mode_and_direction);
         }
     } else if property != prop::CUSTOM {
         properties.push(if longhand_is_logical_alias(property) {
+            let (writing_mode, direction) = writing_mode_and_direction();
             map_logical_alias_to_physical(property, writing_mode, direction)
         } else {
             property
@@ -4742,24 +4749,28 @@ fn active_transition_property_ids(table: &ComputedLonghandTable) -> impl Iterato
 }
 
 pub(crate) fn has_active_transition_properties(table: &ComputedLonghandTable) -> bool {
-    fn has_longhand(property: u16) -> bool {
-        if property_is_shorthand(property) {
-            longhands_for_shorthand(property).iter().copied().any(has_longhand)
-        } else {
-            property != crate::css::property_metadata::property_id::CUSTOM
-        }
-    }
-
-    active_transition_property_ids(table).any(has_longhand)
+    !active_transition_longhands(table).is_empty()
 }
 
-fn active_transition_properties(table: &ComputedLonghandTable) -> Vec<u16> {
-    let (writing_mode, direction) = computed_writing_mode_and_direction(table);
-    let mut properties = Vec::new();
-    for property in active_transition_property_ids(table) {
-        append_transition_longhands(&mut properties, property, writing_mode, direction);
+/// The physical longhands the table's `transition-*` values make transitionable: every
+/// `transition-property` entry with a positive combined duration and delay, expanded from
+/// shorthands and mapped from logical aliases.
+pub(crate) fn active_transition_longhands(table: &ComputedLonghandTable) -> Cow<'_, [u16]> {
+    fn resolve(table: &ComputedLonghandTable) -> Vec<u16> {
+        let mut writing_mode_and_direction = None;
+        let mut writing_mode_and_direction =
+            || *writing_mode_and_direction.get_or_insert_with(|| computed_writing_mode_and_direction(table));
+        let mut properties = Vec::new();
+        for property in active_transition_property_ids(table) {
+            append_transition_longhands(&mut properties, property, &mut writing_mode_and_direction);
+        }
+        properties
     }
-    properties
+
+    match table.frozen_transition_longhands(|table| resolve(table).into_boxed_slice()) {
+        Some(longhands) => Cow::Borrowed(longhands),
+        None => Cow::Owned(resolve(table)),
+    }
 }
 
 fn build_computed_transition_list(table: &ComputedLonghandTable) -> FfiComputedTransitionList {
@@ -4782,7 +4793,7 @@ fn build_computed_transition_list(table: &ComputedLonghandTable) -> FfiComputedT
         };
         let mut properties = Vec::new();
         if let Some(transition_property) = transition_property {
-            append_transition_longhands(&mut properties, transition_property, writing_mode, direction);
+            append_transition_longhands(&mut properties, transition_property, &mut || (writing_mode, direction));
         }
         let properties = properties.into_boxed_slice();
         transitions.push(FfiComputedTransition {
@@ -4985,7 +4996,7 @@ pub unsafe extern "C" fn rust_compute_properties(input: *const FfiComputePropert
     let mut selected_transition_properties = previous_style
         .as_ref()
         .and_then(|view| unsafe { view.longhand_table.as_ref() })
-        .map(active_transition_properties)
+        .map(|table| active_transition_longhands(table).into_owned())
         .unwrap_or_default();
     let has_retained_transition_candidates = !selected_transition_properties.is_empty();
     if input.selected_transition_property_count != 0 {

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -3223,45 +3223,51 @@ fn store_computed_value(longhand_table: &mut ComputedLonghandTable, entry: &Comp
         RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(entry.data.cast()))
     });
     longhand_table.set_drive_inheritance_dependent_value(entry.property_id, specified_value);
-    let retained = match entry.computed_kind {
-        COMPUTED_KIND_UNCHANGED => unsafe {
-            RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
-                entry.data.cast(),
-            ))
-        },
-        COMPUTED_KIND_PX_LENGTH => retained_new(StyleValueData::Length {
-            value: entry.value,
-            unit: px_length_unit(),
-        }),
-        COMPUTED_KIND_INTEGER => retained_new(StyleValueData::Integer {
-            value: entry.value as i32,
-        }),
-        COMPUTED_KIND_SUPERELLIPSE => retained_new(StyleValueData::Superellipse {
-            parameter: retained_new(StyleValueData::Number { value: entry.value }),
-        }),
-        COMPUTED_KIND_NUMBER => retained_new(StyleValueData::Number { value: entry.value }),
-        COMPUTED_KIND_PERCENTAGE => retained_new(StyleValueData::Percentage { value: entry.value }),
-        COMPUTED_KIND_FONT_STYLE => retained_new(StyleValueData::FontStyle {
-            font_style: entry.value as u8,
-            angle_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(std::ptr::null()) },
-        }),
-        COMPUTED_KIND_KEYWORD => retained_new(StyleValueData::Keyword {
-            keyword: entry.value as u16,
-        }),
-        COMPUTED_KIND_DISPLAY => retained_new(StyleValueData::Display {
-            raw: entry.value as u32,
-        }),
-        COMPUTED_KIND_STYLE_VALUE => unsafe {
-            RetainedStyleValueData::from_retained_pointer(entry.computed_data.cast())
-        },
-        _ => unreachable!("unknown computed longhand store kind"),
-    };
     let source_slot = if entry.has_style_sheet_context && entry.computed_kind == COMPUTED_KIND_UNCHANGED {
         entry.source_slot
     } else {
         -1
     };
-    longhand_table.set(entry.property_id, retained, source_slot);
+    let computed = match entry.computed_kind {
+        COMPUTED_KIND_UNCHANGED => {
+            let retained = unsafe {
+                RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
+                    entry.data.cast(),
+                ))
+            };
+            longhand_table.set_or_keep_equal(entry.property_id, retained, source_slot);
+            return;
+        }
+        COMPUTED_KIND_STYLE_VALUE => {
+            let retained = unsafe { RetainedStyleValueData::from_retained_pointer(entry.computed_data.cast()) };
+            longhand_table.set_or_keep_equal(entry.property_id, retained, source_slot);
+            return;
+        }
+        COMPUTED_KIND_PX_LENGTH => StyleValueData::Length {
+            value: entry.value,
+            unit: px_length_unit(),
+        },
+        COMPUTED_KIND_INTEGER => StyleValueData::Integer {
+            value: entry.value as i32,
+        },
+        COMPUTED_KIND_SUPERELLIPSE => StyleValueData::Superellipse {
+            parameter: retained_new(StyleValueData::Number { value: entry.value }),
+        },
+        COMPUTED_KIND_NUMBER => StyleValueData::Number { value: entry.value },
+        COMPUTED_KIND_PERCENTAGE => StyleValueData::Percentage { value: entry.value },
+        COMPUTED_KIND_FONT_STYLE => StyleValueData::FontStyle {
+            font_style: entry.value as u8,
+            angle_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(std::ptr::null()) },
+        },
+        COMPUTED_KIND_KEYWORD => StyleValueData::Keyword {
+            keyword: entry.value as u16,
+        },
+        COMPUTED_KIND_DISPLAY => StyleValueData::Display {
+            raw: entry.value as u32,
+        },
+        _ => unreachable!("unknown computed longhand store kind"),
+    };
+    longhand_table.set_computed(entry.property_id, computed, source_slot);
 }
 
 /// Drives the property computation loop: iterates every longhand in


### PR DESCRIPTION
The commits in this PR make longhand table drives and publication scale with the slots a given recompute changes, rather than with all longhands. The table keeps its slot hash across writes. Equal computed values keep their identity. Full drives now start from the previous record's values. Transition longhand lists are now resolved once per table.

See individual commits for details.

Improves multiple Speedometer3 tests:
```
Benchmark     Suite                                       Test                   Speedup  Old (Mean ± Range)    New (Mean ± Range)
------------  ------------------------------------------  -------------------  ---------  --------------------  --------------------
Speedometer3  Charts-chartjs                              Draw opaque scatter      1.015  0.11 ± 0.02           0.11 ± 0.02
Speedometer3  Charts-chartjs                              Draw scatter             1.007  0.13 ± 0.00           0.13 ± 0.00
Speedometer3  Charts-chartjs                              Show tooltip             1.038  0.00 ± 0.00           0.00 ± 0.00
Speedometer3  Charts-observable-plot                      Dotted                   1.178  0.07 ± 0.01           0.06 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 20            1.135  0.13 ± 0.02           0.12 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 6             1.047  0.10 ± 0.02           0.09 ± 0.02
Speedometer3  Editor-CodeMirror                           Highlight                0.948  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  Editor-CodeMirror                           Long                     0.821  0.03 ± 0.01           0.04 ± 0.01
Speedometer3  Editor-TipTap                               Highlight                0.985  0.19 ± 0.01           0.19 ± 0.01
Speedometer3  Editor-TipTap                               Long                     0.973  0.15 ± 0.03           0.16 ± 0.03
Speedometer3  NewsSite-Next                               NavigateToPolitics       1.007  0.17 ± 0.00           0.17 ± 0.01
Speedometer3  NewsSite-Next                               NavigateToUS             1.003  0.16 ± 0.00           0.16 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToWorld          1.028  0.17 ± 0.00           0.17 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToPolitics       1.035  0.15 ± 0.00           0.14 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToUS             1.008  0.14 ± 0.00           0.14 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToWorld          0.999  0.14 ± 0.00           0.14 ± 0.01
Speedometer3  Perf-Dashboard                              Render                   1.016  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingPoints          0.991  0.12 ± 0.00           0.12 ± 0.01
Speedometer3  Perf-Dashboard                              SelectingRange           1.03   0.06 ± 0.00           0.06 ± 0.00
Speedometer3  React-Stockcharts-SVG                       PanTheChart              0.945  0.12 ± 0.01           0.13 ± 0.03
Speedometer3  React-Stockcharts-SVG                       Render                   0.965  0.13 ± 0.01           0.13 ± 0.02
Speedometer3  React-Stockcharts-SVG                       ZoomTheChart             1.137  0.45 ± 0.04           0.39 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 Adding100Items           0.91   0.12 ± 0.01           0.13 ± 0.03
Speedometer3  TodoMVC-Angular-Complex-DOM                 CompletingAllItems       1.027  0.09 ± 0.03           0.08 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 DeletingAllItems         1.112  0.05 ± 0.01           0.04 ± 0.00
Speedometer3  TodoMVC-Backbone                            Adding100Items           0.943  0.07 ± 0.00           0.07 ± 0.01
Speedometer3  TodoMVC-Backbone                            CompletingAllItems       1.155  0.06 ± 0.01           0.05 ± 0.00
Speedometer3  TodoMVC-Backbone                            DeletingAllItems         0.988  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      Adding100Items           1.011  0.14 ± 0.01           0.14 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES5                      CompletingAllItems       1.005  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      DeletingAllItems         1.104  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  Adding100Items           1.031  0.13 ± 0.01           0.12 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  CompletingAllItems       1.014  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  DeletingAllItems         0.952  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     Adding100Items           1.004  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     CompletingAllItems       1.011  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     DeletingAllItems         1.056  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  Adding100Items           1.003  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  CompletingAllItems       0.754  0.03 ± 0.00           0.04 ± 0.02
Speedometer3  TodoMVC-Preact-Complex-DOM                  DeletingAllItems         2.125  0.01 ± 0.02           0.01 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   Adding100Items           1.019  0.09 ± 0.01           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   CompletingAllItems       0.982  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   DeletingAllItems         1.001  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-React-Redux                         Adding100Items           0.992  0.08 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Redux                         CompletingAllItems       1.011  0.12 ± 0.00           0.12 ± 0.00
Speedometer3  TodoMVC-React-Redux                         DeletingAllItems         1.027  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  Adding100Items           1.063  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  CompletingAllItems       1.064  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  DeletingAllItems         1.049  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Vue                                 Adding100Items           1.006  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Vue                                 CompletingAllItems       0.969  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Vue                                 DeletingAllItems         0.985  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       Adding100Items           1.054  0.07 ± 0.01           0.06 ± 0.00
Speedometer3  TodoMVC-WebComponents                       CompletingAllItems       1.009  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       DeletingAllItems         1.012  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-jQuery                              Adding100Items           1.023  0.17 ± 0.01           0.16 ± 0.01
Speedometer3  TodoMVC-jQuery                              CompletingAllItems       0.994  0.42 ± 0.02           0.42 ± 0.02
Speedometer3  TodoMVC-jQuery                              DeletingAllItems         1.015  0.16 ± 0.02           0.16 ± 0.03

Benchmark     Old Score    New Score      Score Improvement  Old Total Time (s)    New Total Time (s)      Speedup
------------  -----------  -----------  -------------------  --------------------  --------------------  ---------
Speedometer3  4.86 ± 0.11  4.92 ± 0.11                1.012  5.32 ± 0.15           5.23 ± 0.14               1.017
```
