### PR TITLE
LibWeb: Fix a broken step in our HTMLTableElement::insert_row (and make Gmail search work without glitching)

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -440,23 +440,45 @@ WebIDL::ExceptionOr<GC::Ref<HTMLTableRowElement>> HTMLTableElement::insert_row(W
     auto rows = this->rows();
     auto rows_length = rows->length();
 
+    // 1. If index is less than -1 or greater than the number of elements in the rows collection, then throw an
+    //    "IndexSizeError" DOMException.
     if (index < -1 || index > (long)rows_length) {
         return WebIDL::IndexSizeError::create("Index is negative or greater than the number of rows"_utf16);
     }
+
+    // 2. Let tr be the result of creating a table element given this and "tr".
     auto& tr = static_cast<HTMLTableRowElement&>(*TRY(DOM::create_element(document(), TagNames::tr, Namespace::HTML)));
-    if (rows_length == 0 && !has_child_of_type<HTMLTableRowElement>()) {
+
+    auto t_bodies = this->t_bodies();
+    auto t_bodies_length = t_bodies->length();
+
+    // 3. If the rows collection has zero elements in it, and this has no tbody elements in it:
+    if (rows_length == 0 && t_bodies_length == 0) {
+        // 1. Let tbody be the result of creating a table element given this and "tbody".
         auto tbody = TRY(DOM::create_element(document(), TagNames::tbody, Namespace::HTML));
+
+        // 2. Append tr to tbody.
         TRY(tbody->append_child(tr));
+
+        // 3. Append tbody to this.
         TRY(append_child(tbody));
-    } else if (rows_length == 0) {
-        auto tbody = last_child_of_type<HTMLTableRowElement>();
-        TRY(tbody->append_child(tr));
-    } else if (index == -1 || index == (long)rows_length) {
+    }
+    // 4. Otherwise, if the rows collection has zero elements in it, then append tr to the last tbody element in this.
+    else if (rows_length == 0) {
+        TRY(t_bodies->item(t_bodies_length - 1)->append_child(tr));
+    }
+    // 5. Otherwise, if index is -1 or equal to the number of items in the rows collection, then append tr to the
+    //    parent of the last tr element in the rows collection.
+    else if (index == -1 || index == (long)rows_length) {
         auto parent_of_last_tr = rows->item(rows_length - 1)->parent_element();
         TRY(parent_of_last_tr->append_child(tr));
-    } else {
+    }
+    // 6. Otherwise, insert tr immediately before the indexth tr element in the rows collection, in the same parent.
+    else {
         rows->item(index)->parent_element()->insert_before(tr, rows->item(index));
     }
+
+    // 7. Return tr.
     return GC::Ref(tr);
 }
 

--- a/Tests/LibWeb/Text/expected/HTML/table-insertRow-uses-existing-tbody.txt
+++ b/Tests/LibWeb/Text/expected/HTML/table-insertRow-uses-existing-tbody.txt
@@ -1,0 +1,6 @@
+tBodies=1 rows=1 parent=tbody.only
+tBodies=1 rows=1 parent=tbody.only
+tBodies=2 rows=1 parent=tbody.last
+tBodies=1 rows=1 parent=tbody.
+tBodies=1 rows=1 parent=tbody.
+tBodies=1 rows=3 onlyRows=3

--- a/Tests/LibWeb/Text/input/HTML/table-insertRow-uses-existing-tbody.html
+++ b/Tests/LibWeb/Text/input/HTML/table-insertRow-uses-existing-tbody.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function describe(table, tr) {
+            return `tBodies=${table.tBodies.length} rows=${table.rows.length} ` +
+                `parent=${tr.parentNode.localName}.${tr.parentNode.className}`;
+        }
+
+        function makeTable(markup) {
+            const table = document.createElement("table");
+            table.innerHTML = markup;
+            return table;
+        }
+
+        let table = makeTable('<tbody class="only"></tbody>');
+        println(describe(table, table.insertRow(-1)));
+
+        table = makeTable('<tbody class="only"></tbody>');
+        println(describe(table, table.insertRow(0)));
+
+        table = makeTable('<tbody class="first"></tbody><tbody class="last"></tbody>');
+        println(describe(table, table.insertRow(-1)));
+
+        table = makeTable('<thead class="head"></thead>');
+        println(describe(table, table.insertRow(-1)));
+
+        table = makeTable("");
+        println(describe(table, table.insertRow(-1)));
+
+        table = makeTable('<tbody class="only"></tbody>');
+        for (let i = 0; i < 3; ++i)
+            table.insertRow(-1);
+        println(`tBodies=${table.tBodies.length} rows=${table.rows.length} ` +
+            `onlyRows=${table.tBodies[0].rows.length}`);
+    });
+</script>


### PR DESCRIPTION
**Problem:** [Gmail](https://mail.google.com/): typing in the “Search mail” box unexpectedly drew a growing stack of gray horizontal lines above the suggestions in the dropdown, pushing the suggestions themselves further down the list.

**Cause:** The dropdown is a `table` whose only child is an empty `tbody`, and every suggestion row goes in through `insertRow()`. Our `HTMLTableElement::insert_row()` mistakenly asked if the `table` had a `tr` child — where the spec asks whether it has a *`tbody`* child. So, with the `rows` collection empty and no `tr` anywhere, it made a second `tbody` and put the rows in that one. The `tbody` the page owns stayed empty, so the page found no rows to reuse, built a fresh set on every keystroke — and never took the old ones away. Each abandoned separator row painted a spurious divider.

**Fix:** Conform `HTMLTableElement::insert_row()` to the spec steps as written.
