### PR TITLE
LibWeb: Fix several layout issues on Twinings product pages

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -2368,6 +2368,11 @@ public:
             return;
         m_values.m_noninherited.border.access().border_left.color = value.value();
     }
+    void copy_fieldset_content_alignment_from(ComputedValues const& source)
+    {
+        ComputedValuesFFI::rust_alignment_values_copy_fieldset_content_properties(
+            &*source.m_noninherited.alignment, &m_values.m_noninherited.alignment.access());
+    }
     void set_flex_direction(FlexDirection value)
     {
         if (m_values.flex_direction() == value)

--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -668,6 +668,10 @@ input:is([type=reset i], [type=button i], [type=submit i]) {
     white-space: pre;
 }
 
+select {
+    white-space: pre;
+}
+
 input, button {
     display: inline-block;
 }

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -709,6 +709,9 @@ void HTMLSelectElement::create_shadow_tree_if_needed()
     m_inner_text_element = DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     m_inner_text_element->set_attribute_value(HTML::AttributeNames::style, R"~~~(
         flex: 1;
+        min-width: 0;
+        overflow: clip;
+        text-overflow: inherit;
         margin-inline-end: 20px;
     )~~~"_utf16);
     MUST(border->append_child(*m_inner_text_element));

--- a/Libraries/LibWeb/Layout/AnonymousBoxStyle.cpp
+++ b/Libraries/LibWeb/Layout/AnonymousBoxStyle.cpp
@@ -98,7 +98,14 @@ CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer c
         builder->set_min_height(CSS::Size::make_px(CSSPixels(0)));
         break;
     case RustFFI::FfiAnonymousStyleKind::FieldsetContentWrapper:
-        builder->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
+        // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+        // If the computed value of 'display' on the fieldset element is 'flex' or 'inline-flex', then set the used value to 'flex'.
+        if (parent_values->display().is_flex_inside())
+            builder->set_display(CSS::Display { CSS::DisplayOutside::Block, CSS::DisplayInside::Flex });
+        else
+            builder->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
+        // NB: Flex layout and alignment apply to the anonymous content box, excluding the rendered legend.
+        builder->copy_fieldset_content_alignment_from(*parent_values);
         builder->set_overflow_x(static_cast<CSS::Overflow>(overrides.overflow_x));
         builder->set_overflow_y(static_cast<CSS::Overflow>(overrides.overflow_y));
         break;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1364,7 +1364,7 @@ RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_ca
             //     column-width, flex-direction, flex-wrap, grid (grid-auto-columns, grid-auto-flow, grid-auto-rows,
             //     grid-column-gap, grid-row-gap, grid-template-areas, grid-template-columns, grid-template-rows),
             //     justify-content, justify-items, overflow, padding, text-overflow, unicode-bidi
-            // FIXME: Transfer all of these properties, not just overflow.
+            // FIXME: Transfer the remaining properties besides overflow and alignment.
             RustFFI::FfiAnonymousStyleOverrides overrides {
                 .inline_block_wrapper = false,
                 .overflow_x = to_underlying(fieldset_box.overflow_x()),

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -3841,3 +3841,22 @@ mod tests {
         }
     }
 }
+
+/// # Safety
+/// `source` must be a valid alignment payload and `target` a uniquely owned alignment value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_alignment_values_copy_fieldset_content_properties(
+    source: *const AlignmentValues,
+    target: *mut AlignmentValues,
+) {
+    // SAFETY: The caller supplies a valid source and a uniquely owned target.
+    let (source, target) = unsafe { (&*source, &mut *target) };
+    target.flex_direction = source.flex_direction;
+    target.flex_wrap = source.flex_wrap;
+    target.align_content = source.align_content;
+    target.align_items = source.align_items;
+    target.justify_content = source.justify_content;
+    target.justify_items = source.justify_items;
+    target.row_gap = source.row_gap.clone();
+    target.column_gap = source.column_gap.clone();
+}

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -259,8 +259,11 @@ impl<'pass> BlockFormattingContext<'pass> {
                 .treat_block_axis_percentage_insets_as_auto_beyond_root,
             previous_line_data: run.previous_line_data.clone(),
             is_line_clamp_container,
+            // NB: Measurements at a definite inline size need the clamped block size, just like committed layout.
             max_lines: Cell::new(
-                ((!run.purpose.is_measurement() || style.writing_mode() != writing_mode::HORIZONTAL_TB)
+                ((!run.purpose.is_measurement()
+                    || run.records.used_values(run.box_).has_definite_inline_size()
+                    || style.writing_mode() != writing_mode::HORIZONTAL_TB)
                     && is_line_clamp_container
                     && style.max_lines() > 0)
                     .then_some(style.max_lines() as usize),

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -1674,11 +1674,20 @@ impl<'pass> BlockFormattingContext<'pass> {
         containing_input: LayoutInput,
         available_space: AvailableSpace,
     ) -> LayoutInput {
+        let sizing = self.sizing();
+        let containing_block_constraints =
+            sizing.constraints_for_child_context(containing_block, containing_input.containing_block_constraints);
+        let mut available_space = available_space;
+        if sizing.is_anonymous_button_content_box(containing_block)
+            && let Some(block_size) = containing_block_constraints.percentage_basis_block_size
+        {
+            // NB: Percentage heights inside the anonymous content box use the button's height, including during
+            //     intrinsic measurement of the content box itself.
+            available_space.block_size = AvailableSize::definite(block_size);
+        }
         LayoutInput {
             available_space,
-            containing_block_constraints: self
-                .sizing()
-                .constraints_for_child_context(containing_block, containing_input.containing_block_constraints),
+            containing_block_constraints,
             content_box_position_in_bfc_root: containing_input.content_box_position_in_bfc_root,
             sizing: RootSizingDirectives::default(),
             participation: ParticipationInParentFormattingContext::BlockLevel,

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -3032,19 +3032,6 @@ impl<'pass> FlexFormattingContext<'pass> {
         let available_space = layout_input.available_space;
         // This implements https://www.w3.org/TR/css-flexbox-1/#layout-algorithm
 
-        // OPTIMIZATION: If we're in intrinsic sizing layout, but the flex container is not the
-        //               box being measured, we can skip everything here.
-        //               The parent formatting context has already figured out our size anyway.
-        //               However, an inline-level container must still lay out its items, since the
-        //               parent inline formatting context derives the fragment's baseline from them.
-        if self.layout_mode == LayoutMode::IntrinsicSizing
-            && !available_space.inline_size.is_intrinsic_sizing_constraint()
-            && !available_space.block_size.is_intrinsic_sizing_constraint()
-            && !self.facts(self.flex_container).display().is_inline_outside()
-        {
-            return;
-        }
-
         self.available_space = Some(available_space);
         self.layout_input = Some(layout_input);
         self.item_percentage_bases =

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -981,6 +981,13 @@ pub(crate) fn formatting_context_type_created_by_node_data(
         });
     }
     let display = style.map(|style| style.display());
+    // NB: A flex fieldset lays out its legend and anonymous content box in a block formatting context.
+    //     Flex layout applies only to the anonymous content box.
+    if data.kind.get() == crate::layout::node_data::NodeKind::FieldSetBox
+        && display.is_some_and(|display| display.is_flex_inside())
+    {
+        return Some(FfiFormattingContextType::Block);
+    }
     if display.is_some_and(|display| display.is_flex_inside()) {
         return Some(FfiFormattingContextType::Flex);
     }

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -583,13 +583,12 @@ pub(crate) fn box_baseline_with_content_baselines(
     // baseline sets always derive from content; so do flex and grid containers, which are not block containers.
     // FIXME: Per CSS Align, a scroll container's content-derived baseline position should be clamped to its border
     //        edge.
-    let has_visible_overflow = style.overflow_x() == overflow::VISIBLE && style.overflow_y() == overflow::VISIBLE;
     let derive_baseline_from_content =
-        baseline_set == BaselineSet::First || is_flex_or_grid_container || has_visible_overflow;
+        baseline_set == BaselineSet::First || is_flex_or_grid_container || !facts.is_scroll_container();
 
-    // AD-HOC: We also use the content-derived baseline for <input> elements with block children. Per the HTML spec,
-    //         inputs have `overflow: clip !important`, so CSS2 says to use bottom margin edge. However, the internal
-    //         shadow tree baseline should determine the control's baseline for proper alignment with adjacent text.
+    // AD-HOC: We also use the content-derived baseline for <input> elements with block children, even when their
+    //         overflow makes them scroll containers. The internal shadow tree baseline should determine the control's
+    //         baseline for proper alignment with adjacent text.
     //         https://html.spec.whatwg.org/multipage/rendering.html#form-controls
     let input_derives_from_children = facts.is_html_input_element() && !facts.children_are_inline();
 

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3973,84 +3973,116 @@ pub(crate) fn resolve_intrinsic_track_sizes(
         }
     }
 
-    // 4. Increase sizes to accommodate spanning items crossing flexible tracks: Next, repeat the previous
-    // step instead considering (together, rather than grouped by span size) all items that do span a
-    // track with a flexible sizing function while
-    //
-    // https://www.w3.org/TR/css-grid-1/#algo-spanning-flex-items
-    // 11.5.4. Increase sizes to accommodate spanning items crossing flexible tracks
-    let dominated = |track: &Track| {
-        available == AvailableSize::MaxContent
-            || (row_axis && available == AvailableSize::MinContent)
-            || track.min_sizing.is_intrinsic(available)
-    };
-    let mut contributions = vec![CssPixels::default(); tracks.len()];
-    for item in items {
-        // NB: This step repeats the content-sized track step, but only distributes space to flexible tracks. For
-        //     min-content column sizing, the later "Expand Flexible Tracks" step resolves the flex fraction to zero, so
-        //     flexible columns must not grow beyond their items' minimum contribution here. Keep min-content row sizing
-        //     here so intrinsic-height grids still account for their contents.
-        let mut total_flex = 0.0;
-        let mut flexible_count = 0usize;
-        let mut non_flexible_space = CssPixels::default();
-        for &index in &item.spanned_tracks {
-            if let Some(factor) = tracks[index].max_sizing.flex_factor()
-                && dominated(&tracks[index])
-            {
-                total_flex += factor;
-                flexible_count += 1;
-            } else {
-                non_flexible_space += tracks[index].base_size;
-            }
-        }
-        if flexible_count == 0 {
+    // https://www.w3.org/TR/css-grid-2/#algo-spanning-flex-items
+    // 4. Increase sizes to accommodate spanning items crossing flexible tracks:
+    // Next, repeat the previous step instead considering (together, rather than grouped by span size)
+    // all items that do span a track with a flexible sizing function while
+    // - distributing space only to flexible tracks (i.e. treating all other tracks as having a fixed sizing function)
+    // NB: Repeat each minimum-sizing phase, so intrinsic minimums are honored even when the maximum is flexible.
+    #[derive(Clone, Copy)]
+    enum FlexibleMinimumPhase {
+        Intrinsic,
+        MinContent,
+        LimitedMaxContent,
+        MaxContent,
+    }
+    for phase in [
+        FlexibleMinimumPhase::Intrinsic,
+        FlexibleMinimumPhase::MinContent,
+        FlexibleMinimumPhase::LimitedMaxContent,
+        FlexibleMinimumPhase::MaxContent,
+    ] {
+        if matches!(phase, FlexibleMinimumPhase::LimitedMaxContent) && available != AvailableSize::MaxContent {
             continue;
         }
-        let use_limited_min_content =
-            available == AvailableSize::MaxContent || (row_axis && available == AvailableSize::MinContent);
-        let mut contribution = if use_limited_min_content {
-            if total_flex == 0.0 && item.is_scroll_container {
-                // https://drafts.csswg.org/css-grid-2/#min-size-auto
-                // A grid item's automatic minimum size is zero if its computed overflow is a scrollable
-                // overflow value. Preserve that zero minimum for collapsed zero-flex tracks.
-                item.minimum
-            } else {
-                item.limited_min_content
+        let dominated = |track: &Track| match phase {
+            FlexibleMinimumPhase::Intrinsic => {
+                available == AvailableSize::MaxContent
+                    || (row_axis && available == AvailableSize::MinContent)
+                    || track.min_sizing.is_intrinsic(available)
             }
-        } else {
-            item.minimum
+            FlexibleMinimumPhase::MinContent => track.min_sizing.is_min_content() || track.min_sizing.is_max_content(),
+            FlexibleMinimumPhase::LimitedMaxContent => {
+                track.min_sizing.is_auto(available) || track.min_sizing.is_max_content()
+            }
+            FlexibleMinimumPhase::MaxContent => track.min_sizing.is_max_content(),
         };
-        // NB: Subtract the space already accounted for by non-flexible spanned tracks (sized in 11.5.3), since only
-        //     the remaining contribution needs to be distributed among flexible tracks.
-        contribution = CssPixels::default().max(contribution - non_flexible_space);
-        // Distributing space to flexible tracks:
-        // - If the sum of the flexible sizing functions of all flexible tracks spanned by the item is greater
-        //   than or equal to one, distributing space to such tracks according to the ratios of their flexible
-        //   sizing functions rather than distributing space equally.
-        // - If the sum is less than one, distributing that proportion of space according to the ratios of their
-        //   flexible sizing functions and the rest equally.
-        // FIXME: Handle 0 < total_flex < 1 case separately per spec.
-        for &index in &item.spanned_tracks {
-            let Some(factor) = tracks[index].max_sizing.flex_factor() else {
-                continue;
-            };
-            if !dominated(&tracks[index]) {
+        let mut contributions = vec![CssPixels::default(); tracks.len()];
+        for item in items {
+            let mut total_flex = 0.0;
+            let mut flexible_count = 0usize;
+            let mut non_flexible_space = CssPixels::default();
+            for &index in &item.spanned_tracks {
+                if let Some(factor) = tracks[index].max_sizing.flex_factor()
+                    && dominated(&tracks[index])
+                {
+                    total_flex += factor;
+                    flexible_count += 1;
+                } else {
+                    non_flexible_space += tracks[index].base_size;
+                }
+            }
+            if flexible_count == 0 {
                 continue;
             }
-            let share = if total_flex > 0.0 {
-                CssPixels::nearest_value_for(contribution.to_double() * (factor / total_flex))
+            // NB: Preserve the minimum-contribution behavior for min-content column sizing. Rows still need
+            //     limited min-content contributions here to account for their intrinsic height.
+            let use_limited_min_content =
+                available == AvailableSize::MaxContent || (row_axis && available == AvailableSize::MinContent);
+            let mut contribution = if use_limited_min_content {
+                if total_flex == 0.0 && item.is_scroll_container {
+                    // https://drafts.csswg.org/css-grid-2/#min-size-auto
+                    // A grid item's automatic minimum size is zero if its computed overflow is a scrollable
+                    // overflow value. Preserve that zero minimum for collapsed zero-flex tracks.
+                    item.minimum
+                } else {
+                    item.limited_min_content
+                }
             } else {
-                contribution / flexible_count
+                item.minimum
             };
-            contributions[index] = contributions[index].max(share);
+            contribution = match phase {
+                FlexibleMinimumPhase::Intrinsic => contribution,
+                FlexibleMinimumPhase::MinContent => item.min_content,
+                FlexibleMinimumPhase::LimitedMaxContent if total_flex == 0.0 && item.is_scroll_container => {
+                    // NB: Preserve the zero automatic minimum for collapsed zero-flex tracks in this phase too.
+                    item.minimum
+                }
+                FlexibleMinimumPhase::LimitedMaxContent => item.limited_max_content,
+                FlexibleMinimumPhase::MaxContent => item.max_content,
+            };
+            // NB: Subtract the space already accounted for by non-flexible spanned tracks (sized in 11.5.3), since only
+            //     the remaining contribution needs to be distributed among flexible tracks.
+            contribution = CssPixels::default().max(contribution - non_flexible_space);
+            // Distributing space to flexible tracks:
+            // - If the sum of the flexible sizing functions of all flexible tracks spanned by the item is greater
+            //   than or equal to one, distributing space to such tracks according to the ratios of their flexible
+            //   sizing functions rather than distributing space equally.
+            // - If the sum is less than one, distributing that proportion of space according to the ratios of their
+            //   flexible sizing functions and the rest equally.
+            // FIXME: Handle 0 < total_flex < 1 case separately per spec.
+            for &index in &item.spanned_tracks {
+                let Some(factor) = tracks[index].max_sizing.flex_factor() else {
+                    continue;
+                };
+                if !dominated(&tracks[index]) {
+                    continue;
+                }
+                let share = if total_flex > 0.0 {
+                    CssPixels::nearest_value_for(contribution.to_double() * (factor / total_flex))
+                } else {
+                    contribution / flexible_count
+                };
+                contributions[index] = contributions[index].max(share);
+            }
         }
-    }
-    for (track, contribution) in tracks.iter_mut().zip(contributions) {
-        track.base_size = track.base_size.max(contribution);
-        if track.growth_limit.is_some_and(|limit| limit < track.base_size) {
-            // If at this point any track's growth limit is now less than its base size, increase its growth limit to match
-            // its base size.
-            track.growth_limit = Some(track.base_size);
+        for (track, contribution) in tracks.iter_mut().zip(contributions) {
+            track.base_size = track.base_size.max(contribution);
+            if track.growth_limit.is_some_and(|limit| limit < track.base_size) {
+                // If at this point any track's growth limit is now less than its base size, increase its growth limit to match
+                // its base size.
+                track.growth_limit = Some(track.base_size);
+            }
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -723,6 +723,15 @@ impl<'pass> SizingContext<'pass> {
         false
     }
 
+    pub(crate) fn is_anonymous_button_content_box(&self, node: Node) -> bool {
+        let parent = self.parent(node);
+        self.facts(node).is_anonymous()
+            && !parent.is_invalid()
+            && self.facts(parent).is_anonymous()
+            && !self.parent(parent).is_invalid()
+            && self.facts(self.parent(parent)).uses_button_layout()
+    }
+
     pub(crate) fn constraints_for_child_context(
         &self,
         containing_block: Node,
@@ -749,7 +758,15 @@ impl<'pass> SizingContext<'pass> {
         } else {
             None
         };
-        let block = if used.has_definite_block_size() {
+        let forwards_button_content_block_basis = self.is_anonymous_button_content_box(containing_block);
+        // https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level
+        // Anonymous block boxes are ignored when resolving percentage values that would refer to it:
+        // the closest non-anonymous ancestor box is used instead.
+        // NB: The button content box can acquire a definite post-flexing size smaller than the button.
+        //     Its descendants must still resolve percentage heights against the button's content box.
+        let block = if forwards_button_content_block_basis {
+            constraints.percentage_basis_block_size
+        } else if used.has_definite_block_size() {
             Some(used.content_block_size.get())
         } else if should_forward_indefinite_basis {
             constraints.percentage_basis_block_size
@@ -789,8 +806,8 @@ impl<'pass> SizingContext<'pass> {
             constraints.quirks_mode_percentage_basis_block_size
         };
 
-        let forwarded_a_block_basis = (!used.has_definite_block_size()
-            && should_forward_indefinite_basis
+        let forwarded_a_block_basis = (((!used.has_definite_block_size() && should_forward_indefinite_basis)
+            || forwards_button_content_block_basis)
             && constraints.percentage_basis_block_size.is_some())
             || (quirks_block.is_some()
                 && quirks_block == constraints.quirks_mode_percentage_basis_block_size
@@ -861,6 +878,7 @@ impl<'pass> SizingContext<'pass> {
             && facts.is_block_container()
             && !facts.is_table_wrapper();
         svg_root_forwards_quirks_basis
+            || self.is_anonymous_button_content_box(node)
             || forwards_block_basis_as_anonymous_box
             || forwards_quirks_basis_as_auto_height_block_container
     }

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -3342,7 +3342,7 @@ fn wrap_fieldset_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: Lay
     // rendered legend, if there is one.
     if host.data(layout_node).kind.get() == NodeKind::FieldSetBox {
         let legend = rendered_legend(host, layout_node);
-        if legend.is_invalid() {
+        if legend.is_invalid() && !host.display(layout_node).is_flex_inside() {
             return;
         }
 

--- a/Tests/LibWeb/Ref/expected/overflow-clip-inline-block-baseline-ref.html
+++ b/Tests/LibWeb/Ref/expected/overflow-clip-inline-block-baseline-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+    body { font: 20px/20px monospace; }
+    span { display: inline-block; height: 40px; }
+</style>
+Text <span>clipped box</span> text

--- a/Tests/LibWeb/Ref/expected/select-label-clipping-ref.html
+++ b/Tests/LibWeb/Ref/expected/select-label-clipping-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+    @font-face { font-family: Ahem; src: url("../data/fonts/Ahem.ttf"); }
+    select { display: block; width: 100px; height: 40px; padding: 0; border: 0; font: 20px/20px Ahem; }
+</style>
+<select><option>XX X</option></select>
+<select><option>XXXX</option></select>
+<select style="appearance: none"><option>XXXXX</option></select>

--- a/Tests/LibWeb/Ref/input/overflow-clip-inline-block-baseline.html
+++ b/Tests/LibWeb/Ref/input/overflow-clip-inline-block-baseline.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/overflow-clip-inline-block-baseline-ref.html">
+<style>
+    body { font: 20px/20px monospace; }
+    span { display: inline-block; height: 40px; overflow: clip; }
+</style>
+Text <span>clipped box</span> text

--- a/Tests/LibWeb/Ref/input/select-label-clipping.html
+++ b/Tests/LibWeb/Ref/input/select-label-clipping.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/select-label-clipping-ref.html">
+<style>
+    @font-face { font-family: Ahem; src: url("../data/fonts/Ahem.ttf"); }
+    select { display: block; width: 100px; height: 40px; padding: 0; border: 0; font: 20px/20px Ahem; }
+</style>
+<select><option>XX XX XX</option></select>
+<select><option>XXXXXXXX</option></select>
+<select style="appearance: none"><option>XXXXXXXX</option></select>

--- a/Tests/LibWeb/Text/expected/HTML/button-percentage-height-through-content-wrapper.txt
+++ b/Tests/LibWeb/Text/expected/HTML/button-percentage-height-through-content-wrapper.txt
@@ -1,0 +1,7 @@
+ratio: button 60x75, image 60x75 at 0,0
+fixed: button 60x75, image 60x75 at 0,0
+padded: button 80x100, image 60x80 at 10,10
+half: button 60x75, image 60x37.5 at 0,18.75
+auto: button 60x60, image 60x60 at 0,0
+nested: button 60x75, image 60x60 at 0,7.5
+ratio: button 80x100, image 80x100 at 0,0

--- a/Tests/LibWeb/Text/expected/fieldset-flex-content.txt
+++ b/Tests/LibWeb/Text/expected/fieldset-flex-content.txt
@@ -1,0 +1,17 @@
+with-legend
+LEGEND: 0,0 30x20
+DIV: 0,20 80x30
+DIV: 90,20 80x30
+DIV: 0,60 80x30
+without-legend
+DIV: 0,0 80x30
+DIV: 90,0 80x30
+DIV: 0,40 80x30
+column
+LEGEND: 0,0 30x20
+DIV: 120,20 80x30
+DIV: 120,60 80x30
+inline
+LEGEND: 0,0 30x20
+DIV: 30,20 80x30
+DIV: 120,20 80x30

--- a/Tests/LibWeb/Text/expected/flex-intrinsic-height-clamped-title-and-select.txt
+++ b/Tests/LibWeb/Text/expected/flex-intrinsic-height-clamped-title-and-select.txt
@@ -1,0 +1,10 @@
+card: 60
+child: 20
+child: 40
+card: 60
+child: 20
+child: 40
+card: 20
+child: 20
+card: 40
+child: 40

--- a/Tests/LibWeb/Text/expected/grid-flex-track-intrinsic-minimum.txt
+++ b/Tests/LibWeb/Text/expected/grid-flex-track-intrinsic-minimum.txt
@@ -1,0 +1,7 @@
+600: 170px 240px 170px; menu height 20
+400: 120px 200px 60px; menu height 40
+600: 170px 240px 170px; menu height 20
+auto: 50px
+min-content: 60px
+max-content: 120px
+spanning: 40px 80px

--- a/Tests/LibWeb/Text/expected/select-label-overflow.txt
+++ b/Tests/LibWeb/Text/expected/select-label-overflow.txt
@@ -1,0 +1,3 @@
+label: 80x20, text fragments: 1
+label: 80x20, text fragments: 1
+label: 100x20, text fragments: 1

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/fieldset-as-container-justify-center.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/fieldset-as-container-justify-center.tentative.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	.item 1
+1 Pass
+Pass	.item 1

--- a/Tests/LibWeb/Text/input/HTML/button-percentage-height-through-content-wrapper.html
+++ b/Tests/LibWeb/Text/input/HTML/button-percentage-height-through-content-wrapper.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .column { display: flex; flex-direction: column; align-items: start; }
+    button { width: 60px; aspect-ratio: 4 / 5; border: 0; padding: 0; }
+    img { display: block; width: 100%; height: 100%; object-fit: cover; }
+    #fixed { aspect-ratio: auto; height: 75px; }
+    #padded { aspect-ratio: auto; width: 80px; height: 100px; border: 5px solid; padding: 5px; }
+    #auto { aspect-ratio: auto; }
+    #half img { height: 50%; }
+</style>
+<div class="column">
+    <button id="ratio"><img></button>
+    <button id="fixed"><img></button>
+    <button id="padded"><img></button>
+    <button id="half"><img></button>
+    <button id="auto"><img></button>
+    <button id="nested"><div><img></div></button>
+</div>
+<script>
+    asyncTest(async done => {
+        const images = [...document.querySelectorAll("img")];
+        for (const image of images)
+            image.src = "data:image/svg+xml," + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="green"/></svg>');
+        await Promise.all(images.map(image => image.decode()));
+        function printImage(image) {
+            const button = image.closest("button");
+            const buttonRect = button.getBoundingClientRect();
+            const imageRect = image.getBoundingClientRect();
+            println(`${button.id}: button ${buttonRect.width}x${buttonRect.height}, image ${imageRect.width}x${imageRect.height} at ${imageRect.x - buttonRect.x},${imageRect.y - buttonRect.y}`);
+        }
+        for (const image of images)
+            printImage(image);
+        document.getElementById("ratio").style.width = "80px";
+        printImage(images[0]);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/fieldset-flex-content.html
+++ b/Tests/LibWeb/Text/input/fieldset-flex-content.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    fieldset { display: flex; flex-wrap: wrap; gap: 10px; width: 200px; margin: 0; padding: 0; border: 0; }
+    legend { width: 30px; height: 20px; padding: 0; }
+    .item { display: flex; flex: none; width: 80px; height: 30px; }
+</style>
+<fieldset id="with-legend"><legend></legend><div class="item"></div><div class="item"></div><div class="item"></div></fieldset>
+<fieldset id="without-legend"><div class="item"></div><div class="item"></div><div class="item"></div></fieldset>
+<fieldset id="column" style="flex-direction: column; align-items: flex-end"><legend></legend><div class="item"></div><div class="item"></div></fieldset>
+<fieldset id="inline" style="display: inline-flex; justify-content: flex-end"><legend></legend><div class="item"></div><div class="item"></div></fieldset>
+<script>
+    test(() => {
+        for (const fieldset of document.querySelectorAll("fieldset")) {
+            println(fieldset.id);
+            const origin = fieldset.getBoundingClientRect();
+            for (const child of fieldset.children) {
+                const rect = child.getBoundingClientRect();
+                println(`${child.tagName}: ${rect.x - origin.x},${rect.y - origin.y} ${rect.width}x${rect.height}`);
+            }
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/flex-intrinsic-height-clamped-title-and-select.html
+++ b/Tests/LibWeb/Text/input/flex-intrinsic-height-clamped-title-and-select.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; font: 20px/20px monospace; }
+    .row { display: flex; width: 100px; }
+    .card { width: 100px; }
+    .title { display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 1; overflow: hidden; }
+    select { width: 100px; height: 40px; padding: 0; border: 0; font: inherit; }
+</style>
+<div class="row"><div class="card"><div class="title">first second third fourth</div><div><select><option>Tea</option></select></div></div></div>
+<div class="card"><div class="title">first second third fourth</div><div><select><option>Tea</option></select></div></div>
+<div class="row"><div class="card"><div class="title">first second third fourth</div></div></div>
+<div class="row"><div class="card"><div><select><option>Tea</option></select></div></div></div>
+<script>
+    test(() => {
+        for (const card of document.querySelectorAll(".card")) {
+            println(`card: ${card.getBoundingClientRect().height}`);
+            for (const child of card.children)
+                println(`child: ${child.getBoundingClientRect().height}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/grid-flex-track-intrinsic-minimum.html
+++ b/Tests/LibWeb/Text/input/grid-flex-track-intrinsic-minimum.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    .grid { display: grid; width: 400px; grid-template-columns: minmax(max-content, 1fr) auto minmax(max-content, 1fr); gap: 10px; }
+    .left { display: flex; }
+    .left > div { width: 120px; flex-shrink: 0; height: 20px; }
+    .menu { display: flex; flex-wrap: wrap; }
+    .menu > div { width: 80px; height: 20px; }
+    .right > div { width: 60px; height: 20px; }
+    .intrinsic { display: grid; width: 50px; grid-template-columns: minmax(min-content, 1fr); font: 10px/1 monospace; }
+    .intrinsic > div { min-width: 0; }
+    .intrinsic span { display: inline-block; width: 60px; height: 10px; }
+</style>
+<div class="grid"><div class="left"><div></div></div><div class="menu"><div></div><div></div><div></div></div><div class="right"><div></div></div></div>
+<div class="intrinsic"><div><span></span><wbr><span></span></div></div>
+<script>
+    test(() => {
+        const grid = document.querySelector(".grid");
+        for (const width of [600, 400, 600]) {
+            grid.style.width = `${width}px`;
+            println(`${width}: ${getComputedStyle(grid).gridTemplateColumns}; menu height ${grid.children[1].getBoundingClientRect().height}`);
+        }
+        const intrinsic = document.querySelector(".intrinsic");
+        for (const minimum of ["auto", "min-content", "max-content"]) {
+            intrinsic.style.gridTemplateColumns = `minmax(${minimum}, 1fr)`;
+            println(`${minimum}: ${getComputedStyle(intrinsic).gridTemplateColumns}`);
+        }
+        intrinsic.style.gridTemplateColumns = "minmax(max-content, 1fr) minmax(max-content, 2fr)";
+        intrinsic.firstElementChild.style.gridColumn = "span 2";
+        println(`spanning: ${getComputedStyle(intrinsic).gridTemplateColumns}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/select-label-overflow.html
+++ b/Tests/LibWeb/Text/input/select-label-overflow.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    select { width: 100px; height: 40px; border: 0; padding: 0; font: 20px/20px monospace; }
+</style>
+<select><option>20 Envelopes</option></select>
+<select style="direction: rtl"><option>20 Envelopes</option></select>
+<select style="appearance: none"><option>20 Envelopes</option></select>
+<script>
+    test(() => {
+        for (const select of document.querySelectorAll("select")) {
+            const label = internals.getShadowRoot(select).firstChild.firstChild;
+            const rect = label.getBoundingClientRect();
+            const range = document.createRange();
+            range.selectNodeContents(label);
+            println(`label: ${rect.width}x${rect.height}, text fragments: ${range.getClientRects().length}`);
+        }
+    });
+</script>


### PR DESCRIPTION
Fix several sizing and wrapping issues on Twinings product pages: size options now sit side by side, select labels stay on one line, product cards lose their excess height, and thumbnail images fill their buttons. The header menu also wraps when the window narrows instead of overlapping the logo and icons.

These changes correct flex fieldset layout, select label clipping and baselines, intrinsic height measurements, percentage heights through anonymous button boxes, and intrinsic minimums on flexible grid tracks.

Before:

<img width="1624" height="1003" alt="Screenshot 2026-09-07 at 17 11 14" src="https://github.com/user-attachments/assets/d16a8918-683b-431f-a5b4-68a0c5750ea1" />

After:

<img width="1624" height="1003" alt="Screenshot 2026-09-07 at 17 07 36" src="https://github.com/user-attachments/assets/e188aab4-e29c-4400-80ce-90c2e2ab8652" />