### PR TITLE
LibJS+LibWeb: Cache inherited document property reads

### DIFF
--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -214,6 +214,11 @@ void Object::unsafe_set_shape(Shape& shape)
     ensure_named_storage_capacity(shape.property_count());
 }
 
+void Object::invalidate_property_lookup_caches()
+{
+    set_shape(m_shape->create_dictionary_transition());
+}
+
 // 7.2 Testing and Comparison Operations, https://tc39.es/ecma262/#sec-testing-and-comparison-operations
 
 // 7.2.5 IsExtensible ( O ), https://tc39.es/ecma262/#sec-isextensible-o

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -375,6 +375,7 @@ public:
     void unsafe_set_shape(Shape&);
 
     void convert_to_prototype_if_needed();
+    void invalidate_property_lookup_caches();
 
     template<typename T>
     bool fast_is() const = delete;

--- a/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -300,8 +300,10 @@ bool PlatformObject::is_cacheable_for_inherited_property() const
 {
     if (!is_legacy_platform_object())
         return true;
-    return !(m_legacy_platform_object_flags->supports_named_properties
-        && m_legacy_platform_object_flags->has_legacy_override_built_ins_interface_extended_attribute);
+    if (!m_legacy_platform_object_flags->supports_named_properties
+        || !m_legacy_platform_object_flags->has_legacy_override_built_ins_interface_extended_attribute)
+        return true;
+    return is<DOM::Document>(wrappable_impl()) && host_defined_wrapper_world(realm()).is_main_world();
 }
 
 // https://webidl.spec.whatwg.org/#legacy-platform-object-getownproperty

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8764,6 +8764,12 @@ static bool is_potentially_named_element_by_id(DOM::Element const& element)
     return is<HTML::HTMLObjectElement>(element) || is<HTML::HTMLImageElement>(element);
 }
 
+// https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem-filter
+static bool is_named_element_by_id(DOM::Element const& element)
+{
+    return is<HTML::HTMLObjectElement>(element) || (is<HTML::HTMLImageElement>(element) && element.name().has_value());
+}
+
 static void insert_in_tree_order(Vector<GC::Ref<DOM::Element>>& elements, DOM::Element& element)
 {
     for (auto& el : elements) {
@@ -8785,10 +8791,13 @@ void Document::element_id_changed(Badge<DOM::Element>, GC::Ref<DOM::Element> ele
     for (auto* form_associated_element : m_form_associated_elements_with_form_attribute)
         form_associated_element->element_id_changed({});
 
-    if (element->id().has_value())
+    if (element->id().has_value()) {
         insert_in_tree_order(m_potentially_named_elements, element);
-    else if (!element->name().has_value())
+        if (is_named_element_by_id(*element))
+            did_add_supported_property_name();
+    } else if (!element->name().has_value()) {
         (void)m_potentially_named_elements.remove_first_matching([element](auto& e) { return e == element; });
+    }
 
     auto new_id = element->id();
     if (old_id.has_value()) {
@@ -8804,8 +8813,11 @@ void Document::element_with_id_was_added(Badge<DOM::Element>, GC::Ref<DOM::Eleme
     for (auto* form_associated_element : m_form_associated_elements_with_form_attribute)
         form_associated_element->element_with_id_was_added_or_removed({});
 
-    if (is_potentially_named_element_by_id(*element))
+    if (is_potentially_named_element_by_id(*element)) {
         insert_in_tree_order(m_potentially_named_elements, element);
+        if (is_named_element_by_id(*element))
+            did_add_supported_property_name();
+    }
 
     if (auto id = element->id(); id.has_value()) {
         element->document_or_shadow_root_element_by_id_map().add(id.value(), element);
@@ -8828,6 +8840,8 @@ void Document::element_name_changed(Badge<DOM::Element>, GC::Ref<DOM::Element> e
 {
     if (element->name().has_value()) {
         insert_in_tree_order(m_potentially_named_elements, element);
+        if (is_potentially_named_element(element))
+            did_add_supported_property_name();
     } else {
         if (is_potentially_named_element_by_id(element) && element->id().has_value())
             return;
@@ -8837,8 +8851,16 @@ void Document::element_name_changed(Badge<DOM::Element>, GC::Ref<DOM::Element> e
 
 void Document::element_with_name_was_added(Badge<DOM::Element>, GC::Ref<DOM::Element> element)
 {
-    if (is_potentially_named_element(element))
+    if (is_potentially_named_element(element)) {
         insert_in_tree_order(m_potentially_named_elements, element);
+        did_add_supported_property_name();
+    }
+}
+
+void Document::did_add_supported_property_name()
+{
+    if (auto wrapper = cached_main_world_wrapper())
+        wrapper->invalidate_property_lookup_caches();
 }
 
 void Document::element_with_name_was_removed(Badge<DOM::Element>, GC::Ref<DOM::Element> element)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1460,6 +1460,7 @@ protected:
     void initialize_document();
 
 private:
+    void did_add_supported_property_name();
     friend struct AdoptedStyleSheetsAccess;
 
     void finish_animated_style_update();

--- a/Tests/LibWeb/Text/expected/DOM/document-named-property-invalidates-cached-lookups.txt
+++ b/Tests/LibWeb/Text/expected/DOM/document-named-property-invalidates-cached-lookups.txt
@@ -1,0 +1,4 @@
+form named images: true
+object with id forms: true
+image with only an id: false
+iframe renamed after insertion: true

--- a/Tests/LibWeb/Text/input/DOM/document-named-property-invalidates-cached-lookups.html
+++ b/Tests/LibWeb/Text/input/DOM/document-named-property-invalidates-cached-lookups.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function readImages(object) {
+            return object.images;
+        }
+        for (let i = 0; i < 5; ++i)
+            readImages(document);
+        const form = document.createElement("form");
+        form.name = "images";
+        document.body.append(form);
+        println(`form named images: ${readImages(document) === form}`);
+
+        function readForms(object) {
+            return object.forms;
+        }
+        for (let i = 0; i < 5; ++i)
+            readForms(document);
+        const object = document.createElement("object");
+        document.body.append(object);
+        object.id = "forms";
+        println(`object with id forms: ${readForms(document) === object}`);
+
+        function readLinks(object) {
+            return object.links;
+        }
+        for (let i = 0; i < 5; ++i)
+            readLinks(document);
+        const image = document.createElement("img");
+        image.id = "links";
+        document.body.append(image);
+        println(`image with only an id: ${readLinks(document) === image}`);
+
+        function readTitle(object) {
+            return object.title;
+        }
+        for (let i = 0; i < 5; ++i)
+            readTitle(document);
+        const iframe = document.createElement("iframe");
+        document.body.append(iframe);
+        iframe.name = "title";
+        println(`iframe renamed after insertion: ${readTitle(document) === iframe.contentWindow}`);
+    });
+</script>


### PR DESCRIPTION
Previously, a read of an inherited document property, such as `document.getElementById()`, was never cached, because a named element added later could shadow it. Every such read in a hot loop therefore walked the prototype chain and rebuilt the document's supported property names on the way.

We now cache these reads and invalidate the cached lookups on the document's main world wrapper whenever an element that contributes a supported property name is added or renamed. Form elements and `DOMStringMap` objects keep refusing to cache reads of their inherited properties.

This restores the performance of the `WebKit*` benchmarks that regressed after 8169a8988d0:
```
Benchmark       Suite        Test                                    Speedup  Old (Mean ± Range)    New (Mean ± Range)
--------------  -----------  ------------------------------------  ---------  --------------------  --------------------
WebKitBindings               append-child                              1.117  0.08 ± 0.01           0.08 ± 0.00
WebKitBindings               childNodes-traversal                      1.05   0.12 ± 0.00           0.12 ± 0.00
WebKitBindings               children-traversal                        1.112  0.12 ± 0.00           0.11 ± 0.00
WebKitBindings               create-element                            1.641  0.13 ± 0.00           0.08 ± 0.00
WebKitBindings               document-implementation                   8.528  0.42 ± 0.00           0.05 ± 0.01
WebKitBindings               event-target-wrapper                      1.015  0.03 ± 0.00           0.03 ± 0.00
WebKitBindings               first-child                               1.019  0.02 ± 0.00           0.02 ± 0.00
WebKitBindings               gc-forest                                 1.571  0.40 ± 0.01           0.26 ± 0.01
WebKitBindings               gc-mini-tree                              1.444  0.53 ± 0.01           0.37 ± 0.01
WebKitBindings               gc-tree                                   1.302  0.78 ± 0.21           0.60 ± 0.13
WebKitBindings               get-attribute                             1.034  0.11 ± 0.00           0.11 ± 0.00
WebKitBindings               get-element-by-id                         3.774  0.43 ± 0.01           0.11 ± 0.00
WebKitBindings               get-elements-by-tag-name                  0.881  0.10 ± 0.01           0.11 ± 0.19
WebKitBindings               id-getter                                 1.018  0.04 ± 0.00           0.04 ± 0.00
WebKitBindings               id-setter                                 1.092  0.08 ± 0.02           0.07 ± 0.01
WebKitBindings               insert-before                             1.071  0.08 ± 0.00           0.08 ± 0.00
WebKitBindings               node-list-access                          1.011  0.10 ± 0.00           0.10 ± 0.00
WebKitBindings               scroll-top                                0.987  0.11 ± 0.00           0.11 ± 0.00
WebKitBindings               set-attribute                             0.991  0.07 ± 0.00           0.07 ± 0.00
WebKitBindings               typed-array-construct-from-array          1.011  0.11 ± 0.00           0.11 ± 0.00
WebKitBindings               typed-array-construct-from-same-type      0.939  0.06 ± 0.02           0.06 ± 0.00
WebKitBindings               typed-array-construct-from-typed          1.008  0.12 ± 0.02           0.12 ± 0.03
WebKitBindings               typed-array-set-from-typed                1.016  0.11 ± 0.00           0.11 ± 0.00
WebKitBindings               undefined-first-child                     1.009  0.02 ± 0.00           0.02 ± 0.00
WebKitBindings               undefined-get-element-by-id               3.945  0.43 ± 0.00           0.11 ± 0.00
WebKitBindings               undefined-id-getter                       1.033  0.06 ± 0.00           0.06 ± 0.00
WebKitCSS                    CSSPropertySetterGetter                   0.995  0.01 ± 0.00           0.01 ± 0.00
WebKitCSS                    CSSPropertyUpdateValue                    1.033  0.03 ± 0.00           0.03 ± 0.00
WebKitCSS                    FontFaceSetUpdateStyle                    1.012  0.10 ± 0.04           0.09 ± 0.03
WebKitCSS                    HasWithChildCombinatorInIs                0.988  0.04 ± 0.00           0.04 ± 0.00
WebKitCSS                    ManyMatchMediaInstances                   0.904  0.01 ± 0.01           0.01 ± 0.01
WebKitCSS                    PseudoClassSelectors                      2.262  0.27 ± 0.00           0.12 ± 0.00
WebKitCSS                    QuerySelector                             1.711  0.06 ± 0.00           0.03 ± 0.00
WebKitCSS                    StyleSheetInsert                          1.091  0.00 ± 0.00           0.00 ± 0.00
WebKitCSS                    WhereIsClassRuleIndexing                  1.017  0.04                  0.04 ± 0.00
WebKitCSS                    WhereIsRuleIndexing                       1.04   0.15 ± 0.02           0.15 ± 0.01
WebKitDOM                    Accessors                                 1.194  0.24 ± 0.00           0.20 ± 0.00
WebKitDOM                    CloneNodes                                0.999  0.32 ± 0.03           0.32 ± 0.02
WebKitDOM                    CreateNodes                               1.03   0.31 ± 0.05           0.30 ± 0.07
WebKitDOM                    DOMDivWalk                                1.049  0.06 ± 0.01           0.06 ± 0.01
WebKitDOM                    DOMTable                                  1.021  0.67 ± 0.05           0.66 ± 0.04
WebKitDOM                    DOMWalk                                   0.926  0.01 ± 0.00           0.01 ± 0.00
WebKitDOM                    Events                                    1.013  0.13 ± 0.00           0.13 ± 0.01
WebKitDOM                    GetElement                                1.038  0.20 ± 0.01           0.20 ± 0.01
WebKitDOM                    GridSort                                  0.963  0.01 ± 0.00           0.01 ± 0.00
WebKitDOM                    ModifyAttribute                           1.002  0.34 ± 0.00           0.34 ± 0.00
WebKitDOM                    Template                                  1.022  0.01 ± 0.00           0.01 ± 0.00
WebKitDOM                    large-table-edit                          1.028  0.08 ± 0.00           0.07 ± 0.00
WebKitDOM                    textarea-dom                              0.985  0.10 ± 0.00           0.10 ± 0.00
WebKitDOM                    textarea-edit                             2.119  0.19 ± 0.00           0.09 ± 0.00
WebKitDOM       MessagePort  throughput-same-context                   1.04   0.05 ± 0.00           0.04 ± 0.01
WebKitDOM       MessagePort  throughput-same-context-batch             0.598  0.04 ± 0.00           0.07 ± 0.04
WebKitDOM       MessagePort  throughput-same-context-new-ports         0.85   0.01 ± 0.00           0.01 ± 0.01
WebKitParser                 HTML5-8266-ParseOnly                      1.028  0.40 ± 0.07           0.39 ± 0.07
WebKitParser                 css-parser-yui                            1.009  0.06 ± 0.00           0.06 ± 0.00
WebKitParser                 html-parser                               1.023  0.39 ± 0.22           0.38 ± 0.22
WebKitParser                 iframe-append-remove                      1.088  0.05 ± 0.00           0.04 ± 0.00
WebKitParser                 innerHTML-setter                          1.088  0.03 ± 0.00           0.02 ± 0.00
WebKitParser                 query-selector-deep                       2.649  0.18 ± 0.00           0.07 ± 0.00
WebKitParser                 query-selector-first                      2.649  0.22 ± 0.00           0.08 ± 0.00
WebKitParser                 query-selector-last                       2.637  0.17 ± 0.00           0.07 ± 0.00
WebKitParser                 simple-url                                1.125  0.03 ± 0.00           0.02 ± 0.00
WebKitParser                 textarea-parsing                          1.035  0.08 ± 0.00           0.07 ± 0.00
WebKitParser                 tiny-innerHTML                            1.037  0.08 ± 0.00           0.08 ± 0.00
WebKitParser                 url-parser                                1.153  0.01 ± 0.01           0.01 ± 0.00
WebKitParser                 xml-parser                                0.995  0.08 ± 0.00           0.08 ± 0.00

Benchmark       Old Score    New Score    Score Improvement    Old Total Time (s)    New Total Time (s)      Speedup
--------------  -----------  -----------  -------------------  --------------------  --------------------  ---------
WebKitBindings  —            —            —                    4.67 ± 0.21           3.09 ± 0.22               1.511
WebKitCSS       —            —            —                    0.71 ± 0.06           0.53 ± 0.05               1.342
WebKitDOM       —            —            —                    2.77 ± 0.06           2.62 ± 0.06               1.055
WebKitParser    —            —            —                    1.77 ± 0.30           1.38 ± 0.30               1.282
```

Other benchmarks are flat:
| Benchmark | old score | new score | old total (s) | new total (s) | speedup |
|---|---|---|---|---|---|
| MicroWeb | - | - | 7.86 ± 0.09 | 7.75 ± 0.09 | 1.015 |
| StyleBench | 152.18 ± 1.27 | 152.28 ± 1.26 | 1.64 ± 0.01 | 1.64 ± 0.01 | 1.001 |
| Speedometer2 | 80.71 ± 0.70 | 80.54 ± 0.58 | 6.47 ± 0.03 | 6.51 ± 0.04 | 0.994 |
| Speedometer3 | 5.15 ± 0.07 | 5.17 ± 0.07 | 4.96 ± 0.08 | 4.95 ± 0.08 | 1.003 |