### PR TITLE
LibWeb: Pace idle periods instead of continuously restarting them

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -69,6 +69,7 @@ void EventLoop::visit_edges(Visitor& visitor)
     visitor.visit(m_backup_incumbent_realm_stack);
     visitor.visit(m_rendering_task_function);
     visitor.visit(m_system_event_loop_timer);
+    visitor.visit(m_idle_period_timer);
 }
 
 void EventLoop::schedule()
@@ -217,16 +218,35 @@ void EventLoop::process()
     }
 
     // 5. If this is a window event loop that has no runnable task in this event loop's task queues, then:
-    if (m_type == Type::Window && !m_task_queue->has_runnable_tasks()) {
-        // 1. Set this event loop's last idle period start time to the unsafe shared current time.
-        m_last_idle_period_start_time = HighResolutionTime::unsafe_shared_current_time();
+    if (m_type == Type::Window && !m_task_queue->has_runnable_tasks() && (!m_idle_period_timer || !m_idle_period_timer->is_active())) {
+        auto windows = same_loop_windows();
+        bool has_idle_callbacks = false;
+        for (auto& window : windows) {
+            if (!window->associated_document().hidden() && window->has_idle_callbacks()) {
+                has_idle_callbacks = true;
+                break;
+            }
+        }
+        if (has_idle_callbacks) {
+            // NB: Delay the next idle period until this one's 50 ms budget has elapsed. Callbacks registered
+            //     during an idle period belong to the next one; immediately starting it lets self-scheduling
+            //     callbacks spin continuously even when they have no work to do.
+            if (!m_idle_period_timer) {
+                m_idle_period_timer = Platform::Timer::create_single_shot(GC::Heap::the(), 50, GC::create_function(GC::Heap::the(), [this] {
+                    schedule();
+                }));
+            }
+            m_idle_period_timer->restart();
 
-        // 2. Let computeDeadline be the following steps:
-        // Implemented in EventLoop::compute_deadline()
+            // 1. Set this event loop's last idle period start time to the unsafe shared current time.
+            m_last_idle_period_start_time = HighResolutionTime::unsafe_shared_current_time();
 
-        // 3. For each win of the same-loop windows for this event loop, perform the start an idle period algorithm for win with the following step: return the result of calling computeDeadline, coarsened given win's relevant settings object's cross-origin isolated capability. [REQUESTIDLECALLBACK]
-        for (auto& win : same_loop_windows()) {
-            win->start_an_idle_period();
+            // 2. Let computeDeadline be the following steps:
+            // Implemented in EventLoop::compute_deadline()
+
+            // 3. For each win of the same-loop windows for this event loop, perform the start an idle period algorithm for win with the following step: return the result of calling computeDeadline, coarsened given win's relevant settings object's cross-origin isolated capability. [REQUESTIDLECALLBACK]
+            for (auto& window : windows)
+                window->start_an_idle_period();
         }
     }
 

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -160,6 +160,7 @@ private:
     double m_last_idle_period_start_time { 0 };
 
     GC::Ptr<Platform::Timer> m_system_event_loop_timer;
+    GC::Ptr<Platform::Timer> m_idle_period_timer;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#performing-a-microtask-checkpoint
     bool m_performing_a_microtask_checkpoint { false };

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -159,6 +159,7 @@ public:
     WebIDL::ExceptionOr<GC::Ref<Storage>> session_storage();
 
     void start_an_idle_period();
+    bool has_idle_callbacks() const { return !m_idle_request_callbacks.is_empty() || !m_runnable_idle_callbacks.is_empty(); }
 
     // https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation
     bool has_sticky_activation() const;

--- a/Tests/LibWeb/Text/expected/request-idle-callback-nested.txt
+++ b/Tests/LibWeb/Text/expected/request-idle-callback-nested.txt
@@ -1,0 +1,2 @@
+first, microtask, second, nested
+later callback ran

--- a/Tests/LibWeb/Text/input/request-idle-callback-nested.html
+++ b/Tests/LibWeb/Text/input/request-idle-callback-nested.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    asyncTest(async done => {
+        const events = [];
+        const { promise, resolve } = Promise.withResolvers();
+        requestIdleCallback(() => {
+            events.push("first");
+            const cancelled = requestIdleCallback(() => events.push("cancelled"));
+            cancelIdleCallback(cancelled);
+            requestIdleCallback(() => {
+                events.push("nested");
+                resolve();
+            });
+            queueMicrotask(() => events.push("microtask"));
+        });
+        requestIdleCallback(() => events.push("second"));
+        await promise;
+        println(events.join(", "));
+        // A later registration must wake the idle scheduler after the old queue has drained.
+        await new Promise(resolve => requestIdleCallback(resolve));
+        println("later callback ran");
+        done();
+    });
+</script>


### PR DESCRIPTION
A callback that posts another idle callback could start a new idle period immediately after its microtasks drained. GitHub's progressive diff loader uses this pattern to poll an empty queue, causing hundreds of thousands of callbacks and substantial allocation and GC work.

Keep a single-shot timer for the current 50 ms idle-period budget and start another period only after it expires. Wake the event loop when the budget expires, and avoid starting periods without visible idle work. Ordinary tasks and idle callback timeouts remain independently scheduled.

Cover nested callbacks, cancellation, microtask ordering, and subsequent registrations after the idle queue drains.