### PR TITLE
LibJS+LibWeb: Reduce bytecode compilation overhead

### DIFF
--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -1727,29 +1727,7 @@ impl Generator {
         for block in &mut self.basic_blocks {
             remove_redundant_movs(&mut block.instructions);
 
-            let mut index = 0;
-            while index < block.instructions.len() {
-                let instructions = block.instructions[index..]
-                    .iter()
-                    .map(|(instruction, _, _)| instruction);
-                let Some((specialized, component_count)) =
-                    specialize_instruction_sequence(instructions, &self.constants)
-                else {
-                    index += 1;
-                    continue;
-                };
-                let strict = block.instructions[index].2;
-                if block.instructions[index..index + component_count]
-                    .iter()
-                    .any(|(_, _, component_strict)| *component_strict != strict)
-                {
-                    index += 1;
-                    continue;
-                }
-                block.instructions[index].0 = specialized;
-                block.instructions.drain(index + 1..index + component_count);
-                index += 1;
-            }
+            specialize_instructions(&mut block.instructions, &self.constants);
         }
 
         let number_of_registers = self.next_register;
@@ -2137,6 +2115,32 @@ pub fn choose_dst(generator: &mut Generator, preferred_dst: Option<&ScopedOperan
     }
 }
 
+fn specialize_instructions(instructions: &mut Vec<(Instruction, SourceMapEntry, bool)>, constants: &[ConstantValue]) {
+    let mut read_index = 0;
+    let mut write_index = 0;
+    while read_index < instructions.len() {
+        let mut consumed = 1;
+        if let Some((specialized, component_count)) = specialize_instruction_sequence(
+            instructions[read_index..].iter().map(|(instruction, _, _)| instruction),
+            constants,
+        ) {
+            let strict = instructions[read_index].2;
+            if instructions[read_index..read_index + component_count]
+                .iter()
+                .all(|(_, _, component_strict)| *component_strict == strict)
+            {
+                instructions[read_index].0 = specialized;
+                consumed = component_count;
+            }
+        }
+        // Compact once instead of shifting the entire tail after each fused sequence.
+        instructions.swap(write_index, read_index);
+        write_index += 1;
+        read_index += consumed;
+    }
+    instructions.truncate(write_index);
+}
+
 fn remove_redundant_movs(instructions: &mut Vec<(Instruction, SourceMapEntry, bool)>) {
     let mut index = 0;
     while index < instructions.len() {
@@ -2196,6 +2200,67 @@ mod tests {
 
     fn register(index: u32) -> Operand {
         Operand::register(Register(index))
+    }
+
+    #[test]
+    fn compacts_fused_sequences_with_their_original_source_locations() {
+        let mut instructions: Vec<_> = (0..3000)
+            .map(|index| {
+                let mut instruction = mov(register(index), Operand::constant(0));
+                instruction.1.line = index;
+                instruction
+            })
+            .collect();
+        specialize_instructions(&mut instructions, &[ConstantValue::Undefined]);
+        assert_eq!(instructions.len(), 1000);
+        for (index, (instruction, source, strict)) in instructions.iter().enumerate() {
+            assert!(matches!(instruction, Instruction::MovUndefined3 { .. }));
+            assert_eq!(source.line, index as u32 * 3);
+            assert!(!strict);
+        }
+    }
+
+    #[test]
+    fn preserves_strict_mode_boundaries_when_compacting_fused_sequences() {
+        let mut instructions: Vec<_> = (0..7)
+            .map(|index| {
+                let mut instruction = mov(register(index), Operand::constant(0));
+                instruction.1.line = index;
+                instruction.2 = index >= 3;
+                instruction
+            })
+            .collect();
+        specialize_instructions(&mut instructions, &[ConstantValue::Undefined]);
+        assert_eq!(instructions.len(), 3);
+        assert!(matches!(instructions[0].0, Instruction::MovUndefined3 { .. }));
+        assert!(matches!(instructions[1].0, Instruction::MovUndefined3 { .. }));
+        assert!(matches!(instructions[2].0, Instruction::MovSrcUndefined { .. }));
+        assert_eq!(
+            instructions
+                .iter()
+                .map(|(_, source, strict)| (source.line, *strict))
+                .collect::<Vec<_>>(),
+            vec![(0, false), (3, true), (6, true)]
+        );
+    }
+
+    #[test]
+    fn does_not_fuse_a_sequence_that_crosses_strict_mode_boundaries() {
+        let mut instructions = vec![
+            mov(register(0), Operand::constant(0)),
+            mov(register(1), Operand::constant(0)),
+            mov(register(2), Operand::constant(0)),
+        ];
+        instructions[1].2 = true;
+        specialize_instructions(&mut instructions, &[ConstantValue::Undefined]);
+        assert_eq!(instructions.len(), 3);
+        assert!(matches!(instructions[0].0, Instruction::Mov { .. }));
+        assert!(matches!(instructions[1].0, Instruction::Mov { .. }));
+        assert!(matches!(instructions[2].0, Instruction::MovSrcUndefined { .. }));
+        assert_eq!(
+            instructions.iter().map(|(_, _, strict)| *strict).collect::<Vec<_>>(),
+            vec![false, true, false]
+        );
     }
 
     #[test]

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -768,6 +768,33 @@ fn compile_parsed_program_off_thread_impl(
     }
 }
 
+/// Retain an independent parse snapshot for background cache generation.
+/// The immutable arena and compiled regex handles are shared; function-table
+/// ownership is independent so either compilation can consume its functions.
+///
+/// # Safety
+/// `parsed` must point to a valid parsed program with no errors.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_clone_parsed_program(parsed: *const ParsedProgram) -> *mut ParsedProgram {
+    unsafe {
+        abort_on_panic(|| {
+            let parsed = &*parsed;
+            assert!(parsed.errors.is_empty());
+            Box::into_raw(Box::new(ParsedProgram {
+                program: parsed.program.clone(),
+                function_table: parsed.function_table.clone(),
+                arena: parsed.arena.clone(),
+                scope_ref: parsed.scope_ref,
+                program_type: parsed.program_type,
+                is_strict_mode: parsed.is_strict_mode,
+                has_top_level_await: parsed.has_top_level_await,
+                errors: Vec::new(),
+                ast_dump: None,
+            }))
+        })
+    }
+}
+
 /// Compile a parsed program to an off-thread bytecode artifact.
 ///
 /// Consumes and frees the ParsedProgram. The returned CompiledProgram still needs to be materialized on the main thread

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -536,6 +536,11 @@ ParsedProgram* parse_program(u16 const* utf16_data, size_t length_in_code_units,
     return rust_parse_program(utf16_data, length_in_code_units, static_cast<u8>(type), line_number_offset, g_dump_ast, g_dump_ast_use_color);
 }
 
+ParsedProgram* clone_parsed_program(ParsedProgram const* parsed)
+{
+    return rust_clone_parsed_program(parsed);
+}
+
 CompiledProgram* compile_parsed_program_off_thread(ParsedProgram* parsed, size_t length_in_code_units)
 {
     return rust_compile_parsed_program_off_thread(parsed, length_in_code_units);

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -93,6 +93,9 @@ struct ModuleResult {
 // Parse a program (script or module) without GC interaction. Thread-safe.
 JS_API FFI::ParsedProgram* parse_program(u16 const* utf16_data, size_t length_in_code_units, ProgramType type, size_t line_number_offset = 0);
 
+// Clone an error-free parsed program for an independent compilation. Thread-safe.
+JS_API FFI::ParsedProgram* clone_parsed_program(FFI::ParsedProgram const*);
+
 // Compile a parsed program to bytecode without touching the VM or GC. Thread-safe.
 JS_API FFI::CompiledProgram* compile_parsed_program_off_thread(FFI::ParsedProgram* parsed, size_t length_in_code_units);
 

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -52,9 +52,29 @@
 
 namespace Web::HTML {
 
+class ParsedProgramForCache {
+public:
+    explicit ParsedProgramForCache(JS::FFI::ParsedProgram* program)
+        : m_program(program)
+    {
+    }
+
+    ~ParsedProgramForCache()
+    {
+        if (m_program)
+            JS::RustIntegration::free_parsed_program(m_program);
+    }
+
+    JS::FFI::ParsedProgram* release() { return exchange(m_program, nullptr); }
+
+private:
+    JS::FFI::ParsedProgram* m_program;
+};
+
 struct OffThreadCompiledProgram {
     JS::FFI::ParsedProgram* parsed { nullptr };
     JS::FFI::CompiledProgram* compiled { nullptr };
+    OwnPtr<ParsedProgramForCache> cache_parse {};
 };
 
 struct BytecodeCacheContext {
@@ -177,13 +197,13 @@ static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::
 // Schedule a fresh, fully off-thread compile of the script source for the purpose of producing a bytecode cache blob.
 // The execution path has already received its (latency-trimmed) compile artifact and is running, so this work happens
 // entirely on a background thread and never blocks the main thread on cache generation.
-// Reparsing here is intentional: the execution-path compile only eagerly generates top-level bytecode plus direct
-// IIFEs, while the cache wants every nested function compiled so that warm loads avoid lazy compile work entirely. Once
-// the blob is back on the main thread, try to install that same blob into the live script/module before storing it.
-static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode const> original_source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, BytecodeCacheContext cache_context, BytecodeCacheInstallTarget install_target, BytecodeCacheSourceHash source_hash)
+// NB: The execution-path compile only eagerly generates top-level bytecode plus direct IIFEs. Retain a parse snapshot
+//     for the cache compilation, which compiles every nested function, instead of parsing the same source again. Once
+//     the blob is back on the main thread, try to install it into the live script/module before storing it.
+static void schedule_bytecode_cache_generation(OwnPtr<ParsedProgramForCache> cache_parse, NonnullRefPtr<JS::SourceCode const> original_source_code, JS::RustIntegration::ProgramType type, BytecodeCacheContext cache_context, BytecodeCacheInstallTarget install_target, BytecodeCacheSourceHash source_hash)
 {
-    auto filename = original_source_code->filename();
-    auto source_code = original_source_code->code();
+    VERIFY(cache_parse);
+    auto source_length = original_source_code->length_in_code_units();
     auto& main_thread_event_loop = Core::EventLoop::current();
     auto* callback = new Function<void(ByteBuffer, BytecodeCacheSourceHash)>(
         [cache_context = move(cache_context), install_target = move(install_target), original_source_code = move(original_source_code), type](ByteBuffer blob, auto source_hash) mutable {
@@ -202,21 +222,12 @@ static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode cons
                 Fetch::Fetching::update_javascript_bytecode_cache_in_http_memory_cache(*cache_context.memory_cache_partition_key, cache_context.url, cache_context.method, *cache_context.memory_cache_request_headers, cache_context.vary_key, immutable_blob);
         });
 
-    Threading::ThreadPool::the().submit([filename = move(filename), source_code = move(source_code), type, line_number_offset, callback, &main_thread_event_loop, source_hash]() mutable {
-        auto source = JS::SourceCode::create(move(filename), move(source_code));
+    Threading::ThreadPool::the().submit([cache_parse = move(cache_parse), source_length, type, callback, &main_thread_event_loop, source_hash]() mutable {
         ByteBuffer blob;
-
-        auto* parsed = JS::RustIntegration::parse_program(source->utf16_data(), source->length_in_code_units(), type, line_number_offset);
-        if (parsed) {
-            if (JS::RustIntegration::parsed_program_has_errors(parsed)) {
-                JS::RustIntegration::free_parsed_program(parsed);
-            } else {
-                auto* compiled = JS::RustIntegration::compile_parsed_program_fully_off_thread(parsed, source->length_in_code_units());
-                if (compiled) {
-                    blob = JS::RustIntegration::serialize_compiled_program_for_bytecode_cache(*compiled, type, source_hash.bytes());
-                    JS::RustIntegration::free_compiled_program(compiled);
-                }
-            }
+        auto* compiled = JS::RustIntegration::compile_parsed_program_fully_off_thread(cache_parse->release(), source_length);
+        if (compiled) {
+            blob = JS::RustIntegration::serialize_compiled_program_for_bytecode_cache(*compiled, type, source_hash.bytes());
+            JS::RustIntegration::free_compiled_program(compiled);
         }
 
         main_thread_event_loop.deferred_invoke([blob = move(blob), source_hash, callback]() mutable {
@@ -344,7 +355,7 @@ static void prepare_bytecode_cache_off_thread(Core::ImmutableBytes bytecode, JS:
 // artifacts whose GC-backed Executable materialization must still happen on the main thread.
 // NB: The SourceCode stays on the main thread inside the heap-allocated callback. The worker thread only receives raw
 //     UTF-16 data pointers.
-static void compile_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, Function<void(OffThreadCompiledProgram, NonnullRefPtr<JS::SourceCode const>)> on_compiled)
+static void compile_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, bool retain_parse_for_cache, Function<void(OffThreadCompiledProgram, NonnullRefPtr<JS::SourceCode const>)> on_compiled)
 {
     // Extract the raw data the parser needs while still on the main thread.
     auto const* utf16_data = source_code->utf16_data();
@@ -353,23 +364,25 @@ static void compile_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, 
     // Capture source_code in the callback so it stays alive on the main thread and is available for materialization.
     auto* callback = new Function<void(OffThreadCompiledProgram)>(
         [on_compiled = move(on_compiled), source_code = move(source_code)](OffThreadCompiledProgram result) mutable {
-            on_compiled(result, move(source_code));
+            on_compiled(move(result), move(source_code));
         });
 
     auto& main_thread_event_loop = Core::EventLoop::current();
 
-    Threading::ThreadPool::the().submit([utf16_data, length, type, line_number_offset,
+    Threading::ThreadPool::the().submit([utf16_data, length, type, line_number_offset, retain_parse_for_cache,
                                             callback,
                                             &main_thread_event_loop]() {
         auto* parsed = JS::RustIntegration::parse_program(utf16_data, length, type, line_number_offset);
         OffThreadCompiledProgram result { .parsed = parsed };
         if (parsed && !JS::RustIntegration::parsed_program_has_errors(parsed)) {
+            if (retain_parse_for_cache)
+                result.cache_parse = make<ParsedProgramForCache>(JS::RustIntegration::clone_parsed_program(parsed));
             result.compiled = JS::RustIntegration::compile_parsed_program_off_thread(parsed, length);
             result.parsed = nullptr;
         }
 
-        main_thread_event_loop.deferred_invoke([result, callback]() {
-            (*callback)(result);
+        main_thread_event_loop.deferred_invoke([result = move(result), callback]() mutable {
+            (*callback)(move(result));
             delete callback;
             // AD-HOC: Perform a microtask checkpoint so that any microtasks queued by the callback (e.g. promise
             //         reactions from react_to_promise during module linking) are drained. Without this, module worker
@@ -776,7 +789,8 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                             decode_source_text_to_utf16(*fallback_decoder, source_byte_storage.bytes()).release_value_but_fixme_should_propagate_errors());
                     }
 
-                    compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Script, 1,
+                    auto retain_parse_for_cache = bytecode_cache_context.has_value();
+                    compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Script, 1, retain_parse_for_cache,
                         [response_url = move(response_url), response_url_string = move(response_url_string),
                             bytecode_cache_context = move(bytecode_cache_context),
                             source_hash = move(source_hash),
@@ -799,7 +813,7 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                             if (should_generate_bytecode_cache) {
                                 install_target.begin_generation();
                                 VERIFY(source_hash.has_value());
-                                schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
+                                schedule_bytecode_cache_generation(move(result.cache_parse), move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
                             }
                         });
                 });
@@ -812,7 +826,8 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                 decode_source_text_to_utf16(*fallback_decoder, source_bytes).release_value_but_fixme_should_propagate_errors());
         }
 
-        compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Script, 1,
+        auto retain_parse_for_cache = bytecode_cache_context.has_value();
+        compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Script, 1, retain_parse_for_cache,
             [response_url = move(response_url), response_url_string = move(response_url_string),
                 bytecode_cache_context = move(bytecode_cache_context),
                 source_hash = move(source_hash),
@@ -835,7 +850,7 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                 if (should_generate_bytecode_cache) {
                     install_target.begin_generation();
                     VERIFY(source_hash.has_value());
-                    schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
+                    schedule_bytecode_cache_generation(move(result.cache_parse), move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
                 }
             });
     };
@@ -1226,7 +1241,8 @@ void fetch_single_module_script(JS::Realm& realm,
                                     decode_source_text_to_utf16(*fallback_decoder, source_byte_storage.bytes()).release_value_but_fixme_should_propagate_errors());
                             }
 
-                            compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Module, 0,
+                            auto retain_parse_for_cache = bytecode_cache_context.has_value();
+                            compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Module, 0, retain_parse_for_cache,
                                 [url = move(url), url_string = move(url_string), response_url = move(response_url),
                                     module_type_string = move(module_type_string),
                                     bytecode_cache_context = move(bytecode_cache_context),
@@ -1251,7 +1267,7 @@ void fetch_single_module_script(JS::Realm& realm,
                                     if (should_generate_bytecode_cache) {
                                         install_target.begin_generation();
                                         VERIFY(source_hash.has_value());
-                                        schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
+                                        schedule_bytecode_cache_generation(move(result.cache_parse), move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
                                     }
                                 });
                         });
@@ -1264,7 +1280,8 @@ void fetch_single_module_script(JS::Realm& realm,
                         decode_source_text_to_utf16(*decoder, source_bytes).release_value_but_fixme_should_propagate_errors());
                 }
 
-                compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Module, 0,
+                auto retain_parse_for_cache = bytecode_cache_context.has_value();
+                compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Module, 0, retain_parse_for_cache,
                     [url = move(url), url_string = move(url_string), response_url = move(response_url),
                         module_type_string = move(module_type_string),
                         bytecode_cache_context = move(bytecode_cache_context),
@@ -1289,7 +1306,7 @@ void fetch_single_module_script(JS::Realm& realm,
                         if (should_generate_bytecode_cache) {
                             install_target.begin_generation();
                             VERIFY(source_hash.has_value());
-                            schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
+                            schedule_bytecode_cache_generation(move(result.cache_parse), move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
                         }
                     });
                 return;

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -1101,3 +1101,57 @@ TEST_CASE(fresh_instruction_stream_is_readonly_mapped)
 #    endif
 #endif
 }
+
+TEST_CASE(parse_snapshot_survives_independent_execution_and_cache_compilation)
+{
+    for (bool execute_before_cache : { false, true }) {
+        auto vm = JS::VM::create();
+        auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+        auto& realm = *root_execution_context->realm;
+        auto source = R"JS(
+            function outer(text) {
+                class Matcher {
+                    #pattern = /a+/u;
+                    matches() { return this.#pattern.test(text); }
+                }
+                return () => new Matcher().matches();
+            }
+            outer("aaa")();
+        )JS"sv;
+        auto source_code = JS::SourceCode::create("snapshot.js"_utf16, Utf16String::from_utf8(source));
+        auto* parsed = JS::RustIntegration::parse_program(source_code->utf16_data(), source_code->length_in_code_units(), JS::RustIntegration::ProgramType::Script);
+        VERIFY(parsed);
+        VERIFY(!JS::RustIntegration::parsed_program_has_errors(parsed));
+        auto* snapshot = JS::RustIntegration::clone_parsed_program(parsed);
+        VERIFY(snapshot);
+
+        auto* compiled = JS::RustIntegration::compile_parsed_program_off_thread(parsed, source_code->length_in_code_units());
+        VERIFY(compiled);
+        auto script_or_error = JS::Script::create_from_compiled(compiled, source_code, realm, "snapshot.js"sv);
+        VERIFY(!script_or_error.is_error());
+        auto script = script_or_error.release_value();
+        auto execute_original = [&] {
+            auto result = vm->run(script);
+            VERIFY(!result.is_throw_completion());
+            EXPECT_EQ(result.value(), JS::Value(true));
+        };
+        if (execute_before_cache)
+            execute_original();
+
+        auto* compiled_snapshot = JS::RustIntegration::compile_parsed_program_fully_off_thread(snapshot, source_code->length_in_code_units());
+        VERIFY(compiled_snapshot);
+        auto source_hash = bytecode_cache_source_hash(source, "UTF-8"sv);
+        auto blob = JS::RustIntegration::serialize_compiled_program_for_bytecode_cache(*compiled_snapshot, JS::RustIntegration::ProgramType::Script, source_hash.bytes());
+        JS::RustIntegration::free_compiled_program(compiled_snapshot);
+        VERIFY(!blob.is_empty());
+        if (!execute_before_cache)
+            execute_original();
+
+        auto decoded = decode_bytecode_cache_blob(Core::ImmutableBytes::adopt(move(blob)), JS::RustIntegration::ProgramType::Script, source_hash.bytes());
+        auto cached_script = JS::Script::create_from_bytecode_cache(decoded, source_code, realm, "snapshot.js"sv);
+        VERIFY(!cached_script.is_error());
+        auto result = vm->run(cached_script.release_value());
+        VERIFY(!result.is_throw_completion());
+        EXPECT_EQ(result.value(), JS::Value(true));
+    }
+}


### PR DESCRIPTION
Large bytecode blocks could take quadratic time to compact because each fused sequence shifted the remaining vector. This uses a single read/write pass, reducing compaction from O(n²) to O(n).

Cold script loads also parsed source twice when producing persistent bytecode caches. The execution parse is now cloned and reused for cache generation, reducing that path from two parses to one while preserving full nested-function compilation for classic scripts and modules.

Adds coverage for source-map and strict-mode preservation during fusion, plus independent cache compilation with nested functions, private fields, and regular expressions.
