### PR TITLE
LibWeb: Optimize style invalidation indexing and routing

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/impact.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/impact.rs
@@ -926,6 +926,8 @@ pub(super) struct PatchCover {
     prefix_max_end: Vec<u32>,
     keys: Vec<(RuleID, EntryID)>,
     unindexed: Vec<(ImpactRegion, (RuleID, EntryID))>,
+    /// Exact-node attributions without preorder coordinates, sorted by node and rule key.
+    exact_nodes: Vec<(StyleNodeID, (RuleID, EntryID))>,
 }
 
 /// The normalized impact plan for one transaction.
@@ -1428,37 +1430,45 @@ impl ImpactRegions {
     #[must_use]
     /// Compile the transaction's patch coverage: the unattributed regions as the full
     /// re-derivation trigger, and the attributed emissions as stabbable preorder intervals
-    /// carrying rule keys. Extents without preorder coordinates retain their rule attribution
-    /// and are queried through tree relationships.
+    /// carrying rule keys. Exact-node extents without coordinates are indexed by identity; other
+    /// extents retain their rule attribution and are queried through tree relationships.
     pub(super) fn compile_patch_cover(&self, tree: &StyleNodeTree, document_root: Option<StyleNodeID>) -> PatchCover {
         let mut keys: Vec<(RuleID, EntryID)> = Vec::new();
         let mut key_indices: super::HashMap<(RuleID, EntryID), u32> = super::HashMap::default();
         let mut intervals: Vec<(u32, u32, u32)> = Vec::new();
         let mut unindexed = Vec::new();
+        let mut exact_nodes = Vec::new();
         let mut scratch: Vec<PreorderInterval> = Vec::new();
-        if let Some(topology) = &self.topology {
-            for &(region, key) in &self.attributions {
-                scratch.clear();
-                if !topology.collect_region_intervals(region, tree, document_root, &mut scratch) {
-                    unindexed.push((region, key));
-                    continue;
+        for &(region, key) in &self.attributions {
+            scratch.clear();
+            if !self
+                .topology
+                .as_ref()
+                .is_some_and(|topology| topology.collect_region_intervals(region, tree, document_root, &mut scratch))
+            {
+                // OPTIMIZATION: Exact-node coverage needs no tree coordinates. Index it by identity
+                //               instead of scanning every such attribution for every visited node.
+                match region {
+                    ImpactRegion::Node(node) => exact_nodes.push((node, key)),
+                    _ => unindexed.push((region, key)),
                 }
-                let key_index = match key_indices.get(&key).copied() {
-                    Some(index) => index,
-                    None => {
-                        let index = u32::try_from(keys.len()).expect("patch attribution key space exhausted");
-                        keys.push(key);
-                        key_indices.insert(key, index);
-                        index
-                    }
-                };
-                for interval in &scratch {
-                    intervals.push((interval.start, interval.end, key_index));
-                }
+                continue;
             }
-        } else {
-            unindexed.extend_from_slice(&self.attributions);
+            let key_index = match key_indices.get(&key).copied() {
+                Some(index) => index,
+                None => {
+                    let index = u32::try_from(keys.len()).expect("patch attribution key space exhausted");
+                    keys.push(key);
+                    key_indices.insert(key, index);
+                    index
+                }
+            };
+            for interval in &scratch {
+                intervals.push((interval.start, interval.end, key_index));
+            }
         }
+        exact_nodes.sort_unstable();
+        exact_nodes.dedup();
         intervals.sort_unstable();
         intervals.dedup();
         let mut prefix_max_end = Vec::with_capacity(intervals.len());
@@ -1473,6 +1483,7 @@ impl ImpactRegions {
             prefix_max_end,
             keys,
             unindexed,
+            exact_nodes,
         }
     }
 
@@ -1494,6 +1505,13 @@ impl ImpactRegions {
         out: &mut Vec<(RuleID, EntryID)>,
     ) -> bool {
         out.clear();
+        let first = cover.exact_nodes.partition_point(|&(candidate, _)| candidate < node);
+        out.extend(
+            cover.exact_nodes[first..]
+                .iter()
+                .take_while(|&&(candidate, _)| candidate == node)
+                .map(|&(_, key)| key),
+        );
         out.extend(
             cover
                 .unindexed
@@ -2132,5 +2150,51 @@ mod tests {
         assert!(regions.is_covered_by_subtree(ImpactRegion::Node(fixture.nodes[4]), &fixture.tree));
         assert!(regions.is_covered_by_subtree(ImpactRegion::Children(fixture.nodes[5]), &fixture.tree));
         assert!(!regions.is_covered_by_subtree(ImpactRegion::Subtree(fixture.nodes[2]), &fixture.tree));
+    }
+
+    #[test]
+    fn exact_patch_attributions_are_indexed_without_preorder_coordinates() {
+        let mut memory = MemoryController::new(DeviceClass::ForegroundDesktop);
+        let mut tree = StyleNodeTree::new(&mut memory);
+        let root = tree.allocate_element(&mut memory);
+        let host = tree.allocate_element(&mut memory);
+        let shadow_root = tree.allocate_element(&mut memory);
+        tree.set_first_element_child(root, Some(host));
+        tree.set_parent(host, Some(root));
+        tree.enable_tree_scopes(&mut memory);
+        tree.set_tree_scope(shadow_root, TreeScopeID(1));
+        tree.set_shadow_root(host, shadow_root, &mut memory);
+        let nodes: Vec<_> = (0..128).map(|_| tree.allocate_element(&mut memory)).collect();
+        tree.set_first_element_child(shadow_root, Some(nodes[0]));
+        for (index, &node) in nodes.iter().enumerate() {
+            tree.set_parent(node, Some(shadow_root));
+            tree.set_tree_scope(node, TreeScopeID(1));
+            tree.set_next_element_sibling(node, nodes.get(index + 1).copied());
+        }
+        for with_topology in [false, true] {
+            let mut regions = if with_topology {
+                ImpactRegions::with_topology(&tree, root)
+            } else {
+                ImpactRegions::new()
+            };
+            for (index, &node) in nodes.iter().enumerate() {
+                let key = (RuleID(index as u32 + 1), EntryID(index as u32 + 1));
+                regions.attribute_extent(ImpactRegion::Node(node), key);
+                regions.attribute_extent(ImpactRegion::Node(node), key);
+            }
+            let cover = regions.compile_patch_cover(&tree, Some(root));
+            assert!(
+                cover.unindexed.is_empty(),
+                "exact nodes must not require per-node region scans"
+            );
+            let mut sweep = AttributionSweep::default();
+            let mut covering = Vec::new();
+            for (index, &node) in nodes.iter().enumerate().rev() {
+                assert!(regions.covering_attributions(&cover, &tree, &mut sweep, node, &mut covering));
+                assert_eq!(covering, [(RuleID(index as u32 + 1), EntryID(index as u32 + 1))]);
+            }
+            assert!(regions.covering_attributions(&cover, &tree, &mut sweep, host, &mut covering));
+            assert!(covering.is_empty());
+        }
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -4190,10 +4190,13 @@ impl ElementFactStore {
             return;
         }
 
-        let rebuild_started_admitting = memory.is_tier3_admitting(MemoryCategory::FeaturePosting);
+        // NB: Rebuilding needs to admit new postings. Avoid scanning every fact on each
+        //     selector query while admission is closed, and retry once it reopens.
+        if !memory.is_tier3_admitting(MemoryCategory::FeaturePosting) {
+            return;
+        }
         let Some(rebuilt) = self.build_missing_postings(memory) else {
-            self.posting_rebuild_closed_at_headroom =
-                rebuild_started_admitting.then(|| Self::posting_rebuild_headroom(memory));
+            self.posting_rebuild_closed_at_headroom = Some(Self::posting_rebuild_headroom(memory));
             return;
         };
         self.postings.take_rebuilt(rebuilt);
@@ -6007,6 +6010,36 @@ mod tests {
     }
 
     #[test]
+    fn selector_queries_defer_posting_rebuilds_while_admission_is_closed() {
+        let mut memory = MemoryController::new(DeviceClass::ForegroundDesktop);
+        let mut facts = ElementFactStore::new();
+        let node = StyleNodeID::element(1);
+        let class = StyleAtomID(1);
+        let key = SelectorPostingKey::Class(class);
+        facts.set_class(node, class, true, &mut memory);
+        facts.apply_staged(&mut memory);
+        facts.postings_mut().evict_all();
+        facts.set_class(node, class, false, &mut memory);
+
+        memory.set_tier3_limit_for_test(0);
+        let mut other_postings = FeaturePostings::new();
+        other_postings.insert(key, node, &mut memory);
+        assert!(!memory.is_tier3_admitting(MemoryCategory::FeaturePosting));
+
+        for _ in 0..3 {
+            facts.prepare_selector_query(&mut memory);
+            assert!(facts.classes_of_node(node).is_empty());
+            // NB: Even resolving an empty missing posting requires scanning the facts.
+            assert!(matches!(facts.postings().lookup(key), Lookup::Missing(gap) if gap == key));
+        }
+
+        memory.set_tier3_limit_for_test(u64::MAX);
+        memory.begin_tier3_quota_period();
+        facts.prepare_selector_query(&mut memory);
+        assert!(matches!(facts.postings().lookup(key), Lookup::KnownAbsent));
+    }
+
+    #[test]
     fn missing_postings_rebuild_from_mutated_authoritative_facts_when_budget_returns() {
         let mut memory = MemoryController::new(DeviceClass::ForegroundDesktop);
         let mut facts = ElementFactStore::new();
@@ -6032,8 +6065,8 @@ mod tests {
         assert!(matches!(facts.postings().lookup(new_animation_key), Lookup::Missing(gap) if gap == new_animation_key));
         assert_eq!(facts.posting_rebuild_closed_at_headroom, None);
 
-        // Admission was already closed before the rebuild began, so its failure says nothing about
-        // whether the same headroom could fund a later rebuild after another category reopens it.
+        // NB: Closed admission defers rebuilding without recording a failed attempt, so the same
+        //     headroom can fund a later rebuild once admission reopens.
         facts.apply_staged(&mut memory);
         assert_eq!(facts.posting_rebuild_closed_at_headroom, None);
 

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -1731,32 +1731,32 @@ impl StyleEngine {
             return;
         }
 
-        let mut anchors = Vec::new();
-        match anchor.match_in_shadow_tree {
-            true => possible_hosting_anchors(anchor.axis, witness, &self.tree, |candidate| {
-                anchors.push(candidate);
-            }),
-            false => possible_anchors(anchor.axis, witness, &self.tree, None, |candidate| {
-                anchors.push(candidate);
-            }),
-        }
-        self.counters
-            .add(Counter::RelationalAnchorsConsidered, anchors.len() as u64);
-
-        let anchor_posting = anchor
-            .anchor_dispatch
-            .has_selector_posting()
-            .then_some(anchor.anchor_dispatch);
-        for candidate in anchors {
-            // An ancestor that does not carry the anchor compound's feature is not an anchor of
-            // this query at all.
-            if let Some(key) = anchor_posting {
-                match self.facts.postings().lookup(key) {
-                    Lookup::Known(posting) if !posting.contains(candidate) => continue,
-                    Lookup::KnownAbsent => continue,
-                    Lookup::Known(_) | Lookup::Missing(_) => {}
-                }
+        // OPTIMIZATION: Resolve the anchor posting once before walking the inverse axis. A known
+        //               empty posting rules out every anchor, regardless of the number of witnesses.
+        let anchor_posting = if anchor.anchor_dispatch.has_selector_posting() {
+            match self.facts.postings().lookup(anchor.anchor_dispatch) {
+                Lookup::Known(posting) => Some(posting),
+                Lookup::KnownAbsent => return,
+                Lookup::Missing(_) => None,
             }
+        } else {
+            None
+        };
+        let mut anchors = Vec::new();
+        let mut considered = 0;
+        let mut visit = |candidate| {
+            considered += 1;
+            if anchor_posting.is_none_or(|posting| posting.contains(candidate)) {
+                anchors.push(candidate);
+            }
+        };
+        match anchor.match_in_shadow_tree {
+            true => possible_hosting_anchors(anchor.axis, witness, &self.tree, &mut visit),
+            false => possible_anchors(anchor.axis, witness, &self.tree, None, &mut visit),
+        }
+        self.counters.add(Counter::RelationalAnchorsConsidered, considered);
+
+        for candidate in anchors {
             // An anchor whose retained witness still witnesses it was true and stays true: only
             // zero/nonzero witness transitions can affect selector truth, so nothing reached
             // through this anchor has moved and it drops out of the plan. A position-testing

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -10587,3 +10587,65 @@ fn shared_computation_context_checks_fixed_inputs_and_record_liveness() {
     );
     engine.end_style_record_view_epoch();
 }
+
+#[test]
+fn relational_routing_checks_an_absent_anchor_posting_once() {
+    let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
+    let mut raw = [0_u32; 128];
+    engine.allocate_style_nodes(&mut raw);
+    let nodes: Vec<StyleNodeID> = raw.iter().map(|&raw| StyleNodeID::from_raw(raw).unwrap()).collect();
+    for (index, &node) in nodes.iter().enumerate() {
+        let parent = index.checked_sub(1).map(|index| raw[index]);
+        engine.record_tree_delta(node, None, Some(relations(parent, None, None)));
+    }
+    discard_transaction(&mut engine);
+    let anchor_class = StyleAtomID(200);
+    let witness_class = StyleAtomID(201);
+    let mut builder = selector::SelectorProgramBuilder::new();
+    let witness_test = builder.push_feature(selector::FeatureTest::Class(witness_class));
+    let has_witness = builder.push_relative_exists(relative_selector::RelativeQuery {
+        axis: RelativeAxis::Descendant,
+        compound: witness_test,
+        driving_feature: Some(LocalFeatureKey::Class(witness_class)),
+        simple: true,
+        witness_is_below_the_axis: false,
+        match_in_shadow_tree: false,
+    });
+    let anchor_test = builder.push_feature(selector::FeatureTest::Class(anchor_class));
+    let selector = builder.push_compound(&[anchor_test, has_witness]);
+    builder.push_entry(selector);
+    let program = engine.programs.add(builder.finish());
+    let site = RoutingSite {
+        subject: &[],
+        subject_required: &[],
+        position: SubjectPosition::UNBOUNDED,
+        path: &[],
+        waypoints: &[],
+        in_flux: None,
+        exact_entry: None,
+        exact_tree_evaluation: None,
+        refresh_rule: None,
+    };
+    let mut regions = ImpactRegions::new();
+    engine.facts.postings().take_benefit_lookups();
+    engine.route_from_anchors(
+        nodes[127],
+        program,
+        RelativeAnchor {
+            axis: RelativeAxis::Descendant,
+            query: relative_selector::RelativeQueryID(0),
+            anchor_dispatch: DispatchKey::Class(anchor_class),
+            witness_dispatch: DispatchKey::Class(witness_class),
+            input_is_on_the_witness: true,
+            input_is_on_the_anchor: false,
+            adjacent_reach: u32::MAX,
+            witness_is_featureless: false,
+            argument_spans_siblings: false,
+            match_in_shadow_tree: false,
+        },
+        &site,
+        &mut regions,
+    );
+    assert!(regions.regions().is_empty());
+    assert_eq!(engine.facts.postings().take_benefit_lookups(), (1, 0));
+}

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -1522,9 +1522,13 @@ impl LayoutNodeArena {
             return true;
         }
         let step = (upper - lower) / (descendant_count + 1);
-        if step < 2 {
+        // NB: Merely restoring strict order can leave the subtree dense enough to need another
+        //     relabel on the next insertion. Restore the normal insertion spacing, or try a larger
+        //     ancestor. The root already uses all available label space, so it cannot expand further.
+        if step < MAXIMUM_PRE_ORDER_LABEL_STRIDE && !self.data(subtree_root).parent.get().is_invalid() {
             return false;
         }
+        assert!(step >= 2, "pre-order label space exhausted");
         let mut position_in_subtree = 0u64;
         self.for_each_node_in_layout_subtree_in_pre_order(subtree_root, |node| {
             if node == subtree_root {

--- a/Tests/LibWeb/Text/expected/stacking-context/layout-tree-relabeling-leaves-insertion-space.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/layout-tree-relabeling-leaves-insertion-space.txt
@@ -1,0 +1,2 @@
+Relabels stay bounded: true
+Label violations: 0

--- a/Tests/LibWeb/Text/input/stacking-context/layout-tree-relabeling-leaves-insertion-space.html
+++ b/Tests/LibWeb/Text/input/stacking-context/layout-tree-relabeling-leaves-insertion-space.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div><div id="target"></div><div>Following sibling</div></div>
+<script>
+    test(() => {
+        const target = document.getElementById("target");
+        document.body.offsetHeight;
+        const before = internals.layoutTreePreOrderRelabelCount();
+        target.innerHTML = "<div>".repeat(40) + "<span>x</span>".repeat(5000) + "</div>".repeat(40);
+        document.body.offsetHeight;
+        const relabels = internals.layoutTreePreOrderRelabelCount() - before;
+        println(`Relabels stay bounded: ${relabels < 10}`);
+        println(`Label violations: ${internals.layoutTreePreOrderLabelViolationCount()}`);
+    });
+</script>


### PR DESCRIPTION
Reduce unnecessary work during style invalidation and layout-tree updates.

This dramatically reduces style engine work when viewing GitHub diffs.

- Index exact-node attributions by node identity instead of rescanning them for every visited node.
- Resolve relational anchor postings once per query and skip known-empty postings.
- Defer posting rebuilds while memory admission is closed, avoiding repeated full fact scans.
- Preserve insertion space when relabeling layout subtrees to bound repeated relabeling.
- Add coverage for shadow-tree attributions, missing anchor postings, closed admission, and deep-tree relabeling.