### PR TITLE
LibWeb: Speed up style computation for SVG presentation attributes

### DIFF
--- a/Libraries/LibWeb/CSS/Invalidation/AttributeInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/AttributeInvalidator.cpp
@@ -122,7 +122,10 @@ void invalidate_style_after_attribute_change(
         || (element.supports_dimension_attributes() && attribute_name.is_one_of(HTML::AttributeNames::width, HTML::AttributeNames::height))) {
         // The width and height attributes of an element that supports them map to hints the way
         // the presentational hint attributes do.
-        record_element_declarations_changed(element, ElementDeclarationKind::PresentationalHint, true, true);
+        auto kind = element.publishes_presentational_hints_on_arrival() && !element.style_uses_attr_css_function()
+            ? ElementDeclarationKind::SvgPresentationAttribute
+            : ElementDeclarationKind::PresentationalHint;
+        record_element_declarations_changed(element, kind, true, true);
     }
 
     // The pseudo-classes an attribute implies are separate facts about the element, and each is its

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2745,7 +2745,7 @@ RefPtr<StyleComputer::CascadeInput const> StyleComputer::style_engine_cascade_in
     return input;
 }
 
-static Vector<StyleProperty> collect_presentational_hint_properties(DOM::AbstractElement abstract_element)
+Vector<StyleProperty> StyleComputer::collect_presentational_hint_properties(DOM::AbstractElement abstract_element)
 {
     Vector<StyleProperty> properties;
     if (abstract_element.pseudo_element().has_value())

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -75,6 +75,8 @@ public:
 
     static Optional<Utf16String> user_agent_style_sheet_source(Utf16View name);
 
+    static Vector<StyleProperty> collect_presentational_hint_properties(DOM::AbstractElement);
+
     explicit StyleComputer(DOM::Document&);
     virtual ~StyleComputer() override = default;
 

--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -394,6 +394,8 @@ static bool element_may_have_presentational_hints(DOM::Element const& element)
 {
     if (element_may_have_derived_presentational_hints(element))
         return true;
+    if (element.publishes_presentational_hints_on_arrival())
+        return false;
     // The cascade also reads the width and height attributes of an element that supports them.
     if (element.supports_dimension_attributes()
         && (element.has_attribute(HTML::AttributeNames::width) || element.has_attribute(HTML::AttributeNames::height)))
@@ -675,6 +677,8 @@ static void record_element_initial_features(DOM::Element& element)
         record_element_parts_changed(element);
     if (auto const inline_style = element.inline_style(); inline_style && (!inline_style->properties().is_empty() || !inline_style->custom_properties().is_empty()))
         record_element_inline_style_properties(element);
+    if (element.publishes_presentational_hints_on_arrival() && !element_may_have_derived_presentational_hints(element))
+        StyleComputer::collect_presentational_hint_properties({ element });
 }
 
 void record_element_moved(DOM::Element& element, DOM::Node* old_parent, DOM::Element* old_previous_sibling, DOM::Element* old_next_sibling)
@@ -1220,10 +1224,14 @@ static void record_element_inline_style_properties(DOM::Element& element)
 // has while the document is still being parsed. Asking for them on arrival crashes on the first
 // bordered table for that reason. The cascade builds the block anyway, so this costs the call.
 //
-// SVG presentation attributes map through the same hook, so they are published under this kind too.
+// An element that publishes its hints on arrival gets its own kind, which tells the engine the hints
+// are current and lets it compute the element's style itself.
 bool record_element_presentational_hint_properties(DOM::Element& element, ReadonlySpan<StyleProperty> hints)
 {
-    return publish_element_declared_properties(element, StyleEngineFFI::FfiElementDeclarationKind::PresentationalHint, hints);
+    auto kind = element.publishes_presentational_hints_on_arrival()
+        ? StyleEngineFFI::FfiElementDeclarationKind::SvgPresentationAttribute
+        : StyleEngineFFI::FfiElementDeclarationKind::PresentationalHint;
+    return publish_element_declared_properties(element, kind, hints);
 }
 
 void record_element_declarations_changed(DOM::Element& element, ElementDeclarationKind kind, bool had_declarations, bool has_declarations)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -327,6 +327,7 @@ public:
 
     virtual bool is_presentational_hint(Utf16FlyString const&) const { return false; }
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const;
+    virtual bool publishes_presentational_hints_on_arrival() const { return false; }
     bool presentational_hint_properties_need_publication(ReadonlySpan<CSS::StyleProperty>) const;
     void did_publish_presentational_hint_properties(ReadonlySpan<CSS::StyleProperty>);
 

--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -690,7 +690,11 @@ impl StyleEngine {
             .inputs
             .iter()
             .filter_map(|input| match input.key {
-                InputKey::ElementDeclaration(node, _) => Some(node),
+                InputKey::ElementDeclaration(node, kind)
+                    if kind != ElementDeclarationKind::SvgPresentationAttribute =>
+                {
+                    Some(node)
+                }
                 _ => None,
             })
             .collect();

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -131,6 +131,17 @@ static ReadonlySpan<NamedPropertyID> attribute_style_properties()
     return properties;
 }
 
+static HashMap<Utf16FlyString, NamedPropertyID const*> const& attribute_style_properties_by_name()
+{
+    static auto const& properties_by_name = *[] {
+        auto* map = new HashMap<Utf16FlyString, NamedPropertyID const*>;
+        for (auto const& property : attribute_style_properties())
+            map->set(property.name, &property);
+        return map;
+    }();
+    return properties_by_name;
+}
+
 static Optional<CSS::PropertyID> property_id_for_presentational_attribute(Utf16FlyString const& name, Utf16FlyString const& tag_name)
 {
     // https://svgwg.org/svg2-draft/styling.html#PresentationAttributes
@@ -140,17 +151,12 @@ static Optional<CSS::PropertyID> property_id_for_presentational_attribute(Utf16F
         && (tag_name == TagNames::pattern || tag_name == TagNames::linearGradient || tag_name == TagNames::radialGradient))
         return {};
 
-    for (auto const& property : attribute_style_properties()) {
-        if (!property.name.equals_ignoring_ascii_case(name))
-            continue;
-
-        if (!property.supported_elements.is_empty() && !property.supported_elements.contains_slow(tag_name))
-            continue;
-
-        return property.id;
-    }
-
-    return {};
+    auto const* property = attribute_style_properties_by_name().get(name).value_or(nullptr);
+    if (!property)
+        return {};
+    if (!property->supported_elements.is_empty() && !property->supported_elements.contains_slow(tag_name))
+        return {};
+    return property->id;
 }
 
 bool SVGElement::is_presentational_hint(Utf16FlyString const& name) const

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -170,24 +170,25 @@ bool SVGElement::is_presentational_hint(Utf16FlyString const& name) const
 void SVGElement::apply_presentational_hints(Vector<CSS::StyleProperty>& properties) const
 {
     Base::apply_presentational_hints(properties);
+    properties.extend(presentation_attribute_style());
+}
 
-    if (m_presentation_attribute_style.has_value()) {
-        properties.extend(*m_presentation_attribute_style);
-        return;
-    }
+Vector<CSS::StyleProperty> const& SVGElement::presentation_attribute_style() const
+{
+    if (m_presentation_attribute_style.has_value())
+        return *m_presentation_attribute_style;
 
     Vector<CSS::StyleProperty> presentation_attribute_style;
     for_each_attribute([&](DOM::QualifiedName const& name, Utf16View const& value) {
         if (name.namespace_().has_value())
             return;
         if (auto property_id = property_id_for_presentational_attribute(name.as_string(), local_name()); property_id.has_value()) {
-            auto style_value = parse_presentation_attribute(*property_id, value);
-            if (style_value)
+            if (auto style_value = parse_presentation_attribute(*property_id, value))
                 presentation_attribute_style.append({ .property_id = *property_id, .value = style_value.release_nonnull() });
         }
     });
     m_presentation_attribute_style = move(presentation_attribute_style);
-    properties.extend(*m_presentation_attribute_style);
+    return *m_presentation_attribute_style;
 }
 
 RefPtr<CSS::StyleValue const> SVGElement::parse_presentation_attribute(CSS::PropertyID property_id, Utf16View value) const
@@ -226,7 +227,7 @@ RefPtr<CSS::StyleValue const> SVGElement::parse_presentation_attribute(CSS::Prop
     return parse_css_value(parsing_context, value, property_id);
 }
 
-void SVGElement::update_presentation_attribute_style(Utf16FlyString const& name, Optional<Utf16FlyString> const& namespace_)
+void SVGElement::update_presentation_attribute_style(Utf16FlyString const& name, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_)
 {
     if (!m_presentation_attribute_style.has_value() || namespace_.has_value())
         return;
@@ -235,18 +236,23 @@ void SVGElement::update_presentation_attribute_style(Utf16FlyString const& name,
     if (!property_id.has_value())
         return;
 
-    m_presentation_attribute_style->remove_all_matching([&](auto const& property) {
-        return property.property_id == property_id;
+    RefPtr<CSS::StyleValue const> style_value;
+    if (value.has_value())
+        style_value = parse_presentation_attribute(*property_id, *value);
+    auto existing_index = m_presentation_attribute_style->find_first_index_if([&](auto const& property) {
+        return property.property_id == *property_id;
     });
-
-    for_each_attribute([&](DOM::QualifiedName const& attribute_name, Utf16View const& attribute_value) {
-        if (attribute_name.namespace_().has_value())
-            return;
-        if (property_id_for_presentational_attribute(attribute_name.as_string(), local_name()) != property_id)
-            return;
-        if (auto style_value = parse_presentation_attribute(*property_id, attribute_value); style_value)
+    if (style_value) {
+        if (existing_index.has_value()) {
+            (*m_presentation_attribute_style)[*existing_index].value = style_value.release_nonnull();
+        } else {
             m_presentation_attribute_style->append({ .property_id = *property_id, .value = style_value.release_nonnull() });
-    });
+        }
+    } else if (existing_index.has_value()) {
+        m_presentation_attribute_style->remove(*existing_index);
+    } else {
+        return;
+    }
 
     publish_presentation_attribute_style();
 }
@@ -257,17 +263,20 @@ void SVGElement::publish_presentation_attribute_style()
 
     Vector<CSS::StyleProperty> properties;
     Base::apply_presentational_hints(properties);
-    properties.extend(*m_presentation_attribute_style);
-
-    HashTable<CSS::PropertyID> seen_properties;
-    for (size_t i = properties.size(); i > 0; --i) {
-        if (seen_properties.set(properties[i - 1].property_id) != AK::HashSetResult::InsertedNewEntry)
-            properties.remove(i - 1);
+    ReadonlySpan<CSS::StyleProperty> hints = *m_presentation_attribute_style;
+    if (!properties.is_empty()) {
+        properties.extend(*m_presentation_attribute_style);
+        HashTable<CSS::PropertyID> seen_properties;
+        for (size_t i = properties.size(); i > 0; --i) {
+            if (seen_properties.set(properties[i - 1].property_id) != AK::HashSetResult::InsertedNewEntry)
+                properties.remove(i - 1);
+        }
+        hints = properties;
     }
 
-    if (presentational_hint_properties_need_publication(properties)
-        && CSS::record_element_presentational_hint_properties(*this, properties))
-        did_publish_presentational_hint_properties(properties);
+    if (presentational_hint_properties_need_publication(hints)
+        && CSS::record_element_presentational_hint_properties(*this, hints))
+        did_publish_presentational_hint_properties(hints);
 }
 
 bool SVGElement::should_include_in_accessibility_tree() const
@@ -321,7 +330,7 @@ void SVGElement::attribute_changed(Utf16FlyString const& local_name, Optional<Ut
     HTMLOrSVGOrMathMLElement::attribute_changed(local_name, old_value, value, namespace_);
 
     if (old_value != value)
-        update_presentation_attribute_style(local_name, namespace_);
+        update_presentation_attribute_style(local_name, value, namespace_);
     update_use_elements_that_reference_this();
 }
 

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -72,7 +72,8 @@ private:
     virtual bool is_svg_element() const final { return true; }
 
     RefPtr<CSS::StyleValue const> parse_presentation_attribute(CSS::PropertyID, Utf16View) const;
-    void update_presentation_attribute_style(Utf16FlyString const&, Optional<Utf16FlyString> const& namespace_);
+    Vector<CSS::StyleProperty> const& presentation_attribute_style() const;
+    void update_presentation_attribute_style(Utf16FlyString const& name, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_);
     void publish_presentation_attribute_style();
 
     GC::Ptr<SVGAnimatedString> m_class_name_animated_string;

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -48,6 +48,7 @@ public:
 
     virtual bool is_presentational_hint(Utf16FlyString const&) const final override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const final override;
+    virtual bool publishes_presentational_hints_on_arrival() const final override { return true; }
 
     void register_resource_box_referencing_element(Badge<Layout::LayoutTreeBuilderAccess>, DOM::Element&);
 

--- a/Tests/LibWeb/Text/expected/SVG/svg-presentation-attribute-style-update.txt
+++ b/Tests/LibWeb/Text/expected/SVG/svg-presentation-attribute-style-update.txt
@@ -6,7 +6,7 @@ none
 rgb(255, 0, 0)
 rgb(255, 0, 0)
 rgb(255, 0, 0)
-rgb(0, 0, 255)
-rgb(0, 128, 0)
+rgb(255, 0, 0)
+rgb(255, 0, 0)
 rgb(255, 0, 0)
 consecutive mutations preserved the transition start style: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/style-sharing-donor-first-build.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/style-sharing-donor-first-build.txt
@@ -1,4 +1,4 @@
-differing sibling: 12 longhand evaluations
-differing sibling: x 20px, fill rgb(0, 0, 255), width 10px
+differing sibling: 25 longhand evaluations
+differing sibling: color rgb(0, 0, 255)
 identical sibling: 10 longhand evaluations
-identical sibling: x 1px, fill rgb(255, 0, 0), width 10px
+identical sibling: color rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/expected/css/style-engine/svg-presentation-attribute-engine-records.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/svg-presentation-attribute-engine-records.txt
@@ -1,0 +1,14 @@
+insertion: 1 engine records, 0 C++ recomputations
+insertion: x 20px, fill rgb(0, 0, 255), width 10px
+x rewrite: 1 engine records, 0 C++ recomputations
+x rewrite: x 30px, fill rgb(0, 0, 255), width 10px
+x and fill rewrite: 1 engine records, 0 C++ recomputations
+x and fill rewrite: x 40px, fill rgb(255, 0, 0), width 10px
+fill removal: 1 engine records, 0 C++ recomputations
+fill removal: x 40px, fill rgb(0, 0, 0), width 10px
+fill beaten by a rule: 1 engine records, 0 C++ recomputations
+fill beaten by a rule: x 40px, fill rgb(0, 128, 0), width 10px
+attribute under the rule: 0 engine records, 1 C++ recomputations
+attribute under the rule: x 40px, fill rgb(0, 128, 0), width 10px
+rule removed: 1 engine records, 0 C++ recomputations
+rule removed: x 40px, fill rgb(255, 0, 0), width 10px

--- a/Tests/LibWeb/Text/input/css/style-engine/style-sharing-donor-first-build.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/style-sharing-donor-first-build.html
@@ -1,34 +1,30 @@
 <!DOCTYPE html>
 <script src="../../include.js"></script>
-<svg id="svg" width="100" height="100"></svg>
+<div id="container"></div>
 <script>
-    function makeRect(x, fill) {
-        const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
-        rect.setAttribute("x", x);
-        rect.setAttribute("y", "1");
-        rect.setAttribute("width", "10");
-        rect.setAttribute("height", "10");
-        rect.setAttribute("fill", fill);
-        return rect;
+    function makeFont(color) {
+        const font = document.createElement("font");
+        font.setAttribute("color", color);
+        font.textContent = "text";
+        return font;
     }
 
-    function measure(label, x, fill) {
-        svg.replaceChildren(makeRect("1", "red"));
+    function measure(label, color) {
+        container.replaceChildren(makeFont("red"));
         internals.updateStyle();
         const before = internals.getStyleInvalidationCounters();
 
-        const rect = makeRect(x, fill);
-        svg.append(rect);
+        const font = makeFont(color);
+        container.append(font);
         internals.updateStyle();
 
         const after = internals.getStyleInvalidationCounters();
         println(`${label}: ${after.computedLonghandEvaluations - before.computedLonghandEvaluations} longhand evaluations`);
-        const style = getComputedStyle(rect);
-        println(`${label}: x ${style.x}, fill ${style.fill}, width ${style.width}`);
+        println(`${label}: color ${getComputedStyle(font).color}`);
     }
 
     test(() => {
-        measure("differing sibling", "20", "blue");
-        measure("identical sibling", "1", "red");
+        measure("differing sibling", "blue");
+        measure("identical sibling", "red");
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-engine/svg-presentation-attribute-engine-records.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/svg-presentation-attribute-engine-records.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .styled { fill: green; }
+</style>
+<svg id="svg" width="100" height="100"></svg>
+<script>
+    function makeRect(x, fill) {
+        const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+        rect.setAttribute("x", x);
+        rect.setAttribute("y", "1");
+        rect.setAttribute("width", "10");
+        rect.setAttribute("height", "10");
+        rect.setAttribute("fill", fill);
+        return rect;
+    }
+
+    function measure(label, mutate, rect) {
+        internals.updateStyle();
+        const before = internals.getStyleInvalidationCounters();
+        rect = mutate(rect);
+        internals.updateStyle();
+        const after = internals.getStyleInvalidationCounters();
+        const style = getComputedStyle(rect);
+        println(`${label}: ${after.engineComputedStyleRecords - before.engineComputedStyleRecords} engine records, ${after.elementStyleRecomputations - before.elementStyleRecomputations} C++ recomputations`);
+        println(`${label}: x ${style.x}, fill ${style.fill}, width ${style.width}`);
+        return rect;
+    }
+
+    test(() => {
+        let rect = measure("insertion", () => { const rect = makeRect("20", "blue"); svg.append(rect); return rect; });
+        rect = measure("x rewrite", rect => { rect.setAttribute("x", "30"); return rect; }, rect);
+        rect = measure("x and fill rewrite", rect => { rect.setAttribute("x", "40"); rect.setAttribute("fill", "red"); return rect; }, rect);
+        rect = measure("fill removal", rect => { rect.removeAttribute("fill"); return rect; }, rect);
+        rect = measure("fill beaten by a rule", rect => { rect.setAttribute("fill", "blue"); rect.classList.add("styled"); return rect; }, rect);
+        rect = measure("attribute under the rule", rect => { rect.setAttribute("fill", "red"); return rect; }, rect);
+        rect = measure("rule removed", rect => { rect.classList.remove("styled"); return rect; }, rect);
+    });
+</script>


### PR DESCRIPTION
These changes improve style computation performance for SVG elements with presentation attributes by mapping attribute names through a hash map, updating only the changed attribute's hint, and letting the style engine compute such elements' style instead of falling back to C++.

This also fixes a bug where the presentational hint table would previously compare names case-insensitively, which it no longer does.

This improves Speedometer3 `React-Stockcharts-SVG`:

```
Benchmark     Suite                                       Test                   Speedup  Old (Mean ± Range)    New (Mean ± Range)
------------  ------------------------------------------  -------------------  ---------  --------------------  --------------------
Speedometer3  Charts-chartjs                              Draw opaque scatter      0.918  0.10 ± 0.01           0.11 ± 0.02
Speedometer3  Charts-chartjs                              Draw scatter             0.951  0.14 ± 0.02           0.15 ± 0.03
Speedometer3  Charts-chartjs                              Show tooltip             1.056  0.00 ± 0.00           0.00 ± 0.00
Speedometer3  Charts-observable-plot                      Dotted                   1.006  0.06 ± 0.00           0.05 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 20            0.918  0.11 ± 0.00           0.12 ± 0.02
Speedometer3  Charts-observable-plot                      Stacked by 6             1.183  0.09 ± 0.02           0.08 ± 0.00
Speedometer3  Editor-CodeMirror                           Highlight                0.983  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  Editor-CodeMirror                           Long                     1.058  0.03 ± 0.01           0.03 ± 0.00
Speedometer3  Editor-TipTap                               Highlight                1.006  0.18 ± 0.01           0.18 ± 0.01
Speedometer3  Editor-TipTap                               Long                     1.006  0.12 ± 0.00           0.12 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToPolitics       0.998  0.16 ± 0.00           0.16 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToUS             1.006  0.16 ± 0.00           0.16 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToWorld          0.997  0.17 ± 0.00           0.17 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToPolitics       0.962  0.14 ± 0.00           0.14 ± 0.01
Speedometer3  NewsSite-Nuxt                               NavigateToUS             0.998  0.13 ± 0.00           0.13 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToWorld          0.986  0.13 ± 0.00           0.14 ± 0.01
Speedometer3  Perf-Dashboard                              Render                   1.009  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingPoints          1.001  0.11 ± 0.00           0.11 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingRange           1.004  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  React-Stockcharts-SVG                       PanTheChart              1.181  0.12 ± 0.02           0.10 ± 0.01
Speedometer3  React-Stockcharts-SVG                       Render                   1.127  0.13 ± 0.02           0.11 ± 0.01
Speedometer3  React-Stockcharts-SVG                       ZoomTheChart             1.15   0.37 ± 0.01           0.32 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 Adding100Items           1.009  0.11 ± 0.00           0.11 ± 0.00
Speedometer3  TodoMVC-Angular-Complex-DOM                 CompletingAllItems       1.003  0.07 ± 0.00           0.07 ± 0.00
Speedometer3  TodoMVC-Angular-Complex-DOM                 DeletingAllItems         0.994  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Backbone                            Adding100Items           0.995  0.07 ± 0.00           0.07 ± 0.00
Speedometer3  TodoMVC-Backbone                            CompletingAllItems       1.072  0.05 ± 0.01           0.05 ± 0.00
Speedometer3  TodoMVC-Backbone                            DeletingAllItems         1.022  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      Adding100Items           1.015  0.13 ± 0.01           0.13 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES5                      CompletingAllItems       0.997  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      DeletingAllItems         0.986  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  Adding100Items           0.997  0.12 ± 0.00           0.12 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  CompletingAllItems       0.998  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  DeletingAllItems         1.003  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     Adding100Items           0.996  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     CompletingAllItems       1.004  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     DeletingAllItems         0.968  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  Adding100Items           0.98   0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  CompletingAllItems       1.01   0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  DeletingAllItems         1.053  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   Adding100Items           1.003  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   CompletingAllItems       1.006  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   DeletingAllItems         1.025  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-React-Redux                         Adding100Items           1.016  0.08 ± 0.00           0.08 ± 0.00
Speedometer3  TodoMVC-React-Redux                         CompletingAllItems       1.006  0.11 ± 0.00           0.11 ± 0.00
Speedometer3  TodoMVC-React-Redux                         DeletingAllItems         0.975  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  Adding100Items           0.974  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  CompletingAllItems       1.001  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  DeletingAllItems         0.95   0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Vue                                 Adding100Items           1.017  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Vue                                 CompletingAllItems       0.993  0.03 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Vue                                 DeletingAllItems         1.017  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       Adding100Items           0.976  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-WebComponents                       CompletingAllItems       0.991  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       DeletingAllItems         1.034  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-jQuery                              Adding100Items           0.936  0.15 ± 0.00           0.16 ± 0.02
Speedometer3  TodoMVC-jQuery                              CompletingAllItems       0.976  0.41 ± 0.02           0.42 ± 0.04
Speedometer3  TodoMVC-jQuery                              DeletingAllItems         0.948  0.15 ± 0.02           0.16 ± 0.03

Benchmark     Old Score    New Score      Score Improvement  Old Total Time (s)    New Total Time (s)      Speedup
------------  -----------  -----------  -------------------  --------------------  --------------------  ---------
Speedometer3  5.12 ± 0.06  5.15 ± 0.06                1.005  4.97 ± 0.07           4.93 ± 0.08               1.009
```
---
Benchmark summary:

| Benchmark | Old score | New score | Old total (s) | New total (s) |
|---|---|---|---|---|
| Speedometer 3 | 5.12 ± 0.06 | 5.15 ± 0.06 | 4.97 | 4.93 |
| Speedometer 2 | 78.89 ± 0.80 | 79.30 ± 0.68 | 6.68 | 6.63 |
| StyleBench | 151.42 ± 1.39 | 151.49 ± 1.45 | 1.65 | 1.65 |

