### PR TITLE
LibWeb: Check Window named property membership without enumerating IDs

### DIFF
--- a/Libraries/LibWeb/DOM/ElementByIdMap.h
+++ b/Libraries/LibWeb/DOM/ElementByIdMap.h
@@ -18,6 +18,7 @@ public:
     void add(Utf16FlyString const& element_id, Element&);
     void remove(Utf16FlyString const& element_id, Element&);
     GC::Ptr<Element> get(Utf16View element_id, Node const& scope_root) const;
+    bool contains(Utf16FlyString const& element_id) const { return m_map.contains(element_id); }
     void for_each_element_with_id(Utf16View element_id, Node const& scope_root, Function<void(Element&)> callback) const;
 
     template<typename Callback>

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -2227,6 +2227,20 @@ Vector<Utf16FlyString> Window::supported_property_names() const
     return result;
 }
 
+bool Window::is_supported_property_name(Utf16FlyString const& name) const
+{
+    // OPTIMIZATION: Answer membership without constructing the full set of supported names.
+    //               In particular, unrelated element IDs need not be visited for a property lookup.
+    auto& document = associated_document();
+    if (document.element_by_id().contains(name))
+        return true;
+    for (auto element : document.potentially_named_elements()) {
+        if (element->name() == name)
+            return true;
+    }
+    return const_cast<Window&>(*this).document_tree_child_navigable_target_name_property_set().contains(name);
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object
 Variant<Empty, GC::Ref<WindowProxy>, GC::Ref<DOM::Element>, GC::Ref<DOM::HTMLCollection>> Window::named_item(Utf16FlyString const& name) const
 {

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -300,6 +300,7 @@ public:
 
     [[nodiscard]] Variant<Empty, GC::Ref<WindowProxy>, GC::Ref<DOM::Element>, GC::Ref<DOM::HTMLCollection>> named_item(Utf16FlyString const&) const;
     [[nodiscard]] Vector<Utf16FlyString> supported_property_names() const override;
+    [[nodiscard]] virtual bool is_supported_property_name(Utf16FlyString const&) const override;
 
     bool find(Utf16View string);
 

--- a/Tests/LibWeb/Text/expected/HTML/Window-named-property-membership-mutations.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-named-property-membership-mutations.txt
@@ -1,0 +1,10 @@
+Duplicate ID: true
+Remaining ID: true
+Old ID absent: true
+New ID present: true
+Name present: true
+Old name absent: true
+New name present: true
+Shadow ID absent: true
+Removed ID absent: true
+Removed name absent: true

--- a/Tests/LibWeb/Text/input/HTML/Window-named-property-membership-mutations.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-named-property-membership-mutations.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const container = document.createElement("div");
+        document.body.append(container);
+        container.innerHTML = '<div id="namedFirst"></div><div id="namedFirst"></div><form name="namedForm"></form>';
+        const first = container.children[0];
+        const second = container.children[1];
+        const form = container.children[2];
+        println(`Duplicate ID: ${"namedFirst" in window}`);
+        first.remove();
+        println(`Remaining ID: ${window.namedFirst === second}`);
+        second.id = "namedSecond";
+        println(`Old ID absent: ${!("namedFirst" in window)}`);
+        println(`New ID present: ${window.namedSecond === second}`);
+        println(`Name present: ${window.namedForm === form}`);
+        form.name = "namedRenamedForm";
+        println(`Old name absent: ${!("namedForm" in window)}`);
+        println(`New name present: ${window.namedRenamedForm === form}`);
+        container.attachShadow({ mode: "open" }).innerHTML = '<div id="namedShadowOnly"></div>';
+        println(`Shadow ID absent: ${!("namedShadowOnly" in window)}`);
+        container.remove();
+        println(`Removed ID absent: ${!("namedSecond" in window)}`);
+        println(`Removed name absent: ${!("namedRenamedForm" in window)}`);
+    });
+</script>


### PR DESCRIPTION
Property lookups on Window built the complete supported-name collection, including every element ID, just to check whether one name was present. Use the ID index directly and check the remaining name sources without materializing the full collection.

Add coverage for duplicate IDs, renaming, removal, and shadow-tree IDs.