### PR TITLE
LibWeb: Reduce redundant style work when scrolling GitHub diffs

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/impact.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/impact.rs
@@ -925,8 +925,10 @@ pub(super) struct PatchCover {
     /// Running maximum interval end per sorted prefix, bounding the leftward stab walk.
     prefix_max_end: Vec<u32>,
     keys: Vec<(RuleID, EntryID)>,
-    unindexed: Vec<(ImpactRegion, (RuleID, EntryID))>,
-    /// Exact-node attributions without preorder coordinates, sorted by node and rule key.
+    /// Broad coverage needs no per-node expansion.
+    document_keys: Vec<(RuleID, EntryID)>,
+    scope_keys: Vec<(TreeScopeID, (RuleID, EntryID))>,
+    /// Materialized attributions without preorder coordinates, sorted by node and rule key.
     exact_nodes: Vec<(StyleNodeID, (RuleID, EntryID))>,
 }
 
@@ -1430,13 +1432,14 @@ impl ImpactRegions {
     #[must_use]
     /// Compile the transaction's patch coverage: the unattributed regions as the full
     /// re-derivation trigger, and the attributed emissions as stabbable preorder intervals
-    /// carrying rule keys. Exact-node extents without coordinates are indexed by identity; other
-    /// extents retain their rule attribution and are queried through tree relationships.
+    /// carrying rule keys. Extents without coordinates are materialized once and indexed by
+    /// identity, rather than testing their tree relationships again for every candidate.
     pub(super) fn compile_patch_cover(&self, tree: &StyleNodeTree, document_root: Option<StyleNodeID>) -> PatchCover {
         let mut keys: Vec<(RuleID, EntryID)> = Vec::new();
         let mut key_indices: super::HashMap<(RuleID, EntryID), u32> = super::HashMap::default();
         let mut intervals: Vec<(u32, u32, u32)> = Vec::new();
-        let mut unindexed = Vec::new();
+        let mut document_keys = Vec::new();
+        let mut scope_keys = Vec::new();
         let mut exact_nodes = Vec::new();
         let mut scratch: Vec<PreorderInterval> = Vec::new();
         for &(region, key) in &self.attributions {
@@ -1446,11 +1449,28 @@ impl ImpactRegions {
                 .as_ref()
                 .is_some_and(|topology| topology.collect_region_intervals(region, tree, document_root, &mut scratch))
             {
-                // OPTIMIZATION: Exact-node coverage needs no tree coordinates. Index it by identity
-                //               instead of scanning every such attribution for every visited node.
+                // OPTIMIZATION: Resolve fallback coverage once, not once per candidate node.
+                //               Document and scope coverage remain compact even for large trees.
                 match region {
-                    ImpactRegion::Node(node) => exact_nodes.push((node, key)),
-                    _ => unindexed.push((region, key)),
+                    ImpactRegion::Document => document_keys.push(key),
+                    ImpactRegion::TreeScope(scope) => scope_keys.push((scope, key)),
+                    // Preserve the membership predicate for hosted forests and parentless sibling
+                    // sequences, whose coverage differs from the region's streaming traversal.
+                    ImpactRegion::HostedSubtrees(_) => {
+                        exact_nodes.extend(
+                            tree.live_nodes().filter_map(|node| {
+                                self.region_contains_node(region, node, tree).then_some((node, key))
+                            }),
+                        );
+                    }
+                    ImpactRegion::SiblingSequence(member) if tree.parent(member).is_none() => {
+                        exact_nodes.extend(
+                            tree.live_nodes()
+                                .filter_map(|node| tree.parent(node).is_none().then_some((node, key))),
+                        );
+                    }
+                    ImpactRegion::FollowingSiblingSubtrees(anchor) if tree.parent(anchor).is_none() => {}
+                    _ => region.for_each(tree, |node| exact_nodes.push((node, key))),
                 }
                 continue;
             }
@@ -1467,6 +1487,10 @@ impl ImpactRegions {
                 intervals.push((interval.start, interval.end, key_index));
             }
         }
+        document_keys.sort_unstable();
+        document_keys.dedup();
+        scope_keys.sort_unstable();
+        scope_keys.dedup();
         exact_nodes.sort_unstable();
         exact_nodes.dedup();
         intervals.sort_unstable();
@@ -1482,7 +1506,8 @@ impl ImpactRegions {
             intervals,
             prefix_max_end,
             keys,
-            unindexed,
+            document_keys,
+            scope_keys,
             exact_nodes,
         }
     }
@@ -1512,11 +1537,14 @@ impl ImpactRegions {
                 .take_while(|&&(candidate, _)| candidate == node)
                 .map(|&(_, key)| key),
         );
+        out.extend_from_slice(&cover.document_keys);
+        let scope = tree.tree_scope(node);
+        let first = cover.scope_keys.partition_point(|&(candidate, _)| candidate < scope);
         out.extend(
-            cover
-                .unindexed
+            cover.scope_keys[first..]
                 .iter()
-                .filter_map(|&(region, key)| self.region_contains_node(region, node, tree).then_some(key)),
+                .take_while(|&&(candidate, _)| candidate == scope)
+                .map(|&(_, key)| key),
         );
         if cover.intervals.is_empty() {
             out.sort_unstable();
@@ -2153,7 +2181,54 @@ mod tests {
     }
 
     #[test]
-    fn exact_patch_attributions_are_indexed_without_preorder_coordinates() {
+    fn fallback_patch_attributions_match_region_membership() {
+        let fixture = Fixture::new();
+        let nodes = &fixture.nodes;
+        let extents = [
+            ImpactRegion::Node(nodes[1]),
+            ImpactRegion::Children(nodes[0]),
+            ImpactRegion::Subtree(nodes[1]),
+            ImpactRegion::StrictSubtree(nodes[1]),
+            ImpactRegion::NextSibling(nodes[1]),
+            ImpactRegion::FollowingSiblings(nodes[1]),
+            ImpactRegion::FollowingSiblingSubtrees(nodes[1]),
+            ImpactRegion::SiblingSequence(nodes[2]),
+            ImpactRegion::SiblingSequence(nodes[0]),
+            ImpactRegion::Ancestors(nodes[4]),
+            ImpactRegion::PreviousSibling(nodes[2]),
+            ImpactRegion::PrecedingSiblings(nodes[3]),
+            ImpactRegion::TreeScope(TreeScopeID::DOCUMENT),
+            ImpactRegion::Document,
+        ];
+        let mut regions = ImpactRegions::new();
+        for (index, &region) in extents.iter().enumerate() {
+            let key = (RuleID(index as u32 + 1), EntryID(index as u32 + 1));
+            regions.attribute_extent(region, key);
+            regions.attribute_extent(region, key);
+        }
+        let cover = regions.compile_patch_cover(&fixture.tree, Some(nodes[0]));
+        assert!(cover.intervals.is_empty());
+        assert_eq!(cover.document_keys.len(), 1);
+        assert_eq!(cover.scope_keys.len(), 1);
+        let mut sweep = AttributionSweep::default();
+        let mut covering = Vec::new();
+        for &node in nodes.iter().rev() {
+            assert!(regions.covering_attributions(&cover, &fixture.tree, &mut sweep, node, &mut covering));
+            let expected: Vec<_> = extents
+                .iter()
+                .enumerate()
+                .filter_map(|(index, &region)| {
+                    region
+                        .contains_node(node, &fixture.tree)
+                        .then_some((RuleID(index as u32 + 1), EntryID(index as u32 + 1)))
+                })
+                .collect();
+            assert_eq!(covering, expected);
+        }
+    }
+
+    #[test]
+    fn patch_attributions_are_indexed_without_preorder_coordinates() {
         let mut memory = MemoryController::new(DeviceClass::ForegroundDesktop);
         let mut tree = StyleNodeTree::new(&mut memory);
         let root = tree.allocate_element(&mut memory);
@@ -2171,6 +2246,16 @@ mod tests {
             tree.set_tree_scope(node, TreeScopeID(1));
             tree.set_next_element_sibling(node, nodes.get(index + 1).copied());
         }
+        let descendants: Vec<_> = nodes
+            .iter()
+            .map(|&node| {
+                let child = tree.allocate_element(&mut memory);
+                tree.set_parent(child, Some(node));
+                tree.set_tree_scope(child, TreeScopeID(1));
+                tree.set_first_element_child(node, Some(child));
+                child
+            })
+            .collect();
         for with_topology in [false, true] {
             let mut regions = if with_topology {
                 ImpactRegions::with_topology(&tree, root)
@@ -2179,22 +2264,32 @@ mod tests {
             };
             for (index, &node) in nodes.iter().enumerate() {
                 let key = (RuleID(index as u32 + 1), EntryID(index as u32 + 1));
-                regions.attribute_extent(ImpactRegion::Node(node), key);
+                regions.attribute_extent(ImpactRegion::Subtree(node), key);
                 regions.attribute_extent(ImpactRegion::Node(node), key);
             }
             let cover = regions.compile_patch_cover(&tree, Some(root));
-            assert!(
-                cover.unindexed.is_empty(),
-                "exact nodes must not require per-node region scans"
-            );
+            assert_eq!(cover.exact_nodes.len(), nodes.len() + descendants.len());
             let mut sweep = AttributionSweep::default();
             let mut covering = Vec::new();
             for (index, &node) in nodes.iter().enumerate().rev() {
                 assert!(regions.covering_attributions(&cover, &tree, &mut sweep, node, &mut covering));
                 assert_eq!(covering, [(RuleID(index as u32 + 1), EntryID(index as u32 + 1))]);
+                assert!(regions.covering_attributions(&cover, &tree, &mut sweep, descendants[index], &mut covering));
+                assert_eq!(covering, [(RuleID(index as u32 + 1), EntryID(index as u32 + 1))]);
             }
             assert!(regions.covering_attributions(&cover, &tree, &mut sweep, host, &mut covering));
             assert!(covering.is_empty());
+
+            let hosted_key = (RuleID(1000), EntryID(1000));
+            regions.attribute_extent(ImpactRegion::HostedSubtrees(host), hosted_key);
+            let cover = regions.compile_patch_cover(&tree, Some(root));
+            for node in tree.live_nodes() {
+                assert!(regions.covering_attributions(&cover, &tree, &mut sweep, node, &mut covering));
+                assert_eq!(
+                    covering.contains(&hosted_key),
+                    ImpactRegion::HostedSubtrees(host).contains_node(node, &tree),
+                );
+            }
         }
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -3138,7 +3138,9 @@ impl PrefixStates {
     ) -> bool {
         let mut completions = 0;
         for node in nodes {
-            if matches!(self.transition_of(node), PrefixTransitionLookup::Known(_)) {
+            // A relation answer already provides the complete prefix result. Building a
+            // scalar transition for the same node duplicates work and retained state.
+            if self.retained_matches_for(node).is_some() {
                 continue;
             }
             if completions == completion_budget {

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -31,7 +31,10 @@ use super::ScopeProgramID;
 use super::column::Column;
 use super::column::EpochColumn;
 use super::column::advance_epoch;
+use super::fast_hash::FastSet as HashSet;
+use super::index::AttributeFact;
 use super::index::DispatchKey;
+use super::index::StyleAtomID;
 use super::index::StyleNodeFacts;
 use super::instrumentation::Counter;
 use super::instrumentation::Counters;
@@ -264,6 +267,7 @@ pub(super) struct PrefixAutomaton {
     /// The deduplicated structural tests carried by registered chains, in registration order.
     /// Their per-node answers form the positional bits of every transition and completion key.
     positional_tests: Vec<(SelectorProgramID, PrefixStructuralTest)>,
+    local_fact_dependencies: PrefixFactDependencies,
 }
 
 /// The part of an immutable prefix automaton that one transaction can change.
@@ -423,6 +427,9 @@ impl PrefixAutomaton {
         let mut predecessor = None;
         let mut path = Vec::with_capacity(chain.len());
         for (&chain_step, canonical) in chain.iter().zip(canonical_steps) {
+            program.visit_prefix_local_features(chain_step.local, &mut |feature| {
+                self.local_fact_dependencies.add(feature);
+            });
             let predicate = match canonical {
                 Some((features, tests)) => {
                     let mut required_positional_bits = 0_u32;
@@ -786,6 +793,11 @@ impl PrefixAutomaton {
     pub(super) fn capacity_bytes(&self) -> u64 {
         capacity_bytes! {
             shallow [
+                self.local_fact_dependencies.ids,
+                self.local_fact_dependencies.classes,
+                self.local_fact_dependencies.attribute_names,
+                self.local_fact_dependencies.attribute_values,
+                self.local_fact_dependencies.attribute_text_names,
                 self.compounds,
                 self.compound_ids,
                 self.features,
@@ -983,6 +995,86 @@ impl super::intern_table::InternIdentity for LocalFactSlot {
     }
 }
 
+// Prefix answers depend on the selector's observations, not every fact stored on a node.
+// Keep names read by any local predicate, and collapse values no exact test distinguishes.
+// Text comparisons retain their complete inputs, including namespace and case-folded names.
+#[derive(Clone, Default)]
+struct PrefixFactDependencies {
+    ids: HashSet<StyleAtomID>,
+    classes: HashSet<StyleAtomID>,
+    attribute_names: HashSet<StyleAtomID>,
+    attribute_values: HashSet<StyleAtomID>,
+    attribute_text_names: HashSet<StyleAtomID>,
+}
+
+impl PrefixFactDependencies {
+    fn add(&mut self, feature: FeatureTest) {
+        match feature {
+            FeatureTest::Id(id) => {
+                self.ids.insert(id);
+            }
+            FeatureTest::Class(class) => {
+                self.classes.insert(class);
+            }
+            FeatureTest::Attribute(test) => {
+                self.attribute_names.insert(test.name);
+                self.attribute_names.insert(test.folded);
+                match test.operator {
+                    AttributeOperator::Presence => {}
+                    AttributeOperator::Exact
+                        if test.case == super::selector::AttributeCase::Sensitive && !test.value_atom.is_none() =>
+                    {
+                        self.attribute_values.insert(test.value_atom);
+                    }
+                    _ => {
+                        self.attribute_text_names.insert(test.name);
+                        self.attribute_text_names.insert(test.folded);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn id_of(&self, facts: &StyleNodeFacts, row: u32) -> StyleAtomID {
+        let id = facts.id_of(row);
+        if self.ids.contains(&id) { id } else { StyleAtomID::NONE }
+    }
+
+    fn reads_attribute(&self, facts: &StyleNodeFacts, attribute: &AttributeFact) -> bool {
+        Self::name_is_read(&self.attribute_names, facts, attribute)
+    }
+
+    fn name_is_read(names: &HashSet<StyleAtomID>, facts: &StyleNodeFacts, attribute: &AttributeFact) -> bool {
+        if names.is_empty() {
+            return false;
+        }
+        if names.contains(&attribute.name) {
+            return true;
+        }
+        let forms = facts.attribute_name_forms(attribute.name);
+        [forms.local, forms.folded_name, forms.folded_local]
+            .iter()
+            .any(|name| names.contains(name))
+    }
+
+    fn attribute_value<'a>(
+        &self,
+        facts: &'a StyleNodeFacts,
+        attribute: AttributeFact,
+    ) -> (StyleAtomID, Option<&'a [u16]>) {
+        if Self::name_is_read(&self.attribute_text_names, facts, &attribute) {
+            return (attribute.value, facts.text_of(attribute));
+        }
+        let value = if self.attribute_values.contains(&attribute.value) {
+            attribute.value
+        } else {
+            StyleAtomID::NONE
+        };
+        (value, None)
+    }
+}
+
 struct LocalFactInterner {
     identities: super::intern_table::InternTable<LocalFactSlot, (u32, u32)>,
     next_identity: u32,
@@ -996,10 +1088,16 @@ impl LocalFactInterner {
         }
     }
 
-    fn intern(&mut self, facts: &StyleNodeFacts, row: u32, counters: &mut Counters) -> u32 {
-        let hash = hash_local_facts(facts, row);
+    fn intern(
+        &mut self,
+        facts: &StyleNodeFacts,
+        row: u32,
+        dependencies: &PrefixFactDependencies,
+        counters: &mut Counters,
+    ) -> u32 {
+        let hash = hash_local_facts(facts, row, dependencies);
         if let Some(slot) = self.identities.find(hash, |_slot, &(_identity, representative)| {
-            rows_have_equal_local_facts(facts, row, representative)
+            rows_have_equal_local_facts_between(facts, row, facts, representative, dependencies)
         }) {
             counters.bump(Counter::PrefixLocalFactIdentityHits);
             return self.identities[slot].0;
@@ -2527,7 +2625,12 @@ impl PrefixStates {
                     counters.bump(Counter::PrefixLocalFactIdentityMisses);
                     self.local_fact_interner.mint_identity()
                 }
-                false => self.local_fact_interner.intern(row.facts, row.row, counters),
+                false => self.local_fact_interner.intern(
+                    row.facts,
+                    row.row,
+                    &evaluation.automaton.local_fact_dependencies,
+                    counters,
+                ),
             };
             self.set_local_facts(node, identity);
             identity
@@ -3995,7 +4098,12 @@ impl PrefixTransitionSurface<'_> {
                             counters.bump(Counter::PrefixLocalFactIdentityMisses);
                             states.local_fact_interner.mint_identity()
                         }
-                        false => states.local_fact_interner.intern(row.facts, row.row, counters),
+                        false => states.local_fact_interner.intern(
+                            row.facts,
+                            row.row,
+                            &evaluation.automaton.local_fact_dependencies,
+                            counters,
+                        ),
                     };
                     states.set_local_facts(node, identity);
                     identity
@@ -4503,11 +4611,11 @@ impl PrefixStateCache {
     }
 }
 
-fn hash_local_facts(facts: &StyleNodeFacts, row: u32) -> u64 {
+fn hash_local_facts(facts: &StyleNodeFacts, row: u32, dependencies: &PrefixFactDependencies) -> u64 {
     let mut hasher = fast_hasher();
     facts.tag_of(row).hash(&mut hasher);
     facts.folded_tag_of(row).hash(&mut hasher);
-    facts.id_of(row).hash(&mut hasher);
+    dependencies.id_of(facts, row).hash(&mut hasher);
     facts.states_of(row).hash(&mut hasher);
     facts.directionality_of(row).hash(&mut hasher);
     facts.language_of(row).hash(&mut hasher);
@@ -4516,37 +4624,74 @@ fn hash_local_facts(facts: &StyleNodeFacts, row: u32) -> u64 {
     facts.heading_level_of(row).hash(&mut hasher);
     facts.custom_states_of(row).hash(&mut hasher);
     facts.parts_of(row).hash(&mut hasher);
-    facts.classes_of(row).hash(&mut hasher);
-    for &attribute in facts.attributes_of(row) {
+    for class in facts
+        .classes_of(row)
+        .iter()
+        .filter(|class| dependencies.classes.contains(class))
+    {
+        class.hash(&mut hasher);
+    }
+    for &attribute in facts
+        .attributes_of(row)
+        .iter()
+        .filter(|attribute| dependencies.reads_attribute(facts, attribute))
+    {
         attribute.name.hash(&mut hasher);
-        attribute.value.hash(&mut hasher);
-        facts.text_of(attribute).hash(&mut hasher);
+        dependencies.attribute_value(facts, attribute).hash(&mut hasher);
     }
     hasher.finish()
 }
 
-fn rows_have_equal_local_facts(facts: &StyleNodeFacts, left: u32, right: u32) -> bool {
-    if facts.tag_of(left) != facts.tag_of(right)
-        || facts.folded_tag_of(left) != facts.folded_tag_of(right)
-        || facts.id_of(left) != facts.id_of(right)
-        || facts.states_of(left) != facts.states_of(right)
-        || facts.directionality_of(left) != facts.directionality_of(right)
-        || facts.language_of(left) != facts.language_of(right)
-        || facts.language_tag_of(left) != facts.language_tag_of(right)
-        || facts.namespace_of(left) != facts.namespace_of(right)
-        || facts.heading_level_of(left) != facts.heading_level_of(right)
-        || facts.custom_states_of(left) != facts.custom_states_of(right)
-        || facts.parts_of(left) != facts.parts_of(right)
-        || facts.classes_of(left) != facts.classes_of(right)
+fn rows_have_equal_local_facts_between(
+    left_facts: &StyleNodeFacts,
+    left: u32,
+    right_facts: &StyleNodeFacts,
+    right: u32,
+    dependencies: &PrefixFactDependencies,
+) -> bool {
+    if std::ptr::eq(left_facts, right_facts) && left == right {
+        return true;
+    }
+    if left_facts.tag_of(left) != right_facts.tag_of(right)
+        || left_facts.folded_tag_of(left) != right_facts.folded_tag_of(right)
+        || dependencies.id_of(left_facts, left) != dependencies.id_of(right_facts, right)
+        || left_facts.states_of(left) != right_facts.states_of(right)
+        || left_facts.directionality_of(left) != right_facts.directionality_of(right)
+        || left_facts.language_of(left) != right_facts.language_of(right)
+        || left_facts.language_tag_of(left) != right_facts.language_tag_of(right)
+        || left_facts.namespace_of(left) != right_facts.namespace_of(right)
+        || left_facts.heading_level_of(left) != right_facts.heading_level_of(right)
+        || left_facts.custom_states_of(left) != right_facts.custom_states_of(right)
+        || left_facts.parts_of(left) != right_facts.parts_of(right)
+        || !left_facts
+            .classes_of(left)
+            .iter()
+            .filter(|class| dependencies.classes.contains(class))
+            .eq(right_facts
+                .classes_of(right)
+                .iter()
+                .filter(|class| dependencies.classes.contains(class)))
     {
         return false;
     }
-    let left_attributes = facts.attributes_of(left);
-    let right_attributes = facts.attributes_of(right);
-    left_attributes.len() == right_attributes.len()
-        && left_attributes.iter().zip(right_attributes).all(|(&left, &right)| {
-            left.name == right.name && left.value == right.value && facts.text_of(left) == facts.text_of(right)
-        })
+    let mut left_attributes = left_facts
+        .attributes_of(left)
+        .iter()
+        .filter(|attribute| dependencies.reads_attribute(left_facts, attribute));
+    let mut right_attributes = right_facts
+        .attributes_of(right)
+        .iter()
+        .filter(|attribute| dependencies.reads_attribute(right_facts, attribute));
+    loop {
+        match (left_attributes.next(), right_attributes.next()) {
+            (None, None) => return true,
+            (Some(&left), Some(&right))
+                if left.name == right.name
+                    && dependencies.attribute_value(left_facts, left)
+                        == dependencies.attribute_value(right_facts, right) => {}
+            _ => return false,
+        }
+    }
 }
 
 fn matches_feature(facts: &StyleNodeFacts, row: u32, feature: FeatureTest) -> bool {
@@ -4591,6 +4736,59 @@ fn matches_feature(facts: &StyleNodeFacts, row: u32, feature: FeatureTest) -> bo
 mod tests {
     use super::super::index::StyleAtomID;
     use super::*;
+
+    #[test]
+    fn local_fact_identity_distinguishes_only_observed_attribute_values() {
+        use super::super::index::StateSet;
+        use super::super::selector::{AttributeCase, AttributeTest};
+
+        let name = StyleAtomID(20);
+        let mut facts = StyleNodeFacts::new();
+        for index in 0..3 {
+            facts.push_row(
+                StyleNodeID::element(index + 1),
+                StyleAtomID(1),
+                StyleAtomID::NONE,
+                StateSet(0),
+                &[],
+                &[AttributeFact {
+                    name,
+                    value: StyleAtomID(30 + index),
+                    text_offset: 0,
+                    text_length: 0,
+                }],
+            );
+        }
+        for operator in [
+            AttributeOperator::Presence,
+            AttributeOperator::Exact,
+            AttributeOperator::Substring,
+        ] {
+            let mut dependencies = PrefixFactDependencies::default();
+            dependencies.add(FeatureTest::Attribute(AttributeTest {
+                name,
+                any_namespace: false,
+                folded: name,
+                fold_in_namespace: StyleAtomID::NONE,
+                operator,
+                value_atom: StyleAtomID(31),
+                value_offset: 0,
+                value_length: 0,
+                case: AttributeCase::Sensitive,
+            }));
+            let mut interner = LocalFactInterner::new();
+            let mut counters = Counters::default();
+            let identities: Vec<_> = (0..3)
+                .map(|row| interner.intern(&facts, row, &dependencies, &mut counters))
+                .collect();
+            match operator {
+                AttributeOperator::Presence => assert_eq!(identities, [1, 1, 1]),
+                AttributeOperator::Exact => assert_eq!(identities, [1, 2, 1]),
+                AttributeOperator::Substring => assert_eq!(identities, [1, 2, 3]),
+                _ => unreachable!(),
+            }
+        }
+    }
 
     #[test]
     fn begin_transition_sizes_every_scratch_column_independently() {
@@ -5125,7 +5323,9 @@ mod tests {
         );
         {
             let states = cache.get_or_insert(ScopeProgramID(0), facts.generation(), 1);
-            states.local_fact_interner.intern(&facts, 0, &mut counters);
+            states
+                .local_fact_interner
+                .intern(&facts, 0, &PrefixFactDependencies::default(), &mut counters);
         }
         cache.settle_memory(&mut memory);
         assert!(cache.retain(&mut memory));

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -21,11 +21,13 @@
 use super::capacity::capacity_bytes;
 use super::fast_hash::FastMap as HashMap;
 use super::fast_hash::fast_hasher;
+use super::selector::SelectorPrefixPredicate;
 use std::collections::hash_map::Entry;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::mem::size_of;
 use std::num::NonZeroU32;
+use std::rc::Rc;
 
 use super::ScopeProgramID;
 use super::column::Column;
@@ -162,10 +164,7 @@ enum PrefixPredicateKey {
         features: Box<[FeatureTest]>,
         required_positional_bits: u32,
     },
-    Program {
-        program: SelectorProgramID,
-        local: SelectorPrefixLocal,
-    },
+    Program(Rc<SelectorPrefixPredicate>),
 }
 
 #[derive(Clone)]
@@ -178,6 +177,7 @@ enum PrefixPredicate {
     Program {
         program: SelectorProgramID,
         local: SelectorPrefixLocal,
+        identity: Rc<SelectorPrefixPredicate>,
     },
 }
 
@@ -301,10 +301,7 @@ impl PrefixAutomaton {
                             required_positional_bits: *required_positional_bits,
                         }
                     }
-                    PrefixPredicate::Program { program, local } => PrefixPredicateKey::Program {
-                        program: *program,
-                        local: *local,
-                    },
+                    PrefixPredicate::Program { identity, .. } => PrefixPredicateKey::Program(Rc::clone(identity)),
                 };
                 (
                     key,
@@ -448,10 +445,7 @@ impl PrefixAutomaton {
                         required_positional_bits,
                     }
                 }
-                None => PrefixPredicateKey::Program {
-                    program: program_id,
-                    local: chain_step.local,
-                },
+                None => PrefixPredicateKey::Program(Rc::new(program.prefix_local_predicate(chain_step.local))),
             };
             let compound = match self.compound_ids.entry(predicate) {
                 Entry::Occupied(entry) => *entry.get(),
@@ -475,9 +469,10 @@ impl PrefixAutomaton {
                                 required_positional_bits: *required_positional_bits,
                             }
                         }
-                        PrefixPredicateKey::Program { program, local } => PrefixPredicate::Program {
-                            program: *program,
-                            local: *local,
+                        PrefixPredicateKey::Program(identity) => PrefixPredicate::Program {
+                            program: program_id,
+                            local: chain_step.local,
+                            identity: Rc::clone(identity),
                         },
                     };
                     self.compounds.push(PrefixCompound {
@@ -812,12 +807,16 @@ impl PrefixAutomaton {
             ];
             cached [];
             nested [
+                self.compounds.iter().map(|compound| match &compound.predicate {
+                    PrefixPredicate::Program { identity, .. } => size_of::<SelectorPrefixPredicate>() + 2 * size_of::<usize>() + identity.capacity_bytes(),
+                    _ => 0,
+                }).sum::<usize>(),
                 self
                 .compound_ids
                 .keys()
                 .map(|predicate| match predicate {
                     PrefixPredicateKey::Features { features, .. } => features.len() * size_of::<FeatureTest>(),
-                    PrefixPredicateKey::Program { .. } => 0,
+                    PrefixPredicateKey::Program(_) => 0,
                 })
                 .sum::<usize>(),
                 self
@@ -1593,7 +1592,7 @@ impl<'a, 'b> PrefixEvaluation<'a, 'b> {
                     .iter()
                     .all(|&feature| matches_feature(row.facts, row.row, feature)))
             }
-            PrefixPredicate::Program { program, local } => {
+            PrefixPredicate::Program { program, local, .. } => {
                 self.evaluator
                     .matches_prefix_local(*program, self.programs.get(*program), *local, node, counters)
             }
@@ -1622,7 +1621,7 @@ impl<'a, 'b> PrefixEvaluation<'a, 'b> {
                         .iter()
                         .all(|&feature| matches_feature(row.facts, row.row, feature)),
             ),
-            PrefixPredicate::Program { program, local } => {
+            PrefixPredicate::Program { program, local, .. } => {
                 self.evaluator
                     .matches_prefix_local(*program, self.programs.get(*program), *local, node, counters)
             }
@@ -3245,31 +3244,29 @@ impl PrefixStates {
                 self.compound_answer[compound_index]
             } else {
                 let compound = &automaton.compounds[compound_index];
-                let matches = match &compound.predicate {
-                    PrefixPredicate::Features {
-                        feature_start,
-                        feature_len,
-                        required_positional_bits,
-                    } => {
-                        (positional_bits & required_positional_bits) == *required_positional_bits
-                            && automaton
-                                .features_for(*feature_start, *feature_len)
-                                .iter()
-                                .all(|&feature| matches_feature(row.facts, row.row, feature))
-                    }
-                    PrefixPredicate::Program { program, local } => match evaluation.evaluator.matches_prefix_local(
-                        *program,
-                        evaluation.programs.get(*program),
-                        *local,
-                        node,
-                        counters,
-                    ) {
-                        Ok(matches) => matches,
-                        Err(incomplete) => {
-                            return PrefixTransitionLookup::Missing(PrefixTransitionGap::Incomplete(incomplete));
+                let matches =
+                    match &compound.predicate {
+                        PrefixPredicate::Features {
+                            feature_start,
+                            feature_len,
+                            required_positional_bits,
+                        } => {
+                            (positional_bits & required_positional_bits) == *required_positional_bits
+                                && automaton
+                                    .features_for(*feature_start, *feature_len)
+                                    .iter()
+                                    .all(|&feature| matches_feature(row.facts, row.row, feature))
                         }
-                    },
-                };
+                        PrefixPredicate::Program { program, local, .. } => match evaluation
+                            .evaluator
+                            .matches_prefix_local(*program, evaluation.programs.get(*program), *local, node, counters)
+                        {
+                            Ok(matches) => matches,
+                            Err(incomplete) => {
+                                return PrefixTransitionLookup::Missing(PrefixTransitionGap::Incomplete(incomplete));
+                            }
+                        },
+                    };
                 self.compound_epoch[compound_index] = self.epoch;
                 self.compound_answer[compound_index] = matches;
                 counters.bump(Counter::PrefixCompoundsEvaluated);

--- a/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
@@ -477,34 +477,41 @@ impl PrefixRelation {
                 };
                 for &index in compounds {
                     let compound = &automaton.compounds[index];
-                    let matched = *local_matches
-                        .entry((store, identity, is_root, positional, index))
-                        .or_insert_with(|| {
-                            counters.bump(Counter::PrefixCompoundsEvaluated);
-                            match &compound.predicate {
-                                PrefixPredicate::Features {
-                                    feature_start,
-                                    feature_len,
-                                    required_positional_bits,
-                                } => {
-                                    positional & required_positional_bits == *required_positional_bits
-                                        && automaton
-                                            .features_for(*feature_start, *feature_len)
-                                            .iter()
-                                            .all(|&feature| matches_feature(row.facts, row.row, feature))
+                    // Positional truth is checked per node; it does not change the local
+                    // predicate result shared by nodes with identical facts.
+                    let positional_matches = match &compound.predicate {
+                        PrefixPredicate::Features {
+                            required_positional_bits,
+                            ..
+                        } => positional & required_positional_bits == *required_positional_bits,
+                        PrefixPredicate::Program { .. } => true,
+                    };
+                    let matched = positional_matches
+                        && *local_matches
+                            .entry((store, identity, is_root, index))
+                            .or_insert_with(|| {
+                                counters.bump(Counter::PrefixCompoundsEvaluated);
+                                match &compound.predicate {
+                                    PrefixPredicate::Features {
+                                        feature_start,
+                                        feature_len,
+                                        ..
+                                    } => automaton
+                                        .features_for(*feature_start, *feature_len)
+                                        .iter()
+                                        .all(|&feature| matches_feature(row.facts, row.row, feature)),
+                                    PrefixPredicate::Program { program, local } => evaluation
+                                        .evaluator
+                                        .matches_prefix_local(
+                                            *program,
+                                            evaluation.programs.get(*program),
+                                            *local,
+                                            node,
+                                            counters,
+                                        )
+                                        .unwrap(),
                                 }
-                                PrefixPredicate::Program { program, local } => evaluation
-                                    .evaluator
-                                    .matches_prefix_local(
-                                        *program,
-                                        evaluation.programs.get(*program),
-                                        *local,
-                                        node,
-                                        counters,
-                                    )
-                                    .unwrap(),
-                            }
-                        });
+                            });
                     if self.compound_matches[index].binary_search(&position).is_ok() != matched {
                         changed_compounds.entry(index).or_default().push(position);
                     }

--- a/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
@@ -434,6 +434,10 @@ impl PrefixRelation {
                 }
             }
         }
+        // Transaction rows can come from several fact stores. Intern within each store so
+        // representative row indices are never interpreted in another store's columns.
+        let mut local_facts = HashMap::default();
+        let mut local_matches = HashMap::default();
         for &node in changed_nodes {
             let Some(&position) = node
                 .element_index()
@@ -461,37 +465,46 @@ impl PrefixRelation {
                 0
             };
             self.positional[position] = positional;
+            let store = std::ptr::from_ref(row.facts);
+            let identity = local_facts
+                .entry(store)
+                .or_insert_with(super::LocalFactInterner::new)
+                .intern(row.facts, row.row, counters);
+            let is_root = evaluation.tree.parent(node).is_none();
             for key in &keys {
                 let Some(compounds) = self.compounds_by_key.get(key) else {
                     continue;
                 };
                 for &index in compounds {
                     let compound = &automaton.compounds[index];
-                    counters.bump(Counter::PrefixCompoundsEvaluated);
-                    let matched = self.live[position]
-                        && match &compound.predicate {
-                            PrefixPredicate::Features {
-                                feature_start,
-                                feature_len,
-                                required_positional_bits,
-                            } => {
-                                positional & required_positional_bits == *required_positional_bits
-                                    && automaton
-                                        .features_for(*feature_start, *feature_len)
-                                        .iter()
-                                        .all(|&feature| matches_feature(row.facts, row.row, feature))
+                    let matched = *local_matches
+                        .entry((store, identity, is_root, positional, index))
+                        .or_insert_with(|| {
+                            counters.bump(Counter::PrefixCompoundsEvaluated);
+                            match &compound.predicate {
+                                PrefixPredicate::Features {
+                                    feature_start,
+                                    feature_len,
+                                    required_positional_bits,
+                                } => {
+                                    positional & required_positional_bits == *required_positional_bits
+                                        && automaton
+                                            .features_for(*feature_start, *feature_len)
+                                            .iter()
+                                            .all(|&feature| matches_feature(row.facts, row.row, feature))
+                                }
+                                PrefixPredicate::Program { program, local } => evaluation
+                                    .evaluator
+                                    .matches_prefix_local(
+                                        *program,
+                                        evaluation.programs.get(*program),
+                                        *local,
+                                        node,
+                                        counters,
+                                    )
+                                    .unwrap(),
                             }
-                            PrefixPredicate::Program { program, local } => evaluation
-                                .evaluator
-                                .matches_prefix_local(
-                                    *program,
-                                    evaluation.programs.get(*program),
-                                    *local,
-                                    node,
-                                    counters,
-                                )
-                                .unwrap(),
-                        };
+                        });
                     if self.compound_matches[index].binary_search(&position).is_ok() != matched {
                         changed_compounds.entry(index).or_default().push(position);
                     }

--- a/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
@@ -296,7 +296,6 @@ impl PrefixRelation {
                 let bits = evaluation.positional_bits(node, counters).unwrap();
                 if bits != self.positional[position] {
                     extra.push(node);
-                    self.positional[position] = bits;
                 }
             }
         }
@@ -438,6 +437,8 @@ impl PrefixRelation {
         // representative row indices are never interpreted in another store's columns.
         let mut local_facts = HashMap::default();
         let mut local_matches = HashMap::default();
+        self.geometry_targets[0].sort_unstable();
+        self.geometry_targets[0].dedup();
         for &node in changed_nodes {
             let Some(&position) = node
                 .element_index()
@@ -452,6 +453,24 @@ impl PrefixRelation {
             let previous_row = old_evaluation.row_of(node);
             let row = row.or(previous_row).unwrap();
             let previous_row = previous_row.unwrap_or(row);
+            let positional = evaluation.positional_bits(node, counters).unwrap();
+            let positional_changes = self.positional[position] ^ positional;
+            self.positional[position] = positional;
+            // Geometry frontiers include retained nodes whose local facts did not change.
+            // Preserve their predicate memberships, revisiting only changed positional tests.
+            // A changed parent conservatively requires checking :root again.
+            let local_changed = self.arrivals.binary_search(&position).is_ok()
+                || self.geometry_targets[0].binary_search(&position).is_ok()
+                || !super::rows_have_equal_local_facts_between(
+                    row.facts,
+                    row.row,
+                    previous_row.facts,
+                    previous_row.row,
+                    &automaton.local_fact_dependencies,
+                );
+            if !local_changed && positional_changes == 0 {
+                continue;
+            }
             keys.clear();
             for row in [row, previous_row] {
                 row.facts
@@ -459,17 +478,11 @@ impl PrefixRelation {
             }
             keys.sort_unstable();
             keys.dedup();
-            let positional = if self.live[position] {
-                evaluation.positional_bits(node, counters).unwrap()
-            } else {
-                0
-            };
-            self.positional[position] = positional;
             let store = std::ptr::from_ref(row.facts);
             let identity = local_facts
                 .entry(store)
                 .or_insert_with(super::LocalFactInterner::new)
-                .intern(row.facts, row.row, counters);
+                .intern(row.facts, row.row, &automaton.local_fact_dependencies, counters);
             let is_root = evaluation.tree.parent(node).is_none();
             for key in &keys {
                 let Some(compounds) = self.compounds_by_key.get(key) else {
@@ -477,6 +490,16 @@ impl PrefixRelation {
                 };
                 for &index in compounds {
                     let compound = &automaton.compounds[index];
+                    if !local_changed {
+                        match &compound.predicate {
+                            PrefixPredicate::Features {
+                                required_positional_bits,
+                                ..
+                            } if required_positional_bits & positional_changes != 0 => {}
+                            _ => continue,
+                        }
+                    }
+
                     // Positional truth is checked per node; it does not change the local
                     // predicate result shared by nodes with identical facts.
                     let positional_matches = match &compound.predicate {
@@ -912,20 +935,24 @@ impl PrefixAutomaton {
         // Local predicates read the same facts for every member of a fact cohort. Reuse their
         // answers while building memberships, as scalar prefix transitions already do. Keep
         // document-root identity in the key and check positional truth separately per node.
-        let mut local_facts = super::LocalFactInterner::new();
+        let mut local_facts = HashMap::default();
+        let mut identities = HashMap::default();
         let local_fact_keys: Vec<_> = rows
             .iter()
             .enumerate()
             .map(|(position, row)| {
-                let identity = if evaluation.facts_are_composite() {
-                    local_facts.mint_identity()
-                } else {
-                    local_facts.intern(row.facts, row.row, counters)
-                };
-                identity as usize * 2 + usize::from(parents[position] == usize::MAX)
+                let store = std::ptr::from_ref(row.facts);
+                let identity = local_facts
+                    .entry(store)
+                    .or_insert_with(super::LocalFactInterner::new)
+                    .intern(row.facts, row.row, &self.local_fact_dependencies, counters);
+                let next = identities.len();
+                *identities
+                    .entry((store, identity, parents[position] == usize::MAX))
+                    .or_insert(next)
             })
             .collect();
-        let mut local_matches = vec![None; local_facts.next_identity as usize * 2];
+        let mut local_matches = vec![None; identities.len()];
         let mut compound_matches = Vec::with_capacity(self.compounds.len());
         for compound in &self.compounds {
             local_matches.fill(None);

--- a/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
@@ -523,7 +523,7 @@ impl PrefixRelation {
                                         .features_for(*feature_start, *feature_len)
                                         .iter()
                                         .all(|&feature| matches_feature(row.facts, row.row, feature)),
-                                    PrefixPredicate::Program { program, local } => evaluation
+                                    PrefixPredicate::Program { program, local, .. } => evaluation
                                         .evaluator
                                         .matches_prefix_local(
                                             *program,
@@ -980,7 +980,7 @@ impl PrefixAutomaton {
                                 .features_for(*feature_start, *feature_len)
                                 .iter()
                                 .all(|&feature| matches_feature(row.facts, row.row, feature)),
-                            PrefixPredicate::Program { program, local } => evaluation
+                            PrefixPredicate::Program { program, local, .. } => evaluation
                                 .evaluator
                                 .matches_prefix_local(
                                     *program,

--- a/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix/relation.rs
@@ -955,6 +955,26 @@ impl PrefixAutomaton {
         let mut local_matches = vec![None; identities.len()];
         let mut compound_matches = Vec::with_capacity(self.compounds.len());
         for compound in &self.compounds {
+            // Dispatch postings already prove universal, ID, and class predicates. With
+            // no additional local or positional test, the posting is the membership set.
+            if let PrefixPredicate::Features {
+                feature_start,
+                feature_len,
+                required_positional_bits: 0,
+            } = &compound.predicate
+                && self
+                    .features_for(*feature_start, *feature_len)
+                    .iter()
+                    .all(|feature| match feature {
+                        super::FeatureTest::AnyElement => true,
+                        super::FeatureTest::Id(id) => compound.dispatch_key == DispatchKey::Id(*id),
+                        super::FeatureTest::Class(class) => compound.dispatch_key == DispatchKey::Class(*class),
+                        _ => false,
+                    })
+            {
+                compound_matches.push(candidates[&compound.dispatch_key].clone());
+                continue;
+            }
             local_matches.fill(None);
             let matched: Vec<_> = candidates[&compound.dispatch_key]
                 .iter()

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -674,6 +674,34 @@ impl SelectorEntry {
     }
 }
 
+// A local predicate's identity excludes program-relative node IDs and text offsets.
+// Prefix matching does not compute specificity, so :where() is transparent here.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) enum SelectorPrefixPredicate {
+    Leaf(SelectorOp),
+    Attribute(AttributeTest, Box<[u16]>),
+    And(Box<[Self]>),
+    Or(Box<[Self]>),
+    Not(Box<Self>),
+    Language(Box<[Box<[u16]>]>),
+}
+
+impl SelectorPrefixPredicate {
+    pub(super) fn capacity_bytes(&self) -> usize {
+        match self {
+            Self::Leaf(_) => 0,
+            Self::Attribute(_, text) => size_of_val(text.as_ref()),
+            Self::And(operands) | Self::Or(operands) => {
+                size_of_val(operands.as_ref()) + operands.iter().map(Self::capacity_bytes).sum::<usize>()
+            }
+            Self::Not(inner) => size_of::<Self>() + inner.capacity_bytes(),
+            Self::Language(ranges) => {
+                size_of_val(ranges.as_ref()) + ranges.iter().map(|range| size_of_val(range.as_ref())).sum::<usize>()
+            }
+        }
+    }
+}
+
 /// A compiled selector program: one rule's selector list.
 #[derive(Default, PartialEq, Eq, Hash)]
 pub struct SelectorProgram {
@@ -1285,6 +1313,73 @@ impl SelectorProgram {
                 .min_by_key(|key| dispatch_selectivity(*key))
                 .unwrap_or(DispatchKey::Universal),
             _ => self.dispatch_key_of(local.root),
+        }
+    }
+
+    pub(super) fn prefix_local_predicate(&self, local: SelectorPrefixLocal) -> SelectorPrefixPredicate {
+        fn conjunction(mut operands: Vec<SelectorPrefixPredicate>) -> SelectorPrefixPredicate {
+            if operands.len() == 1 {
+                operands.pop().unwrap()
+            } else {
+                SelectorPrefixPredicate::And(operands.into_boxed_slice())
+            }
+        }
+        fn predicate(program: &SelectorProgram, node: SelectorNodeID) -> SelectorPrefixPredicate {
+            match program.node(node) {
+                SelectorOp::And { first, count } => conjunction(
+                    program
+                        .operands(first, count)
+                        .iter()
+                        .map(|&node| predicate(program, node))
+                        .collect(),
+                ),
+                SelectorOp::Or { first, count } => SelectorPrefixPredicate::Or(
+                    program
+                        .operands(first, count)
+                        .iter()
+                        .map(|&node| predicate(program, node))
+                        .collect(),
+                ),
+                SelectorOp::Where(inner) => predicate(program, inner),
+                SelectorOp::Not(inner) => SelectorPrefixPredicate::Not(Box::new(predicate(program, inner))),
+                SelectorOp::Language { first, count } => {
+                    SelectorPrefixPredicate::Language(program.language_ranges(first, count).map(Box::from).collect())
+                }
+                SelectorOp::Feature(FeatureTest::Attribute(mut test)) => {
+                    let text = match test.operator {
+                        AttributeOperator::Presence => {
+                            test.value_atom = StyleAtomID::NONE;
+                            test.case = AttributeCase::Sensitive;
+                            &[][..]
+                        }
+                        AttributeOperator::Exact
+                            if test.case == AttributeCase::Sensitive && !test.value_atom.is_none() =>
+                        {
+                            &[]
+                        }
+                        _ => program.literal(test.value_offset, test.value_length),
+                    };
+                    test.value_offset = 0;
+                    test.value_length = 0;
+                    SelectorPrefixPredicate::Attribute(test, text.into())
+                }
+                leaf @ (SelectorOp::Feature(_)
+                | SelectorOp::State(_)
+                | SelectorOp::Root
+                | SelectorOp::ValueState { .. }
+                | SelectorOp::Heading(_)) => SelectorPrefixPredicate::Leaf(leaf),
+                _ => unreachable!("only local predicates can share a prefix compound"),
+            }
+        }
+        match self.node(local.root) {
+            SelectorOp::And { first, count } => conjunction(
+                self.operands(first, count)
+                    .iter()
+                    .filter(|&&node| Some(node) != local.relation)
+                    .map(|&node| predicate(self, node))
+                    .collect(),
+            ),
+            _ => predicate(self, local.root),
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -1288,6 +1288,23 @@ impl SelectorProgram {
         }
     }
 
+    pub(super) fn visit_prefix_local_features(&self, local: SelectorPrefixLocal, visit: &mut impl FnMut(FeatureTest)) {
+        let mut pending = vec![local.root];
+        while let Some(node) = pending.pop() {
+            if Some(node) == local.relation {
+                continue;
+            }
+            match self.node(node) {
+                SelectorOp::Feature(feature) => visit(feature),
+                SelectorOp::And { first, count } | SelectorOp::Or { first, count } => {
+                    pending.extend_from_slice(self.operands(first, count));
+                }
+                SelectorOp::Where(inner) | SelectorOp::Not(inner) => pending.push(inner),
+                _ => {}
+            }
+        }
+    }
+
     /// The canonical feature list of one prefix step's local compound, plus at most one
     /// positional test. Positional truth is a pure function of the visit index and the
     /// sequence length, both of which the rightward walk knows, so a step carrying one stays

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5208,6 +5208,41 @@ fn update_test_prefix_relation(
 }
 
 #[test]
+fn prefix_completion_reuses_positive_and_negative_relation_answers() {
+    let (mut engine, nodes) = nested_document();
+    let guard = StyleAtomID(200);
+    let target = StyleAtomID(201);
+    add_guard_target_rule(&mut engine, guard, target);
+    add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+    add_feature(&mut engine, nodes[3], LocalFeatureKey::Class(target));
+    discard_transaction(&mut engine);
+    let (dispatch, relation) = test_prefix_relation(&mut engine, nodes[0]);
+    let facts = engine.facts.primary();
+    let evaluator = MatchEvaluator::new(&engine.tree, facts);
+    let evaluation = PrefixEvaluation::new(
+        dispatch.prefixes(),
+        &engine.tree,
+        facts,
+        &engine.programs,
+        &evaluator,
+        None,
+        None,
+    );
+    let mut counters = Counters::default();
+    let mut states = PrefixStates::new(facts.row_count());
+    assert!(!states.complete_nodes_with_budget(&evaluation, nodes.iter().copied(), 0, &mut counters));
+    relation.install_answers(&mut states);
+    states.relation = Some(Box::new(relation));
+    assert!(states.retained_matches_for(nodes[0]).unwrap().is_empty());
+    assert_eq!(states.retained_matches_for(nodes[3]).unwrap().len(), 1);
+    for budget in [0, usize::MAX] {
+        assert!(states.complete_nodes_with_budget(&evaluation, nodes.iter().copied(), budget, &mut counters));
+        assert_eq!(counters.get(Counter::PrefixCompoundsEvaluated), 0);
+        assert_eq!(counters.get(Counter::PrefixTransitionMemoMisses), 0);
+    }
+}
+
+#[test]
 fn prefix_relations_share_program_predicates_without_merging_their_paths() {
     let (mut engine, nodes) = nested_document();
     let attribute_name = StyleAtomID(200);

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5226,8 +5226,20 @@ fn prefix_relation_reuses_local_facts_without_sharing_position() {
             )),
         );
     }
-    for &node in &nodes {
+    let unused_attribute = StyleAtomID(202);
+    let observed_attribute = StyleAtomID(203);
+    for (index, &node) in nodes.iter().enumerate() {
         add_feature(&mut engine, node, LocalFeatureKey::Class(class));
+        engine.record_input(
+            InputKey::LocalFeature(node, LocalFeatureKey::Id),
+            InputValue::Feature(FeatureValue::Absent),
+            InputValue::Feature(FeatureValue::Atom(StyleAtomID(500 + index as u32))),
+        );
+        engine.record_input(
+            InputKey::LocalFeature(node, LocalFeatureKey::Attribute(unused_attribute)),
+            InputValue::Feature(FeatureValue::Absent),
+            InputValue::Feature(FeatureValue::Atom(StyleAtomID(600 + index as u32))),
+        );
     }
 
     // The root has the same local facts as its children, but :root and nth-child
@@ -5236,7 +5248,19 @@ fn prefix_relation_reuses_local_facts_without_sharing_position() {
     let feature = builder.push_feature(selector::FeatureTest::Class(class));
     let root = builder.push(selector::SelectorOp::Root);
     let not_root = builder.push(selector::SelectorOp::Not(root));
-    let compound = builder.push_compound(&[feature, not_root]);
+    let attribute = builder.push_feature(selector::FeatureTest::Attribute(selector::AttributeTest {
+        name: observed_attribute,
+        any_namespace: false,
+        folded: observed_attribute,
+        fold_in_namespace: StyleAtomID::NONE,
+        operator: selector::AttributeOperator::Presence,
+        value_atom: StyleAtomID::NONE,
+        value_offset: 0,
+        value_length: 0,
+        case: selector::AttributeCase::Sensitive,
+    }));
+    let not_attribute = builder.push(selector::SelectorOp::Not(attribute));
+    let compound = builder.push_compound(&[feature, not_root, not_attribute]);
     builder.push_entry_for_pseudo(compound, None);
     let sheet = engine.add_sheet(StyleSheetObjectID(1), CascadeOrigin::Author);
     engine.attach_sheet(sheet, TreeScopeID::DOCUMENT);
@@ -5263,9 +5287,10 @@ fn prefix_relation_reuses_local_facts_without_sharing_position() {
     let old_facts = engine.facts.primary().clone();
     let counters = update_test_prefix_relation(&engine, &dispatch, &mut relation, &old_facts, &nodes, None);
     let evaluations = counters.get(Counter::PrefixCompoundsEvaluated);
-    // Evaluate the program once for roots and once for non-roots, and the class
-    // predicate once for children passing the positional test.
-    assert_eq!(evaluations, 3, "positional truth must not split local predicate reuse");
+    assert_eq!(
+        evaluations, 0,
+        "unchanged local facts must retain their predicate answers"
+    );
     let mut states = PrefixStates::new(0);
     relation.install_answers(&mut states);
     assert!(states.retained_matches_for(nodes[0]).unwrap().is_empty());
@@ -5275,6 +5300,27 @@ fn prefix_relation_reuses_local_facts_without_sharing_position() {
             1 + usize::from(index % 2 == 0)
         );
     }
+    let old_facts = engine.facts.primary().clone();
+    for (index, &node) in nodes.iter().enumerate() {
+        engine.record_input(
+            InputKey::LocalFeature(node, LocalFeatureKey::Attribute(unused_attribute)),
+            InputValue::Feature(FeatureValue::Atom(StyleAtomID(600 + index as u32))),
+            InputValue::Feature(FeatureValue::Atom(StyleAtomID(1000 + index as u32))),
+        );
+    }
+    discard_transaction(&mut engine);
+    let counters = update_test_prefix_relation(&engine, &dispatch, &mut relation, &old_facts, &nodes, None);
+    assert_eq!(counters.get(Counter::PrefixCompoundsEvaluated), 0);
+    assert!(relation.changed_answers.is_empty());
+
+    // A dependency nested inside :not() must still invalidate the predicate.
+    let old_facts = engine.facts.primary().clone();
+    add_feature(&mut engine, nodes[1], LocalFeatureKey::Attribute(observed_attribute));
+    discard_transaction(&mut engine);
+    update_test_prefix_relation(&engine, &dispatch, &mut relation, &old_facts, &[nodes[1]], None);
+    assert_eq!(relation.changed_answers.len(), 1);
+    assert_eq!(relation.changed_answers[0].0, nodes[1]);
+    assert!(relation.changed_answers[0].2.is_empty());
 }
 
 #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5156,7 +5156,7 @@ fn update_test_prefix_relation(
     old_facts: &StyleNodeFacts,
     changed: &[StyleNodeID],
     geometry_root: Option<StyleNodeID>,
-) {
+) -> Counters {
     let workspace = MatchEvaluationWorkspace::default();
     let facts = engine.facts.primary();
     let evaluator =
@@ -5204,10 +5204,11 @@ fn update_test_prefix_relation(
         &changed,
         &mut counters,
     );
+    counters
 }
 
 #[test]
-fn prefix_relation_construction_reuses_local_facts_without_sharing_position() {
+fn prefix_relation_reuses_local_facts_without_sharing_position() {
     let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
     let mut raw = [0; 65];
     engine.allocate_style_nodes(&mut raw);
@@ -5253,11 +5254,18 @@ fn prefix_relation_construction_reuses_local_facts_without_sharing_position() {
     }
     discard_transaction(&mut engine);
     let before = engine.counters.get(Counter::PrefixCompoundsEvaluated);
-    let (_, relation) = test_prefix_relation(&mut engine, nodes[0]);
+    let (dispatch, mut relation) = test_prefix_relation(&mut engine, nodes[0]);
     let evaluations = engine.counters.get(Counter::PrefixCompoundsEvaluated) - before;
     assert!(
         evaluations < 16,
         "repeated local facts required {evaluations} evaluations"
+    );
+    let old_facts = engine.facts.primary().clone();
+    let counters = update_test_prefix_relation(&engine, &dispatch, &mut relation, &old_facts, &nodes, None);
+    let evaluations = counters.get(Counter::PrefixCompoundsEvaluated);
+    assert!(
+        evaluations < 16,
+        "repeated local facts required {evaluations} update evaluations"
     );
     let mut states = PrefixStates::new(0);
     relation.install_answers(&mut states);
@@ -5340,31 +5348,30 @@ fn prefix_relation_local_fact_cache_separates_predicates_and_tracks_changes() {
             );
         }
 
-        // Move one element between fact groups in each direction. Other members
-        // must keep their answers, and rebuilding must agree with the update.
+        // Move every element between fact groups. Shared positive and negative
+        // answers must change, and rebuilding must agree with the update.
         let old_facts = engine.facts.primary().clone();
-        add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(selected));
-        remove_feature(&mut engine, nodes[2], LocalFeatureKey::Class(selected));
+        for (index, &node) in nodes.iter().enumerate() {
+            if index % 2 == 0 {
+                remove_feature(&mut engine, node, LocalFeatureKey::Class(selected));
+            } else {
+                add_feature(&mut engine, node, LocalFeatureKey::Class(selected));
+            }
+        }
         discard_transaction(&mut engine);
-        update_test_prefix_relation(
-            &engine,
-            &dispatch,
-            &mut relation,
-            &old_facts,
-            &[nodes[1], nodes[2]],
-            None,
+        let counters = update_test_prefix_relation(&engine, &dispatch, &mut relation, &old_facts, &nodes, None);
+        let evaluations = counters.get(Counter::PrefixCompoundsEvaluated);
+        assert!(
+            evaluations < 16,
+            "repeated local facts required {evaluations} update evaluations"
         );
-        assert_eq!(relation.changed_answers.len(), 2);
+        assert_eq!(relation.changed_answers.len(), nodes.len());
         relation.install_answers(&mut states);
         let (_, rebuilt) = test_prefix_relation(&mut engine, nodes[0]);
         let mut rebuilt_states = PrefixStates::new(0);
         rebuilt.install_answers(&mut rebuilt_states);
         for (index, &node) in nodes.iter().enumerate() {
-            let selected = match index {
-                1 => true,
-                2 => false,
-                _ => index % 2 == 0,
-            };
+            let selected = index % 2 != 0;
             let matches = states.retained_matches_for(node).unwrap();
             assert_eq!(matches.len(), 1 + usize::from(selected != negate));
             assert_eq!(matches, rebuilt_states.retained_matches_for(node).unwrap());

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5208,6 +5208,60 @@ fn update_test_prefix_relation(
 }
 
 #[test]
+fn prefix_relation_copies_only_dispatch_complete_predicates() {
+    let (mut engine, nodes) = linear_document();
+    let first_class = StyleAtomID(200);
+    let second_class = StyleAtomID(201);
+    let id = StyleAtomID(202);
+    for &node in &nodes {
+        add_feature(&mut engine, node, LocalFeatureKey::Class(first_class));
+    }
+    add_feature(&mut engine, nodes[2], LocalFeatureKey::Class(second_class));
+    set_atom_feature(&mut engine, nodes[3], LocalFeatureKey::Id, id);
+    let mut builder = selector::SelectorProgramBuilder::new();
+    let feature = builder.push_feature(selector::FeatureTest::Id(id));
+    builder.push_entry(feature);
+    let atoms = [("first", first_class), ("second", second_class)];
+    let mut selectors = vec![
+        test_selector_program("*", &[]),
+        test_selector_program(".first", &atoms),
+        builder.finish(),
+    ];
+    let sheet = engine.add_sheet(StyleSheetObjectID(1), CascadeOrigin::Author);
+    engine.attach_sheet(sheet, TreeScopeID::DOCUMENT);
+    for additional_tests in [false, true] {
+        for selector in selectors.drain(..) {
+            let program = engine.programs.add(selector);
+            let rule = engine.append_rule(sheet, None, RuleKind::Style);
+            engine.add_routing_rule(rule, program);
+            let mut version = engine.program.rule_version(rule);
+            version.selector_program = Some(program);
+            version.declaration_block = Some(DeclarationBlockID(1));
+            engine.replace_rule_version(rule, version);
+        }
+        discard_transaction(&mut engine);
+        let before = engine.counters.get(Counter::PrefixCompoundsEvaluated);
+        let (_, relation) = test_prefix_relation(&mut engine, nodes[0]);
+        let evaluated = engine.counters.get(Counter::PrefixCompoundsEvaluated) - before;
+        if additional_tests {
+            assert!(evaluated > 0);
+        } else {
+            assert_eq!(evaluated, 0);
+        }
+        let mut states = PrefixStates::new(0);
+        relation.install_answers(&mut states);
+        let expected = if additional_tests { [2, 2, 4, 3] } else { [2, 2, 2, 3] };
+        for (&node, count) in nodes.iter().zip(expected) {
+            assert_eq!(states.retained_matches_for(node).unwrap().len(), count);
+        }
+        selectors = vec![
+            test_selector_program(".first.second", &atoms),
+            test_selector_program(".first:nth-child(2n)", &atoms),
+        ];
+    }
+}
+
+#[test]
 fn prefix_completion_reuses_positive_and_negative_relation_answers() {
     let (mut engine, nodes) = nested_document();
     let guard = StyleAtomID(200);
@@ -5299,7 +5353,7 @@ fn prefix_relations_share_program_predicates_without_merging_their_paths() {
     discard_transaction(&mut engine);
     let before = engine.counters.get(Counter::PrefixCompoundsEvaluated);
     let (dispatch, mut relation) = test_prefix_relation(&mut engine, nodes[0]);
-    assert_eq!(engine.counters.get(Counter::PrefixCompoundsEvaluated) - before, 4);
+    assert_eq!(engine.counters.get(Counter::PrefixCompoundsEvaluated) - before, 2);
     let mut states = PrefixStates::new(0);
     relation.install_answers(&mut states);
     let original = states.retained_matches_for(nodes[3]).unwrap().to_vec();

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5263,10 +5263,9 @@ fn prefix_relation_reuses_local_facts_without_sharing_position() {
     let old_facts = engine.facts.primary().clone();
     let counters = update_test_prefix_relation(&engine, &dispatch, &mut relation, &old_facts, &nodes, None);
     let evaluations = counters.get(Counter::PrefixCompoundsEvaluated);
-    assert!(
-        evaluations < 16,
-        "repeated local facts required {evaluations} update evaluations"
-    );
+    // Evaluate the program once for roots and once for non-roots, and the class
+    // predicate once for children passing the positional test.
+    assert_eq!(evaluations, 3, "positional truth must not split local predicate reuse");
     let mut states = PrefixStates::new(0);
     relation.install_answers(&mut states);
     assert!(states.retained_matches_for(nodes[0]).unwrap().is_empty());

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5208,6 +5208,85 @@ fn update_test_prefix_relation(
 }
 
 #[test]
+fn prefix_relations_share_program_predicates_without_merging_their_paths() {
+    let (mut engine, nodes) = nested_document();
+    let attribute_name = StyleAtomID(200);
+    let disabled = StyleAtomID(201);
+    let target = StyleAtomID(202);
+    let ready = StyleAtomID(203);
+    let other = StyleAtomID(204);
+    let sheet = engine.add_sheet(StyleSheetObjectID(1), CascadeOrigin::Author);
+    engine.attach_sheet(sheet, TreeScopeID::DOCUMENT);
+    for index in 0..33 {
+        let scope = StyleAtomID(300 + if index == 32 { 0 } else { index });
+        let literal: Vec<u16> = if index == 32 { "other" } else { "ready" }.encode_utf16().collect();
+        let mut builder = selector::SelectorProgramBuilder::new();
+        // Equal predicates deliberately have different program-relative text offsets.
+        builder.push_literal(&vec![0; index as usize]);
+        let (value_offset, value_length) = builder.push_literal(&literal);
+        let scope = builder.push_feature(selector::FeatureTest::Class(scope));
+        let ancestor_scope = builder.push_ancestor(scope);
+        let attribute = builder.push_feature(selector::FeatureTest::Attribute(selector::AttributeTest {
+            name: attribute_name,
+            any_namespace: false,
+            folded: attribute_name,
+            fold_in_namespace: StyleAtomID::NONE,
+            operator: selector::AttributeOperator::Substring,
+            value_atom: StyleAtomID::NONE,
+            value_offset,
+            value_length,
+            case: selector::AttributeCase::Sensitive,
+        }));
+        let disabled = builder.push_feature(selector::FeatureTest::Class(disabled));
+        let not_disabled = builder.push(selector::SelectorOp::Not(disabled));
+        let middle = builder.push_compound(&[attribute, not_disabled, ancestor_scope]);
+        let ancestor_middle = builder.push_ancestor(middle);
+        let subject = builder.push_feature(selector::FeatureTest::Class(target));
+        let subject = builder.push_compound(&[subject, ancestor_middle]);
+        builder.push_entry(subject);
+        let program = engine.programs.add(builder.finish());
+        let rule = engine.append_rule(sheet, None, RuleKind::Style);
+        engine.add_routing_rule(rule, program);
+        let mut version = engine.program.rule_version(rule);
+        version.selector_program = Some(program);
+        version.declaration_block = Some(DeclarationBlockID(1));
+        engine.replace_rule_version(rule, version);
+    }
+    add_feature(&mut engine, nodes[0], LocalFeatureKey::Class(StyleAtomID(300)));
+    add_feature(&mut engine, nodes[3], LocalFeatureKey::Class(target));
+    engine.set_attribute_value_text(ready, &"ready".encode_utf16().collect::<Vec<_>>());
+    engine.set_attribute_value_text(other, &"other".encode_utf16().collect::<Vec<_>>());
+    engine.record_input(
+        InputKey::LocalFeature(nodes[1], LocalFeatureKey::Attribute(attribute_name)),
+        InputValue::Feature(FeatureValue::Absent),
+        InputValue::Feature(FeatureValue::Atom(ready)),
+    );
+    discard_transaction(&mut engine);
+    let before = engine.counters.get(Counter::PrefixCompoundsEvaluated);
+    let (dispatch, mut relation) = test_prefix_relation(&mut engine, nodes[0]);
+    assert_eq!(engine.counters.get(Counter::PrefixCompoundsEvaluated) - before, 4);
+    let mut states = PrefixStates::new(0);
+    relation.install_answers(&mut states);
+    let original = states.retained_matches_for(nodes[3]).unwrap().to_vec();
+    assert_eq!(original.len(), 1);
+
+    let old_facts = engine.facts.primary().clone();
+    engine.record_input(
+        InputKey::LocalFeature(nodes[1], LocalFeatureKey::Attribute(attribute_name)),
+        InputValue::Feature(FeatureValue::Atom(ready)),
+        InputValue::Feature(FeatureValue::Atom(other)),
+    );
+    discard_transaction(&mut engine);
+    let counters = update_test_prefix_relation(&engine, &dispatch, &mut relation, &old_facts, &[nodes[1]], None);
+    assert_eq!(counters.get(Counter::PrefixCompoundsEvaluated), 2);
+    assert_eq!(relation.changed_answers.len(), 1);
+    assert_eq!(relation.changed_answers[0].0, nodes[3]);
+    assert_eq!(relation.changed_answers[0].1, original);
+    assert_eq!(relation.changed_answers[0].2.len(), 1);
+    assert_ne!(relation.changed_answers[0].1, relation.changed_answers[0].2);
+}
+
+#[test]
 fn prefix_relation_reuses_local_facts_without_sharing_position() {
     let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
     let mut raw = [0; 65];


### PR DESCRIPTION
Reuse selector prefix answers across equivalent predicates and changes to unobserved DOM facts. Avoid rebuilding answers already retained by the relation, and use dispatch postings directly when they fully determine a predicate’s matches. Also index fallback style patch coverage once per batch.

In a 50-step scroll through GitHub’s PR files view, the prefix optimizations reduce compound evaluations from 2,565,484 to 296,800, about 8.6× fewer.
