### PR TITLE
LibWeb: Replicate the settings values a document derives from its parent 

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -375,21 +375,21 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
         VERIFY(window);
 
         // 7. Let topLevelCreationURL be creationURL.
-        auto top_level_creation_url = creation_url;
+        Optional<URL::URL> top_level_creation_url = creation_url.copy();
 
         // 8. Let topLevelOrigin be navigationParams's origin.
         auto top_level_origin = navigation_params.origin;
 
         // 9. If navigable's container is not null, then:
-        if (navigation_params.navigable->container()) {
+        // NB: The container's relevant settings object is that of the parent navigable's active document, which the
+        //     parent navigable provides even when the container is hosted in another process.
+        if (auto parent = navigation_params.navigable->parent()) {
             // 1. Let parentEnvironment be navigable's container's relevant settings object.
-            auto& parent_environment = HTML::relevant_settings_object(*navigation_params.navigable->container());
-
             // 2. Set topLevelCreationURL to parentEnvironment's top-level creation URL.
-            top_level_creation_url = parent_environment.top_level_creation_url;
+            top_level_creation_url = parent->active_document_top_level_creation_url();
 
             // 3. Set topLevelOrigin to parentEnvironment's top-level origin.
-            top_level_origin = parent_environment.top_level_origin.value();
+            top_level_origin = parent->active_document_top_level_origin().value();
         }
 
         // 10. Set up a window environment settings object with creationURL, realm execution context,

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1402,16 +1402,40 @@ bool LocalNavigable::active_document_is(DOM::Document const& document) const
     return m_active_document.ptr() == &document;
 }
 
+Optional<URL::URL> LocalNavigable::active_document_top_level_creation_url() const
+{
+    if (!m_active_document)
+        return {};
+    return relevant_settings_object(*m_active_document).top_level_creation_url;
+}
+
+Optional<URL::Origin> LocalNavigable::active_document_top_level_origin() const
+{
+    if (!m_active_document)
+        return {};
+    return relevant_settings_object(*m_active_document).top_level_origin;
+}
+
+bool LocalNavigable::active_document_has_cross_site_ancestor() const
+{
+    VERIFY(m_active_document);
+    return relevant_settings_object(*m_active_document).has_cross_site_ancestor();
+}
+
 ReplicatedNavigableState LocalNavigable::replicated_state() const
 {
     VERIFY(m_active_document);
     VERIFY(m_active_session_history_entry);
+    auto& settings = relevant_settings_object(*m_active_document);
     return {
         .target_name = target_name(),
         .active_document_url = m_active_document->url(),
         .active_document_origin = m_active_document->origin(),
         .active_document_is_fully_active = m_active_document->is_fully_active(),
         .active_session_history_entry_identity = session_history_entry_identity(*m_active_session_history_entry),
+        .top_level_creation_url = settings.top_level_creation_url.value(),
+        .top_level_origin = settings.top_level_origin.value(),
+        .has_cross_site_ancestor = settings.has_cross_site_ancestor(),
     };
 }
 
@@ -2102,9 +2126,8 @@ static void perform_navigation_params_fetch(JS::Realm& realm, GC::Ref<Navigation
         if (!state_holder->navigable->is_top_level_traversable()) {
             // 1. Let parentEnvironment be navigable's parent's active document's relevant settings object.
             auto parent = state_holder->navigable->parent();
-            auto* local_parent = parent ? &as<LocalNavigable>(*parent) : nullptr;
-            auto parent_document = local_parent ? local_parent->active_document() : nullptr;
-            if (!local_parent || local_parent->has_been_destroyed() || !parent_document || parent_document->has_been_destroyed()) {
+            auto parent_top_level_creation_url = parent && !parent->has_been_destroyed() ? parent->active_document_top_level_creation_url() : Optional<URL::URL> {};
+            if (!parent_top_level_creation_url.has_value()) {
                 // AD-HOC: A queued child navigation can resume after its parent document has been destroyed. The
                 //         specification assumes the parent environment is still available here, but browser engines
                 //         abandon this stale detached frame navigation instead of continuing it against a discarded
@@ -2113,13 +2136,12 @@ static void perform_navigation_params_fetch(JS::Realm& realm, GC::Ref<Navigation
                 fetch_completion_steps->function()();
                 return;
             }
-            auto& parent_environment = parent_document->relevant_settings_object();
 
             // 2. Set topLevelCreationURL to parentEnvironment's top-level creation URL.
-            top_level_creation_url = parent_environment.top_level_creation_url;
+            top_level_creation_url = move(parent_top_level_creation_url);
 
             // 3. Set topLevelOrigin to parentEnvironment's top-level origin.
-            top_level_origin = parent_environment.top_level_origin;
+            top_level_origin = parent->active_document_top_level_origin();
         }
 
         // 4. Set request's reserved client to a new environment whose id is a unique opaque string,

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -131,6 +131,9 @@ public:
     virtual Optional<URL::Origin> active_document_origin() const override;
     virtual bool active_document_is_fully_active() const override;
     virtual bool active_document_is(DOM::Document const&) const override;
+    virtual Optional<URL::URL> active_document_top_level_creation_url() const override;
+    virtual Optional<URL::Origin> active_document_top_level_origin() const override;
+    virtual bool active_document_has_cross_site_ancestor() const override;
     ReplicatedNavigableState replicated_state() const;
 
     void save_persisted_state_to_active_session_history_entry();
@@ -216,7 +219,7 @@ public:
     void reload(Optional<StorageSerializationRecord> navigation_api_state = {}, UserNavigationInvolvement = UserNavigationInvolvement::None);
 
     // https://github.com/whatwg/html/issues/9690
-    [[nodiscard]] bool has_been_destroyed() const { return m_has_been_destroyed; }
+    [[nodiscard]] virtual bool has_been_destroyed() const override { return m_has_been_destroyed; }
     void set_has_been_destroyed();
     void report_child_frame_destroyed();
     void unload_child_navigable_before_destruction(GC::Ref<GC::Function<void()>> after_all_unloads);

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -33,6 +33,8 @@ public:
 
     bool is_ancestor_of(Navigable const&) const;
 
+    virtual bool has_been_destroyed() const = 0;
+
     virtual GC::Ptr<WindowProxy> active_window_proxy() = 0;
     virtual Utf16String const& target_name() const = 0;
     virtual bool is_traversable() const { return false; }
@@ -43,6 +45,10 @@ public:
     virtual Optional<URL::Origin> active_document_origin() const = 0;
     virtual bool active_document_is_fully_active() const = 0;
     virtual bool active_document_is(DOM::Document const&) const = 0;
+
+    virtual Optional<URL::URL> active_document_top_level_creation_url() const = 0;
+    virtual Optional<URL::Origin> active_document_top_level_origin() const = 0;
+    virtual bool active_document_has_cross_site_ancestor() const = 0;
 
     virtual bool has_session_history_entry_and_ready_for_navigation() const = 0;
     virtual bool delays_the_load_event_of_its_container() const = 0;

--- a/Libraries/LibWeb/HTML/ReplicatedNavigableState.cpp
+++ b/Libraries/LibWeb/HTML/ReplicatedNavigableState.cpp
@@ -18,6 +18,9 @@ ErrorOr<void> encode(Encoder& encoder, Web::HTML::ReplicatedNavigableState const
     TRY(encoder.encode(state.active_document_origin));
     TRY(encoder.encode(state.active_document_is_fully_active));
     TRY(encoder.encode(state.active_session_history_entry_identity));
+    TRY(encoder.encode(state.top_level_creation_url));
+    TRY(encoder.encode(state.top_level_origin));
+    TRY(encoder.encode(state.has_cross_site_ancestor));
     return {};
 }
 
@@ -30,6 +33,9 @@ ErrorOr<Web::HTML::ReplicatedNavigableState> decode(Decoder& decoder)
         .active_document_origin = TRY(decoder.decode<URL::Origin>()),
         .active_document_is_fully_active = TRY(decoder.decode<bool>()),
         .active_session_history_entry_identity = TRY(decoder.decode<Web::HTML::SessionHistoryEntryIdentity>()),
+        .top_level_creation_url = TRY(decoder.decode<URL::URL>()),
+        .top_level_origin = TRY(decoder.decode<URL::Origin>()),
+        .has_cross_site_ancestor = TRY(decoder.decode<bool>()),
     };
 }
 

--- a/Libraries/LibWeb/HTML/ReplicatedNavigableState.h
+++ b/Libraries/LibWeb/HTML/ReplicatedNavigableState.h
@@ -21,6 +21,9 @@ struct ReplicatedNavigableState {
     URL::Origin active_document_origin;
     bool active_document_is_fully_active { false };
     SessionHistoryEntryIdentity active_session_history_entry_identity;
+    URL::URL top_level_creation_url;
+    URL::Origin top_level_origin;
+    bool has_cross_site_ancestor { false };
 };
 
 }

--- a/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
@@ -113,18 +113,17 @@ URL::Origin WindowEnvironmentSettingsObject::origin() const
 bool WindowEnvironmentSettingsObject::has_cross_site_ancestor() const
 {
     // 1. If window's navigable's parent is null, then return false.
-    if (m_window->navigable()->parent() == nullptr)
+    auto parent = m_window->navigable()->parent();
+    if (!parent)
         return false;
 
     // 2. Let parentDocument be window's navigable's parent's active document.
-    auto parent_document = as<LocalNavigable>(*m_window->navigable()->parent()).active_document();
-
     // 3. If parentDocument's relevant settings object's has cross-site ancestor is true, then return true.
-    if (parent_document->relevant_settings_object().has_cross_site_ancestor())
+    if (parent->active_document_has_cross_site_ancestor())
         return true;
 
     // 4. If parentDocument's origin is not same site with window's associated Document's origin, then return true.
-    if (!parent_document->origin().is_same_site(m_window->associated_document().origin()))
+    if (!parent->active_document_origin()->is_same_site(m_window->associated_document().origin()))
         return true;
 
     // 5. Return false.

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -198,6 +198,9 @@ void CanonicalTraversable::create_a_new_top_level_traversable(Optional<Canonical
         .active_document_origin = document_origin,
         .active_document_is_fully_active = true,
         .active_session_history_entry_identity = Web::HTML::session_history_entry_identity(initial_history_entry),
+        .top_level_creation_url = initial_history_entry.url,
+        .top_level_origin = document_origin,
+        .has_cross_site_ancestor = false,
     });
 
     // 7. Let initialHistoryEntry be traversable's active session history entry.

--- a/Tests/LibWeb/test-web/TestRunCapture.cpp
+++ b/Tests/LibWeb/test-web/TestRunCapture.cpp
@@ -45,7 +45,7 @@ TestRunCapture::TestRunCapture()
     m_previous_on_process_exited = move(process_manager.on_process_exited);
     process_manager.on_process_exited = [this](WebView::Process&& process, Optional<int> exit_status) {
         consume_view_capture(process);
-        consume_helper_capture(process.pid());
+        consume_helper_capture(process);
         log_helper_message(
             { process.type(), process.pid() },
             m_stderr_capture.original_fd.value_or(STDERR_FILENO),
@@ -149,6 +149,14 @@ void TestRunCapture::setup_output_capture_for_view(TestWebView& view, ViewOutput
     if (!output_capture.stdout_file && !output_capture.stderr_file)
         return;
 
+    if (auto capture = m_helper_output_captures.take(process->pid()); capture.has_value()) {
+        auto helper_capture = capture.release_value();
+        if (helper_capture->stdout_notifier)
+            helper_capture->stdout_notifier->close();
+        if (helper_capture->stderr_notifier)
+            helper_capture->stderr_notifier->close();
+    }
+
     view_capture.web_content_pid = process->pid();
 
     if (output_capture.stdout_file) {
@@ -236,7 +244,7 @@ void TestRunCapture::restore_stderr()
 
 void TestRunCapture::setup_output_capture_for_helper_process(WebView::Process& process)
 {
-    if (process.type() == WebView::ProcessType::Browser || process.type() == WebView::ProcessType::WebContent)
+    if (process.type() == WebView::ProcessType::Browser)
         return;
 
     auto const pid = process.pid();
@@ -253,20 +261,16 @@ void TestRunCapture::setup_output_capture_for_helper_process(WebView::Process& p
     auto* helper_capture_ptr = helper_capture.ptr();
 
     if (output_capture.stdout_file) {
-        helper_capture->stdout_reader = move(output_capture.stdout_file);
-        setup_capture_notifier(helper_capture->stdout_notifier, *helper_capture->stdout_reader, false, [this, capture = helper_capture_ptr](StringView message) {
+        setup_capture_notifier(helper_capture->stdout_notifier, *output_capture.stdout_file, false, [this, capture = helper_capture_ptr](StringView message) {
             log_helper_message({ capture->type, capture->pid }, STDOUT_FILENO, message);
         });
     }
     if (output_capture.stderr_file) {
-        helper_capture->stderr_reader = move(output_capture.stderr_file);
-        setup_capture_notifier(helper_capture->stderr_notifier, *helper_capture->stderr_reader, false, [this, capture = helper_capture_ptr](StringView message) {
-            log_helper_message(
-                { capture->type, capture->pid },
-                m_stderr_capture.original_fd.value_or(STDERR_FILENO),
-                message);
+        setup_capture_notifier(helper_capture->stderr_notifier, *output_capture.stderr_file, false, [this, capture = helper_capture_ptr](StringView message) {
+            log_helper_message({ capture->type, capture->pid }, m_stderr_capture.original_fd.value_or(STDERR_FILENO), message);
         });
     }
+
     m_helper_output_captures.set(pid, move(helper_capture));
 }
 
@@ -313,29 +317,33 @@ static bool drain_capture_output(Core::File& file, bool drain_available, Functio
     }
 }
 
-void TestRunCapture::consume_helper_capture(pid_t pid)
+void TestRunCapture::consume_helper_capture(WebView::Process& process)
 {
-    auto capture = m_helper_output_captures.take(pid);
+    auto capture = m_helper_output_captures.take(process.pid());
     if (!capture.has_value())
         return;
 
     auto helper_capture = capture.release_value();
+    if (helper_capture->stdout_notifier)
+        helper_capture->stdout_notifier->set_enabled(false);
+    if (helper_capture->stderr_notifier)
+        helper_capture->stderr_notifier->set_enabled(false);
 
-    helper_capture->stdout_notifier->set_enabled(false);
-    helper_capture->stderr_notifier->set_enabled(false);
-
-    if (helper_capture->stdout_reader) {
-        (void)drain_capture_output(*helper_capture->stdout_reader, true, [this, type = helper_capture->type, pid = helper_capture->pid](StringView message) {
+    auto& output_capture = process.output_capture();
+    if (output_capture.stdout_file) {
+        (void)drain_capture_output(*output_capture.stdout_file, true, [this, type = helper_capture->type, pid = helper_capture->pid](StringView message) {
             log_helper_message({ type, pid }, STDOUT_FILENO, message);
         });
     }
-    if (helper_capture->stderr_reader) {
-        (void)drain_capture_output(*helper_capture->stderr_reader, true, [this, type = helper_capture->type, pid = helper_capture->pid](StringView message) {
+    if (output_capture.stderr_file) {
+        (void)drain_capture_output(*output_capture.stderr_file, true, [this, type = helper_capture->type, pid = helper_capture->pid](StringView message) {
             log_helper_message({ type, pid }, m_stderr_capture.original_fd.value_or(STDERR_FILENO), message);
         });
     }
-    helper_capture->stdout_notifier->close();
-    helper_capture->stderr_notifier->close();
+    if (helper_capture->stdout_notifier)
+        helper_capture->stdout_notifier->close();
+    if (helper_capture->stderr_notifier)
+        helper_capture->stderr_notifier->close();
 }
 
 void TestRunCapture::consume_view_capture(WebView::Process& process)

--- a/Tests/LibWeb/test-web/TestRunCapture.h
+++ b/Tests/LibWeb/test-web/TestRunCapture.h
@@ -53,8 +53,6 @@ private:
     struct HelperOutputCapture {
         WebView::ProcessType type;
         pid_t pid { 0 };
-        OwnPtr<Core::File> stdout_reader;
-        OwnPtr<Core::File> stderr_reader;
         RefPtr<Core::Notifier> stdout_notifier;
         RefPtr<Core::Notifier> stderr_notifier;
     };
@@ -70,7 +68,7 @@ private:
     void restore_stderr();
     void setup_output_capture_for_helper_process(WebView::Process&);
     void setup_output_capture_for_view(TestWebView&, ViewOutputCapture&);
-    void consume_helper_capture(pid_t pid);
+    void consume_helper_capture(WebView::Process&);
     void consume_view_capture(WebView::Process&);
     void destroy_view_capture_of(TestWebView const& view);
 

--- a/Tests/LibWebView/TestCanonicalBrowsingContextGroup.cpp
+++ b/Tests/LibWebView/TestCanonicalBrowsingContextGroup.cpp
@@ -110,6 +110,9 @@ TEST_CASE(response_browsing_context_is_activated_only_at_commit)
                                           .active_document_origin = destination_url.origin(),
                                           .active_document_is_fully_active = true,
                                           .active_session_history_entry_identity = {},
+                                          .top_level_creation_url = destination_url,
+                                          .top_level_origin = destination_url.origin(),
+                                          .has_cross_site_ancestor = false,
                                       },
         navigation_id);
     EXPECT_EQ(&traversable.active_browsing_context(), destination_context.ptr());


### PR DESCRIPTION
I believe we should be able to get rid of top_level_origin and active_document_top_level_origin longer term by some further shuffling of ownership between the browser process and web content at the fetch boundary, but for now take the simpler option of just replicating these fields too.