### PR TITLE
LibWeb: Split the visual context frame tree into clip and effect trees

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -203,8 +203,7 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
     m_visual_context_tree_structural_epoch = visual_context_tree->structural_epoch();
 
     auto context_is_valid = [&](Painting::ContextRef context) {
-        return context.spatial.value() < visual_context_tree->spatial_node_count()
-            && (context.frame == Painting::NO_FRAME_NODE || context.frame.value() < visual_context_tree->frame_node_count());
+        return visual_context_tree->context_is_valid(context);
     };
 
     Vector<Painting::SpatialNodeIndex> animated_spatial_nodes;
@@ -318,8 +317,7 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Painting::Acc
         return {};
 
     auto context_is_valid = [&](Painting::ContextRef context) {
-        return context.spatial.value() < visual_context_tree.spatial_node_count()
-            && (context.frame == Painting::NO_FRAME_NODE || context.frame.value() < visual_context_tree.frame_node_count());
+        return visual_context_tree.context_is_valid(context);
     };
 
     if (m_has_blocking_wheel_event_region_covering_viewport)

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -205,8 +205,7 @@ bool blocks_wheel_event_at_position(AsyncScrollingState const& async_scrolling_s
 
     VERIFY(display_list->compatible_visual_context_tree_structural_epoch() == visual_context_tree->structural_epoch());
     for (auto const& region : async_scrolling_state.blocking_wheel_event_regions) {
-        if (region.context.spatial.value() >= visual_context_tree->spatial_node_count()
-            || (region.context.frame != Painting::NO_FRAME_NODE && region.context.frame.value() >= visual_context_tree->frame_node_count()))
+        if (!visual_context_tree->context_is_valid(region.context))
             return true;
         auto position_in_context = visual_context_tree->transform_point_for_hit_test(region.context, position, scroll_state_snapshot);
         if (position_in_context.has_value() && region.rect.contains(*position_in_context))

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -194,7 +194,7 @@ u64 Internals::visual_context_tree_node_count()
     if (!document.has_committed_viewport_box() || !document.paint_state().has_visual_context_tree())
         return 0;
     auto visual_context_tree = document.paint_state().visual_context_tree(document);
-    return visual_context_tree.live_spatial_node_count() + visual_context_tree.live_frame_node_count();
+    return visual_context_tree.live_node_count();
 }
 
 u64 Internals::visual_context_tree_dead_node_count()
@@ -203,7 +203,7 @@ u64 Internals::visual_context_tree_dead_node_count()
     if (!document.has_committed_viewport_box() || !document.paint_state().has_visual_context_tree())
         return 0;
     auto visual_context_tree = document.paint_state().visual_context_tree(document);
-    return (visual_context_tree.spatial_node_count() - visual_context_tree.live_spatial_node_count()) + (visual_context_tree.frame_node_count() - visual_context_tree.live_frame_node_count());
+    return visual_context_tree.node_count() - visual_context_tree.live_node_count();
 }
 
 u64 Internals::visual_context_tree_structural_epoch()
@@ -220,7 +220,7 @@ u64 Internals::visual_context_tree_node_capacity()
     if (!document.has_committed_viewport_box() || !document.paint_state().has_visual_context_tree())
         return 0;
     auto visual_context_tree = document.paint_state().visual_context_tree(document);
-    return visual_context_tree.spatial_node_count() + visual_context_tree.frame_node_count();
+    return visual_context_tree.node_count();
 }
 
 GC::Ref<JS::Object> Internals::visual_context_node_indices(DOM::Element& element)
@@ -238,7 +238,8 @@ GC::Ref<JS::Object> Internals::visual_context_node_indices(DOM::Element& element
     };
     auto object = JS::Object::create(realm, nullptr);
     object->define_direct_property("spatial"_utf16_fly_string, owned_indices_as_array(Layout::RustFFI::FfiVisualContextBoxNodeList::SpatialNodes), JS::default_attributes);
-    object->define_direct_property("frames"_utf16_fly_string, owned_indices_as_array(Layout::RustFFI::FfiVisualContextBoxNodeList::FrameNodes), JS::default_attributes);
+    object->define_direct_property("clips"_utf16_fly_string, owned_indices_as_array(Layout::RustFFI::FfiVisualContextBoxNodeList::ClipNodes), JS::default_attributes);
+    object->define_direct_property("effects"_utf16_fly_string, owned_indices_as_array(Layout::RustFFI::FfiVisualContextBoxNodeList::EffectNodes), JS::default_attributes);
     object->define_direct_property("needsCompositorEffectsLayer"_utf16_fly_string, JS::Value(layout_node && layout_node->needs_compositor_effects_layer()), JS::default_attributes);
     object->define_direct_property("needsCompositorBackgroundColorFrame"_utf16_fly_string, JS::Value(layout_node && layout_node->needs_compositor_background_color_frame()), JS::default_attributes);
     return object;

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -97,19 +97,19 @@ size_t AccumulatedVisualContextTree::spatial_node_count() const
     return Layout::RustFFI::visual_context_tree_spatial_node_count(m_rust_tree);
 }
 
-size_t AccumulatedVisualContextTree::frame_node_count() const
+bool AccumulatedVisualContextTree::context_is_valid(ContextRef context) const
 {
-    return Layout::RustFFI::visual_context_tree_frame_node_count(m_rust_tree);
+    return Layout::RustFFI::visual_context_tree_context_is_valid(m_rust_tree, context);
 }
 
-size_t AccumulatedVisualContextTree::live_spatial_node_count() const
+size_t AccumulatedVisualContextTree::node_count() const
 {
-    return Layout::RustFFI::visual_context_tree_live_spatial_node_count(m_rust_tree);
+    return Layout::RustFFI::visual_context_tree_node_count(m_rust_tree);
 }
 
-size_t AccumulatedVisualContextTree::live_frame_node_count() const
+size_t AccumulatedVisualContextTree::live_node_count() const
 {
-    return Layout::RustFFI::visual_context_tree_live_frame_node_count(m_rust_tree);
+    return Layout::RustFFI::visual_context_tree_live_node_count(m_rust_tree);
 }
 
 TransformWithOrigin AccumulatedVisualContextTree::visual_viewport_transform() const
@@ -135,10 +135,10 @@ void AccumulatedVisualContextTree::set_visual_animations(Vector<Compositor::Visu
 
 AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation_samples(i64 monotonic_time_ns) const
 {
-    Vector<Layout::RustFFI::FfiFrameOpacitySample> opacity_samples;
-    Vector<Layout::RustFFI::FfiFrameBackgroundColorSample> background_color_samples;
+    Vector<Layout::RustFFI::FfiEffectOpacitySample> opacity_samples;
+    Vector<Layout::RustFFI::FfiEffectBackgroundColorSample> background_color_samples;
     Vector<ByteBuffer> filter_sample_storage;
-    Vector<Layout::RustFFI::FfiFrameFilterSample> filter_samples;
+    Vector<Layout::RustFFI::FfiEffectFilterSample> filter_samples;
     Vector<Layout::RustFFI::FfiSpatialTransformSample> transform_samples;
     filter_sample_storage.ensure_capacity(visual_animations().size());
     for (auto const& animation : visual_animations()) {
@@ -155,12 +155,12 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation
         }
         for (auto node_index : animation.visual_context_node_indices) {
             if (animation.target_kind == Compositor::VisualAnimation::TargetKind::Opacity)
-                opacity_samples.append({ .frame = node_index, .opacity = sample->opacity });
+                opacity_samples.append({ .effect = node_index, .opacity = sample->opacity });
             else if (animation.target_kind == Compositor::VisualAnimation::TargetKind::BackgroundColor)
-                background_color_samples.append({ .frame = node_index, .color = *sample->background_color });
+                background_color_samples.append({ .effect = node_index, .color = *sample->background_color });
             else if (animation.target_kind == Compositor::VisualAnimation::TargetKind::Filter)
                 filter_samples.append({
-                    .frame = node_index,
+                    .effect = node_index,
                     .filter_bytes = filter_bytes.has_value() ? filter_bytes->data() : nullptr,
                     .filter_size = filter_bytes.has_value() ? filter_bytes->size() : 0,
                 });
@@ -196,18 +196,18 @@ bool AccumulatedVisualContextTree::visual_animation_targets_are_valid(Compositor
     return Layout::RustFFI::visual_context_tree_visual_animation_targets_are_valid(m_rust_tree, target_kind, targets.data(), targets.size());
 }
 
-Optional<float> AccumulatedVisualContextTree::effects_opacity(FrameNodeIndex frame) const
+Optional<float> AccumulatedVisualContextTree::effects_opacity(EffectNodeIndex effect) const
 {
     float opacity = 1;
-    if (!Layout::RustFFI::visual_context_tree_effects_opacity(m_rust_tree, frame, &opacity))
+    if (!Layout::RustFFI::visual_context_tree_effects_opacity(m_rust_tree, effect, &opacity))
         return {};
     return opacity;
 }
 
-Optional<Gfx::Color> AccumulatedVisualContextTree::sampled_background_color(FrameNodeIndex frame) const
+Optional<Gfx::Color> AccumulatedVisualContextTree::sampled_background_color(EffectNodeIndex effect) const
 {
     Gfx::Color color;
-    if (!Layout::RustFFI::visual_context_tree_sampled_background_color(m_rust_tree, frame, &color))
+    if (!Layout::RustFFI::visual_context_tree_sampled_background_color(m_rust_tree, effect, &color))
         return {};
     return color;
 }
@@ -252,14 +252,14 @@ Gfx::FloatMatrix4x4 AccumulatedVisualContextTree::accumulated_matrix(SpatialNode
     return Layout::RustFFI::visual_context_tree_accumulated_matrix(m_rust_tree, index, scroll_offsets.data(), scroll_offsets.size(), include_visual_viewport_transform == IncludeVisualViewportTransform::Yes);
 }
 
-bool AccumulatedVisualContextTree::frame_is_isolated_by_layer_frame(FrameNodeIndex frame) const
+bool AccumulatedVisualContextTree::effect_is_isolated_by_layer(EffectNodeIndex effect) const
 {
-    return Layout::RustFFI::visual_context_tree_frame_is_isolated_by_layer_frame(m_rust_tree, frame);
+    return Layout::RustFFI::visual_context_tree_effect_is_isolated_by_layer(m_rust_tree, effect);
 }
 
-bool AccumulatedVisualContextTree::has_unisolated_blending_frame() const
+bool AccumulatedVisualContextTree::has_unisolated_blending_effect() const
 {
-    return Layout::RustFFI::visual_context_tree_has_unisolated_blending_frame(m_rust_tree);
+    return Layout::RustFFI::visual_context_tree_has_unisolated_blending_effect(m_rust_tree);
 }
 
 void AccumulatedVisualContextTree::for_each_effects_filter_bytes(Function<void(ReadonlyBytes)> const& visit) const

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -73,16 +73,18 @@ public:
     void set_visual_animations(RefPtr<VisualAnimationList const> animations) { m_visual_animations = move(animations); }
     WEB_API void set_visual_animations(Vector<Compositor::VisualAnimation>);
 
+    // Node counts cover all slots, live or dead, or only live slots.
     WEB_API size_t spatial_node_count() const;
-    WEB_API size_t frame_node_count() const;
-    WEB_API size_t live_spatial_node_count() const;
-    WEB_API size_t live_frame_node_count() const;
+    WEB_API bool context_is_valid(ContextRef) const;
+    WEB_API size_t node_count() const;
+    WEB_API size_t live_node_count() const;
     WEB_API TransformWithOrigin visual_viewport_transform() const;
     WEB_API AccumulatedVisualContextTree with_visual_viewport_transform(TransformWithOrigin const&) const;
     WEB_API AccumulatedVisualContextTree with_visual_animation_samples(i64 monotonic_time_ns) const;
     WEB_API bool visual_animation_targets_are_valid(Compositor::VisualAnimation const&) const;
-    WEB_API Optional<float> effects_opacity(FrameNodeIndex) const;
-    WEB_API Optional<Gfx::Color> sampled_background_color(FrameNodeIndex) const;
+    WEB_API Optional<float> effects_opacity(EffectNodeIndex) const;
+    // The sampled background color of a recorded fill's animation effect.
+    WEB_API Optional<Gfx::Color> sampled_background_color(EffectNodeIndex) const;
     WEB_API Vector<bool> spatial_nodes_in_subtrees_of(ReadonlySpan<SpatialNodeIndex> roots) const;
 
     WEB_API Optional<Gfx::FloatPoint> transform_point_for_hit_test(ContextRef, Gfx::FloatPoint, ScrollStateSnapshot const&, ClipBehavior = ClipBehavior::Respect) const;
@@ -92,8 +94,8 @@ public:
     WEB_API Gfx::FloatPoint cumulative_scroll_chain_offset(SpatialNodeIndex, ScrollStateSnapshot const&) const;
     WEB_API Gfx::FloatMatrix4x4 accumulated_matrix(SpatialNodeIndex, ScrollStateSnapshot const&, IncludeVisualViewportTransform) const;
 
-    WEB_API bool frame_is_isolated_by_layer_frame(FrameNodeIndex) const;
-    WEB_API bool has_unisolated_blending_frame() const;
+    WEB_API bool effect_is_isolated_by_layer(EffectNodeIndex) const;
+    WEB_API bool has_unisolated_blending_effect() const;
     WEB_API void for_each_effects_filter_bytes(Function<void(ReadonlyBytes)> const&) const;
 
 private:

--- a/Libraries/LibWeb/Painting/ContextRef.h
+++ b/Libraries/LibWeb/Painting/ContextRef.h
@@ -13,21 +13,24 @@
 namespace Web::Painting {
 
 AK_TYPEDEF_DISTINCT_ORDERED_ID(u32, SpatialNodeIndex);
-AK_TYPEDEF_DISTINCT_ORDERED_ID(u32, FrameNodeIndex);
+AK_TYPEDEF_DISTINCT_ORDERED_ID(u32, ClipNodeIndex);
+AK_TYPEDEF_DISTINCT_ORDERED_ID(u32, EffectNodeIndex);
 
 // Spatial node 0 is always the visual viewport transform, so index 0 doubles as "no node" for
 // references to scroll nodes, which can never sit at the root.
 static constexpr SpatialNodeIndex VISUAL_VIEWPORT_NODE_INDEX { 0 };
-static constexpr FrameNodeIndex NO_FRAME_NODE { NumericLimits<u32>::max() };
+static constexpr ClipNodeIndex NO_CLIP_NODE { NumericLimits<u32>::max() };
+static constexpr EffectNodeIndex NO_EFFECT_NODE { NumericLimits<u32>::max() };
 
 struct ContextRef {
     SpatialNodeIndex spatial { VISUAL_VIEWPORT_NODE_INDEX };
-    FrameNodeIndex frame { NO_FRAME_NODE };
+    ClipNodeIndex clip { NO_CLIP_NODE };
+    EffectNodeIndex effect { NO_EFFECT_NODE };
 
     bool operator==(ContextRef const&) const = default;
 };
 
-static_assert(sizeof(ContextRef) == 8);
+static_assert(sizeof(ContextRef) == 12);
 
 }
 
@@ -40,10 +43,18 @@ struct AK::Formatter<Web::Painting::SpatialNodeIndex> : Formatter<FormatString> 
 };
 
 template<>
-struct AK::Formatter<Web::Painting::FrameNodeIndex> : Formatter<FormatString> {
-    ErrorOr<void> format(FormatBuilder& builder, Web::Painting::FrameNodeIndex index)
+struct AK::Formatter<Web::Painting::ClipNodeIndex> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::Painting::ClipNodeIndex index)
     {
-        return Formatter<FormatString>::format(builder, "f{}"sv, index.value());
+        return Formatter<FormatString>::format(builder, "c{}"sv, index.value());
+    }
+};
+
+template<>
+struct AK::Formatter<Web::Painting::EffectNodeIndex> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::Painting::EffectNodeIndex index)
+    {
+        return Formatter<FormatString>::format(builder, "e{}"sv, index.value());
     }
 };
 
@@ -51,8 +62,11 @@ template<>
 struct AK::Formatter<Web::Painting::ContextRef> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Web::Painting::ContextRef context)
     {
-        if (context.frame == Web::Painting::NO_FRAME_NODE)
-            return Formatter<FormatString>::format(builder, "{}"sv, context.spatial);
-        return Formatter<FormatString>::format(builder, "{}/{}"sv, context.spatial, context.frame);
+        TRY(Formatter<FormatString>::format(builder, "{}"sv, context.spatial));
+        if (context.clip != Web::Painting::NO_CLIP_NODE)
+            TRY(Formatter<FormatString>::format(builder, "/{}"sv, context.clip));
+        if (context.effect != Web::Painting::NO_EFFECT_NODE)
+            TRY(Formatter<FormatString>::format(builder, "/{}"sv, context.effect));
+        return {};
     }
 };

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -25,7 +25,7 @@ DisplayList::DisplayList(u64 compatible_visual_context_tree_structural_epoch)
 {
 }
 
-DisplayList::DisplayList(u64 compatible_visual_context_tree_structural_epoch, u64 id, ByteBuffer&& command_bytes, Vector<DisplayListCommandRun>&& command_runs, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata> async_scrolling_metadata, HashMap<FrameNodeIndex, DisplayListResourceId>&& mask_display_lists)
+DisplayList::DisplayList(u64 compatible_visual_context_tree_structural_epoch, u64 id, ByteBuffer&& command_bytes, Vector<DisplayListCommandRun>&& command_runs, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata> async_scrolling_metadata, HashMap<EffectNodeIndex, DisplayListResourceId>&& mask_display_lists)
     : m_compatible_visual_context_tree_structural_epoch(compatible_visual_context_tree_structural_epoch)
     , m_id(id)
     , m_command_bytes(move(command_bytes))
@@ -72,12 +72,12 @@ Vector<DisplayListCommandRun> compute_display_list_command_runs(ReadonlyBytes co
 
 ErrorOr<void> validate_display_list_references_live_visual_context_nodes(DisplayList const& display_list, AccumulatedVisualContextTree const& visual_context_tree)
 {
-    Vector<FrameNodeIndex> mask_frames;
-    mask_frames.ensure_capacity(display_list.mask_display_lists().size());
+    Vector<EffectNodeIndex> mask_effects;
+    mask_effects.ensure_capacity(display_list.mask_display_lists().size());
     for (auto const& mask_display_list : display_list.mask_display_lists())
-        mask_frames.unchecked_append(mask_display_list.key);
+        mask_effects.unchecked_append(mask_display_list.key);
     auto command_runs = display_list.command_runs();
-    if (!Layout::RustFFI::display_list_references_only_live_visual_context_nodes(visual_context_tree.rust_handle(), command_runs.data(), command_runs.size(), mask_frames.data(), mask_frames.size()))
+    if (!Layout::RustFFI::display_list_references_only_live_visual_context_nodes(visual_context_tree.rust_handle(), command_runs.data(), command_runs.size(), mask_effects.data(), mask_effects.size()))
         return Error::from_string_literal("Display list references a visual context node that is not live");
     return {};
 }
@@ -215,10 +215,10 @@ void DisplayListPlayer::execute_impl(DisplayList const& display_list, ScrollStat
         .push_clip_path = [](void* context, void const* path, Gfx::WindingRule winding_rule) { static_cast<ReplayContext*>(context)->player.push_clip_path(*static_cast<Gfx::Path const*>(path), winding_rule); },
         .push_layer = [](void* context, ReplayLayer const* layer) { static_cast<ReplayContext*>(context)->player.push_layer(*layer); },
         .push_mask = [](void* context, ReplayMask const* mask) { static_cast<ReplayContext*>(context)->player.push_mask(*mask); },
-        .pop_mask = [](void* context, ReplayMask const* mask, FrameNodeIndex frame) {
+        .pop_mask = [](void* context, ReplayMask const* mask, EffectNodeIndex effect) {
             auto& replay = *static_cast<ReplayContext*>(context);
             Optional<DisplayListResourceId> mask_content;
-            if (auto display_list_id = replay.player.active_display_list().mask_display_list_id(frame);
+            if (auto display_list_id = replay.player.active_display_list().mask_display_list_id(effect);
                 display_list_id.has_value() && replay.player.resource_storage().has_display_list(*display_list_id))
                 mask_content = *display_list_id;
             replay.player.pop_mask(*mask, mask_content); },
@@ -296,7 +296,7 @@ ErrorOr<NonnullRefPtr<Web::Painting::DisplayList>> decode(Decoder& decoder)
     auto compatible_visual_context_tree_structural_epoch = TRY(decoder.decode<u64>());
     auto surface_clear_color = TRY(decoder.decode<Optional<Gfx::Color>>());
     auto async_scrolling_metadata = TRY(decoder.decode<Optional<Web::Painting::DisplayList::AsyncScrollingMetadata>>());
-    auto mask_display_lists = TRY(decoder.decode<HashMap<Web::Painting::FrameNodeIndex, Web::Painting::DisplayListResourceId>>());
+    auto mask_display_lists = TRY(decoder.decode<HashMap<Web::Painting::EffectNodeIndex, Web::Painting::DisplayListResourceId>>());
     auto command_run_count = TRY(decoder.decode_size());
     Vector<Web::Painting::DisplayListCommandRun> command_runs;
     TRY(command_runs.try_resize(command_run_count));

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -110,9 +110,10 @@ public:
     Optional<Gfx::Color> surface_clear_color() const { return m_surface_clear_color; }
     void set_async_scrolling_metadata(AsyncScrollingMetadata metadata) { m_async_scrolling_metadata = metadata; }
     Optional<AsyncScrollingMetadata> const& async_scrolling_metadata() const { return m_async_scrolling_metadata; }
-    Optional<DisplayListResourceId> mask_display_list_id(FrameNodeIndex frame) const { return m_mask_display_lists.get(frame); }
-    void set_mask_display_list_id(FrameNodeIndex frame, DisplayListResourceId display_list_id) { m_mask_display_lists.set(frame, display_list_id); }
-    HashMap<FrameNodeIndex, DisplayListResourceId> const& mask_display_lists() const { return m_mask_display_lists; }
+    // The mask content of a mask effect node, replayed once when that node's layer exits.
+    Optional<DisplayListResourceId> mask_display_list_id(EffectNodeIndex effect) const { return m_mask_display_lists.get(effect); }
+    void set_mask_display_list_id(EffectNodeIndex effect, DisplayListResourceId display_list_id) { m_mask_display_lists.set(effect, display_list_id); }
+    HashMap<EffectNodeIndex, DisplayListResourceId> const& mask_display_lists() const { return m_mask_display_lists; }
 
     static constexpr size_t command_alignment = 16;
 
@@ -139,7 +140,7 @@ public:
 
 private:
     explicit DisplayList(u64 compatible_visual_context_tree_structural_epoch);
-    DisplayList(u64 compatible_visual_context_tree_structural_epoch, u64 id, ByteBuffer&& command_bytes, Vector<DisplayListCommandRun>&& command_runs, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata>, HashMap<FrameNodeIndex, DisplayListResourceId>&& mask_display_lists);
+    DisplayList(u64 compatible_visual_context_tree_structural_epoch, u64 id, ByteBuffer&& command_bytes, Vector<DisplayListCommandRun>&& command_runs, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata>, HashMap<EffectNodeIndex, DisplayListResourceId>&& mask_display_lists);
 
     u64 m_compatible_visual_context_tree_structural_epoch { 0 };
     u64 m_id { 0 };
@@ -147,7 +148,7 @@ private:
     Vector<DisplayListCommandRun> m_command_runs;
     Optional<Gfx::Color> m_surface_clear_color;
     Optional<AsyncScrollingMetadata> m_async_scrolling_metadata;
-    HashMap<FrameNodeIndex, DisplayListResourceId> m_mask_display_lists;
+    HashMap<EffectNodeIndex, DisplayListResourceId> m_mask_display_lists;
 
     template<typename T>
     friend ErrorOr<void> IPC::encode(IPC::Encoder&, T const&);

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -137,9 +137,9 @@ decltype(auto) visit_display_list_command(
 }
 
 static_assert(IsTriviallyCopyable<DisplayListCommandHeader>);
-static_assert(sizeof(DisplayListCommandHeader) == 32);
+static_assert(sizeof(DisplayListCommandHeader) == 48);
 static_assert(IsTriviallyCopyable<DisplayListCommandRun>);
-static_assert(sizeof(DisplayListCommandRun) == 36);
+static_assert(sizeof(DisplayListCommandRun) == 40);
 static_assert(IsTriviallyCopyable<DisplayListGlyph>);
 static_assert(IsTriviallyCopyable<DisplayListInlineClip>);
 static_assert(sizeof(DisplayListInlineClip) == 64);

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -47,7 +47,7 @@ struct DisplayListPlayerSkia::LayerImageFilterCache {
         ByteBuffer filter_bytes;
         sk_sp<SkImageFilter> image_filter;
     };
-    HashMap<u64, HashMap<u32, Entry>> entries_by_tree_structural_epoch_and_frame;
+    HashMap<u64, HashMap<u32, Entry>> entries_by_tree_structural_epoch_and_effect;
     u64 tree_structural_epoch { 0 };
 };
 
@@ -77,7 +77,7 @@ void DisplayListPlayerSkia::execute(
 {
     TemporaryChange composited_context_resolver_change { m_composited_context_resolver, composited_context_resolver };
     if (m_layer_image_filter_cache->tree_structural_epoch != visual_context_tree.structural_epoch()) {
-        m_layer_image_filter_cache->entries_by_tree_structural_epoch_and_frame.clear();
+        m_layer_image_filter_cache->entries_by_tree_structural_epoch_and_effect.clear();
         m_layer_image_filter_cache->tree_structural_epoch = visual_context_tree.structural_epoch();
     }
     DisplayListPlayer::execute(
@@ -245,9 +245,9 @@ void DisplayListPlayerSkia::play_command(FillRect const& command)
     auto& canvas = surface().canvas();
     SkPaint paint;
     paint.setAntiAlias(true);
-    auto color = command.background_color_animation_frame == NO_FRAME_NODE
+    auto color = command.background_color_animation_effect == NO_EFFECT_NODE
         ? command.color
-        : active_visual_context_tree().sampled_background_color(command.background_color_animation_frame).value_or(command.color);
+        : active_visual_context_tree().sampled_background_color(command.background_color_animation_effect).value_or(command.color);
     paint.setColor(to_skia_color(color));
     apply_compositing_and_blending_operator(paint, command.compositing_and_blending_operator);
     canvas.drawRect(to_skia_rect(rect), paint);
@@ -783,9 +783,9 @@ void DisplayListPlayerSkia::play_command(FillRectWithRoundedCorners const& comma
 
     auto& canvas = surface().canvas();
     SkPaint paint;
-    auto color = command.background_color_animation_frame == NO_FRAME_NODE
+    auto color = command.background_color_animation_effect == NO_EFFECT_NODE
         ? command.color
-        : active_visual_context_tree().sampled_background_color(command.background_color_animation_frame).value_or(command.color);
+        : active_visual_context_tree().sampled_background_color(command.background_color_animation_effect).value_or(command.color);
     paint.setColor(to_skia_color(color));
     paint.setAntiAlias(true);
 
@@ -1293,13 +1293,13 @@ void DisplayListPlayerSkia::push_layer(ReplayLayer const& layer)
 sk_sp<SkImageFilter> DisplayListPlayerSkia::layer_image_filter(ReplayLayer const& layer)
 {
     ReadonlyBytes filter_bytes { layer.filter_bytes, layer.filter_bytes_size };
-    auto& entries_by_frame = m_layer_image_filter_cache->entries_by_tree_structural_epoch_and_frame.ensure(active_visual_context_tree().structural_epoch());
-    if (auto cached = entries_by_frame.get(layer.frame.value()); cached.has_value() && cached->filter_bytes.bytes() == filter_bytes)
+    auto& entries_by_effect = m_layer_image_filter_cache->entries_by_tree_structural_epoch_and_effect.ensure(active_visual_context_tree().structural_epoch());
+    if (auto cached = entries_by_effect.get(layer.effect.value()); cached.has_value() && cached->filter_bytes.bytes() == filter_bytes)
         return cached->image_filter;
     auto image_filter = Gfx::to_skia_image_filter(filter_bytes, [&](u64 image_id) -> Gfx::DecodedImageFrame const& {
         return resource_storage().image_frame(ImageFrameResourceId { image_id });
     });
-    entries_by_frame.set(layer.frame.value(), LayerImageFilterCache::Entry { MUST(ByteBuffer::copy(filter_bytes)), image_filter });
+    entries_by_effect.set(layer.effect.value(), LayerImageFilterCache::Entry { MUST(ByteBuffer::copy(filter_bytes)), image_filter });
     return image_filter;
 }
 

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -562,7 +562,7 @@ bool DisplayListResourceStorage::nested_display_list_requires_direct_replay(Disp
     auto const& list_resource = display_list_resource(id);
 
     auto const& visual_context_tree = list_resource.visual_context_tree;
-    bool requires_direct_replay = visual_context_tree.has_unisolated_blending_frame();
+    bool requires_direct_replay = visual_context_tree.has_unisolated_blending_effect();
 
     auto recurse_into_nested_display_list = [&](DisplayListResourceId nested_display_list_id) {
         if (visited_display_lists.set(nested_display_list_id.value()) != HashSetResult::InsertedNewEntry)
@@ -577,7 +577,7 @@ bool DisplayListResourceStorage::nested_display_list_requires_direct_replay(Disp
         visit_display_list_command(header.command_type, payload, [&](auto const& command) {
             using Command = RemoveCVReference<decltype(command)>;
             if constexpr (IsSame<Command, ApplyBackdropFilter>) {
-                if (command.has_backdrop_filter && !visual_context_tree.frame_is_isolated_by_layer_frame(header.context.frame))
+                if (command.has_backdrop_filter && !visual_context_tree.effect_is_isolated_by_layer(header.context.effect))
                     requires_direct_replay = true;
             } else if constexpr (IsSame<Command, DrawVideoFrame> || IsSame<Command, DrawCanvas> || IsSame<Command, DrawCompositedContext>) {
                 requires_direct_replay = true;
@@ -598,7 +598,7 @@ bool DisplayListResourceStorage::nested_display_list_requires_direct_replay(Disp
                     blends_with_isolated_backdrop_color = command.isolated_backdrop_color.has_value();
                 if (command.compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal
                     && !blends_with_isolated_backdrop_color
-                    && !visual_context_tree.frame_is_isolated_by_layer_frame(header.context.frame))
+                    && !visual_context_tree.effect_is_isolated_by_layer(header.context.effect))
                     requires_direct_replay = true;
             }
         });

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -672,10 +672,10 @@ Utf16String serialize_painting_dump(DOM::Document const& document, AccumulatedVi
         .mask_display_list_count = [](void*, void const* display_list_pointer) -> size_t {
             return static_cast<DisplayList const*>(display_list_pointer)->mask_display_lists().size();
         },
-        .mask_display_lists = [](void*, void const* display_list_pointer, u32* frames, u64* display_list_ids) {
+        .mask_display_lists = [](void*, void const* display_list_pointer, u32* effects, u64* display_list_ids) {
             size_t index = 0;
             for (auto const& entry : static_cast<DisplayList const*>(display_list_pointer)->mask_display_lists()) {
-                frames[index] = entry.key.value();
+                effects[index] = entry.key.value();
                 display_list_ids[index] = entry.value.value();
                 ++index;
             } },
@@ -784,7 +784,7 @@ static NonnullRefPtr<DisplayList> display_list_from_rust_recording(AccumulatedVi
     Vector<DisplayListCommandRun> command_runs { ReadonlySpan<DisplayListCommandRun> { recorded.command_runs, recorded.command_run_count } };
     auto display_list = DisplayList::create_from_command_bytes(visual_context_tree, move(command_bytes), move(command_runs));
     for (auto const& registration : ReadonlySpan<Layout::RustFFI::FfiMaskDisplayListRegistration> { recorded.mask_registrations, recorded.mask_registration_count })
-        display_list->set_mask_display_list_id(registration.frame, DisplayListResourceId { registration.display_list_id });
+        display_list->set_mask_display_list_id(registration.effect, DisplayListResourceId { registration.display_list_id });
     return display_list;
 }
 

--- a/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.cpp
+++ b/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.cpp
@@ -49,25 +49,25 @@ SpatialNodeIndex VisualContextTreeTestBuilder::append_sticky(SpatialNodeIndex pa
     return SpatialNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_sticky(m_builder, parent.value(), ffi_constraints) };
 }
 
-FrameNodeIndex VisualContextTreeTestBuilder::append_clip_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, Gfx::FloatRect rect, Gfx::CornerRadii corner_radii, ClipMode mode)
+ClipNodeIndex VisualContextTreeTestBuilder::append_clip(ClipNodeIndex parent, SpatialNodeIndex spatial, Gfx::FloatRect rect, Gfx::CornerRadii corner_radii, ClipMode mode)
 {
-    return FrameNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_clip_frame(m_builder, parent.value(), spatial.value(), rect, corner_radii, mode) };
+    return ClipNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_clip(m_builder, parent.value(), spatial.value(), rect, corner_radii, mode) };
 }
 
-FrameNodeIndex VisualContextTreeTestBuilder::append_background_color_animation_frame(FrameNodeIndex parent, SpatialNodeIndex spatial)
-{
-    return FrameNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_background_color_animation_frame(m_builder, parent.value(), spatial.value()) };
-}
-
-FrameNodeIndex VisualContextTreeTestBuilder::append_clip_path_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, Gfx::Path const& path, Gfx::IntRect bounding_rect, Gfx::WindingRule fill_rule)
+ClipNodeIndex VisualContextTreeTestBuilder::append_clip_path(ClipNodeIndex parent, SpatialNodeIndex spatial, Gfx::Path const& path, Gfx::IntRect bounding_rect, Gfx::WindingRule fill_rule)
 {
     auto path_bytes = path.serialize_to_bytes();
-    return FrameNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_clip_path_frame(m_builder, parent.value(), spatial.value(), path_bytes.data(), path_bytes.size(), bounding_rect, fill_rule) };
+    return ClipNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_clip_path(m_builder, parent.value(), spatial.value(), path_bytes.data(), path_bytes.size(), bounding_rect, fill_rule) };
 }
 
-FrameNodeIndex VisualContextTreeTestBuilder::append_effects_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, float opacity, Gfx::CompositingAndBlendingOperator blend_mode)
+EffectNodeIndex VisualContextTreeTestBuilder::append_effects(EffectNodeIndex parent, SpatialNodeIndex spatial, ClipNodeIndex output_clip, float opacity, Gfx::CompositingAndBlendingOperator blend_mode)
 {
-    return FrameNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_effects_frame(m_builder, parent.value(), spatial.value(), opacity, blend_mode) };
+    return EffectNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_effects(m_builder, parent.value(), spatial.value(), output_clip.value(), opacity, blend_mode) };
+}
+
+EffectNodeIndex VisualContextTreeTestBuilder::append_background_color_animation(EffectNodeIndex parent, SpatialNodeIndex spatial, ClipNodeIndex output_clip)
+{
+    return EffectNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_background_color_animation(m_builder, parent.value(), spatial.value(), output_clip.value()) };
 }
 
 AccumulatedVisualContextTree VisualContextTreeTestBuilder::finish_with_structural_epoch(u64 structural_epoch)

--- a/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.h
+++ b/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.h
@@ -49,10 +49,11 @@ public:
     SpatialNodeIndex append_transform(SpatialNodeIndex parent, Gfx::FloatMatrix4x4 const&, Gfx::FloatPoint origin = {});
     SpatialNodeIndex append_scroll(SpatialNodeIndex parent);
     SpatialNodeIndex append_sticky(SpatialNodeIndex parent, StickyConstraints const&);
-    FrameNodeIndex append_background_color_animation_frame(FrameNodeIndex parent, SpatialNodeIndex spatial);
-    FrameNodeIndex append_clip_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, Gfx::FloatRect, Gfx::CornerRadii = {}, ClipMode = ClipMode::Intersect);
-    FrameNodeIndex append_clip_path_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, Gfx::Path const&, Gfx::IntRect bounding_rect, Gfx::WindingRule);
-    FrameNodeIndex append_effects_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal);
+    ClipNodeIndex append_clip(ClipNodeIndex parent, SpatialNodeIndex spatial, Gfx::FloatRect, Gfx::CornerRadii = {}, ClipMode = ClipMode::Intersect);
+    ClipNodeIndex append_clip_path(ClipNodeIndex parent, SpatialNodeIndex spatial, Gfx::Path const&, Gfx::IntRect bounding_rect, Gfx::WindingRule);
+    EffectNodeIndex append_effects(EffectNodeIndex parent, SpatialNodeIndex spatial, ClipNodeIndex output_clip = NO_CLIP_NODE, float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal);
+    EffectNodeIndex append_background_color_animation(EffectNodeIndex parent, SpatialNodeIndex spatial, ClipNodeIndex output_clip = NO_CLIP_NODE);
+    // The frame a context names for recording under the given clip and effect.
 
     AccumulatedVisualContextTree finish();
     AccumulatedVisualContextTree finish_with_structural_epoch(u64 structural_epoch);

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -2600,7 +2600,8 @@ fn expose_shared_abi_types_as_cpp_types(config: &mut cbindgen::Config) {
             "ClipMode",
             "FfiChromeMetrics",
             "SpatialNodeIndex",
-            "FrameNodeIndex",
+            "ClipNodeIndex",
+            "EffectNodeIndex",
             "ContextRef",
             "DisplayListCommandRun",
             "ReplayClip",
@@ -2645,7 +2646,8 @@ fn expose_shared_abi_types_as_cpp_types(config: &mut cbindgen::Config) {
         ("ClipMode", "Web::Painting::ClipMode"),
         ("FfiChromeMetrics", "Web::ChromeMetrics"),
         ("SpatialNodeIndex", "Web::Painting::SpatialNodeIndex"),
-        ("FrameNodeIndex", "Web::Painting::FrameNodeIndex"),
+        ("ClipNodeIndex", "Web::Painting::ClipNodeIndex"),
+        ("EffectNodeIndex", "Web::Painting::EffectNodeIndex"),
         ("ContextRef", "Web::Painting::ContextRef"),
         ("DisplayListCommandRun", "Web::Painting::DisplayListCommandRun"),
         ("ReplayClip", "Web::Painting::ReplayClip"),
@@ -3167,11 +3169,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     let mut display_list_commands_config = base_config;
+    display_list_commands_config.layout.aligned_n = Some("alignas".to_string());
     display_list_commands_config.namespaces = Some(vec!["Web".to_string(), "Painting".to_string()]);
     let commands_source = manifest_dir.join("src/painting/display_list/commands.rs");
     let types_with_existing_cpp_definitions = [
         "SpatialNodeIndex",
-        "FrameNodeIndex",
+        "ClipNodeIndex",
+        "EffectNodeIndex",
         "ContextRef",
         "FontResourceId",
         "ImageFrameResourceId",

--- a/Libraries/LibWeb/Rust/src/painting/display_list/builder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/builder.rs
@@ -113,12 +113,13 @@ impl ContextRewrite {
         } else {
             context.spatial
         };
-        let frame = if context.frame == self.recorded_context.frame {
-            self.current_context.frame
-        } else {
-            context.frame
-        };
-        ContextRef { spatial, frame }
+        let (clip, effect) =
+            if context.clip == self.recorded_context.clip && context.effect == self.recorded_context.effect {
+                (self.current_context.clip, self.current_context.effect)
+            } else {
+                (context.clip, context.effect)
+            };
+        ContextRef { spatial, clip, effect }
     }
 }
 
@@ -306,7 +307,7 @@ impl DisplayListBuilder {
                     let field_offset = offset + std::mem::offset_of!(DisplayListCommandHeader, context);
                     context.write_ffi_bytes(&mut bytes[field_offset..field_offset + std::mem::size_of::<ContextRef>()]);
                 }
-                rewrite_background_color_animation_frame(bytes, offset, &header, rewrite);
+                rewrite_background_color_animation_effect(bytes, offset, &header, rewrite);
             }
             let record_size = HEADER_SIZE + header.payload_size as usize;
             note_command(runs, &header, offset, record_size);
@@ -316,28 +317,28 @@ impl DisplayListBuilder {
     }
 }
 
-fn rewrite_background_color_animation_frame(
+fn rewrite_background_color_animation_effect(
     bytes: &mut [u8],
     record_offset: usize,
     header: &DisplayListCommandHeader,
     rewrite: ContextRewrite,
 ) {
     let payload_field_offset = match header.command_type {
-        DisplayListCommandType::FillRect => std::mem::offset_of!(FillRect, background_color_animation_frame),
+        DisplayListCommandType::FillRect => std::mem::offset_of!(FillRect, background_color_animation_effect),
         DisplayListCommandType::FillRectWithRoundedCorners => {
-            std::mem::offset_of!(FillRectWithRoundedCorners, background_color_animation_frame)
+            std::mem::offset_of!(FillRectWithRoundedCorners, background_color_animation_effect)
         }
         _ => return,
     };
     let field_offset = record_offset + HEADER_SIZE + payload_field_offset;
-    let field_size = std::mem::size_of::<FrameNodeIndex>();
-    let frame = FrameNodeIndex(u32::from_ne_bytes(
+    let field_size = std::mem::size_of::<EffectNodeIndex>();
+    let effect = EffectNodeIndex(u32::from_ne_bytes(
         bytes[field_offset..field_offset + field_size].try_into().unwrap(),
     ));
-    if !frame.is_none() && frame == rewrite.recorded_context.frame {
+    if !effect.is_none() && effect == rewrite.recorded_context.effect {
         rewrite
             .current_context
-            .frame
+            .effect
             .write_ffi_bytes(&mut bytes[field_offset..field_offset + field_size]);
     }
 }
@@ -414,7 +415,8 @@ pub fn read_header(bytes: &[u8]) -> DisplayListCommandHeader {
             let base = std::mem::offset_of!(DisplayListCommandHeader, context);
             ContextRef {
                 spatial: SpatialNodeIndex(cursor.u32_at(base + std::mem::offset_of!(ContextRef, spatial))),
-                frame: FrameNodeIndex(cursor.u32_at(base + std::mem::offset_of!(ContextRef, frame))),
+                clip: ClipNodeIndex(cursor.u32_at(base + std::mem::offset_of!(ContextRef, clip))),
+                effect: EffectNodeIndex(cursor.u32_at(base + std::mem::offset_of!(ContextRef, effect))),
             }
         },
         bounding_rect: {
@@ -453,10 +455,11 @@ mod tests {
     use super::*;
     use libgfx_rust::{Color, CompositingAndBlendingOperator, FloatRect, IntRect};
 
-    fn context(spatial: u32, frame: Option<u32>) -> ContextRef {
+    fn context(spatial: u32, effect: Option<u32>) -> ContextRef {
         ContextRef {
             spatial: SpatialNodeIndex(spatial),
-            frame: frame.map_or(FrameNodeIndex::NONE, FrameNodeIndex),
+            clip: ClipNodeIndex::NONE,
+            effect: effect.map_or(EffectNodeIndex::NONE, EffectNodeIndex),
         }
     }
 
@@ -465,7 +468,7 @@ mod tests {
             rect: IntRect::new(x, y, width, height),
             color: Color::default(),
             compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-            background_color_animation_frame: FrameNodeIndex::NONE,
+            background_color_animation_effect: EffectNodeIndex::NONE,
         }
     }
 
@@ -496,21 +499,21 @@ mod tests {
         contexts
     }
 
-    fn background_color_animation_frames(builder: &DisplayListBuilder) -> Vec<FrameNodeIndex> {
-        let mut frames = Vec::new();
+    fn background_color_animation_effects(builder: &DisplayListBuilder) -> Vec<EffectNodeIndex> {
+        let mut effects = Vec::new();
         for_each_command(builder.bytes(), |header, _, payload| {
             let field_offset = match header.command_type {
                 DisplayListCommandType::FillRect => {
-                    std::mem::offset_of!(FillRect, background_color_animation_frame)
+                    std::mem::offset_of!(FillRect, background_color_animation_effect)
                 }
                 DisplayListCommandType::FillRectWithRoundedCorners => {
-                    std::mem::offset_of!(FillRectWithRoundedCorners, background_color_animation_frame)
+                    std::mem::offset_of!(FillRectWithRoundedCorners, background_color_animation_effect)
                 }
                 _ => return,
             };
-            frames.push(FrameNodeIndex(HeaderReader { bytes: payload }.u32_at(field_offset)));
+            effects.push(EffectNodeIndex(HeaderReader { bytes: payload }.u32_at(field_offset)));
         });
-        frames
+        effects
     }
 
     fn assert_runs_cover_tape(builder: &DisplayListBuilder) {
@@ -721,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    fn a_spliced_capture_leaves_frames_other_than_the_phase_frame_untouched() {
+    fn a_spliced_capture_leaves_other_effects_untouched() {
         let mut source = DisplayListBuilder::new();
         source.append(&fill_rect(0, 0, 10, 10), &[], context(2, Some(5)));
         source.append(&fill_rect(20, 20, 10, 10), &[], context(2, Some(6)));
@@ -748,13 +751,37 @@ mod tests {
     }
 
     #[test]
-    fn a_spliced_capture_rewrites_background_color_animation_frames() {
+    fn a_spliced_capture_rewrites_clip_and_effect_together_and_preserves_unclipped_content() {
+        let recorded = context(2, Some(1));
+        let current = ContextRef {
+            clip: ClipNodeIndex(3),
+            ..context(4, Some(5))
+        };
+        let unclipped = ContextRef::spatial_only(recorded.spatial);
+        let mut source = DisplayListBuilder::new();
+        source.append(&fill_rect(0, 0, 10, 10), &[], recorded);
+        source.append(&fill_rect(20, 20, 10, 10), &[], unclipped);
+        let mut builder = DisplayListBuilder::new();
+        builder.append_command_range(
+            &finished(&source),
+            whole_tape(&source),
+            Some(rewrite(recorded, current)),
+        );
+        assert_eq!(
+            header_contexts(&builder),
+            vec![current, ContextRef::spatial_only(current.spatial)]
+        );
+        assert_runs_cover_tape(&builder);
+    }
+
+    #[test]
+    fn a_spliced_capture_rewrites_background_color_animation_effects() {
         let recorded = context(2, Some(1));
         let current = context(3, Some(7));
         let mut source = DisplayListBuilder::new();
         source.append(
             &FillRect {
-                background_color_animation_frame: recorded.frame,
+                background_color_animation_effect: recorded.effect,
                 ..fill_rect(0, 0, 10, 10)
             },
             &[],
@@ -765,7 +792,7 @@ mod tests {
                 rect: IntRect::new(20, 20, 10, 10),
                 color: Color::default(),
                 corner_radii: CornerRadii::default(),
-                background_color_animation_frame: recorded.frame,
+                background_color_animation_effect: recorded.effect,
             },
             &[],
             recorded,
@@ -776,7 +803,7 @@ mod tests {
                 rect: IntRect::new(60, 60, 10, 10),
                 color: Color::default(),
                 corner_radii: CornerRadii::default(),
-                background_color_animation_frame: FrameNodeIndex(5),
+                background_color_animation_effect: EffectNodeIndex(5),
             },
             &[],
             recorded,
@@ -790,8 +817,13 @@ mod tests {
         );
 
         assert_eq!(
-            background_color_animation_frames(&builder),
-            vec![current.frame, current.frame, FrameNodeIndex::NONE, FrameNodeIndex(5)]
+            background_color_animation_effects(&builder),
+            vec![
+                current.effect,
+                current.effect,
+                EffectNodeIndex::NONE,
+                EffectNodeIndex(5)
+            ]
         );
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/display_list/commands.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/commands.rs
@@ -120,38 +120,47 @@ impl FfiBytes for SpatialNodeIndex {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[repr(transparent)]
-pub struct FrameNodeIndex(pub u32);
+// Indices into the clip and effect trees. `u32::MAX` is the absent node.
+macro_rules! optional_node_index {
+    ($name:ident) => {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        #[repr(transparent)]
+        pub struct $name(pub u32);
 
-impl FrameNodeIndex {
-    pub const NONE: Self = Self(u32::MAX);
+        impl $name {
+            pub const NONE: Self = Self(u32::MAX);
 
-    pub const fn is_none(self) -> bool {
-        self.0 == u32::MAX
-    }
+            pub const fn is_none(self) -> bool {
+                self.0 == u32::MAX
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::NONE
+            }
+        }
+
+        impl FfiBytes for $name {
+            #[inline]
+            fn write_ffi_bytes(&self, out: &mut [u8]) {
+                self.0.write_ffi_bytes(out);
+            }
+        }
+    };
 }
 
-impl Default for FrameNodeIndex {
-    fn default() -> Self {
-        Self::NONE
-    }
-}
-
-impl FfiBytes for FrameNodeIndex {
-    #[inline]
-    fn write_ffi_bytes(&self, out: &mut [u8]) {
-        self.0.write_ffi_bytes(out);
-    }
-}
+optional_node_index!(ClipNodeIndex);
+optional_node_index!(EffectNodeIndex);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct ContextRef {
     pub spatial: SpatialNodeIndex,
-    pub frame: FrameNodeIndex,
+    pub clip: ClipNodeIndex,
+    pub effect: EffectNodeIndex,
 }
-ffi_bytes_fields!(ContextRef { spatial, frame });
+ffi_bytes_fields!(ContextRef { spatial, clip, effect });
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -175,7 +184,7 @@ pub struct ReplayLayer {
     pub blend_mode: CompositingAndBlendingOperator,
     pub filter_bytes: *const u8,
     pub filter_bytes_size: usize,
-    pub frame: FrameNodeIndex,
+    pub effect: EffectNodeIndex,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -189,7 +198,8 @@ impl ContextRef {
     pub const fn spatial_only(spatial: SpatialNodeIndex) -> Self {
         Self {
             spatial,
-            frame: FrameNodeIndex::NONE,
+            clip: ClipNodeIndex::NONE,
+            effect: EffectNodeIndex::NONE,
         }
     }
 }
@@ -466,8 +476,9 @@ ffi_bytes_fields!(DisplayListGradientColorStops {
     repeating
 });
 
+// Keep payloads aligned after the three-index context, including inline object arrays.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(C)]
+#[repr(C, align(16))]
 pub struct DisplayListCommandHeader {
     pub command_type: DisplayListCommandType,
     pub has_bounding_rect: bool,
@@ -484,7 +495,7 @@ ffi_bytes_fields!(DisplayListCommandHeader {
     context,
     bounding_rect
 });
-const _: () = assert!(std::mem::size_of::<DisplayListCommandHeader>() == 32);
+const _: () = assert!(std::mem::size_of::<DisplayListCommandHeader>() == 48);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(u8)]
@@ -534,7 +545,7 @@ pub struct DisplayListCommandRun {
     pub has_unbounded_draw: bool,
     pub has_compositor_metadata: bool,
 }
-const _: () = assert!(std::mem::size_of::<DisplayListCommandRun>() == 36);
+const _: () = assert!(std::mem::size_of::<DisplayListCommandRun>() == 40);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[repr(C)]
@@ -703,13 +714,13 @@ pub struct FillRect {
     pub rect: IntRect,
     pub color: Color,
     pub compositing_and_blending_operator: CompositingAndBlendingOperator,
-    pub background_color_animation_frame: FrameNodeIndex,
+    pub background_color_animation_effect: EffectNodeIndex,
 }
 ffi_bytes_fields!(FillRect {
     rect,
     color,
     compositing_and_blending_operator,
-    background_color_animation_frame
+    background_color_animation_effect
 });
 
 impl DisplayListCommand for FillRect {
@@ -1049,13 +1060,13 @@ pub struct FillRectWithRoundedCorners {
     pub rect: IntRect,
     pub color: Color,
     pub corner_radii: CornerRadii,
-    pub background_color_animation_frame: FrameNodeIndex,
+    pub background_color_animation_effect: EffectNodeIndex,
 }
 ffi_bytes_fields!(FillRectWithRoundedCorners {
     rect,
     color,
     corner_radii,
-    background_color_animation_frame
+    background_color_animation_effect
 });
 
 impl DisplayListCommand for FillRectWithRoundedCorners {
@@ -1294,7 +1305,7 @@ pub const NO_MASK_DISPLAY_LIST: DisplayListResourceId = DisplayListResourceId(0)
 
 // Plays its content list inside an internally scoped saveLayer, optionally
 // masked by a second list composited with DestinationIn, so a group that
-// must not blend with the canvas needs no visual context frames.
+// must not blend with the canvas needs no clips or effects.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C)]
 pub struct DrawIsolatedDisplayList {

--- a/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
@@ -10,8 +10,10 @@ use crate::painting::display_list::commands::{
     DrawGlyphRun, DrawScaledDecodedImageFrame, INLINE_CLIP_ENTRY_SIZE, OptionalColor, OptionalFloatRect,
     PaintTextShadow, SpatialNodeIndex, VISUAL_VIEWPORT_NODE_INDEX,
 };
+use crate::painting::visual_context::queries::TreeCullingScratch;
 use crate::painting::visual_context::{
-    FrameData, IncludeVisualViewportTransform, SpatialData, VisualContextTree, device_offset_for_index,
+    ClipNodeData, EffectNodeData, IncludeVisualViewportTransform, SpatialData, VisualContextTree,
+    device_offset_for_index,
 };
 use libgfx_rust::{FloatPoint, FloatRect, IntRect, enclosing_int_rect};
 use std::mem::offset_of;
@@ -215,21 +217,27 @@ fn spatial_data_is_equal(
     }
 }
 
-fn frame_data_is_equal(a: &FrameData, b: &FrameData) -> bool {
+fn clip_data_is_equal(a: &ClipNodeData, b: &ClipNodeData) -> bool {
     match (a, b) {
-        (FrameData::BackgroundColorAnimation, FrameData::BackgroundColorAnimation) => true,
-        (FrameData::Clip(data), FrameData::Clip(other)) => data == other,
-        (FrameData::ClipPath(data), FrameData::ClipPath(other)) => {
+        (ClipNodeData::Rect(data), ClipNodeData::Rect(other)) => data == other,
+        (ClipNodeData::Path(data), ClipNodeData::Path(other)) => {
             data.bounding_rect == other.bounding_rect
                 && data.fill_rule == other.fill_rule
                 && (Rc::ptr_eq(&data.path, &other.path)
                     || data.path.serialize_to_bytes() == other.path.serialize_to_bytes())
         }
-        (FrameData::Effects(data), FrameData::Effects(other)) => {
+        _ => false,
+    }
+}
+
+fn effect_data_is_equal(a: &EffectNodeData, b: &EffectNodeData) -> bool {
+    match (a, b) {
+        (EffectNodeData::BackgroundColorAnimation, EffectNodeData::BackgroundColorAnimation) => true,
+        (EffectNodeData::Effects(data), EffectNodeData::Effects(other)) => {
             data.opacity == other.opacity && data.blend_mode == other.blend_mode && data.filter == other.filter
         }
         // Mask content is per-recording and invisible here, so mask chains always damage.
-        (FrameData::Mask(_), FrameData::Mask(_)) => false,
+        (EffectNodeData::Mask(_), EffectNodeData::Mask(_)) => false,
         _ => false,
     }
 }
@@ -245,16 +253,40 @@ fn spatial_depths(tree: &VisualContextTree) -> Vec<u32> {
     depths
 }
 
+// Walks two root paths in lockstep from their tips, pairing node with node; both must end together.
+fn chains_pair_up(
+    mut old: u32,
+    mut new: u32,
+    old_parent: impl Fn(u32) -> u32,
+    new_parent: impl Fn(u32) -> u32,
+    nodes_match: impl Fn(u32, u32) -> bool,
+) -> bool {
+    loop {
+        if old == u32::MAX || new == u32::MAX {
+            return old == new;
+        }
+        if !nodes_match(old, new) {
+            return false;
+        }
+        old = old_parent(old);
+        new = new_parent(new);
+    }
+}
+
 struct TreeChainComparison<'a> {
     old_tree: &'a VisualContextTree,
     old_scroll_offsets: &'a [FloatPoint],
     old_spatial_depths: Vec<u32>,
+    old_culling: TreeCullingScratch,
     new_tree: &'a VisualContextTree,
     new_scroll_offsets: &'a [FloatPoint],
     new_spatial_depths: Vec<u32>,
+    new_culling: TreeCullingScratch,
 }
 
 impl TreeChainComparison<'_> {
+    // Two contexts have the same shape when their spatial, clip and effect chains pair up node
+    // by node with matching kinds and spatial depths.
     fn chains_are_compatible(&self, old_context: ContextRef, new_context: ContextRef) -> bool {
         if self.old_spatial_depths[old_context.spatial.0 as usize]
             != self.new_spatial_depths[new_context.spatial.0 as usize]
@@ -275,27 +307,38 @@ impl TreeChainComparison<'_> {
             old_index = old_node.parent;
             new_index = new_node.parent;
         }
-        let mut old_frame = old_context.frame;
-        let mut new_frame = new_context.frame;
-        loop {
-            if old_frame.is_none() || new_frame.is_none() {
-                return old_frame == new_frame;
-            }
-            let old_node = &self.old_tree.frame_nodes[old_frame.0 as usize];
-            let new_node = &self.new_tree.frame_nodes[new_frame.0 as usize];
-            if std::mem::discriminant(&old_node.data) != std::mem::discriminant(&new_node.data) {
-                return false;
-            }
-            if self.old_spatial_depths[old_node.spatial.0 as usize]
-                != self.new_spatial_depths[new_node.spatial.0 as usize]
-            {
-                return false;
-            }
-            old_frame = old_node.parent;
-            new_frame = new_node.parent;
-        }
+        let (old_tree, new_tree) = (self.old_tree, self.new_tree);
+        let same_spatial_depth = |old_spatial: SpatialNodeIndex, new_spatial: SpatialNodeIndex| {
+            self.old_spatial_depths[old_spatial.0 as usize] == self.new_spatial_depths[new_spatial.0 as usize]
+        };
+        chains_pair_up(
+            old_context.clip.0,
+            new_context.clip.0,
+            |index| old_tree.clip_nodes[index as usize].parent.0,
+            |index| new_tree.clip_nodes[index as usize].parent.0,
+            |old, new| {
+                let (old, new) = (&old_tree.clip_nodes[old as usize], &new_tree.clip_nodes[new as usize]);
+                std::mem::discriminant(&old.data) == std::mem::discriminant(&new.data)
+                    && same_spatial_depth(old.spatial, new.spatial)
+            },
+        ) && chains_pair_up(
+            old_context.effect.0,
+            new_context.effect.0,
+            |index| old_tree.effect_nodes[index as usize].parent.0,
+            |index| new_tree.effect_nodes[index as usize].parent.0,
+            |old, new| {
+                let (old, new) = (
+                    &old_tree.effect_nodes[old as usize],
+                    &new_tree.effect_nodes[new as usize],
+                );
+                std::mem::discriminant(&old.data) == std::mem::discriminant(&new.data)
+                    && same_spatial_depth(old.spatial, new.spatial)
+            },
+        )
     }
 
+    // Value equality of compatible chains. An effect's output clip is compared by clip depth: a
+    // layer that moved relative to the clips around it is treated as a change.
     fn chains_are_equal(&self, old_context: ContextRef, new_context: ContextRef) -> bool {
         let mut old_index = old_context.spatial;
         let mut new_index = new_context.spatial;
@@ -318,27 +361,42 @@ impl TreeChainComparison<'_> {
             old_index = old_node.parent;
             new_index = new_node.parent;
         }
-        let mut old_frame = old_context.frame;
-        let mut new_frame = new_context.frame;
-        while !old_frame.is_none() {
-            let old_node = &self.old_tree.frame_nodes[old_frame.0 as usize];
-            let new_node = &self.new_tree.frame_nodes[new_frame.0 as usize];
-            if !frame_data_is_equal(&old_node.data, &new_node.data) {
-                return false;
-            }
-            old_frame = old_node.parent;
-            new_frame = new_node.parent;
-        }
-        true
+        let (old_tree, new_tree) = (self.old_tree, self.new_tree);
+        chains_pair_up(
+            old_context.clip.0,
+            new_context.clip.0,
+            |index| old_tree.clip_nodes[index as usize].parent.0,
+            |index| new_tree.clip_nodes[index as usize].parent.0,
+            |old, new| {
+                clip_data_is_equal(
+                    &old_tree.clip_nodes[old as usize].data,
+                    &new_tree.clip_nodes[new as usize].data,
+                )
+            },
+        ) && chains_pair_up(
+            old_context.effect.0,
+            new_context.effect.0,
+            |index| old_tree.effect_nodes[index as usize].parent.0,
+            |index| new_tree.effect_nodes[index as usize].parent.0,
+            |old, new| {
+                let (old, new) = (
+                    &old_tree.effect_nodes[old as usize],
+                    &new_tree.effect_nodes[new as usize],
+                );
+                effect_data_is_equal(&old.data, &new.data)
+                    && self.old_culling.clip_depth(old.output_clip()) == self.new_culling.clip_depth(new.output_clip())
+            },
+        )
     }
 
     fn changing_filter_may_affect_output_bounds(&self, old_context: ContextRef, new_context: ContextRef) -> bool {
-        let mut old_frame = old_context.frame;
-        let mut new_frame = new_context.frame;
-        while !old_frame.is_none() {
-            let old_node = &self.old_tree.frame_nodes[old_frame.0 as usize];
-            let new_node = &self.new_tree.frame_nodes[new_frame.0 as usize];
-            if let (FrameData::Effects(old_effects), FrameData::Effects(new_effects)) = (&old_node.data, &new_node.data)
+        let mut old_effect = old_context.effect;
+        let mut new_effect = new_context.effect;
+        while !old_effect.is_none() {
+            let old_node = &self.old_tree.effect_nodes[old_effect.0 as usize];
+            let new_node = &self.new_tree.effect_nodes[new_effect.0 as usize];
+            if let (EffectNodeData::Effects(old_effects), EffectNodeData::Effects(new_effects)) =
+                (&old_node.data, &new_node.data)
                 && old_effects.filter != new_effects.filter
                 && old_effects
                     .filter
@@ -348,8 +406,8 @@ impl TreeChainComparison<'_> {
             {
                 return true;
             }
-            old_frame = old_node.parent;
-            new_frame = new_node.parent;
+            old_effect = old_node.parent;
+            new_effect = new_node.parent;
         }
         false
     }
@@ -388,10 +446,10 @@ impl DamageAccumulator {
         command: &CommandReference<'_>,
         visual_context_tree: &VisualContextTree,
         scroll_offsets: &[FloatPoint],
-        frames_with_empty_effective_clip: &[bool],
+        culling: &TreeCullingScratch,
     ) {
         let context = command.header.context;
-        if !context.frame.is_none() && frames_with_empty_effective_clip[context.frame.0 as usize] {
+        if culling.context_culls_everything(context) {
             return;
         }
         if !command.header.has_bounding_rect {
@@ -458,16 +516,22 @@ pub fn compute_display_list_damage(
 ) -> Option<IntRect> {
     let old_commands = collect_command_references(old_display_list_commands);
     let new_commands = collect_command_references(new_display_list_commands);
+    let mut old_culling = TreeCullingScratch::default();
+    old_visual_context_tree.fill_culling_scratch(&mut old_culling);
+    let mut new_culling = TreeCullingScratch::default();
+    new_visual_context_tree.fill_culling_scratch(&mut new_culling);
     let chains = TreeChainComparison {
         old_tree: old_visual_context_tree,
         old_scroll_offsets,
         old_spatial_depths: spatial_depths(old_visual_context_tree),
+        old_culling,
         new_tree: new_visual_context_tree,
         new_scroll_offsets,
         new_spatial_depths: spatial_depths(new_visual_context_tree),
+        new_culling,
     };
-    let old_frames_with_empty_effective_clip = old_visual_context_tree.frames_with_empty_effective_clip();
-    let new_frames_with_empty_effective_clip = new_visual_context_tree.frames_with_empty_effective_clip();
+    let old_frames_with_empty_effective_clip = &chains.old_culling;
+    let new_frames_with_empty_effective_clip = &chains.new_culling;
     let commands_are_equal = |old_command: &CommandReference<'_>, new_command: &CommandReference<'_>| {
         display_list_commands_are_equal(old_command, new_command)
             && chains.chains_are_compatible(old_command.header.context, new_command.header.context)
@@ -499,7 +563,7 @@ pub fn compute_display_list_damage(
             command,
             old_visual_context_tree,
             old_scroll_offsets,
-            &old_frames_with_empty_effective_clip,
+            old_frames_with_empty_effective_clip,
         );
     };
     let add_new_command_damage = |damage: &mut DamageAccumulator, command: &CommandReference<'_>| {
@@ -507,7 +571,7 @@ pub fn compute_display_list_damage(
             command,
             new_visual_context_tree,
             new_scroll_offsets,
-            &new_frames_with_empty_effective_clip,
+            new_frames_with_empty_effective_clip,
         );
     };
     let add_visual_context_damage =
@@ -634,13 +698,13 @@ mod tests {
     use crate::painting::display_list::builder::HEADER_SIZE;
     use crate::painting::display_list::commands::{
         CanvasId, CompositorMainThreadWheelEventRegion, DisplayListCommand, DisplayListGlyph, DrawCanvas, FillRect,
-        FontResourceId, FrameNodeIndex, ImageFrameResourceId, InlineClipKind,
+        FontResourceId, ImageFrameResourceId, InlineClipKind,
     };
     use crate::painting::display_list::ffi_bytes::FfiBytes;
     use crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT;
     use crate::painting::visual_context::{
-        ClipData, ClipMode, EffectsData, FrameData, MaskData, MaskLayerOrigin, ScrollData, SpatialData, TransformData,
-        TransformDataRole,
+        ClipData, ClipMode, ClipNodeData, ClipNodeIndex, EffectNodeData, EffectNodeIndex, EffectsData, MaskData,
+        MaskLayerOrigin, ScrollData, SpatialData, TransformData, TransformDataRole,
     };
     use libgfx_rust::filter::Filter;
     use libgfx_rust::{
@@ -705,7 +769,7 @@ mod tests {
                 rect,
                 color,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             Some(rect),
             ContextRef::default(),
@@ -781,28 +845,52 @@ mod tests {
         VisualContextTree::create(transform(FloatMatrix4x4::identity()))
     }
 
-    fn clip(rect: FloatRect) -> FrameData {
-        FrameData::Clip(ClipData {
+    fn clip(rect: FloatRect) -> ClipNodeData {
+        ClipNodeData::Rect(ClipData {
             rect,
             corner_radii: CornerRadii::default(),
             mode: ClipMode::Intersect,
         })
     }
 
-    fn mask(rect: IntRect) -> FrameData {
-        FrameData::Mask(MaskData {
+    fn mask(rect: IntRect) -> EffectNodeData {
+        EffectNodeData::Mask(MaskData {
             rect,
             kind: MaskKind::Alpha,
             origin: MaskLayerOrigin::CssMaskLayers,
         })
     }
 
-    fn effects(filter: Vec<u8>) -> FrameData {
-        FrameData::Effects(EffectsData {
+    fn effects(filter: Vec<u8>) -> EffectNodeData {
+        EffectNodeData::Effects(EffectsData {
             opacity: 1.0,
             blend_mode: CompositingAndBlendingOperator::Normal,
             filter: Some(Rc::new(filter)),
         })
+    }
+
+    // A context under a fresh root clip, or under a fresh root effect without an output clip.
+    fn clip_context(tree: &mut VisualContextTree, data: ClipNodeData) -> ContextRef {
+        let clip = tree.append_clip(data, ClipNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        ContextRef {
+            clip,
+            effect: EffectNodeIndex::NONE,
+            ..ContextRef::default()
+        }
+    }
+
+    fn effect_context(tree: &mut VisualContextTree, data: EffectNodeData) -> ContextRef {
+        let effect = tree.append_effect(
+            data,
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect,
+            ..ContextRef::default()
+        }
     }
 
     fn blur_filter(radius: f32) -> Vec<u8> {
@@ -819,18 +907,18 @@ mod tests {
 
     fn damage_for_filter_change(old_filter: Vec<u8>, new_filter: Vec<u8>) -> Option<IntRect> {
         let mut old_tree = identity_tree();
-        let old_frame = old_tree.append_frame(effects(old_filter), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        let old_context = effect_context(&mut old_tree, effects(old_filter));
         let mut new_tree = identity_tree();
-        let new_frame = new_tree.append_frame(effects(new_filter), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        let new_context = effect_context(&mut new_tree, effects(new_filter));
         let rect = IntRect::new(10, 10, 20, 20);
         let fill = FillRect {
             rect,
             color: RED,
             compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-            background_color_animation_frame: FrameNodeIndex::NONE,
+            background_color_animation_effect: EffectNodeIndex::NONE,
         };
-        let old_display_list = command_bytes(&fill, Some(rect), context_in(VISUAL_VIEWPORT_NODE_INDEX, old_frame));
-        let new_display_list = command_bytes(&fill, Some(rect), context_in(VISUAL_VIEWPORT_NODE_INDEX, new_frame));
+        let old_display_list = command_bytes(&fill, Some(rect), context_in(VISUAL_VIEWPORT_NODE_INDEX, old_context));
+        let new_display_list = command_bytes(&fill, Some(rect), context_in(VISUAL_VIEWPORT_NODE_INDEX, new_context));
         damage(&old_display_list, &old_tree, &new_display_list, &new_tree)
     }
 
@@ -851,8 +939,8 @@ mod tests {
         )
     }
 
-    fn context_in(spatial: SpatialNodeIndex, frame: FrameNodeIndex) -> ContextRef {
-        ContextRef { spatial, frame }
+    fn context_in(spatial: SpatialNodeIndex, context: ContextRef) -> ContextRef {
+        ContextRef { spatial, ..context }
     }
 
     #[test]
@@ -892,20 +980,20 @@ mod tests {
                 rect,
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             Some(rect),
-            context_in(in_order_transform, FrameNodeIndex::NONE),
+            context_in(in_order_transform, ContextRef::default()),
         );
         let new_commands = command_bytes(
             &FillRect {
                 rect,
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             Some(rect),
-            context_in(permuted_transform, FrameNodeIndex::NONE),
+            context_in(permuted_transform, ContextRef::default()),
         );
         assert_eq!(
             damage(&old_commands, &in_order, &new_commands, &permuted),
@@ -1003,7 +1091,7 @@ mod tests {
                 rect,
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             &[],
             Some(rect),
@@ -1061,7 +1149,7 @@ mod tests {
                 rect: IntRect::new(0, 0, 10, 10),
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             None,
             ContextRef::default(),
@@ -1071,7 +1159,7 @@ mod tests {
                 rect: IntRect::new(0, 0, 10, 10),
                 color: BLUE,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             None,
             ContextRef::default(),
@@ -1133,26 +1221,18 @@ mod tests {
     #[test]
     fn mask_visual_context_damages_affected_commands() {
         let mut old_tree = identity_tree();
-        let old_mask_frame = old_tree.append_frame(
-            mask(IntRect::new(0, 0, 100, 100)),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        );
+        let old_mask_context = effect_context(&mut old_tree, mask(IntRect::new(0, 0, 100, 100)));
         let mut new_tree = identity_tree();
-        new_tree.append_frame(
-            mask(IntRect::new(0, 0, 100, 100)),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        );
+        effect_context(&mut new_tree, mask(IntRect::new(0, 0, 100, 100)));
         let display_list = command_bytes(
             &FillRect {
                 rect: IntRect::new(10, 10, 20, 20),
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             Some(IntRect::new(10, 10, 20, 20)),
-            context_in(VISUAL_VIEWPORT_NODE_INDEX, old_mask_frame),
+            context_in(VISUAL_VIEWPORT_NODE_INDEX, old_mask_context),
         );
         assert_eq!(
             damage(&display_list, &old_tree, &display_list, &new_tree),
@@ -1163,36 +1243,28 @@ mod tests {
     #[test]
     fn commands_under_an_empty_effective_clip_do_not_damage() {
         let mut old_tree = identity_tree();
-        let old_frame = old_tree.append_frame(
-            clip(FloatRect::default()),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        );
+        let old_context = clip_context(&mut old_tree, clip(FloatRect::default()));
         let mut new_tree = identity_tree();
-        let new_frame = new_tree.append_frame(
-            clip(FloatRect::default()),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        );
+        let new_context = clip_context(&mut new_tree, clip(FloatRect::default()));
         let old_display_list = command_bytes(
             &FillRect {
                 rect: IntRect::new(10, 10, 20, 20),
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             Some(IntRect::new(10, 10, 20, 20)),
-            context_in(VISUAL_VIEWPORT_NODE_INDEX, old_frame),
+            context_in(VISUAL_VIEWPORT_NODE_INDEX, old_context),
         );
         let new_display_list = command_bytes(
             &FillRect {
                 rect: IntRect::new(30, 30, 20, 20),
                 color: BLUE,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             Some(IntRect::new(30, 30, 20, 20)),
-            context_in(VISUAL_VIEWPORT_NODE_INDEX, new_frame),
+            context_in(VISUAL_VIEWPORT_NODE_INDEX, new_context),
         );
         assert_eq!(
             damage(&old_display_list, &old_tree, &new_display_list, &new_tree),
@@ -1203,32 +1275,24 @@ mod tests {
     #[test]
     fn a_clip_growing_from_empty_damages_the_commands_it_reveals() {
         let mut old_tree = identity_tree();
-        let old_frame = old_tree.append_frame(
-            clip(FloatRect::default()),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        );
+        let old_context = clip_context(&mut old_tree, clip(FloatRect::default()));
         let mut new_tree = identity_tree();
-        let new_frame = new_tree.append_frame(
-            clip(FloatRect::new(0.0, 0.0, 100.0, 100.0)),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        );
+        let new_context = clip_context(&mut new_tree, clip(FloatRect::new(0.0, 0.0, 100.0, 100.0)));
         let fill = FillRect {
             rect: IntRect::new(10, 10, 20, 20),
             color: RED,
             compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-            background_color_animation_frame: FrameNodeIndex::NONE,
+            background_color_animation_effect: EffectNodeIndex::NONE,
         };
         let old_display_list = command_bytes(
             &fill,
             Some(fill.rect),
-            context_in(VISUAL_VIEWPORT_NODE_INDEX, old_frame),
+            context_in(VISUAL_VIEWPORT_NODE_INDEX, old_context),
         );
         let new_display_list = command_bytes(
             &fill,
             Some(fill.rect),
-            context_in(VISUAL_VIEWPORT_NODE_INDEX, new_frame),
+            context_in(VISUAL_VIEWPORT_NODE_INDEX, new_context),
         );
         assert_eq!(
             damage(&old_display_list, &old_tree, &new_display_list, &new_tree),
@@ -1244,14 +1308,13 @@ mod tests {
             VISUAL_VIEWPORT_NODE_INDEX,
         );
         let mut new_tree = identity_tree();
-        new_tree.append_frame(
-            FrameData::Effects(EffectsData {
+        effect_context(
+            &mut new_tree,
+            EffectNodeData::Effects(EffectsData {
                 opacity: 0.5,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
             }),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
         );
         let new_command_spatial = new_tree.append_spatial(
             SpatialData::Transform(transform(FloatMatrix4x4::identity())),
@@ -1261,17 +1324,17 @@ mod tests {
             rect: IntRect::new(10, 10, 20, 20),
             color: RED,
             compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-            background_color_animation_frame: FrameNodeIndex::NONE,
+            background_color_animation_effect: EffectNodeIndex::NONE,
         };
         let old_display_list = command_bytes(
             &fill,
             Some(fill.rect),
-            context_in(old_command_spatial, FrameNodeIndex::NONE),
+            context_in(old_command_spatial, ContextRef::default()),
         );
         let new_display_list = command_bytes(
             &fill,
             Some(fill.rect),
-            context_in(new_command_spatial, FrameNodeIndex::NONE),
+            context_in(new_command_spatial, ContextRef::default()),
         );
         assert_eq!(
             damage(&old_display_list, &old_tree, &new_display_list, &new_tree),

--- a/Libraries/LibWeb/Rust/src/painting/display_list/depth_sorted_plan.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/depth_sorted_plan.rs
@@ -11,6 +11,7 @@ use libgfx_rust::bsp_tree::{
 use libgfx_rust::{FloatMatrix4x4, FloatRect, FloatVector3};
 
 use super::commands::{DisplayListCommandRun, SpatialNodeIndex};
+use crate::painting::visual_context::queries::TreeCullingScratch;
 use crate::painting::visual_context::{NO_SORTING_CONTEXT, SortingContexts};
 
 struct LeafBounds {
@@ -298,7 +299,7 @@ fn partition_command_runs_into_plane_chunks(
     transform_palette: &[FloatMatrix4x4],
     draw_space: &[SpatialNodeIndex],
     backface_culled: &[bool],
-    frame_has_empty_effective_clip: &[bool],
+    culling: &TreeCullingScratch,
 ) -> Vec<CommandChunk> {
     let mut mappings = Vec::new();
     let mut mappings_key = None;
@@ -328,7 +329,7 @@ fn partition_command_runs_into_plane_chunks(
         if run.ink_bounds.is_empty() || sorting_context == NO_SORTING_CONTEXT || backface_culled[spatial.0 as usize] {
             continue;
         }
-        if !run.context.frame.is_none() && frame_has_empty_effective_clip[run.context.frame.0 as usize] {
+        if culling.context_culls_everything(run.context) {
             continue;
         }
         ensure_mappings(
@@ -415,7 +416,7 @@ pub fn build_depth_sorted_replay_plan(
     leaf_to_context_palette: &[FloatMatrix4x4],
     draw_space: &[SpatialNodeIndex],
     backface_culled: &[bool],
-    frame_has_empty_effective_clip: &[bool],
+    culling: &TreeCullingScratch,
 ) -> DepthSortedReplayPlan {
     let chunks = partition_command_runs_into_plane_chunks(
         command_runs,
@@ -423,7 +424,7 @@ pub fn build_depth_sorted_replay_plan(
         transform_palette,
         draw_space,
         backface_culled,
-        frame_has_empty_effective_clip,
+        culling,
     );
     let mut builder = DepthSortedPlanBuilder {
         contexts,
@@ -523,7 +524,7 @@ mod tests {
             &leaf_to_context_palette(&contexts, &palette),
             &draw_space,
             &backface_culled,
-            &[],
+            &TreeCullingScratch::default(),
         );
         assert_eq!(run_spans(&plan), vec![(0, 2)]);
         assert!(plan.vertices.is_empty());
@@ -543,7 +544,7 @@ mod tests {
             &leaf_to_context_palette(&contexts, &palette),
             &draw_space,
             &backface_culled,
-            &[],
+            &TreeCullingScratch::default(),
         );
         assert_eq!(run_spans(&plan), vec![(1, 1), (0, 1)]);
         assert!(
@@ -566,7 +567,7 @@ mod tests {
             &leaf_to_context_palette(&contexts, &palette),
             &draw_space,
             &backface_culled,
-            &[],
+            &TreeCullingScratch::default(),
         );
         let push_steps: Vec<_> = plan
             .steps
@@ -602,7 +603,7 @@ mod tests {
             &leaf_to_context_palette(&contexts, &palette),
             &draw_space,
             &backface_culled,
-            &[],
+            &TreeCullingScratch::default(),
         );
         let push_count = plan
             .steps
@@ -632,7 +633,7 @@ mod tests {
             &leaf_to_context_palette(&contexts, &palette),
             &draw_space,
             &backface_culled,
-            &[],
+            &TreeCullingScratch::default(),
         );
         assert_eq!(run_spans(&plan), vec![(0, 1), (1, 1)]);
         assert!(
@@ -654,7 +655,7 @@ mod tests {
             &leaf_to_context_palette(&contexts, &palette),
             &draw_space,
             &backface_culled,
-            &[],
+            &TreeCullingScratch::default(),
         );
         assert_eq!(run_spans(&plan), vec![(0, 1), (1, 1)]);
     }
@@ -679,7 +680,7 @@ mod tests {
             &leaf_to_context_palette(&contexts, &palette),
             &draw_space,
             &backface_culled,
-            &[],
+            &TreeCullingScratch::default(),
         );
         assert_eq!(run_spans(&plan), vec![(2, 1), (1, 1), (0, 1)]);
     }

--- a/Libraries/LibWeb/Rust/src/painting/display_list/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/dump.rs
@@ -13,6 +13,9 @@ use crate::painting::dump::{
     push_float_like_ak, push_float_point, push_float_rect, push_float_size, push_int_point, push_int_rect,
     push_int_size,
 };
+#[cfg(test)]
+use crate::painting::visual_context::VisualContextTree;
+use crate::painting::visual_context::dump::SlotKind;
 use libgfx_rust::path::OwnedPath;
 use libgfx_rust::{
     Color, CompositingAndBlendingOperator, CornerRadii, FloatPoint, FloatRect, FloatSize, IntPoint, IntRect, IntSize,
@@ -35,7 +38,7 @@ pub struct FfiPaintingDumpCallbacks {
     pub mask_display_lists: unsafe extern "C" fn(
         context: *mut c_void,
         display_list: *const c_void,
-        frames: *mut u32,
+        effects: *mut u32,
         display_list_ids: *mut u64,
     ),
     pub append_text: unsafe extern "C" fn(context: *mut c_void, bytes: *const u8, byte_count: usize),
@@ -70,26 +73,26 @@ impl FfiPaintingDumpCallbacks {
         display_list
     }
 
-    fn mask_display_lists(&self, display_list: *const c_void) -> Vec<(FrameNodeIndex, DisplayListResourceId)> {
+    fn mask_display_lists(&self, display_list: *const c_void) -> Vec<(EffectNodeIndex, DisplayListResourceId)> {
         // SAFETY: The host reports how many mask entries this display list holds.
         let count = unsafe { (self.mask_display_list_count)(self.context, display_list) };
-        let mut frames = vec![0; count];
+        let mut effects = vec![0; count];
         let mut display_list_ids = vec![0; count];
         // SAFETY: Both buffers hold the `count` entries the host just reported.
         unsafe {
             (self.mask_display_lists)(
                 self.context,
                 display_list,
-                frames.as_mut_ptr(),
+                effects.as_mut_ptr(),
                 display_list_ids.as_mut_ptr(),
             );
         };
-        let mut masks: Vec<_> = frames
+        let mut masks: Vec<_> = effects
             .into_iter()
             .zip(display_list_ids)
-            .map(|(frame, id)| (FrameNodeIndex(frame), DisplayListResourceId(id)))
+            .map(|(effect, id)| (EffectNodeIndex(effect), DisplayListResourceId(id)))
             .collect();
-        masks.sort_unstable_by_key(|(frame, _)| *frame);
+        masks.sort_unstable_by_key(|(effect, _)| *effect);
         masks
     }
 
@@ -101,7 +104,8 @@ impl FfiPaintingDumpCallbacks {
 
 struct VisualContextNodeOwners {
     spatial: HashMap<u32, NodeSlotId>,
-    frame: HashMap<u32, NodeSlotId>,
+    clip: HashMap<u32, NodeSlotId>,
+    effect: HashMap<u32, NodeSlotId>,
 }
 
 impl VisualContextNodeOwners {
@@ -109,7 +113,8 @@ impl VisualContextNodeOwners {
         let paintable_rows = arena.paintable_rows();
         let mut owners = Self {
             spatial: HashMap::new(),
-            frame: HashMap::new(),
+            clip: HashMap::new(),
+            effect: HashMap::new(),
         };
         owners.spatial.insert(VISUAL_VIEWPORT_NODE_INDEX.0, viewport);
         owners.spatial.insert(
@@ -122,8 +127,11 @@ impl VisualContextNodeOwners {
                 for spatial in &handles.spatial {
                     owners.spatial.insert(spatial.0, slot);
                 }
-                for frame in handles.frame_handles() {
-                    owners.frame.insert(frame.0, slot);
+                for clip in handles.clip_handles() {
+                    owners.clip.insert(clip.0, slot);
+                }
+                for effect in &handles.effects {
+                    owners.effect.insert(effect.0, slot);
                 }
             });
             let mut child = arena.node_first_child_if_live(slot);
@@ -135,11 +143,11 @@ impl VisualContextNodeOwners {
         owners
     }
 
-    fn owner(&self, is_frame: bool, index: u32) -> Option<NodeSlotId> {
-        if is_frame {
-            self.frame.get(&index).copied()
-        } else {
-            self.spatial.get(&index).copied()
+    fn owner(&self, kind: SlotKind, index: u32) -> Option<NodeSlotId> {
+        match kind {
+            SlotKind::Spatial => self.spatial.get(&index).copied(),
+            SlotKind::Clip => self.clip.get(&index).copied(),
+            SlotKind::Effect => self.effect.get(&index).copied(),
         }
     }
 }
@@ -167,8 +175,8 @@ pub unsafe extern "C" fn painting_dump(
     let visual_context_tree = unsafe { crate::painting::ffi::tree_from_handle(visual_context_tree) };
     let command_runs = unsafe { crate::painting::ffi::ffi_slice(command_runs, command_run_count) };
     let owners = VisualContextNodeOwners::collect(arena, viewport);
-    let mut output = visual_context_tree.dump_nodes_reachable_from_runs(command_runs, |is_frame, index| {
-        let shell = arena.shell_if_live(owners.owner(is_frame, index)?);
+    let mut output = visual_context_tree.dump_nodes_reachable_from_runs(command_runs, |kind, index| {
+        let shell = arena.shell_if_live(owners.owner(kind, index)?);
         (!shell.is_null()).then(|| callbacks.debug_description(shell))
     });
     output.push_str("\nDisplayList:\n");
@@ -212,9 +220,9 @@ fn dump_commands(
         }
     });
 
-    for (frame, id) in callbacks.mask_display_lists(display_list) {
+    for (effect, id) in callbacks.mask_display_lists(display_list) {
         push_indent(output, base_indent);
-        writeln!(output, "MaskDisplayList for frame f{}:", frame.0).unwrap();
+        writeln!(output, "MaskDisplayList for effect e{}:", effect.0).unwrap();
         dump_commands(output, callbacks, callbacks.nested_display_list(id), base_indent + 1);
     }
 }
@@ -593,10 +601,14 @@ fn dump_inline_clips(output: &mut String, header: &DisplayListCommandHeader, pay
     output.push(']');
 }
 
+// A context prints its spatial, clip and effect nodes.
 fn write_context(output: &mut String, context: ContextRef) {
     write_spatial_node_index(output, context.spatial);
-    if !context.frame.is_none() {
-        write!(output, "/f{}", context.frame.0).unwrap();
+    if !context.clip.is_none() {
+        write!(output, "/c{}", context.clip.0).unwrap();
+    }
+    if !context.effect.is_none() {
+        write!(output, "/e{}", context.effect.0).unwrap();
     }
 }
 
@@ -665,29 +677,74 @@ mod tests {
 
     #[test]
     fn command_dump_matches_the_canonical_format() {
-        let mut builder = DisplayListBuilder::new();
-        builder.append(
-            &FillRect {
-                rect: IntRect::new(1, 2, 30, 40),
-                color: Color::from_rgba(101, 2, 0, 204),
-                compositing_and_blending_operator: CompositingAndBlendingOperator::Multiply,
-                background_color_animation_frame: FrameNodeIndex::NONE,
-            },
-            &[],
-            ContextRef {
-                spatial: SpatialNodeIndex(3),
-                frame: FrameNodeIndex(4),
-            },
+        use crate::painting::visual_context::{
+            ClipNodeData, ClipNodeIndex, EffectNodeData, EffectNodeIndex, TransformData, TransformDataRole,
+        };
+        let mut tree = VisualContextTree::create(TransformData {
+            matrix: libgfx_rust::FloatMatrix4x4::identity(),
+            origin: libgfx_rust::FloatPoint::default(),
+            sorting_context_root_index: None,
+            flattens_inherited_transform: false,
+            role: TransformDataRole::CssTransform,
+            synthetic_plane: false,
+            establishes_sorting_context: false,
+        });
+        let clip = tree.append_clip(
+            ClipNodeData::rect_clip(libgfx_rust::FloatRect::new(0.0, 0.0, 9.0, 9.0)),
+            ClipNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let bytes = builder.bytes();
-        let header = read_header(bytes);
-        let payload = &bytes[HEADER_SIZE..HEADER_SIZE + header.payload_size as usize];
-        let mut output = format!("{}@", header.command_type.name());
-        write_context(&mut output, header.context);
-        dump_command(&mut output, header.command_type, payload);
+        let effect = tree.append_effect(
+            EffectNodeData::BackgroundColorAnimation,
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        let effect_only = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect,
+            ..ContextRef::default()
+        };
+        let clip_and_effect = ContextRef {
+            clip,
+            effect,
+            ..ContextRef::default()
+        };
+        let fill = FillRect {
+            rect: IntRect::new(1, 2, 30, 40),
+            color: Color::from_rgba(101, 2, 0, 204),
+            compositing_and_blending_operator: CompositingAndBlendingOperator::Multiply,
+            background_color_animation_effect: EffectNodeIndex::NONE,
+        };
+        let dump = |context: ContextRef| {
+            let mut builder = DisplayListBuilder::new();
+            builder.append(
+                &fill,
+                &[],
+                ContextRef {
+                    spatial: SpatialNodeIndex(0),
+                    ..context
+                },
+            );
+            let bytes = builder.bytes();
+            let header = read_header(bytes);
+            let payload = &bytes[HEADER_SIZE..HEADER_SIZE + header.payload_size as usize];
+            let mut output = format!("{}@", header.command_type.name());
+            write_context(&mut output, header.context);
+            dump_command(&mut output, header.command_type, payload);
+            output
+        };
         assert_eq!(
-            output,
-            "FillRect@s3/f4 rect=[1,2 30x40] color=rgba(101, 2, 0, 0.8) blend_mode=2"
+            dump(clip_and_effect),
+            "FillRect@s0/c0/e0 rect=[1,2 30x40] color=rgba(101, 2, 0, 0.8) blend_mode=2"
+        );
+        assert_eq!(
+            dump(effect_only),
+            "FillRect@s0/e0 rect=[1,2 30x40] color=rgba(101, 2, 0, 0.8) blend_mode=2"
+        );
+        assert_eq!(
+            dump(ContextRef::default()),
+            "FillRect@s0 rect=[1,2 30x40] color=rgba(101, 2, 0, 0.8) blend_mode=2"
         );
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
@@ -245,7 +245,7 @@ pub struct DisplayListRecorder {
     // the draws whose force-dark result is judged against it (borders and selections). None outside those scopes.
     contrast_backdrop: Option<Color>,
     context: ContextRef,
-    mask_display_lists: Vec<(FrameNodeIndex, DisplayListResourceId)>,
+    mask_display_lists: Vec<(EffectNodeIndex, DisplayListResourceId)>,
     ambient_inline_clips: Vec<PendingInlineClip>,
 }
 
@@ -374,13 +374,11 @@ impl DisplayListRecorder {
         self.force_dark.as_ref().map(ForceDarkResolver::settings)
     }
 
-    pub fn register_mask_display_list(&mut self, frames: &[FrameNodeIndex], display_list_id: DisplayListResourceId) {
-        for frame in frames {
-            self.mask_display_lists.push((*frame, display_list_id));
-        }
+    pub fn register_mask_display_list(&mut self, effect: EffectNodeIndex, display_list_id: DisplayListResourceId) {
+        self.mask_display_lists.push((effect, display_list_id));
     }
 
-    pub fn take_mask_display_lists(&mut self) -> Vec<(FrameNodeIndex, DisplayListResourceId)> {
+    pub fn take_mask_display_lists(&mut self) -> Vec<(EffectNodeIndex, DisplayListResourceId)> {
         std::mem::take(&mut self.mask_display_lists)
     }
 
@@ -388,7 +386,7 @@ impl DisplayListRecorder {
         &self.builder
     }
 
-    pub fn mask_display_lists(&self) -> &[(FrameNodeIndex, DisplayListResourceId)] {
+    pub fn mask_display_lists(&self) -> &[(EffectNodeIndex, DisplayListResourceId)] {
         &self.mask_display_lists
     }
 
@@ -480,7 +478,7 @@ impl DisplayListRecorder {
                 rect,
                 color,
                 compositing_and_blending_operator,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             &[],
         );
@@ -512,7 +510,7 @@ impl DisplayListRecorder {
                 rect,
                 color: Color::TRANSPARENT,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             &[],
         );
@@ -1032,7 +1030,7 @@ impl DisplayListRecorder {
                 rect,
                 color,
                 corner_radii,
-                background_color_animation_frame: FrameNodeIndex::NONE,
+                background_color_animation_effect: EffectNodeIndex::NONE,
             },
             &[],
         );
@@ -1043,15 +1041,15 @@ impl DisplayListRecorder {
         rect: IntRect,
         color: Color,
         corner_radii: CornerRadii,
-        animation_frame: Option<FrameNodeIndex>,
+        animation_effect: Option<EffectNodeIndex>,
         force_dark_role: ForceDarkRole,
     ) {
-        if rect.is_empty() || (color.alpha() == 0 && animation_frame.is_none()) {
+        if rect.is_empty() || (color.alpha() == 0 && animation_effect.is_none()) {
             return;
         }
-        // NB: A frame means the player samples the animated color at play time, past this resolution. So while
+        // NB: An effect means the player samples the animated color at play time, past this resolution. So while
         // force-dark applies, Document::update_compositor_animations() keeps background colors off the compositor.
-        let animation_frame = animation_frame.unwrap_or(FrameNodeIndex::NONE);
+        let animation_effect = animation_effect.unwrap_or(EffectNodeIndex::NONE);
         let color = self.resolve_color(color, force_dark_role);
         if !corner_radii.has_any_radius() {
             self.append_command(
@@ -1059,7 +1057,7 @@ impl DisplayListRecorder {
                     rect,
                     color,
                     compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
-                    background_color_animation_frame: animation_frame,
+                    background_color_animation_effect: animation_effect,
                 },
                 &[],
             );
@@ -1070,7 +1068,7 @@ impl DisplayListRecorder {
                 rect,
                 color,
                 corner_radii,
-                background_color_animation_frame: animation_frame,
+                background_color_animation_effect: animation_effect,
             },
             &[],
         );

--- a/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
@@ -5,12 +5,13 @@
  */
 
 use crate::painting::display_list::commands::{
-    ContextRef, DisplayListCommandRun, FrameNodeIndex, ReplayClip, ReplayLayer, ReplayMask, SpatialNodeIndex,
+    ClipNodeIndex, DisplayListCommandRun, EffectNodeIndex, ReplayClip, ReplayLayer, ReplayMask, SpatialNodeIndex,
 };
 use crate::painting::display_list::depth_sorted_plan::{DepthSortedReplayStepKind, build_depth_sorted_replay_plan};
+use crate::painting::visual_context::queries::TreeCullingScratch;
 use crate::painting::visual_context::{
-    FrameData, SpatialData, VisualContextTree, device_offset_for_index, resolve_leaf_to_context_matrices,
-    should_cull_back_face,
+    ClipNodeData, ContextRef, EffectNodeData, SpatialData, VisualContextTree, device_offset_for_index,
+    resolve_leaf_to_context_matrices, should_cull_back_face,
 };
 use libgfx_rust::path::OwnedPath;
 use libgfx_rust::{FloatMatrix4x4, FloatPoint, FloatVector3, IntRect, WindingRule, translation_matrix};
@@ -24,7 +25,7 @@ pub trait ReplayPainter {
     fn push_clip_path(&mut self, path: &OwnedPath, winding_rule: WindingRule);
     fn push_layer(&mut self, layer: &ReplayLayer);
     fn push_mask(&mut self, mask: &ReplayMask);
-    fn pop_mask(&mut self, mask: &ReplayMask, frame: FrameNodeIndex);
+    fn pop_mask(&mut self, mask: &ReplayMask, effect: EffectNodeIndex);
     fn pop(&mut self);
     fn push_device_space_plane_clip(&mut self, vertices: &[FloatVector3]);
     fn execute_run(&mut self, run_index: usize);
@@ -33,9 +34,9 @@ pub trait ReplayPainter {
 // Cumulative to-root matrices for every spatial node, resolved against the live scroll offsets
 // and folded onto the canvas matrix at replay entry, so any node's space can be entered
 // absolutely with a single set_matrix(). Spatial nodes therefore never touch the canvas save
-// stack; only frames do. A backface marker's entry carries the flattened matrix that feeds its
-// cull test and its descendants, while content recorded directly under the marker belongs to
-// its parent's plane, so draw_space redirects the marker to the parent's entry.
+// stack; only clips and effects do. A backface marker's entry carries the flattened matrix that
+// feeds its cull test and its descendants, while content recorded directly under the marker
+// belongs to its parent's plane, so draw_space redirects the marker to the parent's entry.
 #[derive(Default)]
 struct ReplayPaletteStorage {
     to_root_matrices: Vec<FloatMatrix4x4>,
@@ -45,15 +46,22 @@ struct ReplayPaletteStorage {
     flattens_inherited_transform: Vec<bool>,
 }
 
+// One entry of the canvas save stack: a clip or an effect the replay has entered.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Applied {
+    Clip(ClipNodeIndex),
+    Effect(EffectNodeIndex),
+}
+
 // Steady-state replays reuse the previous frame's capacity. Taking the storage out of the slot
 // for the duration of a replay keeps re-entrant nested replays from clobbering the outer
 // driver's buffers; the slot keeps whichever returned storage has the larger palette.
 #[derive(Default)]
 struct ReplayScratchStorage {
     palette: ReplayPaletteStorage,
-    frame_has_empty_effective_clip: Vec<bool>,
-    applied_frames: Vec<FrameNodeIndex>,
-    target_frames: Vec<FrameNodeIndex>,
+    culling: TreeCullingScratch,
+    applied: Vec<Applied>,
+    target: Vec<Applied>,
 }
 
 thread_local! {
@@ -70,9 +78,9 @@ fn return_replay_scratch_storage(mut storage: ReplayScratchStorage) {
     storage.palette.draw_spaces.clear();
     storage.palette.backface_culled.clear();
     storage.palette.flattens_inherited_transform.clear();
-    storage.frame_has_empty_effective_clip.clear();
-    storage.applied_frames.clear();
-    storage.target_frames.clear();
+    storage.culling.clear();
+    storage.applied.clear();
+    storage.target.clear();
     WARM_REPLAY_SCRATCH_STORAGE.with(|slot| {
         let mut slot = slot.borrow_mut();
         let slot_has_larger_palette = slot.as_ref().is_some_and(|kept| {
@@ -95,20 +103,19 @@ struct ReplayDriver<'a, Painter: ReplayPainter> {
     command_runs: &'a [DisplayListCommandRun],
     painter: &'a mut Painter,
     palette: ReplayPaletteStorage,
-    frame_has_empty_effective_clip: Vec<bool>,
+    culling: TreeCullingScratch,
     spatial_dependency_order: Vec<u32>,
     tree_has_sorting_contexts: bool,
     replay_base_matrix: FloatMatrix4x4,
-    // The palette entry the canvas matrix currently equals, if known; popping a frame resets the
-    // matrix to its save point, so unwinding applied frames invalidates it. Recorded streams
-    // contain no matrix-mutating commands, so playing commands never invalidates the cache.
+    // The palette entry the canvas matrix currently equals, if known; popping a clip or a layer
+    // resets the matrix to its save point, so unwinding invalidates it. Recorded streams contain
+    // no matrix-mutating commands, so playing commands never invalidates the cache.
     current_ctm_space: Option<SpatialNodeIndex>,
-    // Applied and target frames track the visual-context chain. Semantic frames push and pop canvas state;
-    // metadata-only frames do not. A context without a frame takes its coordinates from the palette.
-    applied_frames: Vec<FrameNodeIndex>,
-    target_frames: Vec<FrameNodeIndex>,
-    applied_context: Option<ContextRef>,
-    applied_mask_frame_count: usize,
+    // The canvas save stack as clips and effects, the stack a target context needs, and the
+    // pair the applied stack currently serves.
+    applied: Vec<Applied>,
+    target: Vec<Applied>,
+    applied_context: Option<(ClipNodeIndex, EffectNodeIndex)>,
 }
 
 fn replay_clip_of(clip: &crate::painting::visual_context::ClipData) -> ReplayClip {
@@ -119,7 +126,7 @@ fn replay_clip_of(clip: &crate::painting::visual_context::ClipData) -> ReplayCli
     }
 }
 
-fn replay_layer_of(effects: &crate::painting::visual_context::EffectsData, frame: FrameNodeIndex) -> ReplayLayer {
+fn replay_layer_of(effects: &crate::painting::visual_context::EffectsData, effect: EffectNodeIndex) -> ReplayLayer {
     let (filter_bytes, filter_bytes_size) = match &effects.filter {
         Some(bytes) => (bytes.as_ptr(), bytes.len()),
         None => (std::ptr::null(), 0),
@@ -129,7 +136,7 @@ fn replay_layer_of(effects: &crate::painting::visual_context::EffectsData, frame
         blend_mode: effects.blend_mode,
         filter_bytes,
         filter_bytes_size,
-        frame,
+        effect,
     }
 }
 
@@ -258,109 +265,180 @@ impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
         self.current_ctm_space = Some(space);
     }
 
-    fn build_target_frames(&mut self, target_frame: FrameNodeIndex) {
+    // Merge the clip and effect chains from leaf to root. Each effect goes immediately
+    // inside its output clip; reversing once produces the canvas stack in linear time.
+    fn build_target(&mut self, context: ContextRef) {
         let tree = self.tree;
-        self.target_frames.clear();
-        let mut frame = target_frame;
-        while !frame.is_none() {
-            self.target_frames.push(frame);
-            frame = tree.frame_nodes[frame.0 as usize].parent;
+        self.target.clear();
+        let mut clip = context.clip;
+        let mut effect = context.effect;
+        while !effect.is_none() {
+            let node = &tree.effect_nodes[effect.0 as usize];
+            while clip != node.output_clip() {
+                debug_assert!(
+                    !clip.is_none(),
+                    "an effect's output clip lies on the context's clip chain"
+                );
+                self.target.push(Applied::Clip(clip));
+                clip = tree.clip_nodes[clip.0 as usize].parent;
+            }
+            self.target.push(Applied::Effect(effect));
+            effect = node.parent;
         }
-        self.target_frames.reverse();
+        while !clip.is_none() {
+            self.target.push(Applied::Clip(clip));
+            clip = tree.clip_nodes[clip.0 as usize].parent;
+        }
+        self.target.reverse();
+    }
+
+    // Contexts in the same effect share every layer. Their clip chains meet at or below
+    // that effect's output clip, so only the trailing clips can need to be replaced.
+    fn build_target_clip_suffix(&mut self, mut current: ClipNodeIndex, mut target: ClipNodeIndex) -> usize {
+        self.target.clear();
+        let mut current_depth = self.culling.clip_depth(current);
+        let mut target_depth = self.culling.clip_depth(target);
+        let mut clips_to_pop = 0;
+        while current != target {
+            if current_depth >= target_depth {
+                current = self.tree.clip_nodes[current.0 as usize].parent;
+                current_depth -= 1;
+                clips_to_pop += 1;
+            } else {
+                self.target.push(Applied::Clip(target));
+                target = self.tree.clip_nodes[target.0 as usize].parent;
+                target_depth -= 1;
+            }
+        }
+        self.target.reverse();
+        let common_prefix_length = self.applied.len() - clips_to_pop;
+        debug_assert!(
+            self.applied[common_prefix_length..]
+                .iter()
+                .all(|entry| matches!(entry, Applied::Clip(_)))
+        );
+        common_prefix_length
     }
 
     fn restore_to_length(&mut self, length: usize) {
         let tree = self.tree;
         self.applied_context = None;
-        while self.applied_frames.len() > length {
-            let frame_index = self.applied_frames.pop().expect("applied frames are not empty");
-            let frame_node = &tree.frame_nodes[frame_index.0 as usize];
-            let mask = if self.applied_mask_frame_count > 0 {
-                match &frame_node.data {
-                    FrameData::Mask(mask) => Some(mask),
-                    _ => None,
+        while self.applied.len() > length {
+            match self.applied.pop().expect("applied entries are not empty") {
+                Applied::Clip(_) => {
+                    self.painter.pop();
+                    self.current_ctm_space = None;
                 }
-            } else {
-                None
-            };
-            if let Some(mask) = mask {
-                self.applied_mask_frame_count -= 1;
-                self.ensure_ctm_space(frame_node.spatial);
-                self.painter.pop_mask(&replay_mask_of(mask), frame_index);
-            } else if !matches!(frame_node.data, FrameData::BackgroundColorAnimation) {
-                self.painter.pop();
+                Applied::Effect(effect) => {
+                    let node = &tree.effect_nodes[effect.0 as usize];
+                    match &node.data {
+                        EffectNodeData::Effects(_) => {
+                            self.painter.pop();
+                            self.current_ctm_space = None;
+                        }
+                        EffectNodeData::Mask(mask) => {
+                            self.ensure_ctm_space(node.spatial);
+                            self.painter.pop_mask(&replay_mask_of(mask), effect);
+                            self.current_ctm_space = None;
+                        }
+                        // A marker touches no canvas state.
+                        EffectNodeData::BackgroundColorAnimation => {}
+                        EffectNodeData::Dead => unreachable!("a run never records under a tombstoned effect"),
+                    }
+                }
             }
-            self.current_ctm_space = None;
         }
     }
 
-    // OPTIMIZATION: When walking down to layer-pushing frames (effects and masks), check culling before pushing
-    //               each one. Effects don't affect clip state and a mask push only narrows it, so testing against
-    //               the pre-push clip is conservative and valid. This avoids expensive saveLayer/restore cycles
-    //               for off-screen elements.
-    fn switch_to_context(&mut self, target: ContextRef, bounding_rect: Option<IntRect>) -> SwitchResult {
-        if self.applied_context == Some(target) {
+    // OPTIMIZATION: When walking down to layer-pushing effects (opacity/blend/filter layers and masks), check
+    //               culling before pushing each one. The clips entered so far are those outside the layer, so
+    //               testing against them is conservative and valid. This avoids expensive saveLayer/restore
+    //               cycles for off-screen elements.
+    fn switch_to_context(&mut self, context: ContextRef, bounding_rect: Option<IntRect>) -> SwitchResult {
+        if self.applied_context == Some((context.clip, context.effect)) {
             return SwitchResult::Switched;
         }
 
         let tree = self.tree;
-        self.build_target_frames(target.frame);
-
-        let common_prefix_length = self
-            .applied_frames
-            .iter()
-            .zip(&self.target_frames)
-            .take_while(|(applied, target)| applied == target)
-            .count();
+        let (common_prefix_length, target_begin) = if let Some((clip, effect)) = self.applied_context
+            && effect == context.effect
+        {
+            (self.build_target_clip_suffix(clip, context.clip), 0)
+        } else {
+            self.build_target(context);
+            let common_prefix_length = self
+                .applied
+                .iter()
+                .zip(&self.target)
+                .take_while(|(applied, target)| applied == target)
+                .count();
+            (common_prefix_length, common_prefix_length)
+        };
 
         self.restore_to_length(common_prefix_length);
 
-        for i in common_prefix_length..self.target_frames.len() {
-            let frame_index = self.target_frames[i];
-            let frame_node = &tree.frame_nodes[frame_index.0 as usize];
-            let pushes_layer = matches!(frame_node.data, FrameData::Effects(_) | FrameData::Mask(_));
-            if pushes_layer && let Some(bounding_rect) = bounding_rect {
-                let mut culled_by_layer_frame = bounding_rect.is_empty();
-                if !culled_by_layer_frame {
-                    self.ensure_ctm_space(target.spatial);
-                    culled_by_layer_frame = self.painter.would_be_fully_clipped_by_painter(bounding_rect);
+        for i in target_begin..self.target.len() {
+            let entry = self.target[i];
+            match entry {
+                Applied::Clip(clip) => {
+                    let node = &tree.clip_nodes[clip.0 as usize];
+                    self.ensure_ctm_space(node.spatial);
+                    match &node.data {
+                        ClipNodeData::Rect(clip) => self.painter.push_clip(&replay_clip_of(clip)),
+                        ClipNodeData::Path(clip_path) => {
+                            self.painter.push_clip_path(&clip_path.path, clip_path.fill_rule);
+                        }
+                        ClipNodeData::Dead => unreachable!("a run never records under a tombstoned clip"),
+                    }
                 }
-                if culled_by_layer_frame {
-                    self.restore_to_length(common_prefix_length);
-                    // The canvas is unwound to the shared prefix; clearing the applied context
-                    // keeps the fast path from reusing the pre-cull context while the frame
-                    // vector still enables prefix reuse on the next switch.
-                    return SwitchResult::CulledByEffect;
+                Applied::Effect(effect) => {
+                    let node = &tree.effect_nodes[effect.0 as usize];
+                    if node.data.pushes_layer()
+                        && let Some(bounding_rect) = bounding_rect
+                    {
+                        let mut culled_by_layer = bounding_rect.is_empty();
+                        if !culled_by_layer {
+                            self.ensure_ctm_space(context.spatial);
+                            culled_by_layer = self.painter.would_be_fully_clipped_by_painter(bounding_rect);
+                        }
+                        if culled_by_layer {
+                            self.restore_to_length(common_prefix_length);
+                            // The canvas is unwound to the shared prefix; clearing the applied
+                            // context keeps the fast path from reusing the pre-cull context while
+                            // the applied stack still enables prefix reuse on the next switch.
+                            return SwitchResult::CulledByEffect;
+                        }
+                    }
+                    match &node.data {
+                        EffectNodeData::Effects(effects) => {
+                            self.ensure_ctm_space(node.spatial);
+                            self.painter.push_layer(&replay_layer_of(effects, effect));
+                        }
+                        EffectNodeData::Mask(mask) => {
+                            self.ensure_ctm_space(node.spatial);
+                            self.painter.push_mask(&replay_mask_of(mask));
+                        }
+                        EffectNodeData::BackgroundColorAnimation => {}
+                        EffectNodeData::Dead => unreachable!("a run never records under a tombstoned effect"),
+                    }
                 }
             }
-            self.ensure_ctm_space(frame_node.spatial);
-            match &frame_node.data {
-                FrameData::BackgroundColorAnimation => {}
-                FrameData::Clip(clip) => self.painter.push_clip(&replay_clip_of(clip)),
-                FrameData::ClipPath(clip_path) => self.painter.push_clip_path(&clip_path.path, clip_path.fill_rule),
-                FrameData::Effects(effects) => self.painter.push_layer(&replay_layer_of(effects, frame_index)),
-                FrameData::Mask(mask) => {
-                    self.painter.push_mask(&replay_mask_of(mask));
-                    self.applied_mask_frame_count += 1;
-                }
-                FrameData::Dead => unreachable!("a run never records under a tombstoned frame"),
-            }
-            self.applied_frames.push(frame_index);
+            self.applied.push(entry);
         }
 
-        self.applied_context = Some(target);
+        self.applied_context = Some((context.clip, context.effect));
         SwitchResult::Switched
     }
 
     // A run enters its context once. Only a run whose ink bounds are known may be skipped as a
-    // whole, and only such a run offers its bounds to the layer-frame cull. Skipping a run with
-    // nothing to draw before entering its context spares the frame pushes.
+    // whole, and only such a run offers its bounds to the layer cull. Skipping a run with
+    // nothing to draw before entering its context spares the pushes.
     fn execute_run(&mut self, run_index: usize) {
         let run = self.command_runs[run_index];
         if self.palette.backface_culled[run.context.spatial.0 as usize] {
             return;
         }
-        if !run.context.frame.is_none() && self.frame_has_empty_effective_clip[run.context.frame.0 as usize] {
+        if self.culling.context_culls_everything(run.context) {
             return;
         }
         let skippable_ink_bounds = (!run.has_unbounded_draw).then_some(run.ink_bounds);
@@ -388,8 +466,8 @@ impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
                 self.execute_run(run_index);
             }
         } else {
-            let root_isolation_frame = tree.root_isolation_frame;
-            let plane_clip_base_length = usize::from(root_isolation_frame.is_some());
+            let root_isolation_effect = tree.root_isolation_effect;
+            let plane_clip_base_length = usize::from(root_isolation_effect.is_some());
             let contexts = tree.resolve_sorting_contexts_in_order(&self.spatial_dependency_order);
             let parent_by_node: Vec<SpatialNodeIndex> = tree.spatial_nodes.iter().map(|node| node.parent).collect();
             let leaf_to_context_palette = resolve_leaf_to_context_matrices(
@@ -406,7 +484,7 @@ impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
                 &leaf_to_context_palette,
                 &self.palette.draw_spaces,
                 &self.palette.backface_culled,
-                &self.frame_has_empty_effective_clip,
+                &self.culling,
             );
             for step in &plan.steps {
                 match step.kind {
@@ -417,11 +495,14 @@ impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
                         }
                     }
                     DepthSortedReplayStepKind::PushPlaneClip => {
-                        if let Some(root_isolation_frame) = root_isolation_frame {
+                        // The root effect is a layer at the root of the effect tree under no
+                        // clip, so the plane clip sits right above it.
+                        if let Some(root_isolation_effect) = root_isolation_effect {
                             self.switch_to_context(
                                 ContextRef {
-                                    spatial: tree.frame_nodes[root_isolation_frame.0 as usize].spatial,
-                                    frame: root_isolation_frame,
+                                    spatial: tree.effect_nodes[root_isolation_effect.0 as usize].spatial,
+                                    clip: ClipNodeIndex::NONE,
+                                    effect: root_isolation_effect,
                                 },
                                 None,
                             );
@@ -458,31 +539,30 @@ pub fn replay_display_list(
 ) {
     let replay_base_matrix = painter.canvas_matrix();
     let mut scratch = take_replay_scratch_storage();
-    tree.fill_frames_with_empty_effective_clip(&mut scratch.frame_has_empty_effective_clip);
+    tree.fill_culling_scratch(&mut scratch.culling);
     let mut driver = ReplayDriver {
         tree,
         command_runs,
         painter,
         palette: scratch.palette,
-        frame_has_empty_effective_clip: scratch.frame_has_empty_effective_clip,
+        culling: scratch.culling,
         spatial_dependency_order: tree.spatial_dependency_order(),
         tree_has_sorting_contexts: tree.spatial_nodes.iter().any(|node| {
             matches!(&node.data, SpatialData::Transform(transform) if transform.sorting_context_root_index.is_some())
         }),
         replay_base_matrix,
         current_ctm_space: None,
-        applied_frames: scratch.applied_frames,
-        target_frames: scratch.target_frames,
+        applied: scratch.applied,
+        target: scratch.target,
         applied_context: None,
-        applied_mask_frame_count: 0,
     };
     driver.build_transform_palette(scroll_offsets);
     driver.execute();
     return_replay_scratch_storage(ReplayScratchStorage {
         palette: std::mem::take(&mut driver.palette),
-        frame_has_empty_effective_clip: std::mem::take(&mut driver.frame_has_empty_effective_clip),
-        applied_frames: std::mem::take(&mut driver.applied_frames),
-        target_frames: std::mem::take(&mut driver.target_frames),
+        culling: std::mem::take(&mut driver.culling),
+        applied: std::mem::take(&mut driver.applied),
+        target: std::mem::take(&mut driver.target),
     });
 }
 
@@ -490,10 +570,11 @@ pub fn replay_display_list(
 mod tests {
     use super::*;
     use crate::layout::node_data::NodeSlotId;
+    use crate::painting::display_list::commands::ContextRef;
     use crate::painting::display_list::commands::VISUAL_VIEWPORT_NODE_INDEX;
     use crate::painting::visual_context::{
-        BackfaceVisibilityData, ClipData, ClipMode, EffectsData, FrameData, MaskData, MaskLayerOrigin, SpatialData,
-        TransformData, TransformDataRole,
+        BackfaceVisibilityData, ClipData, ClipMode, EffectsData, MaskData, MaskLayerOrigin, SpatialData, TransformData,
+        TransformDataRole,
     };
     use libgfx_rust::{
         CompositingAndBlendingOperator, CornerRadii, FloatRect, MaskKind, scale_matrix, translation_matrix,
@@ -605,7 +686,7 @@ mod tests {
         PushClip(FloatRect),
         PushLayer(f32),
         PushMask(IntRect),
-        PopMask(FrameNodeIndex),
+        PopMask(EffectNodeIndex),
         Pop,
         PushPlaneClip(usize),
         Run(usize),
@@ -649,8 +730,8 @@ mod tests {
         fn push_mask(&mut self, mask: &ReplayMask) {
             self.events.push(PainterEvent::PushMask(mask.rect));
         }
-        fn pop_mask(&mut self, _mask: &ReplayMask, frame: FrameNodeIndex) {
-            self.events.push(PainterEvent::PopMask(frame));
+        fn pop_mask(&mut self, _mask: &ReplayMask, effect: EffectNodeIndex) {
+            self.events.push(PainterEvent::PopMask(effect));
         }
         fn pop(&mut self) {
             self.events.push(PainterEvent::Pop);
@@ -682,30 +763,63 @@ mod tests {
         VisualContextTree::create(root)
     }
 
-    fn clip(rect: FloatRect) -> FrameData {
-        FrameData::Clip(ClipData {
+    fn clip(rect: FloatRect) -> ClipNodeData {
+        ClipNodeData::Rect(ClipData {
             rect,
             corner_radii: CornerRadii::default(),
             mode: ClipMode::Intersect,
         })
     }
 
-    fn effects(opacity: f32) -> FrameData {
-        FrameData::Effects(EffectsData {
+    fn effects(opacity: f32) -> EffectNodeData {
+        EffectNodeData::Effects(EffectsData {
             opacity,
             blend_mode: CompositingAndBlendingOperator::Normal,
             filter: None,
         })
     }
 
-    fn run(spatial: SpatialNodeIndex, frame: FrameNodeIndex, ink_bounds: IntRect) -> DisplayListCommandRun {
+    fn mask(rect: IntRect) -> EffectNodeData {
+        EffectNodeData::Mask(MaskData {
+            rect,
+            kind: MaskKind::Alpha,
+            origin: MaskLayerOrigin::CssMaskLayers,
+        })
+    }
+
+    fn root_clip(tree: &mut VisualContextTree, rect: FloatRect) -> ClipNodeIndex {
+        tree.append_clip(clip(rect), ClipNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX)
+    }
+
+    fn effect_under(
+        tree: &mut VisualContextTree,
+        data: EffectNodeData,
+        parent: EffectNodeIndex,
+        output_clip: ClipNodeIndex,
+    ) -> EffectNodeIndex {
+        tree.append_effect(data, parent, VISUAL_VIEWPORT_NODE_INDEX, output_clip)
+    }
+
+    fn run(spatial: SpatialNodeIndex, context: ContextRef, ink_bounds: IntRect) -> DisplayListCommandRun {
         DisplayListCommandRun {
             offset: 0,
             size: 0,
-            context: ContextRef { spatial, frame },
+            context: ContextRef { spatial, ..context },
             ink_bounds,
             has_unbounded_draw: false,
             has_compositor_metadata: false,
+        }
+    }
+
+    fn rotate_y(degrees: f32) -> FloatMatrix4x4 {
+        let (sin, cos) = degrees.to_radians().sin_cos();
+        FloatMatrix4x4 {
+            elements: [
+                [cos, 0.0, sin, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [-sin, 0.0, cos, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
         }
     }
 
@@ -718,18 +832,24 @@ mod tests {
     }
 
     #[test]
-    fn runs_sharing_a_frame_prefix_push_it_once_and_re_enter_their_space_after_a_pop() {
+    fn runs_sharing_a_stack_prefix_push_it_once_and_re_enter_their_space_after_a_pop() {
         let mut tree = identity_tree();
-        let clip_frame = tree.append_frame(
-            clip(FloatRect::new(1.0, 2.0, 3.0, 4.0)),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        );
-        let layer_frame = tree.append_frame(effects(0.5), clip_frame, VISUAL_VIEWPORT_NODE_INDEX);
+        let clip_node = root_clip(&mut tree, FloatRect::new(1.0, 2.0, 3.0, 4.0));
+        let clip_context = ContextRef {
+            clip: clip_node,
+            effect: EffectNodeIndex::NONE,
+            ..ContextRef::default()
+        };
+        let layer = effect_under(&mut tree, effects(0.5), EffectNodeIndex::NONE, clip_node);
+        let layer_context = ContextRef {
+            clip: clip_node,
+            effect: layer,
+            ..ContextRef::default()
+        };
         let runs = [
-            run(VISUAL_VIEWPORT_NODE_INDEX, clip_frame, visible_bounds()),
-            run(VISUAL_VIEWPORT_NODE_INDEX, layer_frame, visible_bounds()),
-            run(VISUAL_VIEWPORT_NODE_INDEX, clip_frame, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, clip_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, layer_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, clip_context, visible_bounds()),
         ];
         let mut painter = RecordingPainter::new();
         let base = painter.base_matrix;
@@ -754,12 +874,27 @@ mod tests {
     #[test]
     fn a_run_under_an_empty_effective_clip_touches_nothing() {
         let mut tree = identity_tree();
-        let empty_clip = tree.append_frame(
-            clip(FloatRect::default()),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
+        let empty_clip = root_clip(&mut tree, FloatRect::default());
+        let empty_context = ContextRef {
+            clip: empty_clip,
+            effect: EffectNodeIndex::NONE,
+            ..ContextRef::default()
+        };
+        let empty_mask = effect_under(
+            &mut tree,
+            mask(IntRect::default()),
+            EffectNodeIndex::NONE,
+            ClipNodeIndex::NONE,
         );
-        let runs = [run(VISUAL_VIEWPORT_NODE_INDEX, empty_clip, visible_bounds())];
+        let empty_mask_context = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect: empty_mask,
+            ..ContextRef::default()
+        };
+        let runs = [
+            run(VISUAL_VIEWPORT_NODE_INDEX, empty_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, empty_mask_context, visible_bounds()),
+        ];
         let mut painter = RecordingPainter::new();
         let base = painter.base_matrix;
         replay(&tree, &runs, &mut painter);
@@ -767,18 +902,19 @@ mod tests {
     }
 
     #[test]
-    fn a_fully_clipped_layer_frame_is_culled_and_the_next_run_pushes_the_chain_again() {
+    fn a_fully_clipped_layer_is_culled_and_the_next_run_pushes_the_stack_again() {
         let mut tree = identity_tree();
-        let clip_frame = tree.append_frame(
-            clip(FloatRect::new(0.0, 0.0, 50.0, 50.0)),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        );
-        let layer_frame = tree.append_frame(effects(0.25), clip_frame, VISUAL_VIEWPORT_NODE_INDEX);
+        let clip_node = root_clip(&mut tree, FloatRect::new(0.0, 0.0, 50.0, 50.0));
+        let layer = effect_under(&mut tree, effects(0.25), EffectNodeIndex::NONE, clip_node);
+        let layer_context = ContextRef {
+            clip: clip_node,
+            effect: layer,
+            ..ContextRef::default()
+        };
         let off_screen = IntRect::new(999, 0, 10, 10);
         let runs = [
-            run(VISUAL_VIEWPORT_NODE_INDEX, layer_frame, off_screen),
-            run(VISUAL_VIEWPORT_NODE_INDEX, layer_frame, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, layer_context, off_screen),
+            run(VISUAL_VIEWPORT_NODE_INDEX, layer_context, visible_bounds()),
         ];
         let mut painter = RecordingPainter::new();
         painter.fully_clipped_x = 999;
@@ -802,18 +938,20 @@ mod tests {
     }
 
     #[test]
-    fn mask_frames_pop_with_their_frame_index() {
+    fn mask_effects_pop_with_their_effect_index() {
         let mut tree = identity_tree();
-        let mask_frame = tree.append_frame(
-            FrameData::Mask(MaskData {
-                rect: IntRect::new(0, 0, 20, 20),
-                kind: MaskKind::Alpha,
-                origin: MaskLayerOrigin::CssMaskLayers,
-            }),
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
+        let mask_effect = effect_under(
+            &mut tree,
+            mask(IntRect::new(0, 0, 20, 20)),
+            EffectNodeIndex::NONE,
+            ClipNodeIndex::NONE,
         );
-        let runs = [run(VISUAL_VIEWPORT_NODE_INDEX, mask_frame, visible_bounds())];
+        let mask_context = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect: mask_effect,
+            ..ContextRef::default()
+        };
+        let runs = [run(VISUAL_VIEWPORT_NODE_INDEX, mask_context, visible_bounds())];
         let mut painter = RecordingPainter::new();
         let base = painter.base_matrix;
         replay(&tree, &runs, &mut painter);
@@ -823,7 +961,355 @@ mod tests {
                 PainterEvent::SetMatrix(base),
                 PainterEvent::PushMask(IntRect::new(0, 0, 20, 20)),
                 PainterEvent::Run(0),
-                PainterEvent::PopMask(mask_frame),
+                PainterEvent::PopMask(mask_effect),
+                PainterEvent::SetMatrix(base),
+            ]
+        );
+    }
+
+    // An absolute child that skips its parent's overflow clip records under the parent's effect
+    // and the effect's output clip: the layer is entered once and the overflow clip moves in and
+    // out of it around the child's run.
+    #[test]
+    fn an_escaping_absolute_child_under_an_opacity_layer_pushes_the_layer_once() {
+        let mut tree = identity_tree();
+        let layer = effect_under(&mut tree, effects(0.5), EffectNodeIndex::NONE, ClipNodeIndex::NONE);
+        let overflow_clip = root_clip(&mut tree, FloatRect::new(0.0, 0.0, 100.0, 100.0));
+        let normal_context = ContextRef {
+            clip: overflow_clip,
+            effect: layer,
+            ..ContextRef::default()
+        };
+        let escaping_context = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect: layer,
+            ..ContextRef::default()
+        };
+        let runs = [
+            run(VISUAL_VIEWPORT_NODE_INDEX, normal_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, escaping_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, normal_context, visible_bounds()),
+        ];
+        let mut painter = RecordingPainter::new();
+        let base = painter.base_matrix;
+        replay(&tree, &runs, &mut painter);
+        assert_eq!(
+            painter.events,
+            vec![
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushLayer(0.5),
+                PainterEvent::PushClip(FloatRect::new(0.0, 0.0, 100.0, 100.0)),
+                PainterEvent::Run(0),
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+                PainterEvent::Run(1),
+                PainterEvent::PushClip(FloatRect::new(0.0, 0.0, 100.0, 100.0)),
+                PainterEvent::Run(2),
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+            ]
+        );
+    }
+
+    // A box appends an effect with the widest clip a chain could take; tightening moves it back
+    // down to the clips its contexts share, so the layer is entered inside them.
+    #[test]
+    fn a_layer_nothing_escapes_is_entered_inside_the_clips_its_contexts_share() {
+        let mut tree = identity_tree();
+        let layer = effect_under(&mut tree, effects(0.5), EffectNodeIndex::NONE, ClipNodeIndex::NONE);
+        let outer_clip = root_clip(&mut tree, FloatRect::new(0.0, 0.0, 100.0, 100.0));
+        let inner_clip = tree.append_clip(
+            clip(FloatRect::new(0.0, 0.0, 50.0, 50.0)),
+            outer_clip,
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let nested = effect_under(&mut tree, effects(0.25), layer, ClipNodeIndex::NONE);
+        let outer_context = ContextRef {
+            clip: outer_clip,
+            effect: layer,
+            ..ContextRef::default()
+        };
+        let nested_context = ContextRef {
+            clip: inner_clip,
+            effect: nested,
+            ..ContextRef::default()
+        };
+        tree.resolve_effect_output_clips(&[
+            crate::painting::visual_context::EffectClipConstraint {
+                effect: layer,
+                clip: outer_clip,
+            },
+            crate::painting::visual_context::EffectClipConstraint {
+                effect: nested,
+                clip: inner_clip,
+            },
+        ]);
+        let runs = [
+            run(VISUAL_VIEWPORT_NODE_INDEX, outer_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, nested_context, visible_bounds()),
+        ];
+        let mut painter = RecordingPainter::new();
+        let base = painter.base_matrix;
+        replay(&tree, &runs, &mut painter);
+        assert_eq!(
+            painter.events,
+            vec![
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushClip(FloatRect::new(0.0, 0.0, 100.0, 100.0)),
+                PainterEvent::PushLayer(0.5),
+                PainterEvent::Run(0),
+                PainterEvent::PushClip(FloatRect::new(0.0, 0.0, 50.0, 50.0)),
+                PainterEvent::PushLayer(0.25),
+                PainterEvent::Run(1),
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+            ]
+        );
+    }
+
+    // Two chains that differ only in their clip copies swap clips inside the shared layer.
+    #[test]
+    fn a_clip_inside_a_layer_is_re_pushed_when_switching_chains_without_popping_the_layer() {
+        let mut tree = identity_tree();
+        let layer = effect_under(&mut tree, effects(0.5), EffectNodeIndex::NONE, ClipNodeIndex::NONE);
+        let own_clip = root_clip(&mut tree, FloatRect::new(0.0, 0.0, 10.0, 10.0));
+        let escaping_clip = root_clip(&mut tree, FloatRect::new(0.0, 0.0, 20.0, 20.0));
+        let own_context = ContextRef {
+            clip: own_clip,
+            effect: layer,
+            ..ContextRef::default()
+        };
+        let escaping_context = ContextRef {
+            clip: escaping_clip,
+            effect: layer,
+            ..ContextRef::default()
+        };
+        let runs = [
+            run(VISUAL_VIEWPORT_NODE_INDEX, own_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, escaping_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, own_context, visible_bounds()),
+        ];
+        let mut painter = RecordingPainter::new();
+        let base = painter.base_matrix;
+        replay(&tree, &runs, &mut painter);
+        assert_eq!(
+            painter.events,
+            vec![
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushLayer(0.5),
+                PainterEvent::PushClip(FloatRect::new(0.0, 0.0, 10.0, 10.0)),
+                PainterEvent::Run(0),
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushClip(FloatRect::new(0.0, 0.0, 20.0, 20.0)),
+                PainterEvent::Run(1),
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushClip(FloatRect::new(0.0, 0.0, 10.0, 10.0)),
+                PainterEvent::Run(2),
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+            ]
+        );
+    }
+
+    #[test]
+    fn switching_clip_depths_inside_one_effect_keeps_the_layer_and_its_output_clip() {
+        let mut tree = identity_tree();
+        let outer_rect = FloatRect::new(0.0, 0.0, 100.0, 100.0);
+        let common_rect = FloatRect::new(0.0, 0.0, 90.0, 90.0);
+        let deep_rect = FloatRect::new(0.0, 0.0, 80.0, 80.0);
+        let other_rect = FloatRect::new(0.0, 0.0, 70.0, 70.0);
+        let outer = root_clip(&mut tree, outer_rect);
+        let common = tree.append_clip(clip(common_rect), outer, VISUAL_VIEWPORT_NODE_INDEX);
+        let deep = tree.append_clip(clip(deep_rect), common, VISUAL_VIEWPORT_NODE_INDEX);
+        let other = tree.append_clip(clip(other_rect), outer, VISUAL_VIEWPORT_NODE_INDEX);
+        let effect = effect_under(&mut tree, effects(0.5), EffectNodeIndex::NONE, outer);
+        let runs = [deep, other, outer, common].map(|clip| {
+            run(
+                VISUAL_VIEWPORT_NODE_INDEX,
+                ContextRef {
+                    clip,
+                    effect,
+                    ..ContextRef::default()
+                },
+                visible_bounds(),
+            )
+        });
+        let mut painter = RecordingPainter::new();
+        replay(&tree, &runs, &mut painter);
+        let events: Vec<_> = painter
+            .events
+            .into_iter()
+            .filter(|event| !matches!(event, PainterEvent::SetMatrix(_)))
+            .collect();
+        assert_eq!(
+            events,
+            vec![
+                PainterEvent::PushClip(outer_rect),
+                PainterEvent::PushLayer(0.5),
+                PainterEvent::PushClip(common_rect),
+                PainterEvent::PushClip(deep_rect),
+                PainterEvent::Run(0),
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+                PainterEvent::PushClip(other_rect),
+                PainterEvent::Run(1),
+                PainterEvent::Pop,
+                PainterEvent::Run(2),
+                PainterEvent::PushClip(common_rect),
+                PainterEvent::Run(3),
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+            ]
+        );
+    }
+
+    // A mask nested in a layer is entered inside its own output clip, which may sit above a clip
+    // pushed inside the layer; that clip is re-pushed inside the mask and the mask exits once.
+    #[test]
+    fn a_mask_nested_in_a_layer_pops_once_with_its_effect_index() {
+        let mut tree = identity_tree();
+        let layer = effect_under(&mut tree, effects(0.5), EffectNodeIndex::NONE, ClipNodeIndex::NONE);
+        let overflow_clip = root_clip(&mut tree, FloatRect::new(0.0, 0.0, 100.0, 100.0));
+        let mask_effect = effect_under(&mut tree, mask(IntRect::new(0, 0, 20, 20)), layer, ClipNodeIndex::NONE);
+        let layer_context = ContextRef {
+            clip: overflow_clip,
+            effect: layer,
+            ..ContextRef::default()
+        };
+        let masked_context = ContextRef {
+            clip: overflow_clip,
+            effect: mask_effect,
+            ..ContextRef::default()
+        };
+        let escaping_masked_context = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect: mask_effect,
+            ..ContextRef::default()
+        };
+        let runs = [
+            run(VISUAL_VIEWPORT_NODE_INDEX, layer_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, masked_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, escaping_masked_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, layer_context, visible_bounds()),
+        ];
+        let mut painter = RecordingPainter::new();
+        let base = painter.base_matrix;
+        replay(&tree, &runs, &mut painter);
+        let overflow = FloatRect::new(0.0, 0.0, 100.0, 100.0);
+        assert_eq!(
+            painter.events,
+            vec![
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushLayer(0.5),
+                PainterEvent::PushClip(overflow),
+                PainterEvent::Run(0),
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushMask(IntRect::new(0, 0, 20, 20)),
+                PainterEvent::PushClip(overflow),
+                PainterEvent::Run(1),
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+                PainterEvent::Run(2),
+                PainterEvent::PopMask(mask_effect),
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushClip(overflow),
+                PainterEvent::Run(3),
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+            ]
+        );
+    }
+
+    // A background-color animation marker is an effect without canvas state: entering or leaving
+    // it neither pushes nor invalidates the matrix.
+    #[test]
+    fn a_background_color_animation_marker_pushes_nothing() {
+        let mut tree = identity_tree();
+        let layer = effect_under(&mut tree, effects(0.5), EffectNodeIndex::NONE, ClipNodeIndex::NONE);
+        let marker = effect_under(
+            &mut tree,
+            EffectNodeData::BackgroundColorAnimation,
+            layer,
+            ClipNodeIndex::NONE,
+        );
+        let layer_context = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect: layer,
+            ..ContextRef::default()
+        };
+        let marker_context = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect: marker,
+            ..ContextRef::default()
+        };
+        let runs = [
+            run(VISUAL_VIEWPORT_NODE_INDEX, marker_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, layer_context, visible_bounds()),
+            run(VISUAL_VIEWPORT_NODE_INDEX, marker_context, visible_bounds()),
+        ];
+        let mut painter = RecordingPainter::new();
+        let base = painter.base_matrix;
+        replay(&tree, &runs, &mut painter);
+        assert_eq!(
+            painter.events,
+            vec![
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushLayer(0.5),
+                PainterEvent::Run(0),
+                PainterEvent::Run(1),
+                PainterEvent::Run(2),
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+            ]
+        );
+    }
+
+    // Culling the second of two new layers unwinds to the shared prefix, so the next run rebuilds
+    // from there.
+    #[test]
+    fn culling_the_second_of_two_new_layers_unwinds_to_the_shared_prefix() {
+        let mut tree = identity_tree();
+        let clip_node = root_clip(&mut tree, FloatRect::new(0.0, 0.0, 50.0, 50.0));
+        let outer = effect_under(&mut tree, effects(0.5), EffectNodeIndex::NONE, clip_node);
+        let inner = effect_under(&mut tree, effects(0.25), outer, clip_node);
+        let inner_context = ContextRef {
+            clip: clip_node,
+            effect: inner,
+            ..ContextRef::default()
+        };
+        let off_screen = IntRect::new(999, 0, 10, 10);
+        let runs = [
+            run(VISUAL_VIEWPORT_NODE_INDEX, inner_context, off_screen),
+            run(VISUAL_VIEWPORT_NODE_INDEX, inner_context, visible_bounds()),
+        ];
+        let mut painter = RecordingPainter::new();
+        painter.fully_clipped_x = 999;
+        let base = painter.base_matrix;
+        replay(&tree, &runs, &mut painter);
+        assert_eq!(
+            painter.events,
+            vec![
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushClip(FloatRect::new(0.0, 0.0, 50.0, 50.0)),
+                PainterEvent::Pop,
+                PainterEvent::SetMatrix(base),
+                PainterEvent::PushClip(FloatRect::new(0.0, 0.0, 50.0, 50.0)),
+                PainterEvent::PushLayer(0.5),
+                PainterEvent::PushLayer(0.25),
+                PainterEvent::Run(1),
+                PainterEvent::Pop,
+                PainterEvent::Pop,
+                PainterEvent::Pop,
                 PainterEvent::SetMatrix(base),
             ]
         );
@@ -852,8 +1338,8 @@ mod tests {
             VISUAL_VIEWPORT_NODE_INDEX,
         );
         let runs = [
-            run(marker, FrameNodeIndex::NONE, visible_bounds()),
-            run(scroll_node, FrameNodeIndex::NONE, visible_bounds()),
+            run(marker, ContextRef::default(), visible_bounds()),
+            run(scroll_node, ContextRef::default(), visible_bounds()),
         ];
         let mut scroll_offsets = vec![FloatPoint::default(); 4];
         scroll_offsets[scroll_node.0 as usize] = FloatPoint { x: 0.0, y: -30.7 };
@@ -874,23 +1360,12 @@ mod tests {
     fn intersecting_planes_of_a_sorting_context_replay_under_plane_clips() {
         let mut tree = identity_tree();
         let context_root = tree.append_spatial(transform(FloatMatrix4x4::identity(), None), VISUAL_VIEWPORT_NODE_INDEX);
-        let rotate_y = |degrees: f32| {
-            let (sin, cos) = degrees.to_radians().sin_cos();
-            FloatMatrix4x4 {
-                elements: [
-                    [cos, 0.0, sin, 0.0],
-                    [0.0, 1.0, 0.0, 0.0],
-                    [-sin, 0.0, cos, 0.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ],
-            }
-        };
         let first_plane = tree.append_spatial(transform(rotate_y(45.0), Some(context_root)), context_root);
         let second_plane = tree.append_spatial(transform(rotate_y(-45.0), Some(context_root)), context_root);
         let plane_bounds = IntRect::new(-50, -50, 100, 100);
         let runs = [
-            run(first_plane, FrameNodeIndex::NONE, plane_bounds),
-            run(second_plane, FrameNodeIndex::NONE, plane_bounds),
+            run(first_plane, ContextRef::default(), plane_bounds),
+            run(second_plane, ContextRef::default(), plane_bounds),
         ];
         let mut painter = RecordingPainter::new();
         let base = painter.base_matrix;
@@ -913,6 +1388,55 @@ mod tests {
         assert!(plane_clip_pushes > 0);
         assert_eq!(pops, plane_clip_pushes);
         assert!(executed_runs >= runs.len());
+        assert_eq!(painter.events.last(), Some(&PainterEvent::SetMatrix(base)));
+    }
+
+    // Plane clips are pushed right above the root isolation layer: everything under it unwinds
+    // around each plane boundary, and the layer itself is entered once.
+    #[test]
+    fn plane_clips_unwind_to_the_root_isolation_layer() {
+        let mut tree = identity_tree();
+        let root_layer = effect_under(&mut tree, effects(1.0), EffectNodeIndex::NONE, ClipNodeIndex::NONE);
+        tree.root_isolation_effect = Some(root_layer);
+        let clip_node = root_clip(&mut tree, FloatRect::new(-100.0, -100.0, 300.0, 300.0));
+        let clipped_context = ContextRef {
+            clip: clip_node,
+            effect: root_layer,
+            ..ContextRef::default()
+        };
+        let context_root = tree.append_spatial(transform(FloatMatrix4x4::identity(), None), VISUAL_VIEWPORT_NODE_INDEX);
+        let first_plane = tree.append_spatial(transform(rotate_y(45.0), Some(context_root)), context_root);
+        let second_plane = tree.append_spatial(transform(rotate_y(-45.0), Some(context_root)), context_root);
+        let plane_bounds = IntRect::new(-50, -50, 100, 100);
+        let runs = [
+            run(first_plane, clipped_context, plane_bounds),
+            run(second_plane, clipped_context, plane_bounds),
+        ];
+        let mut painter = RecordingPainter::new();
+        let base = painter.base_matrix;
+        replay(&tree, &runs, &mut painter);
+        let layer_pushes = painter
+            .events
+            .iter()
+            .filter(|event| matches!(event, PainterEvent::PushLayer(_)))
+            .count();
+        assert_eq!(layer_pushes, 1);
+        let mut depth = 0i32;
+        let mut plane_clip_pushes = 0;
+        for event in &painter.events {
+            match event {
+                PainterEvent::PushPlaneClip(_) => {
+                    assert_eq!(depth, 1, "a plane clip is pushed right above the root layer");
+                    plane_clip_pushes += 1;
+                    depth += 1;
+                }
+                PainterEvent::PushClip(_) | PainterEvent::PushLayer(_) | PainterEvent::PushMask(_) => depth += 1,
+                PainterEvent::Pop | PainterEvent::PopMask(_) => depth -= 1,
+                _ => {}
+            }
+        }
+        assert!(plane_clip_pushes > 0);
+        assert_eq!(depth, 0);
         assert_eq!(painter.events.last(), Some(&PainterEvent::SetMatrix(base)));
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -12,8 +12,8 @@ use crate::layout::used_values::FfiCssPixelPoint;
 use crate::layout::used_values::FfiCssPixelRect;
 use crate::layout::used_values::FfiCssPixelSize;
 use crate::layout::{grid_formatting_context, svg_formatting_context, used_values};
-use crate::painting::display_list::commands::FrameNodeIndex;
 use crate::painting::display_list::commands::SpatialNodeIndex;
+use crate::painting::display_list::commands::{ClipNodeIndex, ContextRef, EffectNodeIndex};
 use crate::painting::filter_bytes::filter_functions_graph;
 use crate::painting::force_dark::ForceDarkRole;
 use crate::painting::host::FfiRecordedDisplayList;
@@ -1339,7 +1339,7 @@ pub unsafe extern "C" fn layout_arena_paintable_visual_animation_target_indices(
             crate::painting::host::FfiVisualAnimationTargetKind::Opacity
             | crate::painting::host::FfiVisualAnimationTargetKind::BackgroundColor
             | crate::painting::host::FfiVisualAnimationTargetKind::Filter => {
-                handles.frame_handles().map(|index| index.0).collect()
+                handles.effects.iter().map(|index| index.0).collect()
             }
             crate::painting::host::FfiVisualAnimationTargetKind::Transform => {
                 handles.spatial.iter().map(|index| index.0).collect()
@@ -1384,7 +1384,8 @@ pub unsafe extern "C" fn layout_arena_paintable_visual_context_node_count(
     let arena = unsafe { arena_from_handle(arena) };
     arena.with_paintable_visual_context_node_handles(slot, |handles| match list {
         FfiVisualContextBoxNodeList::SpatialNodes => handles.spatial.len(),
-        FfiVisualContextBoxNodeList::FrameNodes => handles.frame_handles().count(),
+        FfiVisualContextBoxNodeList::ClipNodes => handles.clip_handles().count(),
+        FfiVisualContextBoxNodeList::EffectNodes => handles.effects.len(),
     })
 }
 
@@ -1405,7 +1406,8 @@ pub unsafe extern "C" fn layout_arena_paintable_visual_context_copy_node_indices
     arena.with_paintable_visual_context_node_handles(slot, |handles| {
         let indices: Vec<u32> = match list {
             FfiVisualContextBoxNodeList::SpatialNodes => handles.spatial.iter().map(|index| index.0).collect(),
-            FfiVisualContextBoxNodeList::FrameNodes => handles.frame_handles().map(|index| index.0).collect(),
+            FfiVisualContextBoxNodeList::ClipNodes => handles.clip_handles().map(|index| index.0).collect(),
+            FfiVisualContextBoxNodeList::EffectNodes => handles.effects.iter().map(|index| index.0).collect(),
         };
         assert!(indices.len() <= capacity);
         // SAFETY: the caller warrants `capacity` writable indices behind `out`.
@@ -1474,7 +1476,7 @@ fn fresh_visual_context_tree_build(
             VisualContextUpdateScope::FreshTree,
             state,
         ) {
-            IncrementalUpdateResult::Applied(outcome) => outcome,
+            IncrementalUpdateResult::Applied(outcome) => *outcome,
             IncrementalUpdateResult::NeedsFullBuild(_) => {
                 unreachable!("a fresh tree walk has a tree and a viewport record")
             }
@@ -3041,47 +3043,47 @@ pub unsafe extern "C" fn visual_context_tree_spatial_node_count(tree: *const c_v
 ///
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_frame_node_count(tree: *const c_void) -> usize {
-    unsafe { tree_from_handle(tree) }.frame_nodes.len()
+pub unsafe extern "C" fn visual_context_tree_context_is_valid(tree: *const c_void, context: ContextRef) -> bool {
+    unsafe { tree_from_handle(tree) }.context_is_valid(context)
+}
+
+/// # Safety
+///
+/// `tree` must be a live retained tree handle. Every node slot, live or dead.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn visual_context_tree_node_count(tree: *const c_void) -> usize {
+    unsafe { tree_from_handle(tree) }.node_count()
 }
 
 /// # Safety
 ///
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_live_spatial_node_count(tree: *const c_void) -> usize {
-    unsafe { tree_from_handle(tree) }.live_spatial_node_count as usize
-}
-
-/// # Safety
-///
-/// `tree` must be a live retained tree handle.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_live_frame_node_count(tree: *const c_void) -> usize {
-    unsafe { tree_from_handle(tree) }.live_frame_node_count as usize
+pub unsafe extern "C" fn visual_context_tree_live_node_count(tree: *const c_void) -> usize {
+    unsafe { tree_from_handle(tree) }.live_node_count()
 }
 
 /// # Safety
 ///
 /// `tree` must be a live retained tree handle; `command_runs` must address `command_run_count`
-/// runs and `mask_frames` `mask_frame_count` frame indices for the call.
+/// runs and `mask_effects` `mask_effect_count` effect indices for the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn display_list_references_only_live_visual_context_nodes(
     tree: *const c_void,
     command_runs: *const crate::painting::display_list::commands::DisplayListCommandRun,
     command_run_count: usize,
-    mask_frames: *const FrameNodeIndex,
-    mask_frame_count: usize,
+    mask_effects: *const EffectNodeIndex,
+    mask_effect_count: usize,
 ) -> bool {
     let tree = unsafe { tree_from_handle(tree) };
     // SAFETY: The caller guarantees the slices address the stated number of values.
-    let (command_runs, mask_frames) = unsafe {
+    let (command_runs, mask_effects) = unsafe {
         (
             ffi_slice(command_runs, command_run_count),
-            ffi_slice(mask_frames, mask_frame_count),
+            ffi_slice(mask_effects, mask_effect_count),
         )
     };
-    tree.display_list_references_only_live_nodes(command_runs, mask_frames)
+    tree.display_list_references_only_live_nodes(command_runs, mask_effects)
 }
 
 /// # Safety
@@ -3260,34 +3262,34 @@ pub unsafe extern "C" fn visual_context_tree_with_visual_viewport_transform(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
     tree: *const c_void,
-    frame_opacities: *const crate::painting::host::FfiFrameOpacitySample,
-    frame_opacity_count: usize,
-    frame_background_colors: *const crate::painting::host::FfiFrameBackgroundColorSample,
-    frame_background_color_count: usize,
-    frame_filters: *const crate::painting::host::FfiFrameFilterSample,
-    frame_filter_count: usize,
+    effect_opacities: *const crate::painting::host::FfiEffectOpacitySample,
+    effect_opacity_count: usize,
+    effect_background_colors: *const crate::painting::host::FfiEffectBackgroundColorSample,
+    effect_background_color_count: usize,
+    effect_filters: *const crate::painting::host::FfiEffectFilterSample,
+    effect_filter_count: usize,
     spatial_matrices: *const crate::painting::host::FfiSpatialTransformSample,
     spatial_matrix_count: usize,
 ) -> *const c_void {
     let tree = unsafe { tree_from_handle(tree) };
     // SAFETY: The caller guarantees the sample arrays address the stated counts.
-    let (frame_opacities, frame_background_colors, frame_filters, spatial_matrices) = unsafe {
+    let (effect_opacities, effect_background_colors, effect_filters, spatial_matrices) = unsafe {
         (
-            ffi_slice(frame_opacities, frame_opacity_count),
-            ffi_slice(frame_background_colors, frame_background_color_count),
-            ffi_slice(frame_filters, frame_filter_count),
+            ffi_slice(effect_opacities, effect_opacity_count),
+            ffi_slice(effect_background_colors, effect_background_color_count),
+            ffi_slice(effect_filters, effect_filter_count),
             ffi_slice(spatial_matrices, spatial_matrix_count),
         )
     };
-    let frame_opacities: Vec<(FrameNodeIndex, f32)> = frame_opacities
+    let effect_opacities: Vec<(EffectNodeIndex, f32)> = effect_opacities
         .iter()
-        .map(|sample| (FrameNodeIndex(sample.frame), sample.opacity))
+        .map(|sample| (EffectNodeIndex(sample.effect), sample.opacity))
         .collect();
-    let frame_background_colors: Vec<(FrameNodeIndex, libgfx_rust::Color)> = frame_background_colors
+    let effect_background_colors: Vec<(EffectNodeIndex, libgfx_rust::Color)> = effect_background_colors
         .iter()
-        .map(|sample| (FrameNodeIndex(sample.frame), sample.color))
+        .map(|sample| (EffectNodeIndex(sample.effect), sample.color))
         .collect();
-    let frame_filters: Vec<(FrameNodeIndex, Option<Rc<Vec<u8>>>)> = frame_filters
+    let effect_filters: Vec<(EffectNodeIndex, Option<Rc<Vec<u8>>>)> = effect_filters
         .iter()
         .map(|sample| {
             let filter = if sample.filter_size == 0 {
@@ -3298,7 +3300,7 @@ pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
                     unsafe { ffi_slice(sample.filter_bytes, sample.filter_size) }.to_vec(),
                 ))
             };
-            (FrameNodeIndex(sample.frame), filter)
+            (EffectNodeIndex(sample.effect), filter)
         })
         .collect();
     let spatial_matrices: Vec<(SpatialNodeIndex, libgfx_rust::FloatMatrix4x4)> = spatial_matrices
@@ -3306,9 +3308,9 @@ pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
         .map(|sample| (SpatialNodeIndex(sample.spatial), sample.matrix))
         .collect();
     let sampled = tree.with_sampled_visual_animation_values(
-        &frame_opacities,
-        &frame_background_colors,
-        &frame_filters,
+        &effect_opacities,
+        &effect_background_colors,
+        &effect_filters,
         &spatial_matrices,
     );
     Rc::into_raw(Rc::new(sampled)).cast()
@@ -3320,11 +3322,11 @@ pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_sampled_background_color(
     tree: *const c_void,
-    frame: FrameNodeIndex,
+    effect: EffectNodeIndex,
     color: *mut libgfx_rust::Color,
 ) -> bool {
     let tree = unsafe { tree_from_handle(tree) };
-    let Some(sampled_color) = tree.sampled_background_color(frame) else {
+    let Some(sampled_color) = tree.sampled_background_color(effect) else {
         return false;
     };
     // SAFETY: The caller guarantees that `color` points to writable storage.
@@ -3351,14 +3353,14 @@ pub unsafe extern "C" fn visual_context_tree_visual_animation_targets_are_valid(
 /// # Safety
 ///
 /// `tree` must be a live retained tree handle and `out_opacity` must be writable. Returns whether
-/// `frame` names an effects frame.
+/// `effect` names an effects node.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_effects_opacity(
     tree: *const c_void,
-    frame: FrameNodeIndex,
+    effect: EffectNodeIndex,
     out_opacity: *mut f32,
 ) -> bool {
-    match unsafe { tree_from_handle(tree) }.effects_opacity(frame) {
+    match unsafe { tree_from_handle(tree) }.effects_opacity(effect) {
         Some(opacity) => {
             // SAFETY: The caller guarantees `out_opacity` is writable.
             unsafe { *out_opacity = opacity };
@@ -3393,14 +3395,14 @@ pub unsafe extern "C" fn visual_context_tree_mark_spatial_subtrees(
 ///
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_has_unisolated_blending_frame(tree: *const c_void) -> bool {
-    unsafe { tree_from_handle(tree) }.has_unisolated_blending_frame()
+pub unsafe extern "C" fn visual_context_tree_has_unisolated_blending_effect(tree: *const c_void) -> bool {
+    unsafe { tree_from_handle(tree) }.has_unisolated_blending_effect()
 }
 
 /// # Safety
 ///
 /// `tree` must be a live retained tree handle; `visit` is called synchronously with `context` for every
-/// effects frame that carries a filter.
+/// effect node that carries a filter.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_for_each_effects_filter_bytes(
     tree: *const c_void,
@@ -3408,8 +3410,8 @@ pub unsafe extern "C" fn visual_context_tree_for_each_effects_filter_bytes(
     visit: unsafe extern "C" fn(*mut c_void, *const u8, usize),
 ) {
     let tree = unsafe { tree_from_handle(tree) };
-    for frame in &tree.frame_nodes {
-        if let crate::painting::visual_context::FrameData::Effects(effects) = &frame.data
+    for node in &tree.effect_nodes {
+        if let crate::painting::visual_context::EffectNodeData::Effects(effects) = &node.data
             && let Some(filter_bytes) = &effects.filter
         {
             // SAFETY: The C++ visitor reads the bytes synchronously.
@@ -3422,11 +3424,11 @@ pub unsafe extern "C" fn visual_context_tree_for_each_effects_filter_bytes(
 ///
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_frame_is_isolated_by_layer_frame(
+pub unsafe extern "C" fn visual_context_tree_effect_is_isolated_by_layer(
     tree: *const c_void,
-    frame: FrameNodeIndex,
+    effect: EffectNodeIndex,
 ) -> bool {
-    unsafe { tree_from_handle(tree) }.frame_is_isolated_by_layer_frame(frame)
+    unsafe { tree_from_handle(tree) }.effect_is_isolated_by_layer(effect)
 }
 
 /// # Safety
@@ -3543,22 +3545,22 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_sticky(
 ///
 /// `builder` must be a live handle from `visual_context_tree_test_builder_create`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip_frame(
+pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip(
     builder: *mut c_void,
-    parent_frame: u32,
+    parent_clip: u32,
     spatial: u32,
     rect: libgfx_rust::FloatRect,
     corner_radii: libgfx_rust::CornerRadii,
     mode: crate::painting::visual_context::ClipMode,
 ) -> u32 {
     let tree = unsafe { test_builder_tree(builder) };
-    tree.append_frame(
-        crate::painting::visual_context::FrameData::Clip(crate::painting::visual_context::ClipData {
+    tree.append_clip(
+        crate::painting::visual_context::ClipNodeData::Rect(crate::painting::visual_context::ClipData {
             rect,
             corner_radii,
             mode,
         }),
-        FrameNodeIndex(parent_frame),
+        ClipNodeIndex(parent_clip),
         SpatialNodeIndex(spatial),
     )
     .0
@@ -3568,16 +3570,18 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip_frame(
 ///
 /// `builder` must be a live handle from `visual_context_tree_test_builder_create`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_test_builder_append_background_color_animation_frame(
+pub unsafe extern "C" fn visual_context_tree_test_builder_append_background_color_animation(
     builder: *mut c_void,
-    parent_frame: u32,
+    parent_effect: u32,
     spatial: u32,
+    output_clip: u32,
 ) -> u32 {
     let tree = unsafe { test_builder_tree(builder) };
-    tree.append_frame(
-        crate::painting::visual_context::FrameData::BackgroundColorAnimation,
-        FrameNodeIndex(parent_frame),
+    tree.append_effect(
+        crate::painting::visual_context::EffectNodeData::BackgroundColorAnimation,
+        EffectNodeIndex(parent_effect),
         SpatialNodeIndex(spatial),
+        ClipNodeIndex(output_clip),
     )
     .0
 }
@@ -3587,9 +3591,9 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_background_colo
 /// `builder` must be a live handle from `visual_context_tree_test_builder_create`; `path_bytes`
 /// must address `path_bytes_length` readable bytes of a serialized `Gfx::Path`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip_path_frame(
+pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip_path(
     builder: *mut c_void,
-    parent_frame: u32,
+    parent_clip: u32,
     spatial: u32,
     path_bytes: *const u8,
     path_bytes_length: usize,
@@ -3600,13 +3604,13 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip_path_frame
     // SAFETY: The caller guarantees `path_bytes` addresses `path_bytes_length` readable bytes.
     let path_bytes = unsafe { ffi_slice(path_bytes, path_bytes_length) };
     let path = libgfx_rust::path::OwnedPath::from_serialized_bytes(path_bytes);
-    tree.append_frame(
-        crate::painting::visual_context::FrameData::ClipPath(crate::painting::visual_context::ClipPathData {
+    tree.append_clip(
+        crate::painting::visual_context::ClipNodeData::Path(crate::painting::visual_context::ClipPathData {
             path: Rc::new(path),
             bounding_rect,
             fill_rule,
         }),
-        FrameNodeIndex(parent_frame),
+        ClipNodeIndex(parent_clip),
         SpatialNodeIndex(spatial),
     )
     .0
@@ -3616,22 +3620,24 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip_path_frame
 ///
 /// `builder` must be a live handle from `visual_context_tree_test_builder_create`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_test_builder_append_effects_frame(
+pub unsafe extern "C" fn visual_context_tree_test_builder_append_effects(
     builder: *mut c_void,
-    parent_frame: u32,
+    parent_effect: u32,
     spatial: u32,
+    output_clip: u32,
     opacity: f32,
     blend_mode: libgfx_rust::CompositingAndBlendingOperator,
 ) -> u32 {
     let tree = unsafe { test_builder_tree(builder) };
-    tree.append_frame(
-        crate::painting::visual_context::FrameData::Effects(crate::painting::visual_context::EffectsData {
+    tree.append_effect(
+        crate::painting::visual_context::EffectNodeData::Effects(crate::painting::visual_context::EffectsData {
             opacity,
             blend_mode,
             filter: None,
         }),
-        FrameNodeIndex(parent_frame),
+        EffectNodeIndex(parent_effect),
         SpatialNodeIndex(spatial),
+        ClipNodeIndex(output_clip),
     )
     .0
 }

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -7,7 +7,7 @@
 use crate::css::computed_value_types::ComputedStyleValueHandle;
 use crate::layout::used_values;
 use crate::painting::display_list::builder::RecordedDisplayList;
-use crate::painting::display_list::commands::{DisplayListCommandRun, DisplayListResourceId, FrameNodeIndex};
+use crate::painting::display_list::commands::{DisplayListCommandRun, DisplayListResourceId, EffectNodeIndex};
 use crate::painting::display_list::commands::{OptionalAffineTransform, OptionalColor};
 use crate::painting::host::visual_context::{FfiResolvedSvgFilter, ResolvedSvgFilter};
 use libgfx_rust::{AffineTransform, Color, FloatMatrix4x4, FloatRect, FloatSize, IntRect, InterpolationColorSpace};
@@ -383,14 +383,14 @@ pub struct FfiImagePaintFacts {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct FfiMaskDisplayListRegistration {
-    pub frame: FrameNodeIndex,
+    pub effect: EffectNodeIndex,
     pub display_list_id: u64,
 }
 
-impl From<(FrameNodeIndex, DisplayListResourceId)> for FfiMaskDisplayListRegistration {
-    fn from((frame, display_list_id): (FrameNodeIndex, DisplayListResourceId)) -> Self {
+impl From<(EffectNodeIndex, DisplayListResourceId)> for FfiMaskDisplayListRegistration {
+    fn from((effect, display_list_id): (EffectNodeIndex, DisplayListResourceId)) -> Self {
         Self {
-            frame,
+            effect,
             display_list_id: display_list_id.0,
         }
     }

--- a/Libraries/LibWeb/Rust/src/painting/host/replay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/replay.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::painting::display_list::commands::{FrameNodeIndex, ReplayClip, ReplayLayer, ReplayMask};
+use crate::painting::display_list::commands::{EffectNodeIndex, ReplayClip, ReplayLayer, ReplayMask};
 use crate::painting::display_list::replay::ReplayPainter;
 use libgfx_rust::path::OwnedPath;
 use libgfx_rust::{FloatMatrix4x4, FloatVector3, IntRect, WindingRule};
@@ -21,7 +21,7 @@ pub struct FfiDisplayListReplayCallbacks {
     pub push_clip_path: unsafe extern "C" fn(*mut c_void, *const c_void, WindingRule),
     pub push_layer: unsafe extern "C" fn(*mut c_void, *const ReplayLayer),
     pub push_mask: unsafe extern "C" fn(*mut c_void, *const ReplayMask),
-    pub pop_mask: unsafe extern "C" fn(*mut c_void, *const ReplayMask, FrameNodeIndex),
+    pub pop_mask: unsafe extern "C" fn(*mut c_void, *const ReplayMask, EffectNodeIndex),
     pub pop: unsafe extern "C" fn(*mut c_void),
     pub push_device_space_plane_clip: unsafe extern "C" fn(*mut c_void, *const FloatVector3, usize),
     pub execute_run: unsafe extern "C" fn(*mut c_void, usize),
@@ -63,9 +63,9 @@ impl ReplayPainter for FfiDisplayListReplayCallbacks {
         unsafe { (self.push_mask)(self.context, mask) };
     }
 
-    fn pop_mask(&mut self, mask: &ReplayMask, frame: FrameNodeIndex) {
+    fn pop_mask(&mut self, mask: &ReplayMask, effect: EffectNodeIndex) {
         // SAFETY: The C++ painter reads the mask synchronously.
-        unsafe { (self.pop_mask)(self.context, mask, frame) };
+        unsafe { (self.pop_mask)(self.context, mask, effect) };
     }
 
     fn pop(&mut self) {

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -49,7 +49,8 @@ pub enum FfiVisualContextGlobalRebuildReason {
 #[repr(u8)]
 pub enum FfiVisualContextBoxNodeList {
     SpatialNodes,
-    FrameNodes,
+    ClipNodes,
+    EffectNodes,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -276,15 +277,15 @@ pub struct FfiVisualViewportTransform {
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
-pub struct FfiFrameOpacitySample {
-    pub frame: u32,
+pub struct FfiEffectOpacitySample {
+    pub effect: u32,
     pub opacity: f32,
 }
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
-pub struct FfiFrameBackgroundColorSample {
-    pub frame: u32,
+pub struct FfiEffectBackgroundColorSample {
+    pub effect: u32,
     pub color: libgfx_rust::Color,
 }
 
@@ -299,8 +300,8 @@ pub enum FfiVisualAnimationTargetKind {
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
-pub struct FfiFrameFilterSample {
-    pub frame: u32,
+pub struct FfiEffectFilterSample {
+    pub effect: u32,
     pub filter_bytes: *const u8,
     pub filter_size: usize,
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/masks.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/masks.rs
@@ -15,7 +15,9 @@ use crate::painting::node_painting;
 use crate::painting::paintable_geometry::absolute_border_box_rect;
 use crate::painting::record::{NestedRecordingState, PaintPhase, PaintRecorder};
 use crate::painting::visual_context::nested::{NestedAssignments, build_nested_svg_visual_context_tree};
-use crate::painting::visual_context::{FrameData, FrameNodeIndex, MaskLayerOrigin, TransformData, TransformDataRole};
+use crate::painting::visual_context::{
+    EffectNodeData, EffectNodeIndex, MaskLayerOrigin, TransformData, TransformDataRole,
+};
 use libgfx_rust::{AffineTransform, FloatPoint};
 use libgfx_rust::{affine_to_matrix, translated_then_multiplied};
 use std::collections::HashMap;
@@ -117,23 +119,24 @@ impl PaintRecorder<'_> {
             );
             return false;
         };
-        let mut mask_frames: Vec<(FrameNodeIndex, MaskLayerOrigin)> = Vec::new();
+        // One mask effect node per mask layer: the chains a positioned descendant escapes into share it.
+        let mut mask_effects: Vec<(EffectNodeIndex, MaskLayerOrigin)> = Vec::new();
         if let Some(nested) = &self.nested {
-            if let Some(frames) = nested.assignments.mask_frames.get(&paintable.index) {
-                for frame in frames {
+            if let Some(effects) = nested.assignments.mask_effects.get(&paintable.index) {
+                for effect in effects {
                     if let Some(tree) = &self.nested_tree
-                        && let FrameData::Mask(mask) = &tree.frame_nodes[frame.0 as usize].data
+                        && let EffectNodeData::Mask(mask) = &tree.effect_nodes[effect.0 as usize].data
                     {
-                        mask_frames.push((*frame, mask.origin));
+                        mask_effects.push((*effect, mask.origin));
                     }
                 }
             }
         } else if let Some(tree) = self.paint_state.visual_context.tree.as_deref() {
             self.layout_arena
                 .with_paintable_visual_context_node_handles(paintable, |handles| {
-                    for index in handles.frame_handles() {
-                        if let FrameData::Mask(mask) = &tree.frame_nodes[index.0 as usize].data {
-                            mask_frames.push((index, mask.origin));
+                    for index in &handles.effects {
+                        if let EffectNodeData::Mask(mask) = &tree.effect_nodes[index.0 as usize].data {
+                            mask_effects.push((*index, mask.origin));
                         }
                     }
                 });
@@ -151,13 +154,13 @@ impl PaintRecorder<'_> {
             let Some(display_list_id) = layer.display_list_id else {
                 continue;
             };
-            let frames: Vec<FrameNodeIndex> = mask_frames
+            let mut effects = mask_effects
                 .iter()
                 .filter(|(_, origin)| *origin == layer.origin)
-                .map(|(frame, _)| *frame)
-                .collect();
-            assert!(!frames.is_empty(), "a mask display list without a mask node");
-            self.recorder.register_mask_display_list(&frames, display_list_id);
+                .map(|(effect, _)| *effect);
+            let effect = effects.next().expect("a mask display list without a mask node");
+            debug_assert!(effects.next().is_none(), "a mask layer has one mask node");
+            self.recorder.register_mask_display_list(effect, display_list_id);
         }
         any_svg_mask_layer_area_is_empty
     }
@@ -191,7 +194,7 @@ impl PaintRecorder<'_> {
             .as_ref()
             .expect("the nested pre-pass runs with nested assignments")
             .assignments
-            .mask_frames
+            .mask_effects
             .contains_key(&root.index);
         if has_mask_nodes && self.record_mask_entry(root, MaskLayerSet::SvgOnly) {
             return;

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
@@ -225,13 +225,13 @@ fn paint_background_layers(
     let background_rect = resolved.background_rect;
     let color_box = resolved.color_box;
     let layers = &resolved.layers;
-    let background_color_animation_frame = recorder
+    let background_color_animation_effect = recorder
         .layout_arena
         .node_has_compositor_animation_frame(
             paintable,
             crate::layout::node_data::CompositorAnimationFrameKind::BackgroundColor,
         )
-        .then_some(recorder.recorder.accumulated_visual_context().frame)
+        .then_some(recorder.recorder.accumulated_visual_context().effect)
         .filter(|frame| !frame.is_none());
 
     let border_box = BackgroundBox {
@@ -246,7 +246,7 @@ fn paint_background_layers(
             converter.enclosing_device_rect(color_box.rect),
             color,
             libgfx_rust::CornerRadii::default(),
-            background_color_animation_frame,
+            background_color_animation_effect,
             ForceDarkRole::Background,
         );
     } else {
@@ -254,7 +254,7 @@ fn paint_background_layers(
             converter.rounded_device_rect(color_box.rect),
             color,
             color_box.radii.as_corners(&converter),
-            background_color_animation_frame,
+            background_color_animation_effect,
             ForceDarkRole::Background,
         );
     }
@@ -524,10 +524,10 @@ fn paint_image_layer(
         css_enums::background_attachment::FIXED => {
             let data = recorder.data(paintable);
             if data.has_fixed_background_visual_context && !recorder.recording_into_context_free_nested_list {
-                let frame = recorder.recorder.accumulated_visual_context().frame;
+                let context = recorder.recorder.accumulated_visual_context();
                 recorder.recorder.set_accumulated_visual_context(ContextRef {
                     spatial: data.fixed_background_visual_context.spatial,
-                    frame,
+                    ..context
                 });
             }
         }

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -1190,7 +1190,7 @@ impl PaintRecorder<'_> {
         );
         debug_assert!(
             self.captured_range_references_only_the_phase_context(paintable, range, recorded_context),
-            "a per-phase paint capture records under its phase context and its own local frames"
+            "a per-phase paint capture records under its phase context or without clips and effects"
         );
         let cache = self.layout_arena.paintable_paint_cache(paintable);
         cache.register_capture_position(self.current_absolute_position(paintable));
@@ -1220,10 +1220,10 @@ impl PaintRecorder<'_> {
         let bytes = &self.recorder.bytes()[range.offset as usize..(range.offset + range.size) as usize];
         let mut only_the_phase_context = true;
         crate::painting::display_list::builder::for_each_command(bytes, |header, _, _| {
-            let frame = header.context.frame;
-            let frame_belongs_to_the_capture = frame.is_none() || frame == recorded_context.frame;
-            only_the_phase_context &=
-                header.context.spatial == recorded_context.spatial && frame_belongs_to_the_capture;
+            let context = header.context;
+            only_the_phase_context &= context.spatial == recorded_context.spatial
+                && ((context.clip.is_none() && context.effect.is_none())
+                    || (context.clip == recorded_context.clip && context.effect == recorded_context.effect));
         });
         only_the_phase_context
     }

--- a/Libraries/LibWeb/Rust/src/painting/record/verify.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/verify.rs
@@ -251,18 +251,18 @@ pub(crate) fn verify_spliced_recording_matches_fresh(
         "paint cache verification failed: hit-test item counts differ"
     );
 
-    let with_splices_mask_frames: Vec<FrameNodeIndex> = recording_with_splices
+    let with_splices_mask_effects: Vec<EffectNodeIndex> = recording_with_splices
         .mask_display_lists
         .iter()
-        .map(|registration| registration.frame)
+        .map(|registration| registration.effect)
         .collect();
-    let from_scratch_mask_frames: Vec<FrameNodeIndex> = recording_from_scratch
+    let from_scratch_mask_effects: Vec<EffectNodeIndex> = recording_from_scratch
         .mask_display_lists
         .iter()
-        .map(|registration| registration.frame)
+        .map(|registration| registration.effect)
         .collect();
     assert_eq!(
-        with_splices_mask_frames, from_scratch_mask_frames,
+        with_splices_mask_effects, from_scratch_mask_effects,
         "paint cache verification failed: mask display list registrations differ"
     );
     let region_count = |commands: &[DecodedCommand]| {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::reconcile::BoxNodeWriter;
 use super::scroll_state::{NO_SCROLL_STATE_SLOT, ScrollState, ScrollStateSlot};
 use super::*;
 use crate::layout::node_data::{NodeFlag, NodeSlotId};
@@ -77,11 +78,6 @@ impl PaintableVisualContextAssignment {
         }
         layout_arena.set_paintable_visual_context_record(self.slot, self.record);
     }
-}
-
-pub(crate) struct BoxVisualContextBuildOutput {
-    pub assignment: PaintableVisualContextAssignment,
-    pub descendant_contexts: DescendantVisualContexts,
 }
 
 fn scroll_state_slot_for_spatial_node(sink: &impl VisualContextNodeSink, index: SpatialNodeIndex) -> ScrollStateSlot {
@@ -203,17 +199,32 @@ fn append_anchor_scroll_shift_nodes<Arena: PaintableRowsRead, Sink: VisualContex
     own_state
 }
 
-pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: VisualContextNodeSink>(
-    env: &BoxBuildEnvironment<'_, Arena>,
+// Positioned descendants skip intermediate overflow clips. Share the new clip when
+// their spatial and clip chains coincide; otherwise append it under their own chain.
+fn append_clip_to_positioned_chain<Sink: VisualContextNodeSink>(
     sink: &mut Sink,
+    chain: PositioningContext,
+    normal_before: ContextRef,
+    normal_after: ContextRef,
+    data: ClipNodeData,
+) -> PositioningContext {
+    let clip = if chain.spatial == normal_before.spatial && chain.clip == normal_before.clip {
+        normal_after.clip
+    } else {
+        sink.append_clip_node(data, chain.clip, chain.spatial)
+    };
+    PositioningContext { clip, ..chain }
+}
+
+pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead>(
+    env: &BoxBuildEnvironment<'_, Arena>,
+    sink: &mut BoxNodeWriter<'_>,
     slot: NodeSlotId,
     inherited: DescendantVisualContexts,
     may_be_root_element: bool,
     anchor_scroll_shift_resolver: Option<&dyn AnchorScrollShiftResolver>,
-) -> BoxVisualContextBuildOutput {
+) -> PaintableVisualContextAssignment {
     let layout_arena = env.layout_arena;
-    let first_spatial_node_index = sink.next_spatial_node_index().0;
-    let first_frame_node_index = sink.next_frame_node_index().0;
     let facts = super::build::BoxFacts::gather(layout_arena, env.callbacks, slot, env.pixel_ratio, true);
     let position = crate::painting::style_queries::position(layout_arena, slot);
     let is_fixed = position == crate::css::css_enums::positioning::FIXED;
@@ -232,6 +243,7 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
             inherited_input: inherited,
             output_for_descendants: inherited,
             node_handles: BoxVisualContextNodeHandles::default(),
+            effect_clip_constraints: Vec::new(),
             has_mask_nodes: false,
             may_be_root_element,
             owns_geometry_dependent_nodes: false,
@@ -249,13 +261,14 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
         NearestScrollNodeIndices {
             stopping_at_fixed_position_ancestors: VISUAL_VIEWPORT_NODE_INDEX,
             continuing_through_fixed_position_ancestors: inherited
-                .fixed_position_nearest_scroll_nodes
+                .fixed_position
+                .nearest_scroll_nodes
                 .continuing_through_fixed_position_ancestors,
         }
     } else if is_absolute {
-        inherited.absolute_position_nearest_scroll_nodes
+        inherited.absolute_position.nearest_scroll_nodes
     } else {
-        inherited.normal_nearest_scroll_nodes
+        inherited.normal.nearest_scroll_nodes
     };
     let nearest_ancestor_scroll_node_index = if is_sticky {
         nearest_scroll_nodes_for_descendants.continuing_through_fixed_position_ancestors
@@ -268,7 +281,7 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
 
     let creates_sticky_scroll_node = is_sticky;
 
-    let inherited_state = if is_fixed {
+    let inherited_chain = if is_fixed {
         inherited.fixed_position
     } else if is_absolute {
         inherited.absolute_position
@@ -278,7 +291,16 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
         inherited.normal
     };
     // Build this element's own state from inherited state.
-    let mut own_state = inherited_state;
+    let mut own_state = inherited_chain.with_effect(inherited.effect);
+    // Ordinary clip additions only narrow a chain already observed where its effect began.
+    // A positioned box can instead select an ancestor or sibling clip chain; that escape
+    // constrains every enclosing layer even if this box introduces no effect of its own.
+    if inherited_chain.clip != inherited.normal.clip && !inherited.effect.is_none() {
+        assignment.record.effect_clip_constraints.push(EffectClipConstraint {
+            effect: inherited.effect,
+            clip: inherited_chain.clip,
+        });
+    }
 
     match anchor_scroll_shift_resolver {
         Some(resolver) => {
@@ -304,17 +326,40 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     let mut state_for_absolute_position_descendants = inherited.absolute_position;
     let mut state_for_fixed_position_descendants = inherited.fixed_position;
 
-    macro_rules! append_frame_to_own_and_positioned_descendant_contexts {
+    macro_rules! append_clip_to_own_and_positioned_descendant_contexts {
         ($make:expr) => {{
-            own_state = sink.append_frame_node_under(own_state, $make);
+            let normal_before = own_state;
+            own_state = sink.append_clip_node_under(own_state, $make);
+            let normal_after = own_state;
             if !establishes_absolute_cb {
-                state_for_absolute_position_descendants =
-                    sink.append_frame_node_under(state_for_absolute_position_descendants, $make);
+                state_for_absolute_position_descendants = append_clip_to_positioned_chain(
+                    sink,
+                    state_for_absolute_position_descendants,
+                    normal_before,
+                    normal_after,
+                    $make,
+                );
             }
             if !establishes_fixed_cb {
-                state_for_fixed_position_descendants =
-                    sink.append_frame_node_under(state_for_fixed_position_descendants, $make);
+                state_for_fixed_position_descendants = append_clip_to_positioned_chain(
+                    sink,
+                    state_for_fixed_position_descendants,
+                    normal_before,
+                    normal_after,
+                    $make,
+                );
             }
+        }};
+    }
+
+    macro_rules! append_shared_effect {
+        ($make:expr) => {{
+            let effect = sink.append_effect_node($make, own_state.effect, own_state.spatial);
+            assignment.record.effect_clip_constraints.push(EffectClipConstraint {
+                effect,
+                clip: own_state.clip,
+            });
+            own_state.effect = effect;
         }};
     }
 
@@ -341,7 +386,7 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     let transform_data = facts.transform;
 
     if facts.effects.is_some() {
-        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Effects(facts.effects_data().unwrap()));
+        append_shared_effect!(EffectNodeData::Effects(facts.effects_data().unwrap()));
     }
 
     let flattens_inherited_transform = inherited.flattens_inherited_transform;
@@ -360,11 +405,11 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     }
 
     let inherited_plane_root = if is_fixed {
-        inherited.fixed_position_plane_root
+        inherited.fixed_position.plane_root
     } else if is_absolute {
-        inherited.absolute_position_plane_root
+        inherited.absolute_position.plane_root
     } else {
-        inherited.normal_plane_root
+        inherited.normal.plane_root
     };
     let establishes_or_extends_3d_rendering_context = facts.establishes_or_extends_3d_rendering_context;
     let node_data_flags = layout_arena.node_flags_if_live(layout_node);
@@ -452,31 +497,31 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     }
 
     if let Some(css_clip) = facts.css_clip {
-        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Clip(css_clip));
+        append_clip_to_own_and_positioned_descendant_contexts!(ClipNodeData::Rect(css_clip));
     }
 
     if let Some(line_clamp_float_clip) = facts.line_clamp_float_clip {
-        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Clip(line_clamp_float_clip));
+        append_clip_to_own_and_positioned_descendant_contexts!(ClipNodeData::Rect(line_clamp_float_clip));
     }
 
     if facts.clip_path.is_some() {
-        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::ClipPath(facts.clip_path_data().unwrap()));
+        append_clip_to_own_and_positioned_descendant_contexts!(ClipNodeData::Path(facts.clip_path_data().unwrap()));
     }
 
     if !facts.mask_layers.is_empty() {
         assignment.record.has_mask_nodes = true;
     }
     for mask_layer in &facts.mask_layers {
-        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Mask(*mask_layer));
+        append_shared_effect!(EffectNodeData::Mask(*mask_layer));
     }
 
-    if facts.needs_compositor_background_color_frame {
-        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::BackgroundColorAnimation);
+    if facts.needs_compositor_background_color_effect {
+        append_shared_effect!(EffectNodeData::BackgroundColorAnimation);
     }
 
     assignment.has_accumulated_visual_context = true;
     assignment.accumulated_visual_context = own_state;
-    let chain_frames_end = sink.next_frame_node_index().0;
+    sink.begin_descendants();
 
     if super::node_values::wants_fixed_background_visual_context(
         layout_arena,
@@ -485,7 +530,7 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
         may_be_root_element,
     ) {
         // Rooted above every scroll-like node on the box's root path, the background stays put
-        // under scrolling while the box's own frames keep clipping it in their scrolled spaces.
+        // under scrolling while the box's own clips keep clipping it in their scrolled spaces.
         let mut fixed_background_spatial = own_state.spatial;
         let mut index = own_state.spatial;
         while index != VISUAL_VIEWPORT_NODE_INDEX {
@@ -497,7 +542,7 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
         }
         assignment.fixed_background_visual_context = ContextRef {
             spatial: fixed_background_spatial,
-            frame: own_state.frame,
+            ..own_state
         };
         assignment.has_fixed_background_visual_context = true;
     }
@@ -524,7 +569,7 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     if facts.may_have_clip
         && let Some(overflow_clip) = facts.overflow_clip
     {
-        state_for_descendants = sink.append_frame_node_under(state_for_descendants, FrameData::Clip(overflow_clip));
+        state_for_descendants = sink.append_clip_node_under(state_for_descendants, ClipNodeData::Rect(overflow_clip));
     }
 
     if paintable_geometry::has_scrollable_overflow(layout_arena, slot) {
@@ -552,7 +597,12 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     // Positioned descendants that escape into a viewport-establishing containing block lay
     // out in the box's own coordinate space, not the viewport's user units, so they hang
     // above the viewport transform node.
-    let state_for_positioned_descendants = state_for_descendants;
+    let state_for_positioned_descendants = PositioningContext {
+        spatial: state_for_descendants.spatial,
+        clip: state_for_descendants.clip,
+        nearest_scroll_nodes: nearest_scroll_nodes_for_descendants,
+        plane_root: plane_root_for_descendants,
+    };
     if let Some(svg_viewport_transform) = super::build::svg_viewport_transform_of(layout_arena, slot) {
         let mut viewport_transform_data = super::build::compute_svg_viewport_transform_data(
             layout_arena,
@@ -567,38 +617,23 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     }
 
     assignment.accumulated_visual_context_for_descendants = state_for_descendants;
-    let spatial_end = sink.next_spatial_node_index().0;
-    let descendant_frames_end = sink.next_frame_node_index().0;
-    assignment.record.node_handles = BoxVisualContextNodeHandles {
-        spatial: (first_spatial_node_index..spatial_end).map(SpatialNodeIndex).collect(),
-        chain_frames: (first_frame_node_index..chain_frames_end).map(FrameNodeIndex).collect(),
-        descendant_frames: (chain_frames_end..descendant_frames_end).map(FrameNodeIndex).collect(),
-    };
-    let mut absolute_position_nearest_scroll_nodes = inherited.absolute_position_nearest_scroll_nodes;
-    let mut fixed_position_nearest_scroll_nodes = inherited.fixed_position_nearest_scroll_nodes;
-    let mut absolute_position_plane_root = inherited.absolute_position_plane_root;
-    let mut fixed_position_plane_root = inherited.fixed_position_plane_root;
     if establishes_absolute_cb {
         state_for_absolute_position_descendants = state_for_positioned_descendants;
-        absolute_position_nearest_scroll_nodes = nearest_scroll_nodes_for_descendants;
-        absolute_position_plane_root = plane_root_for_descendants;
     }
     if establishes_fixed_cb {
         state_for_fixed_position_descendants = state_for_positioned_descendants;
-        fixed_position_nearest_scroll_nodes = nearest_scroll_nodes_for_descendants;
-        fixed_position_plane_root = plane_root_for_descendants;
     }
 
     let descendant_contexts = DescendantVisualContexts {
-        normal: state_for_descendants,
+        effect: own_state.effect,
+        normal: PositioningContext {
+            spatial: state_for_descendants.spatial,
+            clip: state_for_descendants.clip,
+            nearest_scroll_nodes: nearest_scroll_nodes_for_descendants,
+            plane_root: plane_root_for_descendants,
+        },
         absolute_position: state_for_absolute_position_descendants,
         fixed_position: state_for_fixed_position_descendants,
-        normal_nearest_scroll_nodes: nearest_scroll_nodes_for_descendants,
-        absolute_position_nearest_scroll_nodes,
-        fixed_position_nearest_scroll_nodes,
-        normal_plane_root: plane_root_for_descendants,
-        absolute_position_plane_root,
-        fixed_position_plane_root,
         flattens_inherited_transform: descendants_flatten_inherited_transform,
         sorting_context_root: sorting_context_root_for_descendants,
         enclosing_stacking_context: if stacking_context_facts.establishes_stacking_context {
@@ -608,8 +643,5 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
         },
     };
     assignment.record.output_for_descendants = descendant_contexts;
-    BoxVisualContextBuildOutput {
-        assignment,
-        descendant_contexts,
-    }
+    assignment
 }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -56,7 +56,7 @@ pub(crate) fn svg_viewport_transform_of(
 }
 
 pub(crate) struct BoxFacts {
-    pub needs_compositor_background_color_frame: bool,
+    pub needs_compositor_background_color_effect: bool,
     pub transform: Option<TransformData>,
     pub transform_is_invertible: bool,
     pub perspective: Option<PerspectiveData>,
@@ -91,7 +91,7 @@ impl BoxFacts {
         consults_default_scroll_shift_anchors: bool,
     ) -> Self {
         let mut facts = Self {
-            needs_compositor_background_color_frame: layout_arena.node_has_compositor_animation_frame(
+            needs_compositor_background_color_effect: layout_arena.node_has_compositor_animation_frame(
                 slot,
                 crate::layout::node_data::CompositorAnimationFrameKind::BackgroundColor,
             ),
@@ -187,15 +187,17 @@ pub(crate) fn create_fresh_tree_with_viewport_nodes(
     inputs: &FfiVisualContextTreeInputs,
 ) -> FreshTree {
     let mut tree = VisualContextTree::create(super::node_values::visual_viewport_transform_data(inputs));
-    let root_isolation_frame = tree.append_frame(
-        FrameData::layer_blending_with(CompositingAndBlendingOperator::Normal),
-        FrameNodeIndex::NONE,
+    let root_isolation_effect = tree.append_effect(
+        EffectNodeData::layer_blending_with(CompositingAndBlendingOperator::Normal),
+        EffectNodeIndex::NONE,
         VISUAL_VIEWPORT_NODE_INDEX,
+        ClipNodeIndex::NONE,
     );
-    tree.root_isolation_frame = Some(root_isolation_frame);
+    tree.root_isolation_effect = Some(root_isolation_effect);
     let root_context = ContextRef {
         spatial: VISUAL_VIEWPORT_NODE_INDEX,
-        frame: root_isolation_frame,
+        clip: ClipNodeIndex::NONE,
+        effect: root_isolation_effect,
     };
 
     let viewport_scroll_node = tree.append_spatial(
@@ -208,23 +210,29 @@ pub(crate) fn create_fresh_tree_with_viewport_nodes(
     );
     let viewport_state_for_descendants = ContextRef {
         spatial: viewport_scroll_node,
-        frame: root_isolation_frame,
+        clip: ClipNodeIndex::NONE,
+        effect: root_isolation_effect,
     };
 
     let viewport_nearest_scroll_nodes = NearestScrollNodeIndices {
         stopping_at_fixed_position_ancestors: viewport_scroll_node,
         continuing_through_fixed_position_ancestors: viewport_scroll_node,
     };
+    let scrolled = PositioningContext {
+        spatial: viewport_scroll_node,
+        clip: ClipNodeIndex::NONE,
+        nearest_scroll_nodes: viewport_nearest_scroll_nodes,
+        plane_root: viewport_scroll_node,
+    };
     let viewport_contexts = DescendantVisualContexts {
-        normal: viewport_state_for_descendants,
-        absolute_position: viewport_state_for_descendants,
-        fixed_position: root_context,
-        normal_nearest_scroll_nodes: viewport_nearest_scroll_nodes,
-        absolute_position_nearest_scroll_nodes: viewport_nearest_scroll_nodes,
-        fixed_position_nearest_scroll_nodes: viewport_nearest_scroll_nodes,
-        normal_plane_root: viewport_scroll_node,
-        absolute_position_plane_root: viewport_scroll_node,
-        fixed_position_plane_root: VISUAL_VIEWPORT_NODE_INDEX,
+        effect: root_isolation_effect,
+        normal: scrolled,
+        absolute_position: scrolled,
+        fixed_position: PositioningContext {
+            spatial: VISUAL_VIEWPORT_NODE_INDEX,
+            plane_root: VISUAL_VIEWPORT_NODE_INDEX,
+            ..scrolled
+        },
         flattens_inherited_transform: true,
         sorting_context_root: None,
         enclosing_stacking_context: viewport,
@@ -236,6 +244,7 @@ pub(crate) fn create_fresh_tree_with_viewport_nodes(
             inherited_input: viewport_contexts,
             output_for_descendants: viewport_contexts,
             node_handles: BoxVisualContextNodeHandles::default(),
+            effect_clip_constraints: Vec::new(),
             has_mask_nodes: false,
             may_be_root_element: false,
             owns_geometry_dependent_nodes: false,

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/delta.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/delta.rs
@@ -4,33 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct VisualContextTreeDelta {
     pub structural_epoch_changed: bool,
     pub requires_display_list_recording: bool,
-    pub patched_spatial_node_indices: Vec<u32>,
-    pub patched_frame_node_indices: Vec<u32>,
-    pub tombstoned_spatial_node_indices: Vec<u32>,
-    pub tombstoned_frame_node_indices: Vec<u32>,
+    pub tombstoned_any_node: bool,
 }
 
 impl VisualContextTreeDelta {
-    pub fn note_patched_spatial(&mut self, index: u32) {
-        self.patched_spatial_node_indices.push(index);
-    }
-
-    pub fn note_patched_frame(&mut self, index: u32) {
-        self.patched_frame_node_indices.push(index);
-    }
-
-    pub fn note_tombstoned_spatial(&mut self, index: u32) {
-        self.tombstoned_spatial_node_indices.push(index);
-        self.structural_epoch_changed = true;
-        self.requires_display_list_recording = true;
-    }
-
-    pub fn note_tombstoned_frame(&mut self, index: u32) {
-        self.tombstoned_frame_node_indices.push(index);
+    pub fn note_tombstoned(&mut self) {
+        self.tombstoned_any_node = true;
         self.structural_epoch_changed = true;
         self.requires_display_list_recording = true;
     }
@@ -40,39 +23,10 @@ impl VisualContextTreeDelta {
         self.requires_display_list_recording = true;
     }
 
-    pub fn note_allocated_spatial(&mut self, index: u32, reused_freed_slot: bool) {
-        self.patched_spatial_node_indices.push(index);
+    pub fn note_allocated(&mut self, reused_freed_slot: bool) {
         self.requires_display_list_recording = true;
-        if reused_freed_slot {
-            self.structural_epoch_changed = true;
-        }
+        self.structural_epoch_changed |= reused_freed_slot;
     }
-
-    pub fn note_allocated_frame(&mut self, index: u32, reused_freed_slot: bool) {
-        self.patched_frame_node_indices.push(index);
-        self.requires_display_list_recording = true;
-        if reused_freed_slot {
-            self.structural_epoch_changed = true;
-        }
-    }
-
-    pub fn finish(&mut self) {
-        sort_and_deduplicate(&mut self.tombstoned_spatial_node_indices);
-        sort_and_deduplicate(&mut self.tombstoned_frame_node_indices);
-        let tombstoned_spatial = &self.tombstoned_spatial_node_indices;
-        self.patched_spatial_node_indices
-            .retain(|index| tombstoned_spatial.binary_search(index).is_err());
-        sort_and_deduplicate(&mut self.patched_spatial_node_indices);
-        let tombstoned_frames = &self.tombstoned_frame_node_indices;
-        self.patched_frame_node_indices
-            .retain(|index| tombstoned_frames.binary_search(index).is_err());
-        sort_and_deduplicate(&mut self.patched_frame_node_indices);
-    }
-}
-
-fn sort_and_deduplicate(indices: &mut Vec<u32>) {
-    indices.sort_unstable();
-    indices.dedup();
 }
 
 #[cfg(test)]
@@ -80,40 +34,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn finishing_sorts_deduplicates_and_drops_patches_of_tombstoned_indices() {
-        let mut delta = VisualContextTreeDelta::default();
-        delta.note_patched_spatial(5);
-        delta.note_patched_spatial(3);
-        delta.note_patched_spatial(3);
-        delta.note_patched_spatial(9);
-        delta.note_tombstoned_spatial(5);
-        delta.note_patched_frame(12);
-        delta.note_patched_frame(2);
-        delta.finish();
-        assert_eq!(delta.patched_spatial_node_indices, vec![3, 9]);
-        assert_eq!(delta.tombstoned_spatial_node_indices, vec![5]);
-        assert_eq!(delta.patched_frame_node_indices, vec![2, 12]);
-        assert!(delta.structural_epoch_changed);
-        assert!(delta.requires_display_list_recording);
-    }
-
-    #[test]
-    fn value_patches_alone_need_no_recording() {
-        let mut delta = VisualContextTreeDelta::default();
-        delta.note_patched_frame(1);
-        delta.finish();
-        assert!(!delta.structural_epoch_changed);
-        assert!(!delta.requires_display_list_recording);
-    }
-
-    #[test]
     fn allocating_a_fresh_slot_requires_recording_without_an_epoch_change() {
         let mut delta = VisualContextTreeDelta::default();
-        delta.note_allocated_spatial(7, false);
-        delta.note_allocated_frame(9, false);
-        delta.finish();
-        assert_eq!(delta.patched_spatial_node_indices, vec![7]);
-        assert_eq!(delta.patched_frame_node_indices, vec![9]);
+        delta.note_allocated(false);
         assert!(!delta.structural_epoch_changed);
         assert!(delta.requires_display_list_recording);
     }
@@ -121,9 +44,7 @@ mod tests {
     #[test]
     fn reusing_a_freed_slot_changes_the_structural_epoch() {
         let mut delta = VisualContextTreeDelta::default();
-        delta.note_allocated_frame(4, true);
-        delta.finish();
-        assert_eq!(delta.patched_frame_node_indices, vec![4]);
+        delta.note_allocated(true);
         assert!(delta.structural_epoch_changed);
         assert!(delta.requires_display_list_recording);
     }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
@@ -5,8 +5,8 @@
  */
 
 use super::{
-    ClipMode, FrameData, FrameNodeIndex, MaskLayerOrigin, SpatialData, SpatialNodeIndex, TransformDataRole,
-    VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree,
+    ClipMode, ClipNodeData, ClipNodeIndex, EffectNodeData, EffectNodeIndex, MaskLayerOrigin, SpatialData,
+    SpatialNodeIndex, TransformDataRole, VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree,
 };
 use crate::painting::display_list::commands::DisplayListCommandRun;
 use crate::painting::dump::{
@@ -15,6 +15,13 @@ use crate::painting::dump::{
 use libgfx_rust::{CompositingAndBlendingOperator, FloatPoint, FloatRect, FloatSize, IntRect, MaskKind};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SlotKind {
+    Spatial,
+    Clip,
+    Effect,
+}
 
 fn format_point(point: FloatPoint) -> String {
     let mut text = String::new();
@@ -128,11 +135,10 @@ impl VisualContextTree {
         text
     }
 
-    pub fn dump_frame_node(&self, index: FrameNodeIndex) -> String {
+    pub fn dump_clip_node(&self, index: ClipNodeIndex) -> String {
         let mut text = String::new();
-        match &self.frame_nodes[index.0 as usize].data {
-            FrameData::BackgroundColorAnimation => text.push_str("background-color-animation"),
-            FrameData::Clip(clip) => {
+        match &self.clip_nodes[index.0 as usize].data {
+            ClipNodeData::Rect(clip) => {
                 let _ = write!(text, "clip={}", format_rect(clip.rect));
                 if clip.corner_radii.has_any_radius() {
                     let corner_radii = clip.corner_radii;
@@ -149,7 +155,7 @@ impl VisualContextTree {
                     text.push_str(" mode=difference");
                 }
             }
-            FrameData::ClipPath(clip_path) => {
+            ClipNodeData::Path(clip_path) => {
                 let svg_path = clip_path.path.to_svg_string();
                 let has_curves_with_host_dependent_control_points = svg_path.contains('Q') || svg_path.contains('C');
                 if has_curves_with_host_dependent_control_points {
@@ -172,7 +178,15 @@ impl VisualContextTree {
                     );
                 }
             }
-            FrameData::Effects(effects) => {
+            ClipNodeData::Dead => text.push_str("tombstone"),
+        }
+        text
+    }
+
+    pub fn dump_effect_node(&self, index: EffectNodeIndex) -> String {
+        let mut text = String::new();
+        match &self.effect_nodes[index.0 as usize].data {
+            EffectNodeData::Effects(effects) => {
                 text.push_str("effects=[");
                 let mut has_content = false;
                 if effects.opacity < 1.0 {
@@ -194,7 +208,7 @@ impl VisualContextTree {
                 }
                 text.push(']');
             }
-            FrameData::Mask(mask) => {
+            EffectNodeData::Mask(mask) => {
                 let kind = if mask.kind == MaskKind::Alpha {
                     "alpha"
                 } else {
@@ -213,24 +227,41 @@ impl VisualContextTree {
                     origin
                 );
             }
-            FrameData::Dead => text.push_str("tombstone"),
+            EffectNodeData::BackgroundColorAnimation => text.push_str("background-color-animation"),
+            EffectNodeData::Dead => text.push_str("tombstone"),
         }
         text
     }
 }
 
 impl VisualContextTree {
+    // The nodes the runs record under, each tree in first-seen order. An effect's output clip
+    // chain counts as reachable, since replay enters it before the effect.
     pub fn dump_nodes_reachable_from_runs(
         &self,
         command_runs: &[DisplayListCommandRun],
-        mut owner_label: impl FnMut(bool, u32) -> Option<String>,
+        mut owner_label: impl FnMut(SlotKind, u32) -> Option<String>,
     ) -> String {
         let mut visited_spatial_nodes: HashSet<u32> = HashSet::new();
-        let mut visited_frame_nodes: HashSet<u32> = HashSet::new();
+        let mut visited_clip_nodes: HashSet<u32> = HashSet::new();
+        let mut visited_effect_nodes: HashSet<u32> = HashSet::new();
         let mut spatial_children: HashMap<u32, Vec<u32>> = HashMap::new();
-        let mut frame_children: HashMap<u32, Vec<u32>> = HashMap::new();
-        let mut frame_roots: Vec<u32> = Vec::new();
+        let mut clip_children: HashMap<u32, Vec<u32>> = HashMap::new();
+        let mut clip_roots: Vec<u32> = Vec::new();
+        let mut effect_children: HashMap<u32, Vec<u32>> = HashMap::new();
+        let mut effect_roots: Vec<u32> = Vec::new();
 
+        let mut visit_clip_chain = |mut clip: ClipNodeIndex| {
+            while !clip.is_none() && visited_clip_nodes.insert(clip.0) {
+                let parent = self.clip_nodes[clip.0 as usize].parent;
+                if parent.is_none() {
+                    clip_roots.push(clip.0);
+                } else {
+                    clip_children.entry(parent.0).or_default().push(clip.0);
+                }
+                clip = parent;
+            }
+        };
         for run in command_runs {
             let mut spatial = run.context.spatial;
             while visited_spatial_nodes.insert(spatial.0) {
@@ -241,21 +272,23 @@ impl VisualContextTree {
                 spatial_children.entry(parent.0).or_default().push(spatial.0);
                 spatial = parent;
             }
-            let mut frame = run.context.frame;
-            while !frame.is_none() && visited_frame_nodes.insert(frame.0) {
-                let parent = self.frame_nodes[frame.0 as usize].parent;
-                if parent.is_none() {
-                    frame_roots.push(frame.0);
+            visit_clip_chain(run.context.clip);
+            let mut effect = run.context.effect;
+            while !effect.is_none() && visited_effect_nodes.insert(effect.0) {
+                let node = &self.effect_nodes[effect.0 as usize];
+                visit_clip_chain(node.output_clip());
+                if node.parent.is_none() {
+                    effect_roots.push(effect.0);
                 } else {
-                    frame_children.entry(parent.0).or_default().push(frame.0);
+                    effect_children.entry(node.parent.0).or_default().push(effect.0);
                 }
-                frame = parent;
+                effect = node.parent;
             }
         }
 
         let mut text = String::from("AccumulatedVisualContext Tree:\n");
-        let mut append_owner = |text: &mut String, is_frame: bool, index: u32| {
-            if let Some(label) = owner_label(is_frame, index) {
+        let mut append_owner = |text: &mut String, kind: SlotKind, index: u32| {
+            if let Some(label) = owner_label(kind, index) {
                 let _ = write!(text, " ({label})");
             }
             text.push('\n');
@@ -284,24 +317,49 @@ impl VisualContextTree {
             &mut text,
             &spatial_children,
             &|index: u32| format!("[s{index}] {}", self.dump_spatial_node(SpatialNodeIndex(index))),
-            &mut |text: &mut String, index: u32| append_owner(text, false, index),
+            &mut |text: &mut String, index: u32| append_owner(text, SlotKind::Spatial, index),
             VISUAL_VIEWPORT_NODE_INDEX.0,
             2,
         );
-        if !frame_roots.is_empty() {
-            text.push_str("  frames:\n");
-            for root in frame_roots {
+        if !clip_roots.is_empty() {
+            text.push_str("  clips:\n");
+            for root in clip_roots {
                 dump_subtree(
                     &mut text,
-                    &frame_children,
+                    &clip_children,
                     &|index: u32| {
                         format!(
-                            "[f{index} in s{}] {}",
-                            self.frame_nodes[index as usize].spatial.0,
-                            self.dump_frame_node(FrameNodeIndex(index))
+                            "[c{index} in s{}] {}",
+                            self.clip_nodes[index as usize].spatial.0,
+                            self.dump_clip_node(ClipNodeIndex(index))
                         )
                     },
-                    &mut |text: &mut String, index: u32| append_owner(text, true, index),
+                    &mut |text: &mut String, index: u32| append_owner(text, SlotKind::Clip, index),
+                    root,
+                    2,
+                );
+            }
+        }
+        if !effect_roots.is_empty() {
+            text.push_str("  effects:\n");
+            for root in effect_roots {
+                dump_subtree(
+                    &mut text,
+                    &effect_children,
+                    &|index: u32| {
+                        let node = &self.effect_nodes[index as usize];
+                        let output_clip = if node.output_clip().is_none() {
+                            String::new()
+                        } else {
+                            format!(" out=c{}", node.output_clip().0)
+                        };
+                        format!(
+                            "[e{index} in s{}{output_clip}] {}",
+                            node.spatial.0,
+                            self.dump_effect_node(EffectNodeIndex(index))
+                        )
+                    },
+                    &mut |text: &mut String, index: u32| append_owner(text, SlotKind::Effect, index),
                     root,
                     2,
                 );
@@ -315,9 +373,10 @@ impl VisualContextTree {
 mod node_dump_tests {
     use crate::layout::node_data::NodeSlotId;
     use crate::painting::visual_context::{
-        AnchorScrollShift, BackfaceVisibilityData, ClipData, ClipMode, EffectsData, FrameData, FrameNodeIndex,
-        MaskData, MaskLayerOrigin, PerspectiveData, ScrollData, SpatialData, StickyData, TransformData,
-        TransformDataRole, VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree, scroll_state::NO_SCROLL_STATE_SLOT,
+        AnchorScrollShift, BackfaceVisibilityData, ClipData, ClipMode, ClipNodeData, ClipNodeIndex, EffectNodeData,
+        EffectNodeIndex, EffectsData, MaskData, MaskLayerOrigin, PerspectiveData, ScrollData, SpatialData, StickyData,
+        TransformData, TransformDataRole, VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree,
+        scroll_state::NO_SCROLL_STATE_SLOT,
     };
     use libgfx_rust::{
         CompositingAndBlendingOperator, CornerRadii, FloatMatrix4x4, FloatPoint, FloatRect, FloatSize, IntRect,
@@ -467,91 +526,101 @@ mod node_dump_tests {
     }
 
     #[test]
-    fn frame_nodes_dump_like_the_display_list_expectations() {
+    fn clip_and_effect_nodes_dump_like_the_display_list_expectations() {
         let mut tree = tree();
-        let plain_clip = tree.append_frame(
-            FrameData::Clip(ClipData {
+        let plain_clip = tree.append_clip(
+            ClipNodeData::Rect(ClipData {
                 rect: FloatRect::new(11.0, 10.0, 100.0, 16.0),
                 corner_radii: CornerRadii::default(),
                 mode: ClipMode::Intersect,
             }),
-            FrameNodeIndex::NONE,
+            ClipNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let rounded_difference_clip = tree.append_frame(
-            FrameData::Clip(ClipData {
+        let rounded_difference_clip = tree.append_clip(
+            ClipNodeData::Rect(ClipData {
                 rect: FloatRect::new(0.5, 0.0, 10.0, 10.0),
                 corner_radii: CornerRadii::uniform(3),
                 mode: ClipMode::Difference,
             }),
-            FrameNodeIndex::NONE,
+            ClipNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let plain_effects = tree.append_frame(
-            FrameData::Effects(EffectsData {
+        let plain_effects = tree.append_effect(
+            EffectNodeData::Effects(EffectsData {
                 opacity: 1.0,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
             }),
-            FrameNodeIndex::NONE,
+            EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
         );
-        let full_effects = tree.append_frame(
-            FrameData::Effects(EffectsData {
+        let full_effects = tree.append_effect(
+            EffectNodeData::Effects(EffectsData {
                 opacity: 0.5,
                 blend_mode: CompositingAndBlendingOperator::Multiply,
                 filter: Some(std::rc::Rc::new(vec![1, 2, 3])),
             }),
-            FrameNodeIndex::NONE,
+            EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
         );
-        let mask = tree.append_frame(
-            FrameData::Mask(MaskData {
+        let mask = tree.append_effect(
+            EffectNodeData::Mask(MaskData {
                 rect: IntRect::new(1, 2, 30, 40),
                 kind: MaskKind::Luminance,
                 origin: MaskLayerOrigin::SvgMask,
             }),
-            FrameNodeIndex::NONE,
+            EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        let marker = tree.append_effect(
+            EffectNodeData::BackgroundColorAnimation,
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
         );
 
-        assert_eq!(tree.dump_frame_node(plain_clip), "clip=[11,10 100x16]");
+        assert_eq!(tree.dump_clip_node(plain_clip), "clip=[11,10 100x16]");
         assert_eq!(
-            tree.dump_frame_node(rounded_difference_clip),
+            tree.dump_clip_node(rounded_difference_clip),
             "clip=[0.5,0 10x10] radii=(3,3,3,3) mode=difference"
         );
-        assert_eq!(tree.dump_frame_node(plain_effects), "effects=[]");
+        assert_eq!(tree.dump_effect_node(plain_effects), "effects=[]");
         assert_eq!(
-            tree.dump_frame_node(full_effects),
+            tree.dump_effect_node(full_effects),
             format!(
                 "effects=[opacity=0.5 blend_mode={} filter]",
                 CompositingAndBlendingOperator::Multiply as i32
             )
         );
         assert_eq!(
-            tree.dump_frame_node(mask),
+            tree.dump_effect_node(mask),
             "mask=[1,2 30x40] kind=luminance origin=svg-mask"
         );
+        assert_eq!(tree.dump_effect_node(marker), "background-color-animation");
     }
 }
 
 #[cfg(test)]
 mod section_dump_tests {
+    use super::SlotKind;
     use crate::layout::node_data::NodeSlotId;
-    use crate::painting::display_list::commands::{
-        ContextRef, DisplayListCommandRun, FrameNodeIndex, SpatialNodeIndex,
-    };
+    use crate::painting::display_list::commands::{ContextRef, DisplayListCommandRun, SpatialNodeIndex};
     use crate::painting::visual_context::{
-        ClipData, ClipMode, EffectsData, FrameData, ScrollData, SpatialData, TransformData, TransformDataRole,
-        VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree, scroll_state::NO_SCROLL_STATE_SLOT,
+        ClipData, ClipMode, ClipNodeData, ClipNodeIndex, EffectNodeData, EffectNodeIndex, EffectsData, ScrollData,
+        SpatialData, TransformData, TransformDataRole, VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree,
+        scroll_state::NO_SCROLL_STATE_SLOT,
     };
     use libgfx_rust::{CompositingAndBlendingOperator, CornerRadii, FloatMatrix4x4, FloatPoint, FloatRect, IntRect};
 
-    fn run(spatial: SpatialNodeIndex, frame: FrameNodeIndex) -> DisplayListCommandRun {
+    fn run(spatial: SpatialNodeIndex, context: ContextRef) -> DisplayListCommandRun {
         DisplayListCommandRun {
             offset: 0,
             size: 0,
-            context: ContextRef { spatial, frame },
+            context: ContextRef { spatial, ..context },
             ink_bounds: IntRect::default(),
             has_unbounded_draw: false,
             has_compositor_metadata: false,
@@ -585,37 +654,60 @@ mod section_dump_tests {
             }),
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let clip_frame = tree.append_frame(
-            FrameData::Clip(ClipData {
+        let outer_clip = tree.append_clip(
+            ClipNodeData::Rect(ClipData {
                 rect: FloatRect::new(1.0, 2.0, 3.0, 4.0),
                 corner_radii: CornerRadii::default(),
                 mode: ClipMode::Intersect,
             }),
-            FrameNodeIndex::NONE,
+            ClipNodeIndex::NONE,
             scroll_node,
         );
-        let effects_frame = tree.append_frame(
-            FrameData::Effects(EffectsData {
+        let effect = tree.append_effect(
+            EffectNodeData::Effects(EffectsData {
                 opacity: 0.5,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
             }),
-            clip_frame,
+            EffectNodeIndex::NONE,
+            scroll_node,
+            outer_clip,
+        );
+        let inner_clip = tree.append_clip(
+            ClipNodeData::rect_clip(FloatRect::new(5.0, 6.0, 7.0, 8.0)),
+            outer_clip,
             scroll_node,
         );
-        let _ = unreachable_node;
+        let unreachable_clip = tree.append_clip(
+            ClipNodeData::rect_clip(FloatRect::new(9.0, 9.0, 9.0, 9.0)),
+            ClipNodeIndex::NONE,
+            scroll_node,
+        );
+        let inner_context = ContextRef {
+            clip: inner_clip,
+            effect,
+            ..ContextRef::default()
+        };
+        let escaping_context = ContextRef {
+            clip: outer_clip,
+            effect,
+            ..ContextRef::default()
+        };
+        let _ = (unreachable_node, unreachable_clip);
         let runs = [
-            run(scroll_node, effects_frame),
-            run(VISUAL_VIEWPORT_NODE_INDEX, FrameNodeIndex::NONE),
+            run(scroll_node, inner_context),
+            run(scroll_node, escaping_context),
+            run(VISUAL_VIEWPORT_NODE_INDEX, ContextRef::default()),
         ];
-        let text = tree.dump_nodes_reachable_from_runs(&runs, |is_frame, index| match (is_frame, index) {
-            (false, 1) => Some("BlockContainer<DIV>#scroller".to_string()),
-            (true, 0) => Some("BlockContainer<DIV>#scroller".to_string()),
+        let text = tree.dump_nodes_reachable_from_runs(&runs, |kind, index| match (kind, index) {
+            (SlotKind::Spatial, 1) => Some("BlockContainer<DIV>#scroller".to_string()),
+            (SlotKind::Clip, 0) => Some("BlockContainer<DIV>#scroller".to_string()),
+            (SlotKind::Effect, 0) => Some("BlockContainer<DIV>#faded".to_string()),
             _ => None,
         });
         assert_eq!(
             text,
-            "AccumulatedVisualContext Tree:\n  spatial:\n    [s0] transform=[1,0,0,1,0,0] origin=(0,0)\n      [s1] scroll (BlockContainer<DIV>#scroller)\n  frames:\n    [f0 in s1] clip=[1,2 3x4] (BlockContainer<DIV>#scroller)\n      [f1 in s1] effects=[opacity=0.5]\n"
+            "AccumulatedVisualContext Tree:\n  spatial:\n    [s0] transform=[1,0,0,1,0,0] origin=(0,0)\n      [s1] scroll (BlockContainer<DIV>#scroller)\n  clips:\n    [c0 in s1] clip=[1,2 3x4] (BlockContainer<DIV>#scroller)\n      [c1 in s1] clip=[5,6 7x8]\n  effects:\n    [e0 in s1 out=c0] effects=[opacity=0.5] (BlockContainer<DIV>#faded)\n"
         );
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -12,7 +12,7 @@ use super::dirty::{
     BoxDirtyBits, VisualContextBoxDirtyKind, VisualContextDirtySet, VisualContextGlobalRebuildReason,
     VisualContextUpdateScope,
 };
-use super::reconcile::{BoxNodeScratch, plan_box_node_placement, write_box_nodes};
+use super::reconcile::BoxNodeWriter;
 use super::refresh::compute_sticky_data;
 use super::scroll_state::ScrollState;
 use super::*;
@@ -42,13 +42,12 @@ pub(crate) struct IncrementalUpdateOutcome {
 }
 
 pub(crate) enum IncrementalUpdateResult {
-    Applied(IncrementalUpdateOutcome),
+    Applied(Box<IncrementalUpdateOutcome>),
     NeedsFullBuild(VisualContextGlobalRebuildReason),
 }
 
 fn incremental_tree_requires_fresh_build(tree: &VisualContextTree, delta: &VisualContextTreeDelta) -> bool {
-    (!delta.tombstoned_spatial_node_indices.is_empty() || !delta.tombstoned_frame_node_indices.is_empty())
-        && !tree.node_references_are_consistent()
+    delta.tombstoned_any_node && !tree.node_references_are_consistent()
 }
 
 fn box_is_inside_svg_resource_subtree(layout_arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
@@ -139,12 +138,17 @@ fn tombstone_removed_blocks(
     for removed in &dirty.removed {
         for index in &removed.node_handles.spatial {
             if tree.tombstone_spatial_slot(*index) {
-                delta.note_tombstoned_spatial(index.0);
+                delta.note_tombstoned();
             }
         }
-        for index in removed.node_handles.frame_handles() {
-            if tree.tombstone_frame_slot(index) {
-                delta.note_tombstoned_frame(index.0);
+        for index in removed.node_handles.clip_handles() {
+            if tree.tombstone_clip_slot(index) {
+                delta.note_tombstoned();
+            }
+        }
+        for index in &removed.node_handles.effects {
+            if tree.tombstone_effect_slot(*index) {
+                delta.note_tombstoned();
             }
         }
     }
@@ -199,7 +203,6 @@ pub(crate) fn rebuild_scroll_state_from_tree(
     layout_arena: &impl PaintableRowsRead,
     tree: &mut VisualContextTree,
     tree_inputs: &FfiVisualContextTreeInputs,
-    delta: &mut VisualContextTreeDelta,
 ) -> ScrollState {
     let mut scroll_state = ScrollState::default();
     for node_index in tree.spatial_dependency_order() {
@@ -213,16 +216,12 @@ pub(crate) fn rebuild_scroll_state_from_tree(
         let SpatialData::Sticky(sticky) = &tree.spatial_nodes[index].data else {
             unreachable!("a registered sticky node keeps its payload kind");
         };
-        let refreshed = SpatialData::Sticky(compute_sticky_data(
+        tree.spatial_nodes[index].data = SpatialData::Sticky(compute_sticky_data(
             layout_arena,
             &scroll_state,
             sticky.state_slot,
             tree_inputs,
         ));
-        if !super::shape::spatial_payloads_are_equal(&tree.spatial_nodes[index].data, &refreshed) {
-            delta.note_patched_spatial(node_index.0);
-        }
-        tree.spatial_nodes[index].data = refreshed;
     }
     scroll_state
 }
@@ -245,18 +244,21 @@ pub(crate) fn box_owns_geometry_dependent_nodes(
     let effects_filter_is_resolved_by_the_host_against_geometry = layout_arena
         .node_style_if_live(slot)
         .is_some_and(|style| crate::painting::filter_bytes::contains_url(&style.effects().filter));
-    let frames_are_geometry_dependent = handles.frame_handles().any(|index| {
-        let node = &tree.frame_nodes[index.0 as usize];
+    let clips_are_geometry_dependent = handles
+        .clip_handles()
+        .any(|index| tree.clip_nodes[index.0 as usize].data.is_live());
+    let effects_are_geometry_dependent = handles.effects.iter().any(|index| {
+        let node = &tree.effect_nodes[index.0 as usize];
         match &node.data {
-            FrameData::BackgroundColorAnimation => false,
-            FrameData::Clip(_) | FrameData::ClipPath(_) | FrameData::Mask(_) => true,
-            FrameData::Effects(effects) => {
+            EffectNodeData::BackgroundColorAnimation => false,
+            EffectNodeData::Mask(_) => true,
+            EffectNodeData::Effects(effects) => {
                 effects.filter.is_some() && effects_filter_is_resolved_by_the_host_against_geometry
             }
-            FrameData::Dead => false,
+            EffectNodeData::Dead => false,
         }
     });
-    spatial_is_geometry_dependent || frames_are_geometry_dependent
+    spatial_is_geometry_dependent || clips_are_geometry_dependent || effects_are_geometry_dependent
 }
 
 struct PendingBox {
@@ -391,6 +393,7 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
         .removed
         .iter()
         .any(|removed| state.paintables_with_mask_nodes.contains(&removed.slot));
+    let mut effect_clip_constraints_changed = false;
     let mut stack: Vec<PendingBox> = Vec::new();
     let push_children = |stack: &mut Vec<PendingBox>,
                          parent: NodeSlotId,
@@ -468,8 +471,9 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
             let previous_has_mask_nodes = existing_record.as_ref().is_some_and(|record| record.has_mask_nodes);
             let may_be_root_element = parent == viewport;
             let tree = Rc::make_mut(state.tree.as_mut().expect("the tree exists throughout the pass"));
-            let mut scratch = BoxNodeScratch::new(tree);
-            let output = {
+            let existing_handles = existing_record.as_ref().map(|record| &record.node_handles);
+            let mut writer = BoxNodeWriter::new(tree, existing_handles, &mut delta);
+            let mut assignment = {
                 let anchor_scroll_shift_resolver =
                     scaffold_scroll_state
                         .as_ref()
@@ -481,7 +485,7 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
                         });
                 build_box_visual_context_nodes(
                     &environment,
-                    &mut scratch,
+                    &mut writer,
                     slot,
                     input,
                     may_be_root_element,
@@ -490,39 +494,19 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
                         .map(|resolver| resolver as &dyn AnchorScrollShiftResolver),
                 )
             };
-            let (scratch_spatial, scratch_frames) = scratch.into_nodes();
-            let existing_handles = existing_record.as_ref().map(|record| &record.node_handles);
-            let placement = plan_box_node_placement(
-                tree,
-                existing_handles,
-                &output.assignment.record.node_handles,
-                &mut delta,
-            );
-            let reconcile = write_box_nodes(
-                tree,
-                scratch_spatial,
-                scratch_frames,
-                &placement,
-                existing_handles,
-                &mut delta,
-            );
+            effect_clip_constraints_changed |= existing_record
+                .as_ref()
+                .map_or(!assignment.record.effect_clip_constraints.is_empty(), |record| {
+                    record.effect_clip_constraints != assignment.record.effect_clip_constraints
+                });
+            let (handles, reconcile) = writer.finish();
             if let Some(scroll_state) = scaffold_scroll_state.as_mut() {
-                for handle in &placement.spatial {
+                for handle in &handles.spatial {
                     register_scroll_like_node(layout_arena, tree, scroll_state, *handle);
                 }
             }
-            let mut assignment = output.assignment;
-            assignment.accumulated_visual_context = placement.remap_context(assignment.accumulated_visual_context);
-            assignment.accumulated_visual_context_for_descendants =
-                placement.remap_context(assignment.accumulated_visual_context_for_descendants);
-            assignment.fixed_background_visual_context =
-                placement.remap_context(assignment.fixed_background_visual_context);
-            assignment.enclosing_scroll_node_index = placement.remap_spatial(assignment.enclosing_scroll_node_index);
-            assignment.own_scroll_node_index = placement.remap_spatial(assignment.own_scroll_node_index);
-            let new_output = remap_descendant_contexts(&placement, output.descendant_contexts);
-            assignment.record.inherited_input = input;
-            assignment.record.output_for_descendants = new_output;
-            assignment.record.node_handles = placement.into_node_handles();
+            let new_output = assignment.record.output_for_descendants;
+            assignment.record.node_handles = handles;
             assignment.record.owns_geometry_dependent_nodes =
                 box_owns_geometry_dependent_nodes(layout_arena, tree, slot, &assignment.record.node_handles);
             assignment.record.subtree_may_own_geometry_dependent_nodes =
@@ -550,6 +534,9 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
                     assignment.accumulated_visual_context,
                     assignment.accumulated_visual_context_for_descendants,
                 ));
+            // A box can select different inherited nodes without owning any nodes itself.
+            // Its recorded contexts must still be replaced in the next display list.
+            delta.requires_display_list_recording |= contexts_changed;
             if reconcile.shape_changed || !record_existed {
                 layout_arena.invalidate_paint_cache(slot);
             } else if contexts_changed {
@@ -607,11 +594,39 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
     }
 
     let tree = Rc::make_mut(state.tree.as_mut().expect("the tree exists throughout the pass"));
+    // Payload-only updates keep layer placement unless a box selected a different clip
+    // chain. Structural changes can reparent clips without changing constraint handles;
+    // removed boxes can drop escape constraints even when they owned no tree nodes.
+    if scope.rebuilds_every_box()
+        || effect_clip_constraints_changed
+        || delta.structural_epoch_changed
+        || !state.dirty_boxes.removed.is_empty()
+    {
+        let mut constraints = Vec::new();
+        if scope.rebuilds_every_box() {
+            // Every box's new record is already in the assignments, and the resolver
+            // supplies the viewport's root isolation constraint itself.
+            for assignment in &assignments {
+                constraints.extend_from_slice(&assignment.record.effect_clip_constraints);
+            }
+        } else {
+            paint_order::for_each_in_paint_subtree(layout_arena, viewport, |slot| {
+                if let Some(&index) = assignment_index_by_slot.get(&slot) {
+                    constraints.extend_from_slice(&assignments[index].record.effect_clip_constraints);
+                } else if let Some(record) = layout_arena.paintable_visual_context_record(slot) {
+                    constraints.extend_from_slice(&record.effect_clip_constraints);
+                }
+            });
+        }
+        if tree.resolve_effect_output_clips(&constraints) {
+            delta.note_repurposed_in_place();
+        }
+    }
     if incremental_tree_requires_fresh_build(tree, &delta) {
         return IncrementalUpdateResult::NeedsFullBuild(VisualContextGlobalRebuildReason::InvalidIncrementalReferences);
     }
-    let scroll_state = rebuild_scroll_state_from_tree(layout_arena, tree, &tree_inputs, &mut delta);
-    delta.finish();
+    debug_assert!(tree.node_references_are_consistent());
+    let scroll_state = rebuild_scroll_state_from_tree(layout_arena, tree, &tree_inputs);
     tree.debug_assert_slot_accounting();
     if delta.structural_epoch_changed {
         tree.structural_epoch = allocate_structural_epoch();
@@ -619,11 +634,11 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
     state.scroll_state = scroll_state;
     state.scroll_state_snapshot.clear();
     state.needs_to_refresh_scroll_state = true;
-    IncrementalUpdateResult::Applied(IncrementalUpdateOutcome {
+    IncrementalUpdateResult::Applied(Box::new(IncrementalUpdateOutcome {
         delta,
         assignments,
         mask_node_owners_changed,
-    })
+    }))
 }
 
 #[cfg(debug_assertions)]
@@ -633,34 +648,32 @@ pub(crate) fn debug_assert_every_live_node_is_owned(
     viewport: NodeSlotId,
 ) {
     let mut spatial_is_owned = vec![false; tree.spatial_nodes.len()];
-    let mut frame_is_owned = vec![false; tree.frame_nodes.len()];
+    let mut clip_is_owned = vec![false; tree.clip_nodes.len()];
+    let mut effect_is_owned = vec![false; tree.effect_nodes.len()];
     spatial_is_owned[VISUAL_VIEWPORT_NODE_INDEX.0 as usize] = true;
     let viewport_scroll_node = layout_arena.paintable_data(viewport).own_scroll_node_index;
     if (viewport_scroll_node.0 as usize) < spatial_is_owned.len() {
         spatial_is_owned[viewport_scroll_node.0 as usize] = true;
     }
-    if let Some(root_isolation_frame) = tree.root_isolation_frame {
-        frame_is_owned[root_isolation_frame.0 as usize] = true;
+    if let Some(root_isolation_effect) = tree.root_isolation_effect {
+        effect_is_owned[root_isolation_effect.0 as usize] = true;
+    }
+    fn claim(owned: &mut [bool], index: u32, kind: &str) {
+        assert!(!owned[index as usize], "{kind} {index} is claimed twice");
+        owned[index as usize] = true;
     }
     paint_order::for_each_in_paint_subtree(layout_arena, viewport, |slot| {
         let Some(record) = layout_arena.paintable_visual_context_record(slot) else {
             return;
         };
         for index in &record.node_handles.spatial {
-            assert!(
-                !spatial_is_owned[index.0 as usize],
-                "spatial node {} is claimed twice",
-                index.0
-            );
-            spatial_is_owned[index.0 as usize] = true;
+            claim(&mut spatial_is_owned, index.0, "spatial node");
         }
-        for index in record.node_handles.frame_handles() {
-            assert!(
-                !frame_is_owned[index.0 as usize],
-                "frame node {} is claimed twice",
-                index.0
-            );
-            frame_is_owned[index.0 as usize] = true;
+        for index in record.node_handles.clip_handles() {
+            claim(&mut clip_is_owned, index.0, "clip node");
+        }
+        for index in &record.node_handles.effects {
+            claim(&mut effect_is_owned, index.0, "effect node");
         }
     });
     for (index, node) in tree.spatial_nodes.iter().enumerate() {
@@ -669,10 +682,16 @@ pub(crate) fn debug_assert_every_live_node_is_owned(
             "live spatial node {index} has no owner"
         );
     }
-    for (index, node) in tree.frame_nodes.iter().enumerate() {
+    for (index, node) in tree.clip_nodes.iter().enumerate() {
         assert!(
-            !node.data.is_live() || frame_is_owned[index],
-            "live frame node {index} has no owner"
+            !node.data.is_live() || clip_is_owned[index],
+            "live clip node {index} has no owner"
+        );
+    }
+    for (index, node) in tree.effect_nodes.iter().enumerate() {
+        assert!(
+            !node.data.is_live() || effect_is_owned[index],
+            "live effect node {index} has no owner"
         );
     }
 }
@@ -690,17 +709,16 @@ mod tests {
     use super::*;
     use libgfx_rust::{CompositingAndBlendingOperator, FloatMatrix4x4};
 
-    fn effects() -> FrameData {
-        FrameData::Effects(EffectsData {
+    fn effects() -> EffectNodeData {
+        EffectNodeData::Effects(EffectsData {
             opacity: 0.5,
             blend_mode: CompositingAndBlendingOperator::Normal,
             filter: None,
         })
     }
 
-    #[test]
-    fn a_tombstoned_parent_of_a_live_frame_requires_a_fresh_tree() {
-        let mut tree = VisualContextTree::create(TransformData {
+    fn tree() -> VisualContextTree {
+        VisualContextTree::create(TransformData {
             matrix: FloatMatrix4x4::identity(),
             origin: FloatPoint::default(),
             sorting_context_root_index: None,
@@ -708,41 +726,41 @@ mod tests {
             role: TransformDataRole::CssTransform,
             synthetic_plane: false,
             establishes_sorting_context: false,
-        });
-        let parent = tree.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
-        tree.append_frame(effects(), parent, VISUAL_VIEWPORT_NODE_INDEX);
+        })
+    }
+
+    #[test]
+    fn a_tombstoned_parent_of_a_live_effect_requires_a_fresh_tree() {
+        let mut tree = tree();
+        let parent = tree.append_effect(
+            effects(),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        tree.append_effect(effects(), parent, VISUAL_VIEWPORT_NODE_INDEX, ClipNodeIndex::NONE);
 
         let mut delta = VisualContextTreeDelta::default();
-        assert!(tree.tombstone_frame_slot(parent));
-        delta.note_tombstoned_frame(parent.0);
+        assert!(tree.tombstone_effect_slot(parent));
+        delta.note_tombstoned();
 
         assert!(incremental_tree_requires_fresh_build(&tree, &delta));
     }
-}
 
-fn remap_descendant_contexts(
-    placement: &super::reconcile::BoxNodePlacement,
-    contexts: DescendantVisualContexts,
-) -> DescendantVisualContexts {
-    let remap_scroll_nodes = |nodes: NearestScrollNodeIndices| NearestScrollNodeIndices {
-        stopping_at_fixed_position_ancestors: placement.remap_spatial(nodes.stopping_at_fixed_position_ancestors),
-        continuing_through_fixed_position_ancestors: placement
-            .remap_spatial(nodes.continuing_through_fixed_position_ancestors),
-    };
-    DescendantVisualContexts {
-        normal: placement.remap_context(contexts.normal),
-        absolute_position: placement.remap_context(contexts.absolute_position),
-        fixed_position: placement.remap_context(contexts.fixed_position),
-        normal_nearest_scroll_nodes: remap_scroll_nodes(contexts.normal_nearest_scroll_nodes),
-        absolute_position_nearest_scroll_nodes: remap_scroll_nodes(contexts.absolute_position_nearest_scroll_nodes),
-        fixed_position_nearest_scroll_nodes: remap_scroll_nodes(contexts.fixed_position_nearest_scroll_nodes),
-        normal_plane_root: placement.remap_spatial(contexts.normal_plane_root),
-        absolute_position_plane_root: placement.remap_spatial(contexts.absolute_position_plane_root),
-        fixed_position_plane_root: placement.remap_spatial(contexts.fixed_position_plane_root),
-        flattens_inherited_transform: contexts.flattens_inherited_transform,
-        sorting_context_root: contexts
-            .sorting_context_root
-            .map(|index| placement.remap_spatial(index)),
-        enclosing_stacking_context: contexts.enclosing_stacking_context,
+    #[test]
+    fn a_context_naming_a_tombstoned_clip_is_rejected() {
+        let mut tree = tree();
+        let clip = tree.append_clip(
+            ClipNodeData::rect_clip(FloatRect::new(0.0, 0.0, 1.0, 1.0)),
+            ClipNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let context = ContextRef {
+            clip,
+            ..ContextRef::default()
+        };
+        assert!(tree.context_is_valid(context));
+        assert!(tree.tombstone_clip_slot(clip));
+        assert!(!tree.context_is_valid(context));
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -32,7 +32,7 @@ use libgfx_rust::{
 use scroll_state::{NO_SCROLL_STATE_SLOT, ScrollStateSlot};
 
 pub use crate::painting::display_list::commands::{
-    ClipMode, ContextRef, FrameNodeIndex, SpatialNodeIndex, VISUAL_VIEWPORT_NODE_INDEX,
+    ClipMode, ClipNodeIndex, ContextRef, EffectNodeIndex, SpatialNodeIndex, VISUAL_VIEWPORT_NODE_INDEX,
 };
 pub use queries::{ClipBehavior, should_cull_back_face};
 
@@ -95,17 +95,19 @@ pub struct EffectsData {
     pub filter: Option<std::rc::Rc<Vec<u8>>>,
 }
 
-impl FrameData {
+impl EffectNodeData {
     pub fn layer_blending_with(blend_mode: CompositingAndBlendingOperator) -> Self {
-        FrameData::Effects(EffectsData {
+        EffectNodeData::Effects(EffectsData {
             opacity: 1.0,
             blend_mode,
             filter: None,
         })
     }
+}
 
+impl ClipNodeData {
     pub fn rect_clip(rect: FloatRect) -> Self {
-        FrameData::Clip(ClipData {
+        ClipNodeData::Rect(ClipData {
             rect,
             corner_radii: CornerRadii::default(),
             mode: ClipMode::Intersect,
@@ -244,13 +246,21 @@ pub enum SpatialData {
     Dead,
 }
 
+// The clip tree holds what narrows the painted region without a layer: rectangle (possibly rounded,
+// possibly subtractive) clips and clip paths. The effect tree holds what needs a layer or a
+// per-box marker: opacity/blend/filter layers, masks and compositor background-color animations.
 #[derive(Clone)]
-pub enum FrameData {
-    BackgroundColorAnimation,
-    Clip(ClipData),
-    ClipPath(ClipPathData),
+pub enum ClipNodeData {
+    Rect(ClipData),
+    Path(ClipPathData),
+    Dead,
+}
+
+#[derive(Clone)]
+pub enum EffectNodeData {
     Effects(EffectsData),
     Mask(MaskData),
+    BackgroundColorAnimation,
     Dead,
 }
 
@@ -264,21 +274,35 @@ impl SpatialData {
     }
 }
 
-impl FrameData {
+impl ClipNodeData {
     pub fn clips_everything(&self) -> bool {
         match self {
-            Self::Clip(clip) => clip.mode == ClipMode::Intersect && (clip.rect.width <= 0.0 || clip.rect.height <= 0.0),
-            Self::ClipPath(clip_path) => {
+            Self::Rect(clip) => clip.mode == ClipMode::Intersect && (clip.rect.width <= 0.0 || clip.rect.height <= 0.0),
+            Self::Path(clip_path) => {
                 let [_, _, width, height] = clip_path.path.bounding_box();
                 width <= 0.0 || height <= 0.0
             }
-            Self::BackgroundColorAnimation | Self::Effects(_) | Self::Dead => false,
-            Self::Mask(mask) => mask.rect.is_empty(),
+            Self::Dead => false,
         }
     }
 
     pub fn is_live(&self) -> bool {
         !matches!(self, Self::Dead)
+    }
+}
+
+impl EffectNodeData {
+    pub fn is_live(&self) -> bool {
+        !matches!(self, Self::Dead)
+    }
+
+    pub fn pushes_layer(&self) -> bool {
+        matches!(self, Self::Effects(_) | Self::Mask(_))
+    }
+
+    // An empty mask leaves nothing of the content it wraps.
+    pub fn culls_everything(&self) -> bool {
+        matches!(self, Self::Mask(mask) if mask.rect.is_empty())
     }
 }
 
@@ -289,15 +313,15 @@ pub struct SpatialNode {
 }
 
 #[derive(Clone)]
-pub struct FrameNode {
-    pub data: FrameData,
-    pub parent: FrameNodeIndex,
+pub struct ClipNode {
+    pub data: ClipNodeData,
+    pub parent: ClipNodeIndex,
     pub spatial: SpatialNodeIndex,
     pub clips_everything: bool,
 }
 
-impl FrameNode {
-    pub fn new(data: FrameData, parent: FrameNodeIndex, spatial: SpatialNodeIndex) -> Self {
+impl ClipNode {
+    pub fn new(data: ClipNodeData, parent: ClipNodeIndex, spatial: SpatialNodeIndex) -> Self {
         let clips_everything = data.clips_everything();
         Self {
             data,
@@ -305,6 +329,176 @@ impl FrameNode {
             spatial,
             clips_everything,
         }
+    }
+}
+
+// An effect's layer is pushed inside `output_clip`, the deepest clip shared by every context that
+// records under the effect; the clips below it are pushed inside the layer.
+#[derive(Clone)]
+pub struct EffectNode {
+    pub data: EffectNodeData,
+    pub parent: EffectNodeIndex,
+    pub spatial: SpatialNodeIndex,
+    // New effects have no resolved clip until finalization. Rebuilt effects retain their
+    // previous result so finalization can compare the old and new layer placement.
+    resolved_output_clip: Option<ClipNodeIndex>,
+}
+
+impl EffectNode {
+    pub fn new(
+        data: EffectNodeData,
+        parent: EffectNodeIndex,
+        spatial: SpatialNodeIndex,
+        resolved_output_clip: Option<ClipNodeIndex>,
+    ) -> Self {
+        Self {
+            data,
+            parent,
+            spatial,
+            resolved_output_clip,
+        }
+    }
+
+    pub fn output_clip(&self) -> ClipNodeIndex {
+        self.resolved_output_clip
+            .expect("an effect's output clip is resolved before use")
+    }
+}
+
+// The slot lifecycle every node kind shares: a slot is allocated from the free list or by growing
+// the array, retired into quarantine until the recording that may still name it completes, and
+// released to the free list afterwards.
+pub trait SlotNode: Sized {
+    type Index: Copy + PartialEq + std::fmt::Debug;
+    fn index(raw: u32) -> Self::Index;
+    fn raw(index: Self::Index) -> u32;
+    fn is_live(&self) -> bool;
+    fn dead() -> Self;
+    fn tombstone(&mut self);
+}
+
+#[derive(Clone)]
+struct SlotAccounting<Index> {
+    live_count: u32,
+    free: Vec<Index>,
+    quarantined: Vec<Index>,
+}
+
+impl<Index> Default for SlotAccounting<Index> {
+    fn default() -> Self {
+        Self {
+            live_count: 0,
+            free: Vec::new(),
+            quarantined: Vec::new(),
+        }
+    }
+}
+
+impl<Index: Copy> SlotAccounting<Index> {
+    fn release_quarantined(&mut self) {
+        self.free.append(&mut self.quarantined);
+    }
+}
+
+fn allocate_slot<N: SlotNode>(nodes: &mut Vec<N>, accounting: &mut SlotAccounting<N::Index>) -> (N::Index, bool) {
+    if let Some(index) = accounting.free.pop() {
+        debug_assert!(!nodes[N::raw(index) as usize].is_live());
+        return (index, true);
+    }
+    nodes.push(N::dead());
+    (N::index((nodes.len() - 1) as u32), false)
+}
+
+fn tombstone_slot<N: SlotNode>(nodes: &mut [N], accounting: &mut SlotAccounting<N::Index>, index: N::Index) -> bool {
+    let node = &mut nodes[N::raw(index) as usize];
+    if !node.is_live() {
+        return false;
+    }
+    node.tombstone();
+    accounting.live_count -= 1;
+    accounting.quarantined.push(index);
+    true
+}
+
+fn replace_slot<N: SlotNode>(
+    nodes: &mut [N],
+    accounting: &mut SlotAccounting<N::Index>,
+    index: N::Index,
+    node: N,
+) -> bool {
+    debug_assert!(node.is_live(), "slots are retired by tombstoning");
+    let slot = &mut nodes[N::raw(index) as usize];
+    let was_live = slot.is_live();
+    *slot = node;
+    if !was_live {
+        accounting.live_count += 1;
+    }
+    was_live
+}
+
+impl SlotNode for SpatialNode {
+    type Index = SpatialNodeIndex;
+    fn index(raw: u32) -> SpatialNodeIndex {
+        SpatialNodeIndex(raw)
+    }
+    fn raw(index: SpatialNodeIndex) -> u32 {
+        index.0
+    }
+    fn is_live(&self) -> bool {
+        self.data.is_live()
+    }
+    fn dead() -> Self {
+        Self {
+            data: SpatialData::Dead,
+            parent: VISUAL_VIEWPORT_NODE_INDEX,
+        }
+    }
+    fn tombstone(&mut self) {
+        self.data = SpatialData::Dead;
+    }
+}
+
+impl SlotNode for ClipNode {
+    type Index = ClipNodeIndex;
+    fn index(raw: u32) -> ClipNodeIndex {
+        ClipNodeIndex(raw)
+    }
+    fn raw(index: ClipNodeIndex) -> u32 {
+        index.0
+    }
+    fn is_live(&self) -> bool {
+        self.data.is_live()
+    }
+    fn dead() -> Self {
+        Self::new(ClipNodeData::Dead, ClipNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX)
+    }
+    fn tombstone(&mut self) {
+        self.data = ClipNodeData::Dead;
+        self.clips_everything = false;
+    }
+}
+
+impl SlotNode for EffectNode {
+    type Index = EffectNodeIndex;
+    fn index(raw: u32) -> EffectNodeIndex {
+        EffectNodeIndex(raw)
+    }
+    fn raw(index: EffectNodeIndex) -> u32 {
+        index.0
+    }
+    fn is_live(&self) -> bool {
+        self.data.is_live()
+    }
+    fn dead() -> Self {
+        Self::new(
+            EffectNodeData::Dead,
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            Some(ClipNodeIndex::NONE),
+        )
+    }
+    fn tombstone(&mut self) {
+        self.data = EffectNodeData::Dead;
     }
 }
 
@@ -485,16 +679,16 @@ impl VisualContextState {
 #[derive(Clone)]
 pub struct VisualContextTree {
     pub spatial_nodes: Vec<SpatialNode>,
-    pub frame_nodes: Vec<FrameNode>,
+    pub clip_nodes: Vec<ClipNode>,
+    pub effect_nodes: Vec<EffectNode>,
     pub root_is_visual_viewport: bool,
-    pub root_isolation_frame: Option<FrameNodeIndex>,
+    // The layer at the root of the effect tree that 3D plane clips are pushed right above.
+    pub root_isolation_effect: Option<EffectNodeIndex>,
     pub structural_epoch: u64,
-    pub live_spatial_node_count: u32,
-    pub live_frame_node_count: u32,
-    free_spatial_slots: Vec<SpatialNodeIndex>,
-    free_frame_slots: Vec<FrameNodeIndex>,
-    quarantined_spatial_slots: Vec<SpatialNodeIndex>,
-    quarantined_frame_slots: Vec<FrameNodeIndex>,
+    spatial_slots: SlotAccounting<SpatialNodeIndex>,
+    clip_slots: SlotAccounting<ClipNodeIndex>,
+    effect_slots: SlotAccounting<EffectNodeIndex>,
+    // Keyed by effect node index.
     sampled_background_colors: HashMap<u32, libgfx_rust::Color>,
 }
 
@@ -625,16 +819,46 @@ impl VisualContextTree {
                 data: SpatialData::Transform(root_transform),
                 parent: VISUAL_VIEWPORT_NODE_INDEX,
             }],
-            frame_nodes: Vec::new(),
+            clip_nodes: Vec::new(),
+            effect_nodes: Vec::new(),
             root_is_visual_viewport,
-            root_isolation_frame: None,
+            root_isolation_effect: None,
             structural_epoch: allocate_structural_epoch(),
-            live_spatial_node_count: 1,
-            live_frame_node_count: 0,
-            free_spatial_slots: Vec::new(),
-            free_frame_slots: Vec::new(),
-            quarantined_spatial_slots: Vec::new(),
-            quarantined_frame_slots: Vec::new(),
+            spatial_slots: SlotAccounting {
+                live_count: 1,
+                ..SlotAccounting::default()
+            },
+            clip_slots: SlotAccounting::default(),
+            effect_slots: SlotAccounting::default(),
+            sampled_background_colors: HashMap::new(),
+        }
+    }
+
+    // A tree over decoded arrays: no slot is free or quarantined, the live counts are recounted.
+    pub(crate) fn from_nodes(
+        spatial_nodes: Vec<SpatialNode>,
+        clip_nodes: Vec<ClipNode>,
+        effect_nodes: Vec<EffectNode>,
+        root_is_visual_viewport: bool,
+        root_isolation_effect: Option<EffectNodeIndex>,
+        structural_epoch: u64,
+    ) -> Self {
+        fn accounting<N: SlotNode>(nodes: &[N]) -> SlotAccounting<N::Index> {
+            SlotAccounting {
+                live_count: nodes.iter().filter(|node| node.is_live()).count() as u32,
+                ..SlotAccounting::default()
+            }
+        }
+        Self {
+            spatial_slots: accounting(&spatial_nodes),
+            clip_slots: accounting(&clip_nodes),
+            effect_slots: accounting(&effect_nodes),
+            spatial_nodes,
+            clip_nodes,
+            effect_nodes,
+            root_is_visual_viewport,
+            root_isolation_effect,
+            structural_epoch,
             sampled_background_colors: HashMap::new(),
         }
     }
@@ -645,46 +869,65 @@ impl VisualContextTree {
             .is_some_and(|node| node.data.is_live())
     }
 
-    pub fn frame_is_live(&self, index: FrameNodeIndex) -> bool {
-        self.frame_nodes
+    pub fn clip_is_live(&self, index: ClipNodeIndex) -> bool {
+        self.clip_nodes
             .get(index.0 as usize)
             .is_some_and(|node| node.data.is_live())
     }
 
+    pub fn effect_is_live(&self, index: EffectNodeIndex) -> bool {
+        self.effect_nodes
+            .get(index.0 as usize)
+            .is_some_and(|node| node.data.is_live())
+    }
+
+    // The absent node passes for live where a reference may be absent.
+    pub fn clip_is_none_or_live(&self, index: ClipNodeIndex) -> bool {
+        index.is_none() || self.clip_is_live(index)
+    }
+
+    pub fn effect_is_none_or_live(&self, index: EffectNodeIndex) -> bool {
+        index.is_none() || self.effect_is_live(index)
+    }
+
+    pub fn live_spatial_node_count(&self) -> u32 {
+        self.spatial_slots.live_count
+    }
+
+    pub fn live_clip_node_count(&self) -> u32 {
+        self.clip_slots.live_count
+    }
+
+    pub fn live_effect_node_count(&self) -> u32 {
+        self.effect_slots.live_count
+    }
+
+    pub fn live_node_count(&self) -> usize {
+        (self.spatial_slots.live_count + self.clip_slots.live_count + self.effect_slots.live_count) as usize
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.spatial_nodes.len() + self.clip_nodes.len() + self.effect_nodes.len()
+    }
+
     pub fn dead_node_count(&self) -> usize {
-        self.spatial_nodes.len() + self.frame_nodes.len()
-            - self.live_spatial_node_count as usize
-            - self.live_frame_node_count as usize
+        self.node_count() - self.live_node_count()
     }
 
     pub fn should_compact(&self) -> bool {
-        let live = self.live_spatial_node_count as usize + self.live_frame_node_count as usize;
-        self.dead_node_count() > live.max(COMPACTION_DEAD_NODE_THRESHOLD)
+        self.dead_node_count() > self.live_node_count().max(COMPACTION_DEAD_NODE_THRESHOLD)
     }
 
     pub fn allocate_spatial_slot(&mut self) -> (SpatialNodeIndex, bool) {
-        if let Some(index) = self.free_spatial_slots.pop() {
-            debug_assert!(!self.spatial_nodes[index.0 as usize].data.is_live());
-            return (index, true);
-        }
-        self.spatial_nodes.push(SpatialNode {
-            data: SpatialData::Dead,
-            parent: VISUAL_VIEWPORT_NODE_INDEX,
-        });
-        (SpatialNodeIndex((self.spatial_nodes.len() - 1) as u32), false)
+        allocate_slot(&mut self.spatial_nodes, &mut self.spatial_slots)
     }
 
-    pub fn allocate_frame_slot(&mut self) -> (FrameNodeIndex, bool) {
-        if let Some(index) = self.free_frame_slots.pop() {
-            debug_assert!(!self.frame_nodes[index.0 as usize].data.is_live());
-            return (index, true);
-        }
-        self.frame_nodes.push(FrameNode::new(
-            FrameData::Dead,
-            FrameNodeIndex::NONE,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        ));
-        (FrameNodeIndex((self.frame_nodes.len() - 1) as u32), false)
+    pub fn allocate_clip_slot(&mut self) -> (ClipNodeIndex, bool) {
+        allocate_slot(&mut self.clip_nodes, &mut self.clip_slots)
+    }
+
+    pub fn allocate_effect_slot(&mut self) -> (EffectNodeIndex, bool) {
+        allocate_slot(&mut self.effect_nodes, &mut self.effect_slots)
     }
 
     pub fn tombstone_spatial_slot(&mut self, index: SpatialNodeIndex) -> bool {
@@ -692,67 +935,47 @@ impl VisualContextTree {
             index, VISUAL_VIEWPORT_NODE_INDEX,
             "the visual viewport node is never tombstoned"
         );
-        let node = &mut self.spatial_nodes[index.0 as usize];
-        if !node.data.is_live() {
-            return false;
-        }
-        node.data = SpatialData::Dead;
-        self.live_spatial_node_count -= 1;
-        self.quarantined_spatial_slots.push(index);
-        true
+        tombstone_slot(&mut self.spatial_nodes, &mut self.spatial_slots, index)
     }
 
-    pub fn tombstone_frame_slot(&mut self, index: FrameNodeIndex) -> bool {
+    pub fn tombstone_clip_slot(&mut self, index: ClipNodeIndex) -> bool {
+        tombstone_slot(&mut self.clip_nodes, &mut self.clip_slots, index)
+    }
+
+    pub fn tombstone_effect_slot(&mut self, index: EffectNodeIndex) -> bool {
         assert_ne!(
             Some(index),
-            self.root_isolation_frame,
-            "the root isolation frame is never tombstoned"
+            self.root_isolation_effect,
+            "the root isolation effect is never tombstoned"
         );
-        let node = &mut self.frame_nodes[index.0 as usize];
-        if !node.data.is_live() {
-            return false;
-        }
-        node.data = FrameData::Dead;
-        node.clips_everything = false;
-        self.live_frame_node_count -= 1;
-        self.quarantined_frame_slots.push(index);
-        true
+        tombstone_slot(&mut self.effect_nodes, &mut self.effect_slots, index)
     }
 
     pub fn replace_spatial_node(&mut self, index: SpatialNodeIndex, node: SpatialNode) -> bool {
-        debug_assert!(node.data.is_live(), "slots are retired through tombstone_spatial_slot");
-        let slot = &mut self.spatial_nodes[index.0 as usize];
-        let was_live = slot.data.is_live();
-        *slot = node;
-        if !was_live {
-            self.live_spatial_node_count += 1;
-        }
-        was_live
+        replace_slot(&mut self.spatial_nodes, &mut self.spatial_slots, index, node)
     }
 
-    pub fn replace_frame_node(&mut self, index: FrameNodeIndex, node: FrameNode) -> bool {
-        debug_assert!(node.data.is_live(), "slots are retired through tombstone_frame_slot");
-        let slot = &mut self.frame_nodes[index.0 as usize];
-        let was_live = slot.data.is_live();
-        *slot = node;
-        if !was_live {
-            self.live_frame_node_count += 1;
-        }
-        was_live
+    pub fn replace_clip_node(&mut self, index: ClipNodeIndex, node: ClipNode) -> bool {
+        replace_slot(&mut self.clip_nodes, &mut self.clip_slots, index, node)
+    }
+
+    pub fn replace_effect_node(&mut self, index: EffectNodeIndex, node: EffectNode) -> bool {
+        replace_slot(&mut self.effect_nodes, &mut self.effect_slots, index, node)
     }
 
     pub fn release_quarantined_slots_after_recording(&mut self) {
-        self.free_spatial_slots.append(&mut self.quarantined_spatial_slots);
-        self.free_frame_slots.append(&mut self.quarantined_frame_slots);
+        self.spatial_slots.release_quarantined();
+        self.clip_slots.release_quarantined();
+        self.effect_slots.release_quarantined();
         self.debug_assert_slot_accounting();
     }
 
     pub fn free_slot_count(&self) -> usize {
-        self.free_spatial_slots.len() + self.free_frame_slots.len()
+        self.spatial_slots.free.len() + self.clip_slots.free.len() + self.effect_slots.free.len()
     }
 
     pub fn quarantined_slot_count(&self) -> usize {
-        self.quarantined_spatial_slots.len() + self.quarantined_frame_slots.len()
+        self.spatial_slots.quarantined.len() + self.clip_slots.quarantined.len() + self.effect_slots.quarantined.len()
     }
 
     pub(crate) fn debug_assert_slot_accounting(&self) {
@@ -770,7 +993,7 @@ impl VisualContextTree {
         );
         assert!(data.is_live(), "appended spatial nodes are live");
         self.spatial_nodes.push(SpatialNode { data, parent });
-        self.live_spatial_node_count += 1;
+        self.spatial_slots.live_count += 1;
         SpatialNodeIndex((self.spatial_nodes.len() - 1) as u32)
     }
 
@@ -781,35 +1004,130 @@ impl VisualContextTree {
         }
     }
 
-    pub fn append_frame_under(&mut self, context: ContextRef, data: FrameData) -> ContextRef {
-        ContextRef {
-            frame: self.append_frame(data, context.frame, context.spatial),
-            ..context
-        }
-    }
-
-    pub fn append_frame(
+    pub fn append_clip(
         &mut self,
-        data: FrameData,
-        parent: FrameNodeIndex,
+        data: ClipNodeData,
+        parent: ClipNodeIndex,
         spatial: SpatialNodeIndex,
-    ) -> FrameNodeIndex {
+    ) -> ClipNodeIndex {
         assert!(
             self.spatial_is_live(spatial),
-            "a frame node's spatial node must be a live node"
+            "a clip node's spatial node must be a live node"
         );
-        assert!(data.is_live(), "appended frame nodes are live");
+        assert!(data.is_live(), "appended clip nodes are live");
         if !parent.is_none() {
-            assert!(self.frame_is_live(parent), "a frame node's parent must be a live node");
-            let parent_node = &self.frame_nodes[parent.0 as usize];
+            assert!(self.clip_is_live(parent), "a clip node's parent must be a live node");
+            let parent_node = &self.clip_nodes[parent.0 as usize];
             debug_assert!(self.spatial_is_ancestor_or_self(parent_node.spatial, spatial));
         }
-        self.frame_nodes.push(FrameNode::new(data, parent, spatial));
-        self.live_frame_node_count += 1;
-        FrameNodeIndex((self.frame_nodes.len() - 1) as u32)
+        self.clip_nodes.push(ClipNode::new(data, parent, spatial));
+        self.clip_slots.live_count += 1;
+        ClipNodeIndex((self.clip_nodes.len() - 1) as u32)
     }
 
-    fn spatial_is_ancestor_or_self(&self, ancestor: SpatialNodeIndex, mut node: SpatialNodeIndex) -> bool {
+    pub fn append_effect(
+        &mut self,
+        data: EffectNodeData,
+        parent: EffectNodeIndex,
+        spatial: SpatialNodeIndex,
+        output_clip: ClipNodeIndex,
+    ) -> EffectNodeIndex {
+        assert!(
+            self.spatial_is_live(spatial),
+            "an effect node's spatial node must be a live node"
+        );
+        assert!(data.is_live(), "appended effect nodes are live");
+        assert!(
+            self.clip_is_none_or_live(output_clip),
+            "an effect node's output clip must be a live node"
+        );
+        if !parent.is_none() {
+            assert!(
+                self.effect_is_live(parent),
+                "an effect node's parent must be a live node"
+            );
+        }
+        self.effect_nodes
+            .push(EffectNode::new(data, parent, spatial, Some(output_clip)));
+        self.effect_slots.live_count += 1;
+        EffectNodeIndex((self.effect_nodes.len() - 1) as u32)
+    }
+
+    pub fn clip_is_ancestor_or_self(&self, ancestor: ClipNodeIndex, node: ClipNodeIndex) -> bool {
+        VisualContextNodeSink::clip_is_ancestor_or_self(self, ancestor, node)
+    }
+
+    // An effect only this chain records under already has its final output clip.
+    pub fn append_effect_node_under(&mut self, context: ContextRef, data: EffectNodeData) -> ContextRef {
+        let effect = self.append_effect(data, context.effect, context.spatial, context.clip);
+        ContextRef { effect, ..context }
+    }
+
+    // Resolve layer placement from the clips where effects begin and from positioned
+    // descendants that escape clips. These constraints belong to the boxes that build them;
+    // they have no identity or lifetime in the published tree. Report changes to previously
+    // resolved clips; resolving a newly allocated effect does not invalidate existing handles.
+    pub fn resolve_effect_output_clips(&mut self, constraints: &[EffectClipConstraint]) -> bool {
+        let clip_depths = self.clip_depths();
+        let depth_of = |index: ClipNodeIndex| {
+            if index.is_none() {
+                0
+            } else {
+                clip_depths[index.0 as usize]
+            }
+        };
+        let parent_of = |index: ClipNodeIndex| self.clip_nodes[index.0 as usize].parent;
+        let mut shared: Vec<Option<ClipNodeIndex>> = vec![None; self.effect_nodes.len()];
+        let narrow = |shared: &mut Option<ClipNodeIndex>, clip: ClipNodeIndex| {
+            *shared = Some(match *shared {
+                Some(current) => clip_lowest_common_ancestor_with_depths(parent_of, depth_of, current, clip),
+                None => clip,
+            });
+        };
+        if let Some(effect) = self.root_isolation_effect {
+            narrow(&mut shared[effect.0 as usize], ClipNodeIndex::NONE);
+        }
+        for constraint in constraints {
+            if !constraint.effect.is_none() {
+                narrow(&mut shared[constraint.effect.0 as usize], constraint.clip);
+            }
+        }
+        // Parents come first in the dependency order, so walking it backwards folds every
+        // effect's clip into its parent's before the parent is read.
+        for &index in self.effect_dependency_order().iter().rev() {
+            let parent = self.effect_nodes[index as usize].parent;
+            if parent.is_none() {
+                continue;
+            }
+            if let Some(clip) = shared[index as usize] {
+                narrow(&mut shared[parent.0 as usize], clip);
+            }
+        }
+        let mut changed = false;
+        for (node, shared) in self.effect_nodes.iter_mut().zip(&shared) {
+            if let Some(clip) = *shared {
+                changed |= node.resolved_output_clip.is_some_and(|previous| previous != clip);
+                node.resolved_output_clip = Some(clip);
+            }
+        }
+        changed
+    }
+
+    // Root path lengths of the clip nodes; the absent clip has depth 0.
+    pub fn clip_depths(&self) -> Vec<u32> {
+        let mut depths = vec![0; self.clip_nodes.len()];
+        for index in self.clip_dependency_order() {
+            let parent = self.clip_nodes[index as usize].parent;
+            depths[index as usize] = if parent.is_none() {
+                1
+            } else {
+                depths[parent.0 as usize] + 1
+            };
+        }
+        depths
+    }
+
+    pub fn spatial_is_ancestor_or_self(&self, ancestor: SpatialNodeIndex, mut node: SpatialNodeIndex) -> bool {
         loop {
             if node == ancestor {
                 return true;
@@ -952,12 +1270,26 @@ impl VisualContextTree {
         )
     }
 
-    pub(crate) fn frame_dependency_order_with_back_edges(&self) -> NodeDependencyOrder {
+    pub(crate) fn clip_dependency_order_with_back_edges(&self) -> NodeDependencyOrder {
         dependency_order(
-            self.frame_nodes.len(),
-            |index| self.frame_nodes[index].data.is_live(),
+            self.clip_nodes.len(),
+            |index| self.clip_nodes[index].data.is_live(),
             |index, references| {
-                let parent = self.frame_nodes[index].parent;
+                let parent = self.clip_nodes[index].parent;
+                if !parent.is_none() {
+                    references.push(parent.0 as usize);
+                }
+            },
+        )
+    }
+
+    // Output clips live in the clip tree, so they are validated separately rather than ordered here.
+    pub(crate) fn effect_dependency_order_with_back_edges(&self) -> NodeDependencyOrder {
+        dependency_order(
+            self.effect_nodes.len(),
+            |index| self.effect_nodes[index].data.is_live(),
+            |index, references| {
+                let parent = self.effect_nodes[index].parent;
                 if !parent.is_none() {
                     references.push(parent.0 as usize);
                 }
@@ -976,11 +1308,22 @@ impl VisualContextTree {
         dependency_order.order
     }
 
-    pub fn frame_dependency_order(&self) -> Vec<u32> {
-        let dependency_order = self.frame_dependency_order_with_back_edges();
+    pub fn clip_dependency_order(&self) -> Vec<u32> {
+        let dependency_order = self.clip_dependency_order_with_back_edges();
         debug_assert!(
             dependency_order.back_edges.is_empty() && dependency_order.dangling_references.is_empty(),
-            "frame node parents form a cycle or dangle: {:?} {:?}",
+            "clip node parents form a cycle or dangle: {:?} {:?}",
+            dependency_order.back_edges,
+            dependency_order.dangling_references
+        );
+        dependency_order.order
+    }
+
+    pub fn effect_dependency_order(&self) -> Vec<u32> {
+        let dependency_order = self.effect_dependency_order_with_back_edges();
+        debug_assert!(
+            dependency_order.back_edges.is_empty() && dependency_order.dangling_references.is_empty(),
+            "effect node parents form a cycle or dangle: {:?} {:?}",
             dependency_order.back_edges,
             dependency_order.dangling_references
         );
@@ -1015,17 +1358,60 @@ impl VisualContextTree {
     }
 }
 
+pub fn clip_is_ancestor_or_self(
+    parent_of: impl Fn(ClipNodeIndex) -> ClipNodeIndex,
+    ancestor: ClipNodeIndex,
+    mut node: ClipNodeIndex,
+) -> bool {
+    loop {
+        if node == ancestor {
+            return true;
+        }
+        if node.is_none() {
+            return false;
+        }
+        node = parent_of(node);
+    }
+}
+
+// The deepest clip on both root paths; the absent clip when the paths only share the root. The
+// deeper node climbs first, then both climb together.
+pub fn clip_lowest_common_ancestor_with_depths(
+    parent_of: impl Fn(ClipNodeIndex) -> ClipNodeIndex,
+    depth_of: impl Fn(ClipNodeIndex) -> u32,
+    mut a: ClipNodeIndex,
+    mut b: ClipNodeIndex,
+) -> ClipNodeIndex {
+    if a == b {
+        return a;
+    }
+    let mut a_depth = depth_of(a);
+    let mut b_depth = depth_of(b);
+    while a_depth > b_depth {
+        a = parent_of(a);
+        a_depth -= 1;
+    }
+    while b_depth > a_depth {
+        b = parent_of(b);
+        b_depth -= 1;
+    }
+    while a != b {
+        a = parent_of(a);
+        b = parent_of(b);
+    }
+    a
+}
+
 pub trait VisualContextNodeSink {
     fn append_spatial_node(&mut self, data: SpatialData, parent: SpatialNodeIndex) -> SpatialNodeIndex;
-    fn append_frame_node(
+    fn append_clip_node(
         &mut self,
-        data: FrameData,
-        parent: FrameNodeIndex,
+        data: ClipNodeData,
+        parent: ClipNodeIndex,
         spatial: SpatialNodeIndex,
-    ) -> FrameNodeIndex;
+    ) -> ClipNodeIndex;
     fn spatial_node_at(&self, index: SpatialNodeIndex) -> &SpatialNode;
-    fn next_spatial_node_index(&self) -> SpatialNodeIndex;
-    fn next_frame_node_index(&self) -> FrameNodeIndex;
+    fn clip_node_at(&self, index: ClipNodeIndex) -> &ClipNode;
 
     fn append_spatial_node_under(&mut self, context: ContextRef, data: SpatialData) -> ContextRef {
         ContextRef {
@@ -1034,11 +1420,13 @@ pub trait VisualContextNodeSink {
         }
     }
 
-    fn append_frame_node_under(&mut self, context: ContextRef, data: FrameData) -> ContextRef {
-        ContextRef {
-            frame: self.append_frame_node(data, context.frame, context.spatial),
-            ..context
-        }
+    fn append_clip_node_under(&mut self, context: ContextRef, data: ClipNodeData) -> ContextRef {
+        let clip = self.append_clip_node(data, context.clip, context.spatial);
+        ContextRef { clip, ..context }
+    }
+
+    fn clip_is_ancestor_or_self(&self, ancestor: ClipNodeIndex, node: ClipNodeIndex) -> bool {
+        clip_is_ancestor_or_self(|index| self.clip_node_at(index).parent, ancestor, node)
     }
 }
 
@@ -1047,48 +1435,44 @@ impl VisualContextNodeSink for VisualContextTree {
         self.append_spatial(data, parent)
     }
 
-    fn append_frame_node(
+    fn append_clip_node(
         &mut self,
-        data: FrameData,
-        parent: FrameNodeIndex,
+        data: ClipNodeData,
+        parent: ClipNodeIndex,
         spatial: SpatialNodeIndex,
-    ) -> FrameNodeIndex {
-        self.append_frame(data, parent, spatial)
+    ) -> ClipNodeIndex {
+        self.append_clip(data, parent, spatial)
     }
 
     fn spatial_node_at(&self, index: SpatialNodeIndex) -> &SpatialNode {
         &self.spatial_nodes[index.0 as usize]
     }
 
-    fn next_spatial_node_index(&self) -> SpatialNodeIndex {
-        SpatialNodeIndex(self.spatial_nodes.len() as u32)
-    }
-
-    fn next_frame_node_index(&self) -> FrameNodeIndex {
-        FrameNodeIndex(self.frame_nodes.len() as u32)
+    fn clip_node_at(&self, index: ClipNodeIndex) -> &ClipNode {
+        &self.clip_nodes[index.0 as usize]
     }
 }
 
+// The nodes a box appended, by kind. The chain units end at the box's own accumulated
+// context; the descendant units hold what only descendants record under (the overflow clip).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BoxVisualContextNodeHandles {
     pub spatial: Vec<SpatialNodeIndex>,
-    pub chain_frames: Vec<FrameNodeIndex>,
-    pub descendant_frames: Vec<FrameNodeIndex>,
+    pub chain_clips: Vec<ClipNodeIndex>,
+    pub descendant_clips: Vec<ClipNodeIndex>,
+    pub effects: Vec<EffectNodeIndex>,
 }
 
 pub static EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES: BoxVisualContextNodeHandles = BoxVisualContextNodeHandles {
     spatial: Vec::new(),
-    chain_frames: Vec::new(),
-    descendant_frames: Vec::new(),
+    chain_clips: Vec::new(),
+    descendant_clips: Vec::new(),
+    effects: Vec::new(),
 };
 
 impl BoxVisualContextNodeHandles {
-    pub fn frame_handles(&self) -> impl Iterator<Item = FrameNodeIndex> + '_ {
-        self.chain_frames.iter().chain(&self.descendant_frames).copied()
-    }
-
-    pub fn contains_frame(&self, frame: FrameNodeIndex) -> bool {
-        self.frame_handles().any(|handle| handle == frame)
+    pub fn clip_handles(&self) -> impl Iterator<Item = ClipNodeIndex> + '_ {
+        self.chain_clips.iter().chain(&self.descendant_clips).copied()
     }
 }
 
@@ -1102,17 +1486,37 @@ pub(crate) struct NearestScrollNodeIndices {
     pub continuing_through_fixed_position_ancestors: SpatialNodeIndex,
 }
 
+// One positioning chain; effects are shared by all three chains.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PositioningContext {
+    pub spatial: SpatialNodeIndex,
+    pub clip: ClipNodeIndex,
+    pub nearest_scroll_nodes: NearestScrollNodeIndices,
+    pub plane_root: SpatialNodeIndex,
+}
+
+impl PositioningContext {
+    pub fn with_effect(self, effect: EffectNodeIndex) -> ContextRef {
+        ContextRef {
+            spatial: self.spatial,
+            clip: self.clip,
+            effect,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EffectClipConstraint {
+    pub effect: EffectNodeIndex,
+    pub clip: ClipNodeIndex,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct DescendantVisualContexts {
-    pub normal: ContextRef,
-    pub absolute_position: ContextRef,
-    pub fixed_position: ContextRef,
-    pub normal_nearest_scroll_nodes: NearestScrollNodeIndices,
-    pub absolute_position_nearest_scroll_nodes: NearestScrollNodeIndices,
-    pub fixed_position_nearest_scroll_nodes: NearestScrollNodeIndices,
-    pub normal_plane_root: SpatialNodeIndex,
-    pub absolute_position_plane_root: SpatialNodeIndex,
-    pub fixed_position_plane_root: SpatialNodeIndex,
+    pub effect: EffectNodeIndex,
+    pub normal: PositioningContext,
+    pub absolute_position: PositioningContext,
+    pub fixed_position: PositioningContext,
     pub flattens_inherited_transform: bool,
     pub sorting_context_root: Option<SpatialNodeIndex>,
     pub enclosing_stacking_context: NodeSlotId,
@@ -1123,6 +1527,7 @@ pub(crate) struct PaintableVisualContextRecord {
     pub inherited_input: DescendantVisualContexts,
     pub output_for_descendants: DescendantVisualContexts,
     pub node_handles: BoxVisualContextNodeHandles,
+    pub effect_clip_constraints: Vec<EffectClipConstraint>,
     pub has_mask_nodes: bool,
     pub may_be_root_element: bool,
     pub owns_geometry_dependent_nodes: bool,
@@ -1155,16 +1560,16 @@ mod tests {
         VisualContextTree::create(transform(0.0))
     }
 
-    fn effects() -> FrameData {
-        FrameData::Effects(EffectsData {
+    fn effects() -> EffectNodeData {
+        EffectNodeData::Effects(EffectsData {
             opacity: 1.0,
             blend_mode: CompositingAndBlendingOperator::Normal,
             filter: None,
         })
     }
 
-    fn clip(rect: FloatRect, mode: ClipMode) -> FrameData {
-        FrameData::Clip(ClipData {
+    fn clip(rect: FloatRect, mode: ClipMode) -> ClipNodeData {
+        ClipNodeData::Rect(ClipData {
             rect,
             corner_radii: CornerRadii::default(),
             mode,
@@ -1296,16 +1701,78 @@ mod tests {
     }
 
     #[test]
-    fn frame_dependency_order_follows_parents_only() {
+    fn clip_and_effect_dependency_orders_follow_parents_only() {
         let mut tree = tree();
-        let root_isolation_frame = tree.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
-        let child = tree.append_frame(effects(), root_isolation_frame, VISUAL_VIEWPORT_NODE_INDEX);
-        let parent = tree.append_frame(effects(), root_isolation_frame, VISUAL_VIEWPORT_NODE_INDEX);
-        tree.frame_nodes[child.0 as usize].parent = parent;
-        assert_eq!(
-            tree.frame_dependency_order(),
-            vec![root_isolation_frame.0, parent.0, child.0]
+        let root_effect = tree.append_effect(
+            effects(),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
         );
+        let child = tree.append_effect(effects(), root_effect, VISUAL_VIEWPORT_NODE_INDEX, ClipNodeIndex::NONE);
+        let parent = tree.append_effect(effects(), root_effect, VISUAL_VIEWPORT_NODE_INDEX, ClipNodeIndex::NONE);
+        tree.effect_nodes[child.0 as usize].parent = parent;
+        assert_eq!(tree.effect_dependency_order(), vec![root_effect.0, parent.0, child.0]);
+
+        let outer = tree.append_clip(
+            clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect),
+            ClipNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let inner_child = tree.append_clip(
+            clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect),
+            outer,
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let inner = tree.append_clip(
+            clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect),
+            outer,
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        tree.clip_nodes[inner_child.0 as usize].parent = inner;
+        assert_eq!(tree.clip_dependency_order(), vec![outer.0, inner.0, inner_child.0]);
+    }
+
+    #[test]
+    fn the_lowest_common_clip_ancestor_is_the_deepest_shared_clip() {
+        let mut tree = tree();
+        let rect = || clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect);
+        let root = tree.append_clip(rect(), ClipNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        let left = tree.append_clip(rect(), root, VISUAL_VIEWPORT_NODE_INDEX);
+        let left_leaf = tree.append_clip(rect(), left, VISUAL_VIEWPORT_NODE_INDEX);
+        let right = tree.append_clip(rect(), root, VISUAL_VIEWPORT_NODE_INDEX);
+        let other_root = tree.append_clip(rect(), ClipNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        let depths = tree.clip_depths();
+        let common_ancestor = |a, b| {
+            clip_lowest_common_ancestor_with_depths(
+                |index| tree.clip_nodes[index.0 as usize].parent,
+                |index| if index.is_none() { 0 } else { depths[index.0 as usize] },
+                a,
+                b,
+            )
+        };
+        assert_eq!(common_ancestor(left_leaf, right), root);
+        assert_eq!(common_ancestor(left_leaf, left), left);
+        assert_eq!(common_ancestor(left, left_leaf), left);
+        assert_eq!(common_ancestor(left_leaf, left_leaf), left_leaf);
+        assert_eq!(common_ancestor(left_leaf, other_root), ClipNodeIndex::NONE);
+        assert_eq!(common_ancestor(ClipNodeIndex::NONE, right), ClipNodeIndex::NONE);
+        assert!(tree.clip_is_ancestor_or_self(ClipNodeIndex::NONE, left_leaf));
+        assert!(tree.clip_is_ancestor_or_self(root, left_leaf));
+        assert!(!tree.clip_is_ancestor_or_self(right, left_leaf));
+    }
+
+    #[test]
+    fn contexts_name_spatial_clip_and_effect_nodes_directly() {
+        let mut tree = tree();
+        let root = ContextRef::spatial_only(VISUAL_VIEWPORT_NODE_INDEX);
+        let clipped = tree.append_clip_node_under(root, clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect));
+        let layered = tree.append_effect_node_under(clipped, effects());
+        assert_eq!(layered.spatial, root.spatial);
+        assert_eq!(layered.clip, clipped.clip);
+        assert_eq!(clipped.effect, EffectNodeIndex::NONE);
+        assert_eq!(tree.effect_nodes[layered.effect.0 as usize].output_clip(), clipped.clip);
+        assert_eq!(tree.live_node_count(), 3);
     }
 
     #[test]
@@ -1399,30 +1866,79 @@ mod tests {
     }
 
     #[test]
+    fn effect_clip_constraints_include_positioned_escapes_and_descendant_effects() {
+        let mut tree = tree();
+        let rect = || clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect);
+        let outer = tree.append_clip(rect(), ClipNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        let inner = tree.append_clip(rect(), outer, VISUAL_VIEWPORT_NODE_INDEX);
+        let sibling = tree.append_clip(rect(), outer, VISUAL_VIEWPORT_NODE_INDEX);
+        let layer = tree.append_effect(
+            effects(),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        let nested = tree.append_effect(effects(), layer, VISUAL_VIEWPORT_NODE_INDEX, ClipNodeIndex::NONE);
+        let mut constraints = vec![
+            EffectClipConstraint {
+                effect: layer,
+                clip: inner,
+            },
+            EffectClipConstraint {
+                effect: nested,
+                clip: inner,
+            },
+        ];
+        assert!(tree.resolve_effect_output_clips(&constraints));
+        assert_eq!(tree.effect_nodes[layer.0 as usize].output_clip(), inner);
+        assert_eq!(tree.effect_nodes[nested.0 as usize].output_clip(), inner);
+        assert!(!tree.resolve_effect_output_clips(&constraints));
+        constraints.push(EffectClipConstraint {
+            effect: nested,
+            clip: sibling,
+        });
+        assert!(tree.resolve_effect_output_clips(&constraints));
+        assert_eq!(tree.effect_nodes[nested.0 as usize].output_clip(), outer);
+        assert_eq!(tree.effect_nodes[layer.0 as usize].output_clip(), outer);
+        constraints.pop();
+        assert!(tree.resolve_effect_output_clips(&constraints));
+        assert_eq!(tree.effect_nodes[layer.0 as usize].output_clip(), inner);
+        assert!(!tree.resolve_effect_output_clips(&constraints));
+    }
+
+    #[test]
     fn tombstones_keep_their_links_and_leave_the_live_counts() {
         let mut tree = tree();
         let transform = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
-        let empty_clip = tree.append_frame(
+        let empty_clip = tree.append_clip(
             clip(FloatRect::new(0.0, 0.0, 0.0, 0.0), ClipMode::Intersect),
-            FrameNodeIndex::NONE,
+            ClipNodeIndex::NONE,
             transform,
         );
-        assert_eq!(tree.live_spatial_node_count, 2);
-        assert_eq!(tree.live_frame_node_count, 1);
-        assert!(tree.frame_nodes[empty_clip.0 as usize].clips_everything);
-        assert!(tree.tombstone_frame_slot(empty_clip));
+        let effect = tree.append_effect(effects(), EffectNodeIndex::NONE, transform, empty_clip);
+        assert_eq!(tree.live_spatial_node_count(), 2);
+        assert_eq!(tree.live_clip_node_count(), 1);
+        assert_eq!(tree.live_effect_node_count(), 1);
+        assert!(tree.clip_nodes[empty_clip.0 as usize].clips_everything);
+        assert!(tree.tombstone_effect_slot(effect));
+        assert!(tree.tombstone_clip_slot(empty_clip));
         assert!(tree.tombstone_spatial_slot(transform));
         assert!(!tree.tombstone_spatial_slot(transform));
+        assert!(!tree.tombstone_clip_slot(empty_clip));
         assert!(!tree.spatial_is_live(transform));
-        assert!(!tree.frame_is_live(empty_clip));
+        assert!(!tree.clip_is_live(empty_clip));
+        assert!(!tree.effect_is_live(effect));
         assert_eq!(
             tree.spatial_nodes[transform.0 as usize].parent,
             VISUAL_VIEWPORT_NODE_INDEX
         );
-        assert!(!tree.frame_nodes[empty_clip.0 as usize].clips_everything);
-        assert_eq!(tree.live_spatial_node_count, 1);
-        assert_eq!(tree.live_frame_node_count, 0);
-        assert_eq!(tree.dead_node_count(), 2);
+        assert_eq!(tree.clip_nodes[empty_clip.0 as usize].parent, ClipNodeIndex::NONE);
+        assert!(!tree.clip_nodes[empty_clip.0 as usize].clips_everything);
+        assert_eq!(tree.effect_nodes[effect.0 as usize].output_clip(), empty_clip);
+        assert_eq!(tree.live_spatial_node_count(), 1);
+        assert_eq!(tree.live_clip_node_count(), 0);
+        assert_eq!(tree.live_effect_node_count(), 0);
+        assert_eq!(tree.dead_node_count(), 3);
         assert!(!tree.should_compact());
     }
 
@@ -1454,38 +1970,57 @@ mod tests {
     #[test]
     fn released_slots_are_reused_before_the_arrays_grow() {
         let mut tree = tree();
-        let first = tree.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
-        let second = tree.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
-        assert!(tree.tombstone_frame_slot(first));
-        assert!(tree.tombstone_frame_slot(second));
+        let first = tree.append_effect(
+            effects(),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        let second = tree.append_effect(
+            effects(),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+
+        assert!(tree.tombstone_effect_slot(first));
+        assert!(tree.tombstone_effect_slot(second));
         tree.release_quarantined_slots_after_recording();
-        let frame_count = tree.frame_nodes.len();
-        assert_eq!(tree.allocate_frame_slot(), (second, true));
-        assert_eq!(tree.allocate_frame_slot(), (first, true));
-        assert_eq!(tree.frame_nodes.len(), frame_count);
-        assert_eq!(tree.allocate_frame_slot(), (FrameNodeIndex(frame_count as u32), false));
+        let effect_count = tree.effect_nodes.len();
+        assert_eq!(tree.allocate_effect_slot(), (second, true));
+        assert_eq!(tree.allocate_effect_slot(), (first, true));
+        assert_eq!(tree.effect_nodes.len(), effect_count);
+        assert_eq!(
+            tree.allocate_effect_slot(),
+            (EffectNodeIndex(effect_count as u32), false)
+        );
     }
 
     #[test]
     fn dead_node_count_counts_free_and_quarantined_slots() {
         let mut tree = tree();
         let transform_node = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
-        let clip_frame = tree.append_frame(
+        let clip_node = tree.append_clip(
             clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect),
-            FrameNodeIndex::NONE,
+            ClipNodeIndex::NONE,
             transform_node,
         );
-        assert!(tree.tombstone_frame_slot(clip_frame));
+
+        assert!(tree.tombstone_clip_slot(clip_node));
         tree.release_quarantined_slots_after_recording();
         assert!(tree.tombstone_spatial_slot(transform_node));
         assert_eq!(tree.dead_node_count(), 2);
         assert_eq!(tree.free_slot_count(), 1);
         assert_eq!(tree.quarantined_slot_count(), 1);
-        let (slot, reused) = tree.allocate_frame_slot();
+        let (slot, reused) = tree.allocate_clip_slot();
         assert!(reused);
-        assert!(!tree.replace_frame_node(
+        assert!(!tree.replace_clip_node(
             slot,
-            FrameNode::new(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX)
+            ClipNode::new(
+                clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect),
+                ClipNodeIndex::NONE,
+                VISUAL_VIEWPORT_NODE_INDEX
+            )
         ));
         assert_eq!(tree.dead_node_count(), 1);
         tree.debug_assert_slot_accounting();
@@ -1496,14 +2031,21 @@ mod tests {
         let mut tree = tree();
         let stale = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
         let other = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
-        let frame = tree.append_frame(effects(), FrameNodeIndex::NONE, other);
+        let effect = tree.append_effect(effects(), EffectNodeIndex::NONE, other, ClipNodeIndex::NONE);
+        let clip_node = tree.append_clip(
+            clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect),
+            ClipNodeIndex::NONE,
+            other,
+        );
         assert!(tree.tombstone_spatial_slot(stale));
-        assert!(tree.tombstone_frame_slot(frame));
+        assert!(tree.tombstone_effect_slot(effect));
+        assert!(tree.tombstone_clip_slot(clip_node));
         let order = tree.spatial_dependency_order_with_back_edges();
         assert_eq!(order.order, vec![VISUAL_VIEWPORT_NODE_INDEX.0, other.0]);
         assert!(order.back_edges.is_empty());
         assert!(order.dangling_references.is_empty());
-        assert!(tree.frame_dependency_order().is_empty());
+        assert!(tree.effect_dependency_order().is_empty());
+        assert!(tree.clip_dependency_order().is_empty());
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
@@ -13,13 +13,14 @@ use crate::painting::visual_context::build::{
     BoxFacts, compute_svg_viewport_transform_data, svg_viewport_transform_of,
 };
 use crate::painting::visual_context::{
-    ContextRef, FrameData, FrameNodeIndex, MaskLayerOrigin, SpatialData, TransformData, VisualContextTree,
+    ClipNodeData, ContextRef, EffectNodeData, EffectNodeIndex, MaskLayerOrigin, SpatialData, TransformData,
+    VisualContextNodeSink, VisualContextTree,
 };
 
 #[derive(Default)]
 pub struct NestedAssignments {
     pub paintable_contexts: HashMap<u32, (ContextRef, ContextRef)>,
-    pub mask_frames: HashMap<u32, Vec<FrameNodeIndex>>,
+    pub mask_effects: HashMap<u32, Vec<EffectNodeIndex>>,
 }
 
 struct NestedBuilder<'a, Arena> {
@@ -35,7 +36,9 @@ impl<Arena: PaintableRowsRead> NestedBuilder<'_, Arena> {
         let facts = BoxFacts::gather(self.layout_arena, self.callbacks, slot, self.pixel_ratio, false);
         let mut own_state = inherited_state;
         if let Some(effects) = facts.effects_data() {
-            own_state = self.tree.append_frame_under(own_state, FrameData::Effects(effects));
+            own_state = self
+                .tree
+                .append_effect_node_under(own_state, EffectNodeData::Effects(effects));
         }
 
         if include_element_transform && let Some(transform) = facts.transform {
@@ -49,12 +52,14 @@ impl<Arena: PaintableRowsRead> NestedBuilder<'_, Arena> {
             .iter()
             .filter(|layer| layer.origin != MaskLayerOrigin::CssMaskLayers)
         {
-            own_state = self.tree.append_frame_under(own_state, FrameData::Mask(*mask_layer));
+            own_state = self
+                .tree
+                .append_effect_node_under(own_state, EffectNodeData::Mask(*mask_layer));
             self.assignments
-                .mask_frames
+                .mask_effects
                 .entry(slot.index)
                 .or_default()
-                .push(own_state.frame);
+                .push(own_state.effect);
         }
 
         let mut state_for_descendants = own_state;
@@ -64,7 +69,7 @@ impl<Arena: PaintableRowsRead> NestedBuilder<'_, Arena> {
         {
             state_for_descendants = self
                 .tree
-                .append_frame_under(state_for_descendants, FrameData::Clip(clip));
+                .append_clip_node_under(state_for_descendants, ClipNodeData::Rect(clip));
         }
 
         if let Some(svg_viewport_transform) = svg_viewport_transform_of(self.layout_arena, slot) {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
@@ -5,8 +5,9 @@
  */
 
 use super::{
-    ClipData, ClipMode, ContextRef, FrameData, FrameNode, FrameNodeIndex, IncludeVisualViewportTransform, SpatialData,
-    SpatialNodeIndex, TransformDataRole, VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree, device_offset_for_index,
+    ClipData, ClipMode, ClipNode, ClipNodeData, ClipNodeIndex, ContextRef, EffectNodeData, EffectNodeIndex,
+    IncludeVisualViewportTransform, SpatialData, SpatialNodeIndex, TransformDataRole, VISUAL_VIEWPORT_NODE_INDEX,
+    VisualContextTree, device_offset_for_index,
 };
 use libgfx_rust::{
     CompositingAndBlendingOperator, FloatMatrix4x4, FloatPoint, FloatRect, IntPoint, IntRect, map_rect_through_matrix,
@@ -59,9 +60,9 @@ impl ClipData {
     }
 }
 
-// One root path of spatial nodes with the screen point mapped down it one inverse step at a time. Frames attach
-// to a path in non-decreasing depth order, so the steps still to apply before a frame always start where the
-// previous frame left off.
+// One root path of spatial nodes with the screen point mapped down it one inverse step at a time. Clips attach
+// to a path in non-decreasing depth order, so the steps still to apply before a clip always start where the
+// previous clip left off.
 struct SpatialChainWalk {
     chain: Vec<SpatialNodeIndex>,
     needs_accumulated_matrices: bool,
@@ -72,21 +73,63 @@ struct SpatialChainWalk {
     applied_steps: usize,
 }
 
-impl VisualContextTree {
-    pub fn fill_frames_with_empty_effective_clip(&self, empty: &mut Vec<bool>) {
-        empty.clear();
-        empty.resize(self.frame_nodes.len(), false);
-        for index in self.frame_dependency_order() {
-            let node = &self.frame_nodes[index as usize];
-            let parent_is_empty = !node.parent.is_none() && empty[node.parent.0 as usize];
-            empty[index as usize] = node.clips_everything || parent_is_empty;
-        }
+// Whether nothing painted under a node can show, plus the clip
+// depths the replay needs to place effects on a context's clip chain. Depth counts the absent clip
+// as 0, so a node's depth is the length of its root path.
+#[derive(Default)]
+pub struct TreeCullingScratch {
+    pub clip_depths: Vec<u32>,
+    clip_has_empty_effective_clip: Vec<bool>,
+    effect_culls_everything: Vec<bool>,
+}
+
+impl TreeCullingScratch {
+    pub fn clear(&mut self) {
+        self.clip_depths.clear();
+        self.clip_has_empty_effective_clip.clear();
+        self.effect_culls_everything.clear();
     }
 
-    pub fn frames_with_empty_effective_clip(&self) -> Vec<bool> {
-        let mut empty = Vec::new();
-        self.fill_frames_with_empty_effective_clip(&mut empty);
-        empty
+    pub fn context_culls_everything(&self, context: ContextRef) -> bool {
+        (!context.clip.is_none() && self.clip_has_empty_effective_clip[context.clip.0 as usize])
+            || (!context.effect.is_none() && self.effect_culls_everything[context.effect.0 as usize])
+    }
+
+    pub fn clip_depth(&self, index: ClipNodeIndex) -> u32 {
+        if index.is_none() {
+            0
+        } else {
+            self.clip_depths[index.0 as usize]
+        }
+    }
+}
+
+impl VisualContextTree {
+    pub fn fill_culling_scratch(&self, scratch: &mut TreeCullingScratch) {
+        scratch.clear();
+        scratch.clip_depths.resize(self.clip_nodes.len(), 0);
+        scratch
+            .clip_has_empty_effective_clip
+            .resize(self.clip_nodes.len(), false);
+        for index in self.clip_dependency_order() {
+            let node = &self.clip_nodes[index as usize];
+            let (parent_depth, parent_is_empty) = if node.parent.is_none() {
+                (0, false)
+            } else {
+                (
+                    scratch.clip_depths[node.parent.0 as usize],
+                    scratch.clip_has_empty_effective_clip[node.parent.0 as usize],
+                )
+            };
+            scratch.clip_depths[index as usize] = parent_depth + 1;
+            scratch.clip_has_empty_effective_clip[index as usize] = node.clips_everything || parent_is_empty;
+        }
+        scratch.effect_culls_everything.resize(self.effect_nodes.len(), false);
+        for index in self.effect_dependency_order() {
+            let node = &self.effect_nodes[index as usize];
+            let parent_culls = !node.parent.is_none() && scratch.effect_culls_everything[node.parent.0 as usize];
+            scratch.effect_culls_everything[index as usize] = node.data.culls_everything() || parent_culls;
+        }
     }
 
     fn chain_contains_3d_transform(&self, index: SpatialNodeIndex) -> bool {
@@ -272,13 +315,12 @@ impl VisualContextTree {
         }
     }
 
-    fn point_passes_frame(frame: &FrameNode, point: FloatPoint, clip_behavior: ClipBehavior) -> bool {
+    fn point_passes_clip(clip: &ClipNode, point: FloatPoint, clip_behavior: ClipBehavior) -> bool {
         if clip_behavior == ClipBehavior::Ignore {
             return true;
         }
-        match &frame.data {
-            FrameData::BackgroundColorAnimation => true,
-            FrameData::Clip(clip) => {
+        match &clip.data {
+            ClipNodeData::Rect(clip) => {
                 // NOTE: The clip rect is in absolute device-pixel coordinates. After inverse-transforming, `point`
                 //       is also in device-pixel coordinates, so we compare them directly.
                 let inside = clip.contains(point);
@@ -288,7 +330,7 @@ impl VisualContextTree {
                     !inside
                 }
             }
-            FrameData::ClipPath(clip_path) => {
+            ClipNodeData::Path(clip_path) => {
                 // NOTE: The clip path is in absolute device-pixel coordinates. After inverse-transforming, `point`
                 //       is also in device-pixel coordinates, so we compare them directly.
                 if !clip_path.bounding_rect.contains_point(IntPoint {
@@ -299,7 +341,7 @@ impl VisualContextTree {
                 }
                 clip_path.path.contains(point.x, point.y, clip_path.fill_rule as i32)
             }
-            FrameData::Effects(_) | FrameData::Mask(_) | FrameData::Dead => true,
+            ClipNodeData::Dead => true,
         }
     }
 
@@ -310,31 +352,32 @@ impl VisualContextTree {
         scroll_offsets: &[FloatPoint],
         clip_behavior: ClipBehavior,
     ) -> Option<FloatPoint> {
-        let mut frame_chain: Vec<FrameNodeIndex> = Vec::with_capacity(8);
-        let mut frame = context.frame;
-        while frame != FrameNodeIndex::NONE {
-            frame_chain.push(frame);
-            frame = self.frame_nodes[frame.0 as usize].parent;
+        // Effects never clip a point, so only the clip chain takes part.
+        let mut clip_chain: Vec<ClipNodeIndex> = Vec::with_capacity(8);
+        let mut clip = context.clip;
+        while !clip.is_none() {
+            clip_chain.push(clip);
+            clip = self.clip_nodes[clip.0 as usize].parent;
         }
-        frame_chain.reverse();
+        clip_chain.reverse();
 
         // The backface test needs forward matrices, but this walk only applies inverses. When the chain contains
         // backface markers, we accumulate the forward matrices as we walk, from the root down, so a marker can look up
         // the matrix at its plane root by chain position.
         let mut context_walk = self.begin_hit_test_walk(context.spatial, screen_point);
-        for frame_index in frame_chain {
-            let frame = &self.frame_nodes[frame_index.0 as usize];
-            let mut frame_walk;
-            let walk = if context_walk.chain.contains(&frame.spatial) {
+        for clip_index in clip_chain {
+            let clip = &self.clip_nodes[clip_index.0 as usize];
+            let mut clip_walk;
+            let walk = if context_walk.chain.contains(&clip.spatial) {
                 &mut context_walk
             } else {
-                // A fixed-background context is rooted above the scroll nodes its frames record in, so such a frame
+                // A fixed-background context is rooted above the scroll nodes its clips record in, so such a clip
                 // hangs below the context's node and takes its own walk from the root.
-                frame_walk = self.begin_hit_test_walk(frame.spatial, screen_point);
-                &mut frame_walk
+                clip_walk = self.begin_hit_test_walk(clip.spatial, screen_point);
+                &mut clip_walk
             };
-            if !self.apply_hit_test_spatial_steps_through_node(walk, frame.spatial, screen_point, scroll_offsets)
-                || !Self::point_passes_frame(frame, walk.point, clip_behavior)
+            if !self.apply_hit_test_spatial_steps_through_node(walk, clip.spatial, screen_point, scroll_offsets)
+                || !Self::point_passes_clip(clip, walk.point, clip_behavior)
             {
                 return None;
             }
@@ -615,21 +658,22 @@ impl VisualContextTree {
 }
 
 impl VisualContextTree {
-    pub fn frame_is_isolated_by_layer_frame(&self, mut frame: FrameNodeIndex) -> bool {
-        while !frame.is_none() {
-            let node = &self.frame_nodes[frame.0 as usize];
-            if matches!(node.data, FrameData::Effects(_) | FrameData::Mask(_)) {
+    // Whether the effect or one of its ancestors pushes a layer.
+    pub fn effect_is_isolated_by_layer(&self, mut effect: EffectNodeIndex) -> bool {
+        while !effect.is_none() {
+            let node = &self.effect_nodes[effect.0 as usize];
+            if node.data.pushes_layer() {
                 return true;
             }
-            frame = node.parent;
+            effect = node.parent;
         }
         false
     }
 
-    pub fn has_unisolated_blending_frame(&self) -> bool {
-        self.frame_nodes.iter().any(|node| {
-            matches!(&node.data, FrameData::Effects(effects) if effects.blend_mode != CompositingAndBlendingOperator::Normal)
-                && !self.frame_is_isolated_by_layer_frame(node.parent)
+    pub fn has_unisolated_blending_effect(&self) -> bool {
+        self.effect_nodes.iter().any(|node| {
+            matches!(&node.data, EffectNodeData::Effects(effects) if effects.blend_mode != CompositingAndBlendingOperator::Normal)
+                && !self.effect_is_isolated_by_layer(node.parent)
         })
     }
 }
@@ -637,22 +681,26 @@ impl VisualContextTree {
 impl VisualContextTree {
     pub fn with_sampled_visual_animation_values(
         &self,
-        frame_opacities: &[(FrameNodeIndex, f32)],
-        frame_background_colors: &[(FrameNodeIndex, libgfx_rust::Color)],
-        frame_filters: &[(FrameNodeIndex, Option<std::rc::Rc<Vec<u8>>>)],
+        effect_opacities: &[(EffectNodeIndex, f32)],
+        effect_background_colors: &[(EffectNodeIndex, libgfx_rust::Color)],
+        effect_filters: &[(EffectNodeIndex, Option<std::rc::Rc<Vec<u8>>>)],
         spatial_matrices: &[(SpatialNodeIndex, FloatMatrix4x4)],
     ) -> VisualContextTree {
         let mut sampled = self.clone();
-        for (frame, opacity) in frame_opacities {
-            if let Some(FrameData::Effects(effects)) =
-                sampled.frame_nodes.get_mut(frame.0 as usize).map(|node| &mut node.data)
+        for (effect, opacity) in effect_opacities {
+            if let Some(EffectNodeData::Effects(effects)) = sampled
+                .effect_nodes
+                .get_mut(effect.0 as usize)
+                .map(|node| &mut node.data)
             {
                 effects.opacity = *opacity;
             }
         }
-        for (frame, filter) in frame_filters {
-            if let Some(FrameData::Effects(effects)) =
-                sampled.frame_nodes.get_mut(frame.0 as usize).map(|node| &mut node.data)
+        for (effect, filter) in effect_filters {
+            if let Some(EffectNodeData::Effects(effects)) = sampled
+                .effect_nodes
+                .get_mut(effect.0 as usize)
+                .map(|node| &mut node.data)
             {
                 effects.filter = filter.clone();
             }
@@ -667,8 +715,8 @@ impl VisualContextTree {
             }
         }
         sampled.sampled_background_colors.clear();
-        for (frame, color) in frame_background_colors {
-            sampled.sampled_background_colors.insert(frame.0, *color);
+        for (effect, color) in effect_background_colors {
+            sampled.sampled_background_colors.insert(effect.0, *color);
         }
         sampled
     }
@@ -681,12 +729,12 @@ impl VisualContextTree {
         use crate::painting::host::FfiVisualAnimationTargetKind;
         match target_kind {
             FfiVisualAnimationTargetKind::Opacity | FfiVisualAnimationTargetKind::Filter => matches!(
-                self.frame_nodes.get(target as usize).map(|node| &node.data),
-                Some(FrameData::Effects(_))
+                self.effect_nodes.get(target as usize).map(|node| &node.data),
+                Some(EffectNodeData::Effects(_))
             ),
             FfiVisualAnimationTargetKind::BackgroundColor => matches!(
-                self.frame_nodes.get(target as usize).map(|node| &node.data),
-                Some(FrameData::BackgroundColorAnimation)
+                self.effect_nodes.get(target as usize).map(|node| &node.data),
+                Some(EffectNodeData::BackgroundColorAnimation)
             ),
             FfiVisualAnimationTargetKind::Transform => matches!(
                 self.spatial_nodes.get(target as usize).map(|node| &node.data),
@@ -695,8 +743,9 @@ impl VisualContextTree {
         }
     }
 
-    pub fn sampled_background_color(&self, frame: FrameNodeIndex) -> Option<libgfx_rust::Color> {
-        self.sampled_background_colors.get(&frame.0).copied()
+    // A recorded fill directly names its background-color animation effect.
+    pub fn sampled_background_color(&self, effect: EffectNodeIndex) -> Option<libgfx_rust::Color> {
+        self.sampled_background_colors.get(&effect.0).copied()
     }
 
     pub fn visual_animation_targets_are_valid(
@@ -709,24 +758,32 @@ impl VisualContextTree {
             .all(|&target| self.visual_animation_target_is_valid(target_kind, target))
     }
 
-    pub fn effects_opacity(&self, frame: FrameNodeIndex) -> Option<f32> {
-        match self.frame_nodes.get(frame.0 as usize).map(|node| &node.data) {
-            Some(FrameData::Effects(effects)) => Some(effects.opacity),
+    pub fn effects_opacity(&self, effect: EffectNodeIndex) -> Option<f32> {
+        match self.effect_nodes.get(effect.0 as usize).map(|node| &node.data) {
+            Some(EffectNodeData::Effects(effects)) => Some(effects.opacity),
             _ => None,
         }
+    }
+
+    pub fn context_is_valid(&self, context: ContextRef) -> bool {
+        self.spatial_is_live(context.spatial)
+            && self.clip_is_none_or_live(context.clip)
+            && self.effect_is_none_or_live(context.effect)
+            && (context.effect.is_none()
+                || self.effect_nodes[context.effect.0 as usize]
+                    .resolved_output_clip
+                    .is_some_and(|clip| self.clip_is_ancestor_or_self(clip, context.clip)))
     }
 
     pub fn display_list_references_only_live_nodes(
         &self,
         command_runs: &[crate::painting::display_list::commands::DisplayListCommandRun],
-        mask_frames: &[FrameNodeIndex],
+        mask_effects: &[EffectNodeIndex],
     ) -> bool {
-        let context_is_live = |context: ContextRef| {
-            self.spatial_is_live(context.spatial) && (context.frame.is_none() || self.frame_is_live(context.frame))
-        };
-        command_runs.iter().all(|run| context_is_live(run.context))
-            && mask_frames.iter().all(|frame| {
-                self.frame_is_live(*frame) && matches!(self.frame_nodes[frame.0 as usize].data, FrameData::Mask(_))
+        command_runs.iter().all(|run| self.context_is_valid(run.context))
+            && mask_effects.iter().all(|effect| {
+                self.effect_is_live(*effect)
+                    && matches!(self.effect_nodes[effect.0 as usize].data, EffectNodeData::Mask(_))
             })
     }
 
@@ -754,8 +811,8 @@ mod tests {
     use super::*;
     use crate::layout::node_data::NodeSlotId;
     use crate::painting::visual_context::{
-        BackfaceVisibilityData, ClipData, ClipMode, EffectsData, FrameData, PerspectiveData, ScrollData, SpatialData,
-        SpatialNode, StickyData, TransformData, TransformDataRole, scroll_state::NO_SCROLL_STATE_SLOT,
+        BackfaceVisibilityData, ClipData, ClipMode, EffectsData, PerspectiveData, ScrollData, SpatialData, SpatialNode,
+        StickyData, TransformData, TransformDataRole, scroll_state::NO_SCROLL_STATE_SLOT,
     };
     use libgfx_rust::{CornerRadii, FloatMatrix4x4, FloatSize, perspective_matrix, scale_matrix, translation_matrix};
 
@@ -783,28 +840,44 @@ mod tests {
         })
     }
 
-    fn clip(rect: FloatRect, mode: ClipMode) -> FrameData {
-        FrameData::Clip(ClipData {
+    fn clip(rect: FloatRect, mode: ClipMode) -> ClipNodeData {
+        ClipNodeData::Rect(ClipData {
             rect,
             corner_radii: CornerRadii::default(),
             mode,
         })
     }
 
+    fn empty_clip_flags(tree: &VisualContextTree) -> Vec<bool> {
+        let mut scratch = TreeCullingScratch::default();
+        tree.fill_culling_scratch(&mut scratch);
+        scratch.clip_has_empty_effective_clip
+    }
+
+    // A context under a fresh clip node with no effect.
+    fn clip_context(tree: &mut VisualContextTree, data: ClipNodeData, spatial: SpatialNodeIndex) -> ContextRef {
+        let clip = tree.append_clip(data, ClipNodeIndex::NONE, spatial);
+        ContextRef {
+            clip,
+            effect: EffectNodeIndex::NONE,
+            ..ContextRef::default()
+        }
+    }
+
     fn point(x: f32, y: f32) -> FloatPoint {
         FloatPoint { x, y }
     }
 
-    fn context_of(spatial: SpatialNodeIndex, frame: FrameNodeIndex) -> ContextRef {
-        ContextRef { spatial, frame }
+    fn context_of(spatial: SpatialNodeIndex, context: ContextRef) -> ContextRef {
+        ContextRef { spatial, ..context }
     }
 
     fn rotate_y_180_degrees() -> FloatMatrix4x4 {
         scale_matrix(-1.0, 1.0, -1.0)
     }
 
-    fn effects(opacity: f32, blend_mode: CompositingAndBlendingOperator) -> FrameData {
-        FrameData::Effects(EffectsData {
+    fn effects(opacity: f32, blend_mode: CompositingAndBlendingOperator) -> EffectNodeData {
+        EffectNodeData::Effects(EffectsData {
             opacity,
             blend_mode,
             filter: None,
@@ -812,61 +885,139 @@ mod tests {
     }
 
     #[test]
-    fn a_frame_is_isolated_by_an_effects_or_mask_ancestor_or_self() {
+    fn direct_contexts_validate_each_index_and_the_effect_output_clip() {
         let mut tree = identity_tree();
-        let clip_frame = tree.append_frame(
+        let outer = tree.append_clip(
+            clip(FloatRect::new(0.0, 0.0, 20.0, 20.0), ClipMode::Intersect),
+            ClipNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let inner = tree.append_clip(
             clip(FloatRect::new(0.0, 0.0, 10.0, 10.0), ClipMode::Intersect),
-            FrameNodeIndex::NONE,
+            outer,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let effects_frame = tree.append_frame(
+        let effect = tree.append_effect(
             effects(0.5, CompositingAndBlendingOperator::Normal),
-            clip_frame,
+            EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
+            inner,
         );
-        let nested_clip_frame = tree.append_frame(
-            clip(FloatRect::new(0.0, 0.0, 5.0, 5.0), ClipMode::Intersect),
-            effects_frame,
-            VISUAL_VIEWPORT_NODE_INDEX,
-        );
-        assert!(!tree.frame_is_isolated_by_layer_frame(FrameNodeIndex::NONE));
-        assert!(!tree.frame_is_isolated_by_layer_frame(clip_frame));
-        assert!(tree.frame_is_isolated_by_layer_frame(effects_frame));
-        assert!(tree.frame_is_isolated_by_layer_frame(nested_clip_frame));
+        let context = ContextRef {
+            clip: inner,
+            effect,
+            ..ContextRef::default()
+        };
+        assert!(tree.context_is_valid(context));
+        assert!(tree.context_is_valid(ContextRef::default()));
+        assert!(!tree.context_is_valid(ContextRef {
+            spatial: SpatialNodeIndex(50),
+            ..context
+        }));
+        assert!(!tree.context_is_valid(ContextRef {
+            clip: ClipNodeIndex(50),
+            ..context
+        }));
+        assert!(!tree.context_is_valid(ContextRef {
+            effect: EffectNodeIndex(50),
+            ..context
+        }));
+        assert!(!tree.context_is_valid(ContextRef { clip: outer, ..context }));
+        assert!(!tree.context_is_valid(ContextRef {
+            clip: ClipNodeIndex::NONE,
+            ..context
+        }));
+        assert!(tree.tombstone_effect_slot(effect));
+        assert!(!tree.context_is_valid(context));
     }
 
     #[test]
-    fn a_blending_frame_counts_as_unisolated_only_without_a_layer_ancestor() {
+    fn a_context_is_isolated_by_an_effects_or_mask_ancestor_or_self() {
         let mut tree = identity_tree();
-        assert!(!tree.has_unisolated_blending_frame());
-        let opacity_frame = tree.append_frame(
+        let outer_clip = tree.append_clip(
+            clip(FloatRect::new(0.0, 0.0, 10.0, 10.0), ClipMode::Intersect),
+            ClipNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let clip_context = ContextRef {
+            clip: outer_clip,
+            effect: EffectNodeIndex::NONE,
+            ..ContextRef::default()
+        };
+        let effect = tree.append_effect(
             effects(0.5, CompositingAndBlendingOperator::Normal),
-            FrameNodeIndex::NONE,
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            outer_clip,
+        );
+        let effects_context = ContextRef {
+            clip: outer_clip,
+            effect,
+            ..ContextRef::default()
+        };
+        let nested_clip = tree.append_clip(
+            clip(FloatRect::new(0.0, 0.0, 5.0, 5.0), ClipMode::Intersect),
+            outer_clip,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        tree.append_frame(
+        let nested_clip_context = ContextRef {
+            clip: nested_clip,
+            effect,
+            ..ContextRef::default()
+        };
+        let marker = tree.append_effect(
+            EffectNodeData::BackgroundColorAnimation,
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        let marker_context = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect: marker,
+            ..ContextRef::default()
+        };
+        assert!(!tree.effect_is_isolated_by_layer(EffectNodeIndex::NONE));
+        assert!(!tree.effect_is_isolated_by_layer(clip_context.effect));
+        assert!(tree.effect_is_isolated_by_layer(effects_context.effect));
+        assert!(tree.effect_is_isolated_by_layer(nested_clip_context.effect));
+        assert!(!tree.effect_is_isolated_by_layer(marker_context.effect));
+    }
+
+    #[test]
+    fn a_blending_context_counts_as_unisolated_only_without_a_layer_ancestor() {
+        let mut tree = identity_tree();
+        assert!(!tree.has_unisolated_blending_effect());
+        let opacity_effect = tree.append_effect(
+            effects(0.5, CompositingAndBlendingOperator::Normal),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        tree.append_effect(
             effects(1.0, CompositingAndBlendingOperator::Multiply),
-            opacity_frame,
+            opacity_effect,
             VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
         );
-        assert!(!tree.has_unisolated_blending_frame());
-        tree.append_frame(
+        assert!(!tree.has_unisolated_blending_effect());
+        tree.append_effect(
             effects(1.0, CompositingAndBlendingOperator::Multiply),
-            FrameNodeIndex::NONE,
+            EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
         );
-        assert!(tree.has_unisolated_blending_frame());
+        assert!(tree.has_unisolated_blending_effect());
     }
 
     #[test]
     fn a_difference_clip_passes_only_points_outside_its_rect() {
         let mut tree = identity_tree();
-        let frame = tree.append_frame(
+        let context = clip_context(
+            &mut tree,
             clip(FloatRect::new(10.0, 10.0, 20.0, 20.0), ClipMode::Difference),
-            FrameNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let context = context_of(VISUAL_VIEWPORT_NODE_INDEX, frame);
+        let context = context_of(VISUAL_VIEWPORT_NODE_INDEX, context);
         assert!(
             tree.transform_point_for_hit_test(context, point(15.0, 15.0), &[], ClipBehavior::Respect)
                 .is_none()
@@ -880,12 +1031,12 @@ mod tests {
     #[test]
     fn a_fractional_clip_rect_contains_points_by_float_containment() {
         let mut tree = identity_tree();
-        let frame = tree.append_frame(
+        let context = clip_context(
+            &mut tree,
             clip(FloatRect::new(10.5, 10.5, 20.0, 20.0), ClipMode::Intersect),
-            FrameNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let context = context_of(VISUAL_VIEWPORT_NODE_INDEX, frame);
+        let context = context_of(VISUAL_VIEWPORT_NODE_INDEX, context);
         assert!(
             tree.transform_point_for_hit_test(context, point(10.25, 15.0), &[], ClipBehavior::Respect)
                 .is_none()
@@ -899,12 +1050,12 @@ mod tests {
     #[test]
     fn an_integral_clip_rect_contains_points_by_integer_containment() {
         let mut tree = identity_tree();
-        let frame = tree.append_frame(
+        let context = clip_context(
+            &mut tree,
             clip(FloatRect::new(10.0, 10.0, 20.0, 20.0), ClipMode::Intersect),
-            FrameNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let context = context_of(VISUAL_VIEWPORT_NODE_INDEX, frame);
+        let context = context_of(VISUAL_VIEWPORT_NODE_INDEX, context);
         assert!(
             tree.transform_point_for_hit_test(context, point(9.5, 15.0), &[], ClipBehavior::Respect)
                 .is_none()
@@ -922,16 +1073,16 @@ mod tests {
     #[test]
     fn a_rounded_clip_rejects_points_outside_its_corner_ellipses() {
         let mut tree = identity_tree();
-        let frame = tree.append_frame(
-            FrameData::Clip(ClipData {
+        let context = clip_context(
+            &mut tree,
+            ClipNodeData::Rect(ClipData {
                 rect: FloatRect::new(0.0, 0.0, 100.0, 100.0),
                 corner_radii: CornerRadii::uniform(20.0 as i32),
                 mode: ClipMode::Intersect,
             }),
-            FrameNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let context = context_of(VISUAL_VIEWPORT_NODE_INDEX, frame);
+        let context = context_of(VISUAL_VIEWPORT_NODE_INDEX, context);
         assert!(
             tree.transform_point_for_hit_test(context, point(1.0, 1.0), &[], ClipBehavior::Respect)
                 .is_none()
@@ -966,7 +1117,7 @@ mod tests {
 
         let local = tree
             .transform_point_for_hit_test(
-                context_of(scroll_node, FrameNodeIndex::NONE),
+                context_of(scroll_node, ContextRef::default()),
                 point(40.0, 60.0),
                 &scroll_offsets,
                 ClipBehavior::Respect,
@@ -998,7 +1149,7 @@ mod tests {
         );
         let local = tree
             .transform_point_for_hit_test(
-                context_of(lifted, FrameNodeIndex::NONE),
+                context_of(lifted, ContextRef::default()),
                 point(100.0, 100.0),
                 &[],
                 ClipBehavior::Respect,
@@ -1047,7 +1198,7 @@ mod tests {
         assert_eq!(rect.width, 100000.0);
         assert!(
             tree.transform_point_for_hit_test(
-                context_of(on_the_eye_plane, FrameNodeIndex::NONE),
+                context_of(on_the_eye_plane, ContextRef::default()),
                 point(100.0, 100.0),
                 &[],
                 ClipBehavior::Respect,
@@ -1072,7 +1223,7 @@ mod tests {
         );
         assert!(
             tree.transform_point_for_hit_test(
-                context_of(marker, FrameNodeIndex::NONE),
+                context_of(marker, ContextRef::default()),
                 point(0.0, 0.0),
                 &[],
                 ClipBehavior::Respect
@@ -1090,7 +1241,7 @@ mod tests {
         );
         assert_eq!(
             front_facing_tree.transform_point_for_hit_test(
-                context_of(front_marker, FrameNodeIndex::NONE),
+                context_of(front_marker, ContextRef::default()),
                 point(3.0, 4.0),
                 &[],
                 ClipBehavior::Respect
@@ -1100,17 +1251,17 @@ mod tests {
     }
 
     #[test]
-    fn a_frame_below_the_context_node_takes_its_own_walk_from_the_root() {
+    fn a_context_below_the_context_node_takes_its_own_walk_from_the_root() {
         let mut tree = identity_tree();
         let scroll_node = tree.append_spatial(scroll(), VISUAL_VIEWPORT_NODE_INDEX);
-        let frame = tree.append_frame(
+        let context = clip_context(
+            &mut tree,
             clip(FloatRect::new(0.0, 0.0, 50.0, 50.0), ClipMode::Intersect),
-            FrameNodeIndex::NONE,
             scroll_node,
         );
         let mut scroll_offsets = vec![FloatPoint::default(); 2];
         scroll_offsets[scroll_node.0 as usize] = point(0.0, -100.0);
-        let fixed_background_context = context_of(VISUAL_VIEWPORT_NODE_INDEX, frame);
+        let fixed_background_context = context_of(VISUAL_VIEWPORT_NODE_INDEX, context);
 
         assert!(
             tree.transform_point_for_hit_test(
@@ -1330,8 +1481,11 @@ mod tests {
                 parent: map(node.parent),
             };
         }
-        for (index, node) in tree.frame_nodes.iter().enumerate() {
-            permuted.frame_nodes[index].spatial = map(node.spatial);
+        for (index, node) in tree.clip_nodes.iter().enumerate() {
+            permuted.clip_nodes[index].spatial = map(node.spatial);
+        }
+        for (index, node) in tree.effect_nodes.iter().enumerate() {
+            permuted.effect_nodes[index].spatial = map(node.spatial);
         }
         permuted
     }
@@ -1360,19 +1514,29 @@ mod tests {
         );
         let outer_sticky = in_order.append_spatial(sticky(scroll_node, None, 100.0), scroll_node);
         let inner_sticky = in_order.append_spatial(sticky(scroll_node, Some(outer_sticky), 120.0), outer_sticky);
-        let outer_clip = in_order.append_frame(
+        let outer_clip = in_order.append_clip(
             clip(FloatRect::new(0.0, 0.0, 0.0, 0.0), ClipMode::Intersect),
-            FrameNodeIndex::NONE,
+            ClipNodeIndex::NONE,
             sorted_transform,
         );
-        in_order.append_frame(
+        in_order.append_clip(
             clip(FloatRect::new(0.0, 0.0, 50.0, 50.0), ClipMode::Intersect),
             outer_clip,
             sorted_transform,
         );
-        in_order.frame_nodes.swap(0, 1);
-        in_order.frame_nodes[0].parent = FrameNodeIndex(1);
-        in_order.frame_nodes[1].parent = FrameNodeIndex::NONE;
+        in_order.clip_nodes.swap(0, 1);
+        in_order.clip_nodes[0].parent = ClipNodeIndex(1);
+        in_order.clip_nodes[1].parent = ClipNodeIndex::NONE;
+        ContextRef {
+            clip: ClipNodeIndex(0),
+            effect: EffectNodeIndex::NONE,
+            ..ContextRef::default()
+        };
+        ContextRef {
+            clip: ClipNodeIndex(1),
+            effect: EffectNodeIndex::NONE,
+            ..ContextRef::default()
+        };
 
         let permutation = [0, 6, 5, 4, 3, 2, 1];
         let permuted = permuted_tree(&in_order, &permutation);
@@ -1420,11 +1584,8 @@ mod tests {
             assert_eq!(permuted_subtree[permutation[index] as usize], in_order_subtree[index]);
         }
 
-        assert_eq!(
-            permuted.frames_with_empty_effective_clip(),
-            in_order.frames_with_empty_effective_clip()
-        );
-        assert_eq!(in_order.frames_with_empty_effective_clip(), vec![true, true]);
+        assert_eq!(empty_clip_flags(&permuted), empty_clip_flags(&in_order));
+        assert_eq!(empty_clip_flags(&in_order), vec![true, true]);
     }
 
     #[test]
@@ -1439,41 +1600,63 @@ mod tests {
             SpatialData::Transform(transform_data(FloatMatrix4x4::identity(), FloatPoint::default())),
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let live_frame = tree.append_frame(
+        let live_effect = tree.append_effect(
             effects(1.0, CompositingAndBlendingOperator::Normal),
-            FrameNodeIndex::NONE,
+            EffectNodeIndex::NONE,
             live_spatial,
+            ClipNodeIndex::NONE,
         );
-        let dead_frame = tree.append_frame(
+        let live_context = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect: live_effect,
+            ..ContextRef::default()
+        };
+        let dead_effect = tree.append_effect(
             effects(1.0, CompositingAndBlendingOperator::Normal),
-            FrameNodeIndex::NONE,
+            EffectNodeIndex::NONE,
             live_spatial,
+            ClipNodeIndex::NONE,
         );
-        let mask_frame = tree.append_frame(
-            FrameData::Mask(crate::painting::visual_context::MaskData {
+        let context_of_dead_effect = ContextRef {
+            clip: ClipNodeIndex::NONE,
+            effect: dead_effect,
+            ..ContextRef::default()
+        };
+        let mask_effect = tree.append_effect(
+            EffectNodeData::Mask(crate::painting::visual_context::MaskData {
                 rect: IntRect::new(0, 0, 4, 4),
                 kind: libgfx_rust::MaskKind::Alpha,
                 origin: crate::painting::visual_context::MaskLayerOrigin::CssMaskLayers,
             }),
-            FrameNodeIndex::NONE,
+            EffectNodeIndex::NONE,
             live_spatial,
+            ClipNodeIndex::NONE,
         );
         assert!(tree.tombstone_spatial_slot(dead_spatial));
-        assert!(tree.tombstone_frame_slot(dead_frame));
+        assert!(tree.tombstone_effect_slot(dead_effect));
         let run = |context: ContextRef| DisplayListCommandRun {
             context,
             ..DisplayListCommandRun::default()
         };
-        assert!(tree.display_list_references_only_live_nodes(&[run(context_of(live_spatial, live_frame))], &[]));
+        assert!(tree.display_list_references_only_live_nodes(&[run(context_of(live_spatial, live_context))], &[]));
         assert!(
-            !tree.display_list_references_only_live_nodes(&[run(context_of(dead_spatial, FrameNodeIndex::NONE))], &[])
+            tree.display_list_references_only_live_nodes(&[run(context_of(live_spatial, ContextRef::default()))], &[])
         );
-        assert!(!tree.display_list_references_only_live_nodes(&[run(context_of(live_spatial, dead_frame))], &[]));
         assert!(
-            tree.display_list_references_only_live_nodes(&[run(context_of(live_spatial, live_frame))], &[mask_frame])
+            !tree.display_list_references_only_live_nodes(&[run(context_of(dead_spatial, ContextRef::default()))], &[])
         );
-        assert!(!tree.display_list_references_only_live_nodes(&[], &[dead_frame]));
-        assert!(!tree.display_list_references_only_live_nodes(&[], &[live_frame]));
+        assert!(
+            !tree
+                .display_list_references_only_live_nodes(&[run(context_of(live_spatial, context_of_dead_effect))], &[])
+        );
+        assert!(
+            tree.display_list_references_only_live_nodes(
+                &[run(context_of(live_spatial, live_context))],
+                &[mask_effect]
+            )
+        );
+        assert!(!tree.display_list_references_only_live_nodes(&[], &[dead_effect]));
+        assert!(!tree.display_list_references_only_live_nodes(&[], &[live_effect]));
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/reconcile.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/reconcile.rs
@@ -5,348 +5,282 @@
  */
 
 use super::delta::VisualContextTreeDelta;
-use super::shape::{frame_node_shape, frame_payloads_are_equal, spatial_node_shape, spatial_payloads_are_equal};
+use super::shape::{
+    clip_node_shape, clip_payloads_are_equal, effect_node_shape, effect_payloads_are_equal, spatial_node_shape,
+    spatial_payloads_are_equal,
+};
 use super::*;
 
-pub(crate) struct BoxNodeScratch<'a> {
-    live: &'a VisualContextTree,
-    provisional_spatial_begin: u32,
-    provisional_frames_begin: u32,
-    spatial: Vec<SpatialNode>,
-    frames: Vec<FrameNode>,
+// Reuse a box's handles in emission order, writing each node before returning its final
+// handle. Surplus handles stay live until finish(), then enter the usual quarantine.
+pub(crate) struct BoxNodeWriter<'a> {
+    tree: &'a mut VisualContextTree,
+    existing: &'a BoxVisualContextNodeHandles,
+    handles: BoxVisualContextNodeHandles,
+    delta: &'a mut VisualContextTreeDelta,
+    outcome: ReconcileOutcome,
+    building_descendants: bool,
 }
 
-impl<'a> BoxNodeScratch<'a> {
-    pub(crate) fn new(live: &'a VisualContextTree) -> Self {
+impl<'a> BoxNodeWriter<'a> {
+    pub(crate) fn new(
+        tree: &'a mut VisualContextTree,
+        existing: Option<&'a BoxVisualContextNodeHandles>,
+        delta: &'a mut VisualContextTreeDelta,
+    ) -> Self {
         Self {
-            live,
-            provisional_spatial_begin: live.spatial_nodes.len() as u32,
-            provisional_frames_begin: live.frame_nodes.len() as u32,
-            spatial: Vec::new(),
-            frames: Vec::new(),
+            tree,
+            existing: existing.unwrap_or(&EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES),
+            handles: BoxVisualContextNodeHandles::default(),
+            delta,
+            outcome: ReconcileOutcome::default(),
+            building_descendants: false,
         }
     }
 
-    pub(crate) fn into_nodes(self) -> (Vec<SpatialNode>, Vec<FrameNode>) {
-        (self.spatial, self.frames)
+    pub(crate) fn begin_descendants(&mut self) {
+        debug_assert!(!self.building_descendants);
+        self.building_descendants = true;
     }
 
-    fn frame_node_at(&self, index: FrameNodeIndex) -> &FrameNode {
-        if index.0 >= self.provisional_frames_begin {
-            &self.frames[(index.0 - self.provisional_frames_begin) as usize]
-        } else {
-            &self.live.frame_nodes[index.0 as usize]
-        }
+    pub(crate) fn append_effect_node(
+        &mut self,
+        data: EffectNodeData,
+        parent: EffectNodeIndex,
+        spatial: SpatialNodeIndex,
+    ) -> EffectNodeIndex {
+        debug_assert!(!self.building_descendants, "descendant contexts add no effects");
+        debug_assert!(self.tree.spatial_is_live(spatial));
+        debug_assert!(self.tree.effect_is_none_or_live(parent));
+        write_node(
+            self.tree,
+            &self.existing.effects,
+            &mut self.handles.effects,
+            EffectNode::new(data, parent, spatial, None),
+            self.delta,
+            &mut self.outcome,
+        )
+    }
+
+    pub(crate) fn finish(mut self) -> (BoxVisualContextNodeHandles, ReconcileOutcome) {
+        retire_surplus::<SpatialNode>(
+            self.tree,
+            &self.existing.spatial,
+            self.handles.spatial.len(),
+            self.delta,
+            &mut self.outcome,
+        );
+        retire_surplus::<ClipNode>(
+            self.tree,
+            &self.existing.chain_clips,
+            self.handles.chain_clips.len(),
+            self.delta,
+            &mut self.outcome,
+        );
+        retire_surplus::<ClipNode>(
+            self.tree,
+            &self.existing.descendant_clips,
+            self.handles.descendant_clips.len(),
+            self.delta,
+            &mut self.outcome,
+        );
+        retire_surplus::<EffectNode>(
+            self.tree,
+            &self.existing.effects,
+            self.handles.effects.len(),
+            self.delta,
+            &mut self.outcome,
+        );
+        (self.handles, self.outcome)
     }
 }
 
-impl VisualContextNodeSink for BoxNodeScratch<'_> {
+impl VisualContextNodeSink for BoxNodeWriter<'_> {
     fn append_spatial_node(&mut self, data: SpatialData, parent: SpatialNodeIndex) -> SpatialNodeIndex {
-        debug_assert!(self.spatial_node_at(parent).data.is_live());
-        self.spatial.push(SpatialNode { data, parent });
-        SpatialNodeIndex(self.provisional_spatial_begin + self.spatial.len() as u32 - 1)
+        debug_assert!(self.tree.spatial_is_live(parent));
+        write_node(
+            self.tree,
+            &self.existing.spatial,
+            &mut self.handles.spatial,
+            SpatialNode { data, parent },
+            self.delta,
+            &mut self.outcome,
+        )
     }
 
-    fn append_frame_node(
+    fn append_clip_node(
         &mut self,
-        data: FrameData,
-        parent: FrameNodeIndex,
+        data: ClipNodeData,
+        parent: ClipNodeIndex,
         spatial: SpatialNodeIndex,
-    ) -> FrameNodeIndex {
-        debug_assert!(self.spatial_node_at(spatial).data.is_live());
-        debug_assert!(parent.is_none() || self.frame_node_at(parent).data.is_live());
-        self.frames.push(FrameNode::new(data, parent, spatial));
-        FrameNodeIndex(self.provisional_frames_begin + self.frames.len() as u32 - 1)
+    ) -> ClipNodeIndex {
+        debug_assert!(self.tree.spatial_is_live(spatial));
+        debug_assert!(self.tree.clip_is_none_or_live(parent));
+        let (existing, handles) = if self.building_descendants {
+            (&self.existing.descendant_clips, &mut self.handles.descendant_clips)
+        } else {
+            (&self.existing.chain_clips, &mut self.handles.chain_clips)
+        };
+        write_node(
+            self.tree,
+            existing,
+            handles,
+            ClipNode::new(data, parent, spatial),
+            self.delta,
+            &mut self.outcome,
+        )
     }
 
     fn spatial_node_at(&self, index: SpatialNodeIndex) -> &SpatialNode {
-        if index.0 >= self.provisional_spatial_begin {
-            &self.spatial[(index.0 - self.provisional_spatial_begin) as usize]
-        } else {
-            &self.live.spatial_nodes[index.0 as usize]
-        }
+        &self.tree.spatial_nodes[index.0 as usize]
     }
 
-    fn next_spatial_node_index(&self) -> SpatialNodeIndex {
-        SpatialNodeIndex(self.provisional_spatial_begin + self.spatial.len() as u32)
-    }
-
-    fn next_frame_node_index(&self) -> FrameNodeIndex {
-        FrameNodeIndex(self.provisional_frames_begin + self.frames.len() as u32)
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct BoxNodePlacement {
-    provisional_spatial_begin: u32,
-    provisional_frames_begin: u32,
-    pub spatial: Vec<SpatialNodeIndex>,
-    pub chain_frames: Vec<FrameNodeIndex>,
-    pub descendant_frames: Vec<FrameNodeIndex>,
-}
-
-impl BoxNodePlacement {
-    pub(crate) fn remap_spatial(&self, index: SpatialNodeIndex) -> SpatialNodeIndex {
-        if index.0 >= self.provisional_spatial_begin {
-            self.spatial[(index.0 - self.provisional_spatial_begin) as usize]
-        } else {
-            index
-        }
-    }
-
-    pub(crate) fn remap_frame(&self, index: FrameNodeIndex) -> FrameNodeIndex {
-        if index.is_none() || index.0 < self.provisional_frames_begin {
-            return index;
-        }
-        let mut offset = (index.0 - self.provisional_frames_begin) as usize;
-        for unit in [&self.chain_frames, &self.descendant_frames] {
-            if offset < unit.len() {
-                return unit[offset];
-            }
-            offset -= unit.len();
-        }
-        panic!("provisional frame {} lies outside the box's units", index.0)
-    }
-
-    pub(crate) fn remap_context(&self, context: ContextRef) -> ContextRef {
-        ContextRef {
-            spatial: self.remap_spatial(context.spatial),
-            frame: self.remap_frame(context.frame),
-        }
-    }
-
-    pub(crate) fn into_node_handles(self) -> BoxVisualContextNodeHandles {
-        BoxVisualContextNodeHandles {
-            spatial: self.spatial,
-            chain_frames: self.chain_frames,
-            descendant_frames: self.descendant_frames,
-        }
+    fn clip_node_at(&self, index: ClipNodeIndex) -> &ClipNode {
+        &self.tree.clip_nodes[index.0 as usize]
     }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ReconcileOutcome {
     pub shape_changed: bool,
-    pub any_payload_changed: bool,
 }
 
-fn provisional_begin<Handle: Copy>(handles: &[Handle], index_of: impl Fn(Handle) -> u32) -> u32 {
-    handles.first().map_or(u32::MAX, |first| index_of(*first))
-}
-
-fn place_unit<Handle: Copy>(
-    existing: &[Handle],
-    new_len: usize,
-    mut allocate: impl FnMut() -> (Handle, bool),
-    mut note_allocated: impl FnMut(Handle, bool),
-) -> Vec<Handle> {
-    let mut handles: Vec<Handle> = existing.iter().take(new_len).copied().collect();
-    while handles.len() < new_len {
-        let (handle, reused) = allocate();
-        note_allocated(handle, reused);
-        handles.push(handle);
+// A slot whose shape differs is repurposed, one whose payload differs is patched, and
+// surplus slots the box no longer needs are tombstoned.
+trait ReconciledNode: SlotNode {
+    fn slots(tree: &VisualContextTree) -> &[Self];
+    fn allocate(tree: &mut VisualContextTree) -> (Self::Index, bool);
+    fn same_shape(&self, other: &Self) -> bool;
+    fn same_payload(&self, other: &Self) -> bool;
+    fn replace(tree: &mut VisualContextTree, index: Self::Index, node: Self) -> bool;
+    fn tombstone_slot(tree: &mut VisualContextTree, index: Self::Index) -> bool;
+    fn patch_requires_recording(&self) -> bool {
+        false
     }
-    handles
 }
 
-pub(crate) fn plan_box_node_placement(
+impl ReconciledNode for SpatialNode {
+    fn allocate(tree: &mut VisualContextTree) -> (SpatialNodeIndex, bool) {
+        tree.allocate_spatial_slot()
+    }
+    fn slots(tree: &VisualContextTree) -> &[Self] {
+        &tree.spatial_nodes
+    }
+    fn same_shape(&self, other: &Self) -> bool {
+        spatial_node_shape(self) == spatial_node_shape(other)
+    }
+    fn same_payload(&self, other: &Self) -> bool {
+        spatial_payloads_are_equal(&self.data, &other.data)
+    }
+    fn replace(tree: &mut VisualContextTree, index: SpatialNodeIndex, node: Self) -> bool {
+        tree.replace_spatial_node(index, node)
+    }
+    fn tombstone_slot(tree: &mut VisualContextTree, index: SpatialNodeIndex) -> bool {
+        tree.tombstone_spatial_slot(index)
+    }
+}
+
+impl ReconciledNode for ClipNode {
+    fn allocate(tree: &mut VisualContextTree) -> (ClipNodeIndex, bool) {
+        tree.allocate_clip_slot()
+    }
+    fn slots(tree: &VisualContextTree) -> &[Self] {
+        &tree.clip_nodes
+    }
+    fn same_shape(&self, other: &Self) -> bool {
+        clip_node_shape(self) == clip_node_shape(other)
+    }
+    fn same_payload(&self, other: &Self) -> bool {
+        clip_payloads_are_equal(&self.data, &other.data)
+    }
+    fn replace(tree: &mut VisualContextTree, index: ClipNodeIndex, node: Self) -> bool {
+        tree.replace_clip_node(index, node)
+    }
+    fn tombstone_slot(tree: &mut VisualContextTree, index: ClipNodeIndex) -> bool {
+        tree.tombstone_clip_slot(index)
+    }
+}
+
+impl ReconciledNode for EffectNode {
+    fn allocate(tree: &mut VisualContextTree) -> (EffectNodeIndex, bool) {
+        tree.allocate_effect_slot()
+    }
+    fn slots(tree: &VisualContextTree) -> &[Self] {
+        &tree.effect_nodes
+    }
+    fn same_shape(&self, other: &Self) -> bool {
+        effect_node_shape(self) == effect_node_shape(other)
+    }
+    fn same_payload(&self, other: &Self) -> bool {
+        effect_payloads_are_equal(&self.data, &other.data)
+    }
+    fn replace(tree: &mut VisualContextTree, index: EffectNodeIndex, mut node: Self) -> bool {
+        let previous = &tree.effect_nodes[index.0 as usize];
+        if previous.data.is_live() {
+            node.resolved_output_clip = previous.resolved_output_clip;
+        }
+        tree.replace_effect_node(index, node)
+    }
+    fn tombstone_slot(tree: &mut VisualContextTree, index: EffectNodeIndex) -> bool {
+        tree.tombstone_effect_slot(index)
+    }
+    // A mask's content is recorded per display list, so a changed mask needs a recording.
+    fn patch_requires_recording(&self) -> bool {
+        matches!(self.data, EffectNodeData::Mask(_))
+    }
+}
+
+fn write_node<N: ReconciledNode>(
     tree: &mut VisualContextTree,
-    existing: Option<&BoxVisualContextNodeHandles>,
-    provisional: &BoxVisualContextNodeHandles,
+    existing: &[N::Index],
+    handles: &mut Vec<N::Index>,
+    node: N,
     delta: &mut VisualContextTreeDelta,
-) -> BoxNodePlacement {
-    let existing = existing.unwrap_or(&EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES);
-    let provisional_frames: Vec<FrameNodeIndex> = provisional.frame_handles().collect();
-    debug_assert!(
-        provisional.spatial.windows(2).all(|pair| pair[1].0 == pair[0].0 + 1)
-            && provisional_frames.windows(2).all(|pair| pair[1].0 == pair[0].0 + 1),
-        "a scratch build hands out consecutive provisional indices"
-    );
-    let spatial = place_unit(
-        &existing.spatial,
-        provisional.spatial.len(),
-        || tree.allocate_spatial_slot(),
-        |handle, reused| delta.note_allocated_spatial(handle.0, reused),
-    );
-    let mut place_frames = |existing: &[FrameNodeIndex], new_len: usize| {
-        place_unit(
-            existing,
-            new_len,
-            || tree.allocate_frame_slot(),
-            |handle, reused| delta.note_allocated_frame(handle.0, reused),
-        )
+    outcome: &mut ReconcileOutcome,
+) -> N::Index {
+    let handle = match existing.get(handles.len()) {
+        Some(&handle) => handle,
+        None => {
+            let (handle, reused) = N::allocate(tree);
+            delta.note_allocated(reused);
+            handle
+        }
     };
-    let chain_frames = place_frames(&existing.chain_frames, provisional.chain_frames.len());
-    let descendant_frames = place_frames(&existing.descendant_frames, provisional.descendant_frames.len());
-    BoxNodePlacement {
-        provisional_spatial_begin: provisional_begin(&provisional.spatial, |index| index.0),
-        provisional_frames_begin: provisional_begin(&provisional_frames, |index| index.0),
-        spatial,
-        chain_frames,
-        descendant_frames,
-    }
-}
-
-fn remap_spatial_payload(placement: &BoxNodePlacement, data: SpatialData) -> SpatialData {
-    match data {
-        SpatialData::Scroll(mut scroll) => {
-            scroll.registry_parent_node = placement.remap_spatial(scroll.registry_parent_node);
-            SpatialData::Scroll(scroll)
-        }
-        SpatialData::Sticky(mut sticky) => {
-            sticky.scroller = placement.remap_spatial(sticky.scroller);
-            sticky.parent_sticky = sticky.parent_sticky.map(|index| placement.remap_spatial(index));
-            sticky.registry_parent_node = placement.remap_spatial(sticky.registry_parent_node);
-            SpatialData::Sticky(sticky)
-        }
-        SpatialData::Transform(mut transform) => {
-            transform.sorting_context_root_index = transform
-                .sorting_context_root_index
-                .map(|index| placement.remap_spatial(index));
-            SpatialData::Transform(transform)
-        }
-        SpatialData::BackfaceVisibility(mut backface) => {
-            backface.plane_root_index = placement.remap_spatial(backface.plane_root_index);
-            SpatialData::BackfaceVisibility(backface)
-        }
-        SpatialData::AnchorScrollShift(mut shift) => {
-            shift.scroll_node_index = placement.remap_spatial(shift.scroll_node_index);
-            SpatialData::AnchorScrollShift(shift)
-        }
-        other => other,
-    }
-}
-
-fn write_spatial_unit(
-    tree: &mut VisualContextTree,
-    handles: &[SpatialNodeIndex],
-    existing: &[SpatialNodeIndex],
-    nodes: Vec<SpatialNode>,
-    delta: &mut VisualContextTreeDelta,
-    outcome: &mut ReconcileOutcome,
-) {
-    debug_assert_eq!(handles.len(), nodes.len());
-    if handles.len() != existing.len() {
+    let current = &N::slots(tree)[N::raw(handle) as usize];
+    let was_live = current.is_live();
+    let shape_matches = was_live && current.same_shape(&node);
+    let payload_matches = shape_matches && current.same_payload(&node);
+    if !shape_matches {
         outcome.shape_changed = true;
-    }
-    for (handle, node) in handles.iter().zip(nodes) {
-        let current = &tree.spatial_nodes[handle.0 as usize];
-        let was_live = current.data.is_live();
-        let shape_matches = was_live && spatial_node_shape(current) == spatial_node_shape(&node);
-        let payload_matches = shape_matches && spatial_payloads_are_equal(&current.data, &node.data);
-        if !shape_matches {
-            outcome.shape_changed = true;
-            if was_live {
-                delta.note_repurposed_in_place();
-            }
-        }
-        if payload_matches {
-            continue;
-        }
-        outcome.any_payload_changed = true;
-        tree.replace_spatial_node(*handle, node);
-        delta.note_patched_spatial(handle.0);
-    }
-    for surplus in existing.get(handles.len()..).unwrap_or(&[]) {
-        if tree.tombstone_spatial_slot(*surplus) {
-            delta.note_tombstoned_spatial(surplus.0);
+        if was_live {
+            delta.note_repurposed_in_place();
         }
     }
-}
-
-fn write_frame_unit(
-    tree: &mut VisualContextTree,
-    handles: &[FrameNodeIndex],
-    existing: &[FrameNodeIndex],
-    nodes: Vec<FrameNode>,
-    delta: &mut VisualContextTreeDelta,
-    outcome: &mut ReconcileOutcome,
-) {
-    debug_assert_eq!(handles.len(), nodes.len());
-    if handles.len() != existing.len() {
-        outcome.shape_changed = true;
-    }
-    for (handle, node) in handles.iter().zip(nodes) {
-        let current = &tree.frame_nodes[handle.0 as usize];
-        let was_live = current.data.is_live();
-        let shape_matches = was_live && frame_node_shape(current) == frame_node_shape(&node);
-        let payload_matches = shape_matches && frame_payloads_are_equal(&current.data, &node.data);
-        if !shape_matches {
-            outcome.shape_changed = true;
-            if was_live {
-                delta.note_repurposed_in_place();
-            }
-        }
-        if payload_matches {
-            continue;
-        }
-        outcome.any_payload_changed = true;
-        if matches!(node.data, FrameData::Mask(_)) {
+    if !payload_matches {
+        if node.patch_requires_recording() {
             delta.requires_display_list_recording = true;
         }
-        tree.replace_frame_node(*handle, node);
-        delta.note_patched_frame(handle.0);
+        N::replace(tree, handle, node);
     }
-    for surplus in existing.get(handles.len()..).unwrap_or(&[]) {
-        if tree.tombstone_frame_slot(*surplus) {
-            delta.note_tombstoned_frame(surplus.0);
-        }
-    }
+    handles.push(handle);
+    handle
 }
 
-pub(crate) fn write_box_nodes(
+fn retire_surplus<N: ReconciledNode>(
     tree: &mut VisualContextTree,
-    spatial: Vec<SpatialNode>,
-    frames: Vec<FrameNode>,
-    placement: &BoxNodePlacement,
-    existing: Option<&BoxVisualContextNodeHandles>,
+    existing: &[N::Index],
+    used: usize,
     delta: &mut VisualContextTreeDelta,
-) -> ReconcileOutcome {
-    let existing = existing.unwrap_or(&EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES);
-    let mut outcome = ReconcileOutcome::default();
-    let spatial_nodes: Vec<SpatialNode> = spatial
-        .into_iter()
-        .map(|node| SpatialNode {
-            data: remap_spatial_payload(placement, node.data),
-            parent: placement.remap_spatial(node.parent),
-        })
-        .collect();
-    let mut frames = frames.into_iter().map(|node| {
-        FrameNode::new(
-            node.data,
-            placement.remap_frame(node.parent),
-            placement.remap_spatial(node.spatial),
-        )
-    });
-    let chain: Vec<FrameNode> = frames.by_ref().take(placement.chain_frames.len()).collect();
-    let descendant: Vec<FrameNode> = frames.collect();
-    debug_assert_eq!(descendant.len(), placement.descendant_frames.len());
-
-    write_spatial_unit(
-        tree,
-        &placement.spatial,
-        &existing.spatial,
-        spatial_nodes,
-        delta,
-        &mut outcome,
-    );
-    write_frame_unit(
-        tree,
-        &placement.chain_frames,
-        &existing.chain_frames,
-        chain,
-        delta,
-        &mut outcome,
-    );
-    write_frame_unit(
-        tree,
-        &placement.descendant_frames,
-        &existing.descendant_frames,
-        descendant,
-        delta,
-        &mut outcome,
-    );
-    outcome
+    outcome: &mut ReconcileOutcome,
+) {
+    if used < existing.len() {
+        outcome.shape_changed = true;
+    }
+    for &handle in existing.get(used..).unwrap_or(&[]) {
+        if N::tombstone_slot(tree, handle) {
+            delta.note_tombstoned();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -370,28 +304,35 @@ mod tests {
         SpatialData::Transform(transform_data())
     }
 
-    fn clip(size: f32) -> FrameData {
-        FrameData::rect_clip(FloatRect::new(0.0, 0.0, size, size))
+    fn clip(size: f32) -> ClipNodeData {
+        ClipNodeData::rect_clip(FloatRect::new(0.0, 0.0, size, size))
+    }
+
+    fn effects() -> EffectNodeData {
+        EffectNodeData::layer_blending_with(CompositingAndBlendingOperator::Normal)
     }
 
     const VIEWPORT_SCROLL: SpatialNodeIndex = SpatialNodeIndex(1);
-    const ROOT_ISOLATION_FRAME: FrameNodeIndex = FrameNodeIndex(0);
+    const ROOT_ISOLATION_EFFECT: EffectNodeIndex = EffectNodeIndex(0);
     const BOX_A_SPATIAL: SpatialNodeIndex = SpatialNodeIndex(2);
     const BOX_B_SPATIAL: SpatialNodeIndex = SpatialNodeIndex(3);
-    const BOX_A_CHAIN_FRAME: FrameNodeIndex = FrameNodeIndex(1);
-    const BOX_A_PATCHED_CHAIN_FRAME: FrameNodeIndex = FrameNodeIndex(2);
-    const BOX_A_DESCENDANT_FRAME: FrameNodeIndex = FrameNodeIndex(3);
-    const BOX_B_FRAME: FrameNodeIndex = FrameNodeIndex(4);
+    const BOX_A_CHAIN_CLIP: ClipNodeIndex = ClipNodeIndex(0);
+    const BOX_A_PATCHED_CHAIN_CLIP: ClipNodeIndex = ClipNodeIndex(1);
+    const BOX_A_DESCENDANT_CLIP: ClipNodeIndex = ClipNodeIndex(2);
+    const BOX_B_CLIP: ClipNodeIndex = ClipNodeIndex(3);
+    const BOX_A_EFFECT: EffectNodeIndex = EffectNodeIndex(1);
 
     fn tree_with_viewport_nodes() -> VisualContextTree {
         let mut tree = VisualContextTree::create(transform_data());
-        let root_isolation_frame = tree.append_frame(
-            FrameData::layer_blending_with(CompositingAndBlendingOperator::Normal),
-            FrameNodeIndex::NONE,
+        let root_isolation_effect = tree.append_effect(
+            effects(),
+            EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
         );
-        tree.root_isolation_frame = Some(root_isolation_frame);
-        assert_eq!(root_isolation_frame, ROOT_ISOLATION_FRAME);
+        assert_eq!(root_isolation_effect, ROOT_ISOLATION_EFFECT);
+        tree.root_isolation_effect = Some(root_isolation_effect);
+
         assert_eq!(
             tree.append_spatial(transform(), VISUAL_VIEWPORT_NODE_INDEX),
             VIEWPORT_SCROLL
@@ -399,25 +340,36 @@ mod tests {
         tree
     }
 
+    // Box A: two chain clips, an effect under the second, an overflow clip for descendants.
+    // Box B: one clip under A's overflow clip.
     fn tree_with_box_a_followed_by_box_b() -> VisualContextTree {
         let mut tree = tree_with_viewport_nodes();
         assert_eq!(tree.append_spatial(transform(), VIEWPORT_SCROLL), BOX_A_SPATIAL);
         assert_eq!(
-            tree.append_frame(clip(10.0), ROOT_ISOLATION_FRAME, BOX_A_SPATIAL),
-            BOX_A_CHAIN_FRAME
+            tree.append_clip(clip(10.0), ClipNodeIndex::NONE, BOX_A_SPATIAL),
+            BOX_A_CHAIN_CLIP
         );
         assert_eq!(
-            tree.append_frame(clip(20.0), BOX_A_CHAIN_FRAME, BOX_A_SPATIAL),
-            BOX_A_PATCHED_CHAIN_FRAME
+            tree.append_clip(clip(20.0), BOX_A_CHAIN_CLIP, BOX_A_SPATIAL),
+            BOX_A_PATCHED_CHAIN_CLIP
         );
         assert_eq!(
-            tree.append_frame(clip(30.0), BOX_A_PATCHED_CHAIN_FRAME, BOX_A_SPATIAL),
-            BOX_A_DESCENDANT_FRAME
+            tree.append_effect(
+                effects(),
+                ROOT_ISOLATION_EFFECT,
+                BOX_A_SPATIAL,
+                BOX_A_PATCHED_CHAIN_CLIP
+            ),
+            BOX_A_EFFECT
+        );
+        assert_eq!(
+            tree.append_clip(clip(30.0), BOX_A_PATCHED_CHAIN_CLIP, BOX_A_SPATIAL),
+            BOX_A_DESCENDANT_CLIP
         );
         assert_eq!(tree.append_spatial(transform(), BOX_A_SPATIAL), BOX_B_SPATIAL);
         assert_eq!(
-            tree.append_frame(clip(40.0), BOX_A_DESCENDANT_FRAME, BOX_B_SPATIAL),
-            BOX_B_FRAME
+            tree.append_clip(clip(40.0), BOX_A_DESCENDANT_CLIP, BOX_B_SPATIAL),
+            BOX_B_CLIP
         );
         tree
     }
@@ -425,111 +377,100 @@ mod tests {
     fn box_a_handles() -> BoxVisualContextNodeHandles {
         BoxVisualContextNodeHandles {
             spatial: vec![BOX_A_SPATIAL],
-            chain_frames: vec![BOX_A_CHAIN_FRAME, BOX_A_PATCHED_CHAIN_FRAME],
-            descendant_frames: vec![BOX_A_DESCENDANT_FRAME],
+            chain_clips: vec![BOX_A_CHAIN_CLIP, BOX_A_PATCHED_CHAIN_CLIP],
+            descendant_clips: vec![BOX_A_DESCENDANT_CLIP],
+            effects: vec![BOX_A_EFFECT],
         }
     }
 
-    struct ScratchBox {
+    struct BoxDescription {
         spatial_parent: SpatialNodeIndex,
+        inherited_context: ContextRef,
         spatial_count: u32,
         chain_count: u32,
         patched_chain_count: u32,
+        effect_count: u32,
         descendant_count: u32,
         patched_chain_clip_size: f32,
     }
 
-    impl Default for ScratchBox {
+    impl Default for BoxDescription {
         fn default() -> Self {
             Self {
                 spatial_parent: VIEWPORT_SCROLL,
+                inherited_context: ContextRef {
+                    effect: ROOT_ISOLATION_EFFECT,
+                    ..ContextRef::default()
+                },
                 spatial_count: 1,
                 chain_count: 1,
                 patched_chain_count: 1,
+                effect_count: 1,
                 descendant_count: 1,
                 patched_chain_clip_size: 20.0,
             }
         }
     }
 
-    fn fill_scratch(scratch: &mut BoxNodeScratch<'_>, description: &ScratchBox) -> BoxVisualContextNodeHandles {
-        let mut handles = BoxVisualContextNodeHandles::default();
-        let mut spatial = description.spatial_parent;
-        for _ in 0..description.spatial_count {
-            spatial = scratch.append_spatial_node(transform(), spatial);
-            handles.spatial.push(spatial);
-        }
-        let mut frame = ROOT_ISOLATION_FRAME;
-        for _ in 0..description.chain_count {
-            frame = scratch.append_frame_node(clip(10.0), frame, spatial);
-            handles.chain_frames.push(frame);
-        }
-        for _ in 0..description.patched_chain_count {
-            frame = scratch.append_frame_node(clip(description.patched_chain_clip_size), frame, spatial);
-            handles.chain_frames.push(frame);
-        }
-        for _ in 0..description.descendant_count {
-            frame = scratch.append_frame_node(clip(30.0), frame, spatial);
-            handles.descendant_frames.push(frame);
-        }
-        handles
-    }
-
-    struct Planned {
-        placement: BoxNodePlacement,
-        spatial: Vec<SpatialNode>,
-        frames: Vec<FrameNode>,
-        delta: VisualContextTreeDelta,
-    }
-
-    fn plan(
-        tree: &mut VisualContextTree,
-        existing: Option<&BoxVisualContextNodeHandles>,
-        description: &ScratchBox,
-    ) -> Planned {
-        let mut scratch = BoxNodeScratch::new(tree);
-        let provisional = fill_scratch(&mut scratch, description);
-        let (spatial, frames) = scratch.into_nodes();
-        let mut delta = VisualContextTreeDelta::default();
-        let placement = plan_box_node_placement(tree, existing, &provisional, &mut delta);
-        Planned {
-            placement,
-            spatial,
-            frames,
-            delta,
-        }
-    }
-
     fn write(
         tree: &mut VisualContextTree,
         existing: Option<&BoxVisualContextNodeHandles>,
-        description: &ScratchBox,
-    ) -> (BoxNodePlacement, ReconcileOutcome, VisualContextTreeDelta) {
-        let planned = plan(tree, existing, description);
-        let placement = planned.placement;
-        let mut delta = planned.delta;
-        let outcome = write_box_nodes(tree, planned.spatial, planned.frames, &placement, existing, &mut delta);
-        (placement, outcome, delta)
+        description: &BoxDescription,
+    ) -> (BoxVisualContextNodeHandles, ReconcileOutcome, VisualContextTreeDelta) {
+        let mut delta = VisualContextTreeDelta::default();
+        let mut writer = BoxNodeWriter::new(tree, existing, &mut delta);
+        let mut context = ContextRef {
+            spatial: description.spatial_parent,
+            ..description.inherited_context
+        };
+        for _ in 0..description.spatial_count {
+            context = writer.append_spatial_node_under(context, transform());
+        }
+        for _ in 0..description.chain_count {
+            context = writer.append_clip_node_under(context, clip(10.0));
+        }
+        for _ in 0..description.patched_chain_count {
+            context = writer.append_clip_node_under(context, clip(description.patched_chain_clip_size));
+        }
+        for _ in 0..description.effect_count {
+            context.effect = writer.append_effect_node(effects(), context.effect, context.spatial);
+        }
+        writer.begin_descendants();
+        for _ in 0..description.descendant_count {
+            context = writer.append_clip_node_under(context, clip(30.0));
+        }
+        let (handles, outcome) = writer.finish();
+        (handles, outcome, delta)
+    }
+
+    fn box_b_description() -> BoxDescription {
+        BoxDescription {
+            spatial_parent: BOX_A_SPATIAL,
+            inherited_context: ContextRef {
+                clip: BOX_A_DESCENDANT_CLIP,
+                effect: BOX_A_EFFECT,
+                ..ContextRef::default()
+            },
+            patched_chain_count: 0,
+            effect_count: 0,
+            descendant_count: 0,
+            ..BoxDescription::default()
+        }
     }
 
     #[test]
     fn boxes_without_records_are_numbered_in_write_order_on_a_fresh_tree() {
         let mut tree = tree_with_viewport_nodes();
-        let (placement_a, outcome_a, delta_a) = write(&mut tree, None, &ScratchBox::default());
-        assert_eq!(placement_a.clone().into_node_handles(), box_a_handles());
+        let (handles_a, outcome_a, delta_a) = write(&mut tree, None, &BoxDescription::default());
+        assert_eq!(handles_a, box_a_handles());
         assert!(outcome_a.shape_changed);
         assert!(!delta_a.structural_epoch_changed);
         assert!(delta_a.requires_display_list_recording);
 
-        let description_b = ScratchBox {
-            spatial_parent: BOX_A_SPATIAL,
-            patched_chain_count: 0,
-            descendant_count: 0,
-            ..ScratchBox::default()
-        };
-        let (placement_b, _, _) = write(&mut tree, None, &description_b);
-        assert_eq!(placement_b.spatial, vec![BOX_B_SPATIAL]);
-        assert_eq!(placement_b.chain_frames, vec![BOX_B_FRAME]);
+        let (handles_b, _, _) = write(&mut tree, None, &box_b_description());
+        assert_eq!(handles_b.spatial, vec![BOX_B_SPATIAL]);
+        assert_eq!(handles_b.chain_clips, vec![BOX_B_CLIP]);
+        assert!(handles_b.effects.is_empty());
         assert_eq!(tree.free_slot_count(), 0);
         assert_eq!(tree.quarantined_slot_count(), 0);
     }
@@ -537,15 +478,11 @@ mod tests {
     #[test]
     fn a_slot_tombstoned_in_the_same_walk_is_not_handed_to_a_later_box() {
         let mut tree = tree_with_box_a_followed_by_box_b();
-        assert!(tree.tombstone_frame_slot(BOX_A_PATCHED_CHAIN_FRAME));
-        let description = ScratchBox {
-            patched_chain_count: 0,
-            descendant_count: 0,
-            ..ScratchBox::default()
-        };
-        let (placement, _, _) = write(&mut tree, None, &description);
-        assert_eq!(placement.spatial, vec![SpatialNodeIndex(4)]);
-        assert_eq!(placement.chain_frames, vec![FrameNodeIndex(5)]);
+
+        assert!(tree.tombstone_clip_slot(BOX_A_PATCHED_CHAIN_CLIP));
+        let (handles, _, _) = write(&mut tree, None, &box_b_description());
+        assert_eq!(handles.spatial, vec![SpatialNodeIndex(4)]);
+        assert_eq!(handles.chain_clips, vec![ClipNodeIndex(4)]);
         assert_eq!(tree.quarantined_slot_count(), 1);
         assert_eq!(tree.free_slot_count(), 0);
     }
@@ -554,54 +491,55 @@ mod tests {
     fn matching_units_keep_their_handles() {
         let mut tree = tree_with_box_a_followed_by_box_b();
         let existing = box_a_handles();
-        let planned = plan(&mut tree, Some(&existing), &ScratchBox::default());
-        let placement = planned.placement;
-        assert_eq!(placement.clone().into_node_handles(), existing);
-        assert_eq!(placement.remap_spatial(SpatialNodeIndex(4)), BOX_A_SPATIAL);
-        assert_eq!(placement.remap_frame(FrameNodeIndex(5)), BOX_A_CHAIN_FRAME);
-        assert_eq!(placement.remap_frame(FrameNodeIndex(6)), BOX_A_PATCHED_CHAIN_FRAME);
-        assert_eq!(placement.remap_frame(FrameNodeIndex(7)), BOX_A_DESCENDANT_FRAME);
-        assert_eq!(placement.remap_frame(ROOT_ISOLATION_FRAME), ROOT_ISOLATION_FRAME);
-        assert_eq!(planned.delta, VisualContextTreeDelta::default());
+        let (handles, outcome, delta) = write(&mut tree, Some(&existing), &BoxDescription::default());
+        assert_eq!(handles, existing);
+        assert!(!outcome.shape_changed);
+        assert_eq!(delta, VisualContextTreeDelta::default());
         assert_eq!(tree.spatial_nodes.len(), 4);
-        assert_eq!(tree.frame_nodes.len(), 5);
+        assert_eq!(tree.clip_nodes.len(), 4);
+        assert_eq!(tree.effect_nodes.len(), 2);
     }
 
     #[test]
     fn a_grown_unit_allocates_fresh_slots_at_the_end_when_nothing_is_free() {
         let mut tree = tree_with_box_a_followed_by_box_b();
         let existing = box_a_handles();
-        let description = ScratchBox {
+        let description = BoxDescription {
             spatial_count: 2,
             chain_count: 2,
             descendant_count: 0,
-            ..ScratchBox::default()
+            ..BoxDescription::default()
         };
-        let (placement, outcome, delta) = write(&mut tree, Some(&existing), &description);
-        assert_eq!(placement.spatial, vec![BOX_A_SPATIAL, SpatialNodeIndex(4)]);
+        let (handles, outcome, delta) = write(&mut tree, Some(&existing), &description);
+        assert_eq!(handles.spatial, vec![BOX_A_SPATIAL, SpatialNodeIndex(4)]);
         assert_eq!(
-            placement.chain_frames,
-            vec![BOX_A_CHAIN_FRAME, BOX_A_PATCHED_CHAIN_FRAME, FrameNodeIndex(5)]
+            handles.chain_clips,
+            vec![BOX_A_CHAIN_CLIP, BOX_A_PATCHED_CHAIN_CLIP, ClipNodeIndex(4)]
         );
-        assert!(placement.descendant_frames.is_empty());
+        assert!(handles.descendant_clips.is_empty());
+        assert_eq!(handles.effects, vec![BOX_A_EFFECT]);
         assert!(outcome.shape_changed);
         assert_eq!(tree.spatial_nodes[4].parent, BOX_A_SPATIAL);
         assert_eq!(
-            tree.frame_nodes[BOX_A_PATCHED_CHAIN_FRAME.0 as usize].parent,
-            BOX_A_CHAIN_FRAME
+            tree.clip_nodes[BOX_A_PATCHED_CHAIN_CLIP.0 as usize].parent,
+            BOX_A_CHAIN_CLIP
         );
-        assert_eq!(tree.frame_nodes[5].parent, BOX_A_PATCHED_CHAIN_FRAME);
-        assert_eq!(tree.frame_nodes[5].spatial, SpatialNodeIndex(4));
-        assert!(!tree.frame_is_live(BOX_A_DESCENDANT_FRAME));
+        assert_eq!(tree.clip_nodes[4].parent, BOX_A_PATCHED_CHAIN_CLIP);
+        assert_eq!(tree.clip_nodes[4].spatial, SpatialNodeIndex(4));
+        assert_eq!(
+            tree.effect_nodes[BOX_A_EFFECT.0 as usize].output_clip(),
+            BOX_A_PATCHED_CHAIN_CLIP
+        );
+        assert_eq!(tree.effect_nodes[BOX_A_EFFECT.0 as usize].spatial, SpatialNodeIndex(4));
+        assert!(!tree.clip_is_live(BOX_A_DESCENDANT_CLIP));
         assert_eq!(tree.quarantined_slot_count(), 1);
         assert_eq!(tree.free_slot_count(), 0);
-        assert!(delta.patched_spatial_node_indices.contains(&4));
-        assert!(delta.patched_frame_node_indices.contains(&5));
-        assert_eq!(delta.tombstoned_frame_node_indices, vec![BOX_A_DESCENDANT_FRAME.0]);
+        assert!(delta.tombstoned_any_node);
         assert!(delta.structural_epoch_changed);
         assert!(delta.requires_display_list_recording);
-        assert_eq!(tree.live_spatial_node_count, 5);
-        assert_eq!(tree.live_frame_node_count, 5);
+        assert_eq!(tree.live_spatial_node_count(), 5);
+        assert_eq!(tree.live_clip_node_count(), 4);
+        assert_eq!(tree.live_effect_node_count(), 2);
         tree.debug_assert_slot_accounting();
     }
 
@@ -609,127 +547,251 @@ mod tests {
     fn a_unit_may_reference_a_node_at_a_higher_index() {
         let mut tree = tree_with_box_a_followed_by_box_b();
         let existing = box_a_handles();
-        let description = ScratchBox {
+        let description = BoxDescription {
             spatial_parent: BOX_B_SPATIAL,
-            ..ScratchBox::default()
+            ..BoxDescription::default()
         };
-        let (placement, outcome, delta) = write(&mut tree, Some(&existing), &description);
-        assert_eq!(placement.into_node_handles(), existing);
+        let (handles, outcome, delta) = write(&mut tree, Some(&existing), &description);
+        assert_eq!(handles, existing);
         assert!(outcome.shape_changed);
         assert_eq!(tree.spatial_nodes[BOX_A_SPATIAL.0 as usize].parent, BOX_B_SPATIAL);
-        assert_eq!(delta.patched_spatial_node_indices, vec![BOX_A_SPATIAL.0]);
-        assert!(delta.tombstoned_spatial_node_indices.is_empty());
+        assert!(!delta.tombstoned_any_node);
         assert!(delta.structural_epoch_changed);
+        assert!(delta.requires_display_list_recording);
         assert_eq!(tree.spatial_nodes.len(), 4);
     }
 
     #[test]
-    fn writing_in_place_patches_only_the_changed_payloads() {
+    fn writing_a_clip_value_in_place_needs_no_recording_or_epoch_change() {
         let mut tree = tree_with_box_a_followed_by_box_b();
         let existing = box_a_handles();
-        let description = ScratchBox {
+        let description = BoxDescription {
             patched_chain_clip_size: 25.0,
-            ..ScratchBox::default()
+            ..BoxDescription::default()
         };
         let (_, outcome, delta) = write(&mut tree, Some(&existing), &description);
         assert!(!outcome.shape_changed);
-        assert!(outcome.any_payload_changed);
-        assert_eq!(delta.patched_spatial_node_indices, Vec::<u32>::new());
-        assert_eq!(delta.patched_frame_node_indices, vec![BOX_A_PATCHED_CHAIN_FRAME.0]);
-        assert!(delta.tombstoned_frame_node_indices.is_empty());
+        let ClipNodeData::Rect(updated_clip) = &tree.clip_nodes[BOX_A_PATCHED_CHAIN_CLIP.0 as usize].data else {
+            panic!("the updated clip remains a rectangle");
+        };
+        assert_eq!(updated_clip.rect, FloatRect::new(0.0, 0.0, 25.0, 25.0));
+        assert!(!delta.tombstoned_any_node);
         assert!(!delta.structural_epoch_changed);
         assert!(!delta.requires_display_list_recording);
-        assert_eq!(tree.live_spatial_node_count, 4);
-        assert_eq!(tree.live_frame_node_count, 5);
+        assert_eq!(tree.live_spatial_node_count(), 4);
+        assert_eq!(tree.live_clip_node_count(), 4);
+        assert_eq!(tree.live_effect_node_count(), 2);
+    }
+
+    #[test]
+    fn rebuilding_an_effect_preserves_its_resolved_clip_until_finalization() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        let constraints = [
+            EffectClipConstraint {
+                effect: BOX_A_EFFECT,
+                clip: BOX_A_PATCHED_CHAIN_CLIP,
+            },
+            EffectClipConstraint {
+                effect: BOX_A_EFFECT,
+                clip: ClipNodeIndex::NONE,
+            },
+        ];
+        assert!(tree.resolve_effect_output_clips(&constraints));
+        let existing = BoxVisualContextNodeHandles {
+            effects: vec![BOX_A_EFFECT],
+            ..BoxVisualContextNodeHandles::default()
+        };
+        let mut delta = VisualContextTreeDelta::default();
+        let mut writer = BoxNodeWriter::new(&mut tree, Some(&existing), &mut delta);
+        let effect = writer.append_effect_node(
+            EffectNodeData::Effects(EffectsData {
+                opacity: 0.7,
+                blend_mode: CompositingAndBlendingOperator::Normal,
+                filter: None,
+            }),
+            ROOT_ISOLATION_EFFECT,
+            BOX_A_SPATIAL,
+        );
+        let (_, outcome) = writer.finish();
+
+        assert_eq!(effect, BOX_A_EFFECT);
+        assert_eq!(tree.effects_opacity(effect), Some(0.7));
+        assert_eq!(tree.effect_nodes[effect.0 as usize].output_clip(), ClipNodeIndex::NONE);
+        assert!(!outcome.shape_changed);
+        assert_eq!(delta, VisualContextTreeDelta::default());
+        assert!(!tree.resolve_effect_output_clips(&constraints));
+        // Removing the escape changes only the derived result, without rebuilding the effect.
+        assert!(tree.resolve_effect_output_clips(&constraints[..1]));
+        assert_eq!(
+            tree.effect_nodes[effect.0 as usize].output_clip(),
+            BOX_A_PATCHED_CHAIN_CLIP
+        );
+    }
+
+    #[test]
+    fn new_and_recycled_effects_have_no_previous_output_clip() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        for recycled in [false, true] {
+            let mut delta = VisualContextTreeDelta::default();
+            let mut writer = BoxNodeWriter::new(&mut tree, None, &mut delta);
+            let effect = writer.append_effect_node(effects(), ROOT_ISOLATION_EFFECT, BOX_A_SPATIAL);
+            writer.finish();
+            let context = ContextRef {
+                spatial: BOX_A_SPATIAL,
+                clip: BOX_A_CHAIN_CLIP,
+                effect,
+            };
+            assert!(!tree.context_is_valid(context));
+            assert!(!tree.node_references_are_consistent());
+            assert!(!tree.resolve_effect_output_clips(&[EffectClipConstraint {
+                effect,
+                clip: context.clip,
+            }]));
+            assert!(tree.context_is_valid(context));
+            assert!(tree.node_references_are_consistent());
+            assert_eq!(delta.structural_epoch_changed, recycled);
+            assert!(delta.requires_display_list_recording);
+            assert_eq!(effect, EffectNodeIndex(2));
+            assert!(tree.tombstone_effect_slot(effect));
+            tree.release_quarantined_slots_after_recording();
+        }
     }
 
     #[test]
     fn a_shrunken_unit_tombstones_its_surplus_handles_into_quarantine() {
         let mut tree = tree_with_box_a_followed_by_box_b();
         let existing = box_a_handles();
-        let description = ScratchBox {
+        let description = BoxDescription {
             descendant_count: 0,
-            ..ScratchBox::default()
+            ..BoxDescription::default()
         };
-        let (placement, outcome, delta) = write(&mut tree, Some(&existing), &description);
-        assert!(placement.descendant_frames.is_empty());
+        let (handles, outcome, delta) = write(&mut tree, Some(&existing), &description);
+        assert!(handles.descendant_clips.is_empty());
         assert!(outcome.shape_changed);
-        assert!(!tree.frame_is_live(BOX_A_DESCENDANT_FRAME));
-        assert_eq!(delta.tombstoned_frame_node_indices, vec![BOX_A_DESCENDANT_FRAME.0]);
+        assert!(!tree.clip_is_live(BOX_A_DESCENDANT_CLIP));
+        assert!(delta.tombstoned_any_node);
         assert!(delta.structural_epoch_changed);
         assert!(delta.requires_display_list_recording);
         assert_eq!(tree.quarantined_slot_count(), 1);
         assert_eq!(tree.free_slot_count(), 0);
-        assert_eq!(tree.frame_nodes.len(), 5);
+        assert_eq!(tree.clip_nodes.len(), 4);
         tree.debug_assert_slot_accounting();
     }
 
     #[test]
     fn a_reused_slot_changes_the_structural_epoch_and_a_fresh_slot_does_not() {
         let mut tree = tree_with_box_a_followed_by_box_b();
-        assert!(tree.tombstone_frame_slot(BOX_B_FRAME));
+
+        assert!(tree.tombstone_clip_slot(BOX_B_CLIP));
         tree.release_quarantined_slots_after_recording();
         let existing = box_a_handles();
-        let description = ScratchBox {
+        let description = BoxDescription {
             descendant_count: 2,
-            ..ScratchBox::default()
+            ..BoxDescription::default()
         };
-        let (placement, _, delta) = write(&mut tree, Some(&existing), &description);
-        assert_eq!(placement.descendant_frames, vec![BOX_A_DESCENDANT_FRAME, BOX_B_FRAME]);
+        let (handles, _, delta) = write(&mut tree, Some(&existing), &description);
+        assert_eq!(handles.descendant_clips, vec![BOX_A_DESCENDANT_CLIP, BOX_B_CLIP]);
         assert!(delta.structural_epoch_changed);
         assert!(delta.requires_display_list_recording);
-        assert_eq!(tree.frame_nodes.len(), 5);
+        assert_eq!(tree.clip_nodes.len(), 4);
 
         let mut fresh_tree = tree_with_box_a_followed_by_box_b();
-        let (placement, _, delta) = write(&mut fresh_tree, Some(&existing), &description);
-        assert_eq!(
-            placement.descendant_frames,
-            vec![BOX_A_DESCENDANT_FRAME, FrameNodeIndex(5)]
-        );
+        let (handles, _, delta) = write(&mut fresh_tree, Some(&existing), &description);
+        assert_eq!(handles.descendant_clips, vec![BOX_A_DESCENDANT_CLIP, ClipNodeIndex(4)]);
         assert!(!delta.structural_epoch_changed);
         assert!(delta.requires_display_list_recording);
-        assert_eq!(fresh_tree.frame_nodes.len(), 6);
+        assert_eq!(fresh_tree.clip_nodes.len(), 5);
     }
 
     #[test]
-    fn provisional_references_between_units_resolve_to_final_handles() {
+    fn emitted_nodes_are_readable_by_their_final_handles() {
         let mut tree = tree_with_box_a_followed_by_box_b();
         let existing = box_a_handles();
-        let description = ScratchBox {
-            spatial_count: 2,
-            chain_count: 2,
-            ..ScratchBox::default()
+        let mut delta = VisualContextTreeDelta::default();
+        let mut writer = BoxNodeWriter::new(&mut tree, Some(&existing), &mut delta);
+        let context = ContextRef {
+            spatial: VIEWPORT_SCROLL,
+            effect: ROOT_ISOLATION_EFFECT,
+            ..ContextRef::default()
         };
-        let (placement, _, _) = write(&mut tree, Some(&existing), &description);
-        let patched_chain = placement.chain_frames[2];
-        assert_eq!(
-            tree.frame_nodes[patched_chain.0 as usize].parent,
-            placement.chain_frames[1]
+        let context = writer.append_spatial_node_under(context, transform());
+        assert_eq!(context.spatial, BOX_A_SPATIAL);
+        let transformed = writer.append_spatial_node_under(
+            context,
+            SpatialData::Transform(TransformData {
+                sorting_context_root_index: Some(context.spatial),
+                ..transform_data()
+            }),
         );
-        assert_eq!(tree.frame_nodes[patched_chain.0 as usize].spatial, placement.spatial[1]);
-        let descendant = placement.descendant_frames[0];
-        assert_eq!(tree.frame_nodes[descendant.0 as usize].parent, patched_chain);
+        assert_eq!(transformed.spatial, SpatialNodeIndex(4));
+        let spatial_node = writer.spatial_node_at(transformed.spatial);
+        assert_eq!(spatial_node.parent, BOX_A_SPATIAL);
+        let SpatialData::Transform(data) = &spatial_node.data else {
+            panic!("the appended node is a transform");
+        };
+        assert_eq!(data.sorting_context_root_index, Some(BOX_A_SPATIAL));
+
+        let first_clip = writer.append_clip_node_under(transformed, clip(15.0));
+        assert_eq!(first_clip.clip, BOX_A_CHAIN_CLIP);
+        let ClipNodeData::Rect(data) = &writer.clip_node_at(first_clip.clip).data else {
+            panic!("the updated clip remains a rectangle");
+        };
+        assert_eq!(data.rect, FloatRect::new(0.0, 0.0, 15.0, 15.0));
+        let second_clip = writer.append_clip_node_under(first_clip, clip(20.0));
+        assert_eq!(second_clip.clip, BOX_A_PATCHED_CHAIN_CLIP);
+        assert_eq!(writer.clip_node_at(second_clip.clip).spatial, transformed.spatial);
+        assert!(writer.clip_is_ancestor_or_self(first_clip.clip, second_clip.clip));
+        let third_clip = writer.append_clip_node_under(second_clip, clip(25.0));
+        assert_eq!(third_clip.clip, ClipNodeIndex(4));
+        assert_eq!(writer.clip_node_at(third_clip.clip).parent, second_clip.clip);
+        let own_context = ContextRef {
+            effect: writer.append_effect_node(effects(), third_clip.effect, third_clip.spatial),
+            ..third_clip
+        };
+        assert_eq!(own_context.effect, BOX_A_EFFECT);
+        assert!(writer.tree.context_is_valid(own_context));
+        writer.begin_descendants();
+        let descendant_context = writer.append_clip_node_under(own_context, clip(30.0));
+        assert_eq!(descendant_context.clip, BOX_A_DESCENDANT_CLIP);
+        assert_eq!(writer.clip_node_at(descendant_context.clip).parent, own_context.clip);
+        assert!(writer.tree.context_is_valid(descendant_context));
+
+        let (handles, _) = writer.finish();
+        assert!(tree.resolve_effect_output_clips(&[EffectClipConstraint {
+            effect: own_context.effect,
+            clip: own_context.clip,
+        }]));
+        assert_eq!(handles.spatial, vec![BOX_A_SPATIAL, transformed.spatial]);
         assert_eq!(
-            tree.spatial_nodes[placement.spatial[1].0 as usize].parent,
-            placement.spatial[0]
+            handles.chain_clips,
+            vec![BOX_A_CHAIN_CLIP, BOX_A_PATCHED_CHAIN_CLIP, third_clip.clip]
         );
+        assert_eq!(handles.descendant_clips, existing.descendant_clips);
+        assert_eq!(handles.effects, existing.effects);
+        assert_eq!(tree.effect_nodes[BOX_A_EFFECT.0 as usize].parent, ROOT_ISOLATION_EFFECT);
+        assert_eq!(
+            tree.effect_nodes[BOX_A_EFFECT.0 as usize].output_clip(),
+            own_context.clip
+        );
+        assert_eq!(tree.effect_nodes[BOX_A_EFFECT.0 as usize].spatial, transformed.spatial);
+        tree.debug_assert_slot_accounting();
     }
 
     #[test]
     fn a_box_without_a_record_allocates_every_unit() {
         let mut tree = tree_with_box_a_followed_by_box_b();
-        let (placement, outcome, mut delta) = write(&mut tree, None, &ScratchBox::default());
-        delta.finish();
-        assert_eq!(placement.spatial, vec![SpatialNodeIndex(4)]);
-        assert_eq!(placement.chain_frames, vec![FrameNodeIndex(5), FrameNodeIndex(6)]);
-        assert_eq!(placement.descendant_frames, vec![FrameNodeIndex(7)]);
+        let (handles, outcome, delta) = write(&mut tree, None, &BoxDescription::default());
+        assert_eq!(handles.spatial, vec![SpatialNodeIndex(4)]);
+        assert_eq!(handles.chain_clips, vec![ClipNodeIndex(4), ClipNodeIndex(5)]);
+        assert_eq!(handles.descendant_clips, vec![ClipNodeIndex(6)]);
+        assert_eq!(handles.effects, vec![EffectNodeIndex(2)]);
         assert!(outcome.shape_changed);
-        assert_eq!(delta.patched_spatial_node_indices, vec![4]);
-        assert_eq!(delta.patched_frame_node_indices, vec![5, 6, 7]);
+        assert!(!delta.tombstoned_any_node);
         assert!(!delta.structural_epoch_changed);
         assert!(delta.requires_display_list_recording);
-        assert_eq!(tree.live_spatial_node_count, 5);
-        assert_eq!(tree.live_frame_node_count, 8);
+        assert_eq!(tree.live_spatial_node_count(), 5);
+        assert_eq!(tree.live_clip_node_count(), 7);
+        assert_eq!(tree.live_effect_node_count(), 3);
         assert!(tree.spatial_is_live(BOX_A_SPATIAL));
         tree.debug_assert_slot_accounting();
     }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
@@ -5,10 +5,10 @@
  */
 
 use super::{
-    AnchorScrollShift, BackfaceVisibilityData, ClipData, ClipMode, ClipPathData, EffectsData, FrameData, FrameNode,
-    FrameNodeIndex, MaskData, MaskLayerOrigin, PerspectiveData, ScrollData, SpatialData, SpatialNode, SpatialNodeIndex,
-    StickyData, TransformData, TransformDataRole, VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree,
-    scroll_state::NO_SCROLL_STATE_SLOT,
+    AnchorScrollShift, BackfaceVisibilityData, ClipData, ClipMode, ClipNode, ClipNodeData, ClipNodeIndex, ClipPathData,
+    EffectNode, EffectNodeData, EffectNodeIndex, EffectsData, MaskData, MaskLayerOrigin, PerspectiveData, ScrollData,
+    SpatialData, SpatialNode, SpatialNodeIndex, StickyData, TransformData, TransformDataRole,
+    VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree, scroll_state::NO_SCROLL_STATE_SLOT,
 };
 use crate::layout::node_data::NodeSlotId;
 use libgfx_rust::path::OwnedPath;
@@ -19,7 +19,7 @@ use libgfx_rust::{
 use std::rc::Rc;
 
 const SERIALIZED_TREE_MAGIC: u32 = 0x5443_5641;
-const SERIALIZED_TREE_FORMAT: u32 = 1;
+const SERIALIZED_TREE_FORMAT: u32 = 3;
 
 const SPATIAL_KIND_SCROLL: u8 = 0;
 const SPATIAL_KIND_STICKY: u8 = 1;
@@ -29,15 +29,18 @@ const SPATIAL_KIND_BACKFACE_VISIBILITY: u8 = 4;
 const SPATIAL_KIND_ANCHOR_SCROLL_SHIFT: u8 = 5;
 const SPATIAL_KIND_DEAD: u8 = 6;
 
-const FRAME_KIND_CLIP: u8 = 0;
-const FRAME_KIND_CLIP_PATH: u8 = 1;
-const FRAME_KIND_EFFECTS: u8 = 2;
-const FRAME_KIND_MASK: u8 = 3;
-const FRAME_KIND_DEAD: u8 = 4;
-const FRAME_KIND_BACKGROUND_COLOR_ANIMATION: u8 = 5;
+const CLIP_KIND_RECT: u8 = 0;
+const CLIP_KIND_PATH: u8 = 1;
+const CLIP_KIND_DEAD: u8 = 2;
+
+const EFFECT_KIND_EFFECTS: u8 = 0;
+const EFFECT_KIND_MASK: u8 = 1;
+const EFFECT_KIND_BACKGROUND_COLOR_ANIMATION: u8 = 2;
+const EFFECT_KIND_DEAD: u8 = 3;
 
 const MINIMUM_SERIALIZED_SPATIAL_NODE_SIZE: usize = 5;
-const MINIMUM_SERIALIZED_FRAME_NODE_SIZE: usize = 9;
+const MINIMUM_SERIALIZED_CLIP_NODE_SIZE: usize = 9;
+const MINIMUM_SERIALIZED_EFFECT_NODE_SIZE: usize = 13;
 
 #[derive(Default)]
 struct TreeByteWriter {
@@ -74,7 +77,10 @@ impl TreeByteWriter {
         self.bool(index.is_some());
         self.u32(index.map_or(0, |index| index.0));
     }
-    fn frame_index(&mut self, index: FrameNodeIndex) {
+    fn clip_index(&mut self, index: ClipNodeIndex) {
+        self.u32(index.0);
+    }
+    fn effect_index(&mut self, index: EffectNodeIndex) {
         self.u32(index.0);
     }
     fn point(&mut self, point: FloatPoint) {
@@ -176,8 +182,11 @@ impl<'a> TreeByteReader<'a> {
         let index = self.u32()?;
         Some(has_value.then_some(SpatialNodeIndex(index)))
     }
-    fn frame_index(&mut self) -> Option<FrameNodeIndex> {
-        self.u32().map(FrameNodeIndex)
+    fn clip_index(&mut self) -> Option<ClipNodeIndex> {
+        self.u32().map(ClipNodeIndex)
+    }
+    fn effect_index(&mut self) -> Option<EffectNodeIndex> {
+        self.u32().map(EffectNodeIndex)
     }
     fn point(&mut self) -> Option<FloatPoint> {
         Some(FloatPoint {
@@ -370,73 +379,86 @@ fn read_spatial_data(reader: &mut TreeByteReader<'_>) -> Option<SpatialData> {
     })
 }
 
-fn write_frame_data(writer: &mut TreeByteWriter, data: &FrameData) {
+fn write_clip_data(writer: &mut TreeByteWriter, data: &ClipNodeData) {
     match data {
-        FrameData::BackgroundColorAnimation => writer.u8(FRAME_KIND_BACKGROUND_COLOR_ANIMATION),
-        FrameData::Clip(clip) => {
-            writer.u8(FRAME_KIND_CLIP);
+        ClipNodeData::Rect(clip) => {
+            writer.u8(CLIP_KIND_RECT);
             writer.float_rect(clip.rect);
             writer.corner_radii(clip.corner_radii);
             writer.u8(clip.mode as u8);
         }
-        FrameData::ClipPath(clip_path) => {
-            writer.u8(FRAME_KIND_CLIP_PATH);
+        ClipNodeData::Path(clip_path) => {
+            writer.u8(CLIP_KIND_PATH);
             writer.int_rect(clip_path.bounding_rect);
             writer.i32(clip_path.fill_rule as i32);
             writer.length_prefixed_bytes(&clip_path.path.serialize_to_bytes());
         }
-        FrameData::Effects(effects) => {
-            writer.u8(FRAME_KIND_EFFECTS);
-            writer.f32(effects.opacity);
-            writer.i32(effects.blend_mode as i32);
-            writer.bool(effects.filter.is_some());
-            writer.length_prefixed_bytes(effects.filter.as_deref().map_or(&[], Vec::as_slice));
-        }
-        FrameData::Mask(mask) => {
-            writer.u8(FRAME_KIND_MASK);
-            writer.int_rect(mask.rect);
-            writer.i32(mask.kind as i32);
-            writer.u8(mask.origin as u8);
-        }
-        FrameData::Dead => writer.u8(FRAME_KIND_DEAD),
+        ClipNodeData::Dead => writer.u8(CLIP_KIND_DEAD),
     }
 }
 
-fn read_frame_data(reader: &mut TreeByteReader<'_>) -> Option<FrameData> {
+fn read_clip_data(reader: &mut TreeByteReader<'_>) -> Option<ClipNodeData> {
     Some(match reader.u8()? {
-        FRAME_KIND_BACKGROUND_COLOR_ANIMATION => FrameData::BackgroundColorAnimation,
-        FRAME_KIND_CLIP => FrameData::Clip(ClipData {
+        CLIP_KIND_RECT => ClipNodeData::Rect(ClipData {
             rect: reader.float_rect()?,
             corner_radii: reader.corner_radii()?,
             mode: reader.clip_mode()?,
         }),
-        FRAME_KIND_CLIP_PATH => {
+        CLIP_KIND_PATH => {
             let bounding_rect = reader.int_rect()?;
             let fill_rule = reader.winding_rule()?;
             let path = OwnedPath::from_serialized_bytes(reader.length_prefixed_bytes()?);
-            FrameData::ClipPath(ClipPathData {
+            ClipNodeData::Path(ClipPathData {
                 path: Rc::new(path),
                 bounding_rect,
                 fill_rule,
             })
         }
-        FRAME_KIND_EFFECTS => {
+        CLIP_KIND_DEAD => ClipNodeData::Dead,
+        _ => return None,
+    })
+}
+
+fn write_effect_data(writer: &mut TreeByteWriter, data: &EffectNodeData) {
+    match data {
+        EffectNodeData::Effects(effects) => {
+            writer.u8(EFFECT_KIND_EFFECTS);
+            writer.f32(effects.opacity);
+            writer.i32(effects.blend_mode as i32);
+            writer.bool(effects.filter.is_some());
+            writer.length_prefixed_bytes(effects.filter.as_deref().map_or(&[], Vec::as_slice));
+        }
+        EffectNodeData::Mask(mask) => {
+            writer.u8(EFFECT_KIND_MASK);
+            writer.int_rect(mask.rect);
+            writer.i32(mask.kind as i32);
+            writer.u8(mask.origin as u8);
+        }
+        EffectNodeData::BackgroundColorAnimation => writer.u8(EFFECT_KIND_BACKGROUND_COLOR_ANIMATION),
+        EffectNodeData::Dead => writer.u8(EFFECT_KIND_DEAD),
+    }
+}
+
+fn read_effect_data(reader: &mut TreeByteReader<'_>) -> Option<EffectNodeData> {
+    Some(match reader.u8()? {
+        EFFECT_KIND_EFFECTS => {
             let opacity = reader.f32()?;
             let blend_mode = reader.compositing_and_blending_operator()?;
             let has_filter = reader.bool()?;
             let filter_bytes = reader.length_prefixed_bytes()?;
-            FrameData::Effects(EffectsData {
+            EffectNodeData::Effects(EffectsData {
                 opacity,
                 blend_mode,
                 filter: has_filter.then(|| Rc::new(filter_bytes.to_vec())),
             })
         }
-        FRAME_KIND_MASK => FrameData::Mask(MaskData {
+        EFFECT_KIND_MASK => EffectNodeData::Mask(MaskData {
             rect: reader.int_rect()?,
             kind: reader.mask_kind()?,
             origin: reader.mask_layer_origin()?,
         }),
-        FRAME_KIND_DEAD => FrameData::Dead,
+        EFFECT_KIND_BACKGROUND_COLOR_ANIMATION => EffectNodeData::BackgroundColorAnimation,
+        EFFECT_KIND_DEAD => EffectNodeData::Dead,
         _ => return None,
     })
 }
@@ -452,7 +474,7 @@ fn spatial_node_has_ancestor(nodes: &[SpatialNode], mut node: usize, ancestor: S
 }
 
 impl VisualContextTree {
-    pub(super) fn node_references_are_consistent(&self) -> bool {
+    pub(crate) fn node_references_are_consistent(&self) -> bool {
         let spatial_nodes = &self.spatial_nodes;
         let root = &spatial_nodes[VISUAL_VIEWPORT_NODE_INDEX.0 as usize];
         if root.parent != VISUAL_VIEWPORT_NODE_INDEX || !matches!(root.data, SpatialData::Transform(_)) {
@@ -486,20 +508,59 @@ impl VisualContextTree {
                 _ => {}
             }
         }
-        for node in &self.frame_nodes {
-            let spatial_is_out_of_range = node.spatial.0 as usize >= spatial_nodes.len();
-            let live_frame_in_a_tombstone = node.data.is_live() && !self.spatial_is_live(node.spatial);
-            if spatial_is_out_of_range || live_frame_in_a_tombstone {
+        // A node's spatial node is in range, and live where the node is live.
+        let spatial_reference_is_consistent = |spatial: SpatialNodeIndex, is_live: bool| {
+            (spatial.0 as usize) < spatial_nodes.len() && (!is_live || self.spatial_is_live(spatial))
+        };
+        if !self
+            .clip_nodes
+            .iter()
+            .all(|node| spatial_reference_is_consistent(node.spatial, node.data.is_live()))
+        {
+            return false;
+        }
+        let clip_order = self.clip_dependency_order_with_back_edges();
+        if !clip_order.back_edges.is_empty() || !clip_order.dangling_references.is_empty() {
+            return false;
+        }
+        for node in &self.effect_nodes {
+            if !spatial_reference_is_consistent(node.spatial, node.data.is_live()) {
+                return false;
+            }
+            if node.data.is_live()
+                && node
+                    .resolved_output_clip
+                    .is_none_or(|clip| !self.clip_is_none_or_live(clip))
+            {
                 return false;
             }
         }
-        let frame_order = self.frame_dependency_order_with_back_edges();
-        if !frame_order.back_edges.is_empty() || !frame_order.dangling_references.is_empty() {
+        let effect_order = self.effect_dependency_order_with_back_edges();
+        if !effect_order.back_edges.is_empty() || !effect_order.dangling_references.is_empty() {
             return false;
         }
-        if let Some(root_isolation_frame) = self.root_isolation_frame {
-            let index = root_isolation_frame.0 as usize;
-            if index >= self.frame_nodes.len() || !matches!(self.frame_nodes[index].data, FrameData::Effects(_)) {
+        // Replay pushes each effect's layer inside its output clip and the remaining clips inside
+        // the layer, which needs the output clips nested along the effect chain. Display-list
+        // contexts are validated against these clips separately. The clip tree has
+        // just been checked for cycles.
+        for node in &self.effect_nodes {
+            if !node.data.is_live() || node.parent.is_none() {
+                continue;
+            }
+            let parent_output_clip = self.effect_nodes[node.parent.0 as usize].output_clip();
+            if !self.clip_is_ancestor_or_self(parent_output_clip, node.output_clip()) {
+                return false;
+            }
+        }
+        // Plane clips are pushed immediately above this root isolation layer.
+        if let Some(effect) = self.root_isolation_effect {
+            let Some(node) = self.effect_nodes.get(effect.0 as usize) else {
+                return false;
+            };
+            if !matches!(node.data, EffectNodeData::Effects(_))
+                || !node.parent.is_none()
+                || !node.output_clip().is_none()
+            {
                 return false;
             }
         }
@@ -514,17 +575,24 @@ impl VisualContextTree {
         writer.u32(SERIALIZED_TREE_FORMAT);
         writer.u64(self.structural_epoch);
         writer.bool(self.root_is_visual_viewport);
-        writer.frame_index(self.root_isolation_frame.unwrap_or(FrameNodeIndex::NONE));
+        writer.effect_index(self.root_isolation_effect.unwrap_or(EffectNodeIndex::NONE));
         writer.u32(self.spatial_nodes.len() as u32);
-        writer.u32(self.frame_nodes.len() as u32);
+        writer.u32(self.clip_nodes.len() as u32);
+        writer.u32(self.effect_nodes.len() as u32);
         for node in &self.spatial_nodes {
             writer.spatial_index(node.parent);
             write_spatial_data(&mut writer, &node.data);
         }
-        for node in &self.frame_nodes {
-            writer.frame_index(node.parent);
+        for node in &self.clip_nodes {
+            writer.clip_index(node.parent);
             writer.spatial_index(node.spatial);
-            write_frame_data(&mut writer, &node.data);
+            write_clip_data(&mut writer, &node.data);
+        }
+        for node in &self.effect_nodes {
+            writer.effect_index(node.parent);
+            writer.spatial_index(node.spatial);
+            writer.clip_index(node.output_clip());
+            write_effect_data(&mut writer, &node.data);
         }
         writer.bytes
     }
@@ -536,12 +604,14 @@ impl VisualContextTree {
         }
         let structural_epoch = reader.u64()?;
         let root_is_visual_viewport = reader.bool()?;
-        let root_isolation_frame = reader.frame_index()?;
+        let root_isolation_effect = reader.effect_index()?;
         let spatial_count = reader.u32()? as usize;
-        let frame_count = reader.u32()? as usize;
+        let clip_count = reader.u32()? as usize;
+        let effect_count = reader.u32()? as usize;
         if spatial_count == 0
             || spatial_count > reader.remaining() / MINIMUM_SERIALIZED_SPATIAL_NODE_SIZE
-            || frame_count > reader.remaining() / MINIMUM_SERIALIZED_FRAME_NODE_SIZE
+            || clip_count > reader.remaining() / MINIMUM_SERIALIZED_CLIP_NODE_SIZE
+            || effect_count > reader.remaining() / MINIMUM_SERIALIZED_EFFECT_NODE_SIZE
         {
             return None;
         }
@@ -553,34 +623,40 @@ impl VisualContextTree {
             spatial_nodes.push(SpatialNode { data, parent });
         }
 
-        let mut frame_nodes = Vec::with_capacity(frame_count);
-        for _ in 0..frame_count {
-            let parent = reader.frame_index()?;
+        let mut clip_nodes = Vec::with_capacity(clip_count);
+        for _ in 0..clip_count {
+            let parent = reader.clip_index()?;
             let spatial = reader.spatial_index()?;
-            let data = read_frame_data(&mut reader)?;
-            frame_nodes.push(FrameNode::new(data, parent, spatial));
+            let data = read_clip_data(&mut reader)?;
+            clip_nodes.push(ClipNode::new(data, parent, spatial));
+        }
+
+        let mut effect_nodes = Vec::with_capacity(effect_count);
+        for _ in 0..effect_count {
+            let parent = reader.effect_index()?;
+            let spatial = reader.spatial_index()?;
+            let output_clip = reader.clip_index()?;
+            let data = read_effect_data(&mut reader)?;
+            effect_nodes.push(EffectNode {
+                data,
+                parent,
+                spatial,
+                resolved_output_clip: Some(output_clip),
+            });
         }
 
         if reader.remaining() != 0 {
             return None;
         }
 
-        let live_spatial_node_count = spatial_nodes.iter().filter(|node| node.data.is_live()).count() as u32;
-        let live_frame_node_count = frame_nodes.iter().filter(|node| node.data.is_live()).count() as u32;
-        let tree = Self {
+        let tree = Self::from_nodes(
             spatial_nodes,
-            frame_nodes,
+            clip_nodes,
+            effect_nodes,
             root_is_visual_viewport,
-            root_isolation_frame: (!root_isolation_frame.is_none()).then_some(root_isolation_frame),
+            (!root_isolation_effect.is_none()).then_some(root_isolation_effect),
             structural_epoch,
-            live_spatial_node_count,
-            live_frame_node_count,
-            free_spatial_slots: Vec::new(),
-            free_frame_slots: Vec::new(),
-            quarantined_spatial_slots: Vec::new(),
-            quarantined_frame_slots: Vec::new(),
-            sampled_background_colors: std::collections::HashMap::new(),
-        };
+        );
         tree.node_references_are_consistent().then_some(tree)
     }
 }
@@ -698,8 +774,8 @@ mod tests {
             scroll_node,
         );
 
-        let clip = tree.append_frame(
-            FrameData::Clip(ClipData {
+        let clip = tree.append_clip(
+            ClipNodeData::Rect(ClipData {
                 rect: FloatRect::new(0.5, 1.0, 20.0, 30.0),
                 corner_radii: CornerRadii {
                     top_left: CornerRadius {
@@ -721,46 +797,50 @@ mod tests {
                 },
                 mode: ClipMode::Difference,
             }),
-            FrameNodeIndex::NONE,
+            ClipNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        let effects = tree.append_frame(
-            FrameData::Effects(EffectsData {
-                opacity: 0.25,
-                blend_mode: CompositingAndBlendingOperator::PlusLighter,
-                filter: Some(Rc::new(vec![1, 2, 3, 4])),
+        let clip_path = tree.append_clip(
+            ClipNodeData::Path(ClipPathData {
+                path: Rc::new(OwnedPath::from_serialized_bytes(&[])),
+                bounding_rect: IntRect::new(5, 6, 7, 8),
+                fill_rule: WindingRule::EvenOdd,
             }),
             clip,
             scroll_node,
         );
-        tree.append_frame(
-            FrameData::Effects(EffectsData {
+        let root_effect = tree.append_effect(
+            EffectNodeData::Effects(EffectsData {
                 opacity: 1.0,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
             }),
-            effects,
-            scroll_node,
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
         );
-        tree.append_frame(
-            FrameData::Mask(MaskData {
+        let effects = tree.append_effect(
+            EffectNodeData::Effects(EffectsData {
+                opacity: 0.25,
+                blend_mode: CompositingAndBlendingOperator::PlusLighter,
+                filter: Some(Rc::new(vec![1, 2, 3, 4])),
+            }),
+            root_effect,
+            scroll_node,
+            clip,
+        );
+        let mask = tree.append_effect(
+            EffectNodeData::Mask(MaskData {
                 rect: IntRect::new(1, 2, 3, 4),
                 kind: MaskKind::Luminance,
                 origin: MaskLayerOrigin::SvgClip,
             }),
             effects,
             sorting_root,
+            clip_path,
         );
-        tree.append_frame(
-            FrameData::ClipPath(ClipPathData {
-                path: Rc::new(OwnedPath::from_serialized_bytes(&[])),
-                bounding_rect: IntRect::new(5, 6, 7, 8),
-                fill_rule: WindingRule::EvenOdd,
-            }),
-            FrameNodeIndex::NONE,
-            scroll_node,
-        );
-        tree.root_isolation_frame = Some(effects);
+        tree.append_effect(EffectNodeData::BackgroundColorAnimation, mask, sorting_root, clip_path);
+        tree.root_isolation_effect = Some(root_effect);
         tree
     }
 
@@ -784,18 +864,25 @@ mod tests {
         }
     }
 
-    fn frame_data_matches(a: &FrameData, b: &FrameData) -> bool {
+    fn clip_data_matches(a: &ClipNodeData, b: &ClipNodeData) -> bool {
         match (a, b) {
-            (FrameData::BackgroundColorAnimation, FrameData::BackgroundColorAnimation) => true,
-            (FrameData::Clip(a), FrameData::Clip(b)) => a == b,
-            (FrameData::ClipPath(a), FrameData::ClipPath(b)) => {
+            (ClipNodeData::Rect(a), ClipNodeData::Rect(b)) => a == b,
+            (ClipNodeData::Path(a), ClipNodeData::Path(b)) => {
                 a.bounding_rect == b.bounding_rect && a.fill_rule == b.fill_rule
             }
-            (FrameData::Effects(a), FrameData::Effects(b)) => {
+            (ClipNodeData::Dead, ClipNodeData::Dead) => true,
+            _ => false,
+        }
+    }
+
+    fn effect_data_matches(a: &EffectNodeData, b: &EffectNodeData) -> bool {
+        match (a, b) {
+            (EffectNodeData::Effects(a), EffectNodeData::Effects(b)) => {
                 a.opacity == b.opacity && a.blend_mode == b.blend_mode && a.filter == b.filter
             }
-            (FrameData::Mask(a), FrameData::Mask(b)) => a == b,
-            (FrameData::Dead, FrameData::Dead) => true,
+            (EffectNodeData::Mask(a), EffectNodeData::Mask(b)) => a == b,
+            (EffectNodeData::BackgroundColorAnimation, EffectNodeData::BackgroundColorAnimation) => true,
+            (EffectNodeData::Dead, EffectNodeData::Dead) => true,
             _ => false,
         }
     }
@@ -803,19 +890,28 @@ mod tests {
     fn assert_trees_match(a: &VisualContextTree, b: &VisualContextTree) {
         assert_eq!(a.structural_epoch, b.structural_epoch);
         assert_eq!(a.root_is_visual_viewport, b.root_is_visual_viewport);
-        assert_eq!(a.root_isolation_frame, b.root_isolation_frame);
+        assert_eq!(a.root_isolation_effect, b.root_isolation_effect);
         assert_eq!(a.spatial_nodes.len(), b.spatial_nodes.len());
-        assert_eq!(a.frame_nodes.len(), b.frame_nodes.len());
-        assert_eq!(a.live_spatial_node_count, b.live_spatial_node_count);
-        assert_eq!(a.live_frame_node_count, b.live_frame_node_count);
+        assert_eq!(a.clip_nodes.len(), b.clip_nodes.len());
+        assert_eq!(a.effect_nodes.len(), b.effect_nodes.len());
+        assert_eq!(a.live_spatial_node_count(), b.live_spatial_node_count());
+        assert_eq!(a.live_clip_node_count(), b.live_clip_node_count());
+        assert_eq!(a.live_effect_node_count(), b.live_effect_node_count());
         for (node, other) in a.spatial_nodes.iter().zip(&b.spatial_nodes) {
             assert_eq!(node.parent, other.parent);
             assert!(spatial_data_matches(&node.data, &other.data));
         }
-        for (node, other) in a.frame_nodes.iter().zip(&b.frame_nodes) {
+        for (node, other) in a.clip_nodes.iter().zip(&b.clip_nodes) {
             assert_eq!(node.parent, other.parent);
             assert_eq!(node.spatial, other.spatial);
-            assert!(frame_data_matches(&node.data, &other.data));
+            assert_eq!(node.clips_everything, other.clips_everything);
+            assert!(clip_data_matches(&node.data, &other.data));
+        }
+        for (node, other) in a.effect_nodes.iter().zip(&b.effect_nodes) {
+            assert_eq!(node.parent, other.parent);
+            assert_eq!(node.spatial, other.spatial);
+            assert_eq!(node.output_clip(), other.output_clip());
+            assert!(effect_data_matches(&node.data, &other.data));
         }
     }
 
@@ -836,23 +932,31 @@ mod tests {
             SpatialData::Transform(transform(FloatMatrix4x4::identity())),
             scroll_node,
         );
-        let stale_frame = tree.append_frame(
-            FrameData::Effects(EffectsData {
+        let stale_effect = tree.append_effect(
+            EffectNodeData::Effects(EffectsData {
                 opacity: 0.5,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
             }),
-            FrameNodeIndex::NONE,
+            EffectNodeIndex::NONE,
+            scroll_node,
+            ClipNodeIndex::NONE,
+        );
+        let stale_clip = tree.append_clip(
+            ClipNodeData::rect_clip(FloatRect::new(0.0, 0.0, 1.0, 1.0)),
+            ClipNodeIndex::NONE,
             scroll_node,
         );
         assert!(tree.tombstone_spatial_slot(stale_transform));
-        assert!(tree.tombstone_frame_slot(stale_frame));
+        assert!(tree.tombstone_effect_slot(stale_effect));
+        assert!(tree.tombstone_clip_slot(stale_clip));
         let bytes = tree.to_bytes();
         let decoded = VisualContextTree::from_bytes(&bytes).expect("a serialized tree decodes");
         assert_trees_match(&tree, &decoded);
         assert!(!decoded.spatial_is_live(stale_transform));
-        assert!(!decoded.frame_is_live(stale_frame));
-        assert_eq!(decoded.dead_node_count(), 2);
+        assert!(!decoded.clip_is_live(stale_clip));
+        assert!(!decoded.effect_is_live(stale_effect));
+        assert_eq!(decoded.dead_node_count(), 3);
         assert_eq!(decoded.to_bytes(), bytes);
     }
 
@@ -919,35 +1023,76 @@ mod tests {
         assert!(VisualContextTree::from_bytes(&encode_tree(&child_under_tombstone)).is_none());
 
         let effects = || {
-            FrameData::Effects(EffectsData {
+            EffectNodeData::Effects(EffectsData {
                 opacity: 1.0,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
             })
         };
-        let mut frame_under_tombstone = VisualContextTree::create(transform(FloatMatrix4x4::identity()));
-        let parent_frame =
-            frame_under_tombstone.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
-        frame_under_tombstone.append_frame(effects(), parent_frame, VISUAL_VIEWPORT_NODE_INDEX);
-        assert!(frame_under_tombstone.tombstone_frame_slot(parent_frame));
-        assert!(!frame_under_tombstone.node_references_are_consistent());
-        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_under_tombstone)).is_none());
+        let rect = || ClipNodeData::rect_clip(FloatRect::new(0.0, 0.0, 1.0, 1.0));
+        let fresh = || VisualContextTree::create(transform(FloatMatrix4x4::identity()));
+        let rejected = |tree: &VisualContextTree| {
+            assert!(!tree.node_references_are_consistent());
+            assert!(VisualContextTree::from_bytes(&encode_tree(tree)).is_none());
+        };
 
-        let mut frame_in_tombstone = VisualContextTree::create(transform(FloatMatrix4x4::identity()));
-        let spatial = frame_in_tombstone.append_spatial(
+        let mut effect_under_tombstone = fresh();
+        let parent_effect = effect_under_tombstone.append_effect(
+            effects(),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        effect_under_tombstone.append_effect(
+            effects(),
+            parent_effect,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        assert!(effect_under_tombstone.tombstone_effect_slot(parent_effect));
+        rejected(&effect_under_tombstone);
+
+        let mut clip_under_tombstone = fresh();
+        let parent_clip = clip_under_tombstone.append_clip(rect(), ClipNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        clip_under_tombstone.append_clip(rect(), parent_clip, VISUAL_VIEWPORT_NODE_INDEX);
+        assert!(clip_under_tombstone.tombstone_clip_slot(parent_clip));
+        rejected(&clip_under_tombstone);
+
+        let mut nodes_in_tombstone = fresh();
+        let spatial = nodes_in_tombstone.append_spatial(
             SpatialData::Transform(transform(FloatMatrix4x4::identity())),
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        frame_in_tombstone.append_frame(effects(), FrameNodeIndex::NONE, spatial);
-        assert!(frame_in_tombstone.tombstone_spatial_slot(spatial));
-        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_in_tombstone)).is_none());
+        let mut clip_in_tombstone = nodes_in_tombstone.clone();
+        clip_in_tombstone.append_clip(rect(), ClipNodeIndex::NONE, spatial);
+        assert!(clip_in_tombstone.tombstone_spatial_slot(spatial));
+        rejected(&clip_in_tombstone);
+        nodes_in_tombstone.append_effect(effects(), EffectNodeIndex::NONE, spatial, ClipNodeIndex::NONE);
+        assert!(nodes_in_tombstone.tombstone_spatial_slot(spatial));
+        rejected(&nodes_in_tombstone);
 
-        let mut tombstoned_isolation_frame = VisualContextTree::create(transform(FloatMatrix4x4::identity()));
-        let isolation_frame =
-            tombstoned_isolation_frame.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
-        assert!(tombstoned_isolation_frame.tombstone_frame_slot(isolation_frame));
-        tombstoned_isolation_frame.root_isolation_frame = Some(isolation_frame);
-        assert!(VisualContextTree::from_bytes(&encode_tree(&tombstoned_isolation_frame)).is_none());
+        let mut effect_under_tombstoned_output_clip = fresh();
+        let output_clip =
+            effect_under_tombstoned_output_clip.append_clip(rect(), ClipNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        effect_under_tombstoned_output_clip.append_effect(
+            effects(),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            output_clip,
+        );
+        assert!(effect_under_tombstoned_output_clip.tombstone_clip_slot(output_clip));
+        rejected(&effect_under_tombstoned_output_clip);
+
+        let mut tombstoned_isolation_effect = fresh();
+        let isolation_effect = tombstoned_isolation_effect.append_effect(
+            effects(),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        assert!(tombstoned_isolation_effect.tombstone_effect_slot(isolation_effect));
+        tombstoned_isolation_effect.root_isolation_effect = Some(isolation_effect);
+        rejected(&tombstoned_isolation_effect);
     }
 
     #[test]
@@ -1011,23 +1156,41 @@ mod tests {
             )),
             SpatialNodeIndex(1),
         );
-        tree.append_frame(
-            FrameData::Effects(EffectsData {
-                opacity: 1.0,
-                blend_mode: CompositingAndBlendingOperator::Normal,
-                filter: None,
-            }),
-            FrameNodeIndex::NONE,
+        // Clips: c0 at the root, c1 under it in s2. Effects: e0 at the root under no clip, e1 under
+        // e0 with output clip c0.
+        tree.append_clip(
+            ClipNodeData::rect_clip(FloatRect::new(0.0, 0.0, 10.0, 10.0)),
+            ClipNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
         );
-        tree.append_frame(
-            FrameData::Clip(ClipData {
+        tree.append_clip(
+            ClipNodeData::Rect(ClipData {
                 rect: FloatRect::default(),
                 corner_radii: CornerRadii::default(),
                 mode: ClipMode::Intersect,
             }),
-            FrameNodeIndex(0),
+            ClipNodeIndex(0),
             SpatialNodeIndex(2),
+        );
+        tree.append_effect(
+            EffectNodeData::Effects(EffectsData {
+                opacity: 1.0,
+                blend_mode: CompositingAndBlendingOperator::Normal,
+                filter: None,
+            }),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        tree.append_effect(
+            EffectNodeData::Effects(EffectsData {
+                opacity: 0.5,
+                blend_mode: CompositingAndBlendingOperator::Normal,
+                filter: None,
+            }),
+            EffectNodeIndex(0),
+            SpatialNodeIndex(2),
+            ClipNodeIndex(0),
         );
         tree
     }
@@ -1040,12 +1203,17 @@ mod tests {
             data: SpatialData::Transform(transform(translation_matrix(5.0, 5.0, 0.0))),
             parent: VISUAL_VIEWPORT_NODE_INDEX,
         };
-        child_stored_below_its_parent.frame_nodes[0].parent = FrameNodeIndex(1);
-        child_stored_below_its_parent.frame_nodes[1].parent = FrameNodeIndex::NONE;
+        child_stored_below_its_parent.clip_nodes[0].parent = ClipNodeIndex(1);
+        child_stored_below_its_parent.clip_nodes[1].parent = ClipNodeIndex::NONE;
+        child_stored_below_its_parent.effect_nodes[0].parent = EffectNodeIndex(1);
+        child_stored_below_its_parent.effect_nodes[1].parent = EffectNodeIndex::NONE;
+        child_stored_below_its_parent.effect_nodes[1].resolved_output_clip = Some(ClipNodeIndex::NONE);
+        child_stored_below_its_parent.effect_nodes[0].resolved_output_clip = Some(ClipNodeIndex(1));
         let decoded = VisualContextTree::from_bytes(&encode_tree(&child_stored_below_its_parent))
             .expect("acyclic forward references decode");
         assert_eq!(decoded.spatial_dependency_order(), vec![0, 2, 1]);
-        assert_eq!(decoded.frame_dependency_order(), vec![1, 0]);
+        assert_eq!(decoded.clip_dependency_order(), vec![1, 0]);
+        assert_eq!(decoded.effect_dependency_order(), vec![1, 0]);
         assert_eq!(
             decoded.transform_rect_to_viewport(
                 SpatialNodeIndex(1),
@@ -1170,52 +1338,101 @@ mod tests {
     }
 
     #[test]
-    fn frame_reference_cycles_and_ranges_are_rejected() {
-        let mut frame_parent_cycle = hostile_tree();
-        frame_parent_cycle.frame_nodes[0].parent = FrameNodeIndex(1);
-        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_parent_cycle)).is_none());
+    fn clip_and_effect_reference_cycles_and_ranges_are_rejected() {
+        let rejected = |tree: &VisualContextTree| assert!(VisualContextTree::from_bytes(&encode_tree(tree)).is_none());
 
-        let mut frame_parent_out_of_range = hostile_tree();
-        frame_parent_out_of_range.frame_nodes[1].parent = FrameNodeIndex(4);
-        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_parent_out_of_range)).is_none());
+        let mut clip_parent_cycle = hostile_tree();
+        clip_parent_cycle.clip_nodes[0].parent = ClipNodeIndex(1);
+        rejected(&clip_parent_cycle);
 
-        let mut frame_spatial_out_of_range = hostile_tree();
-        frame_spatial_out_of_range.frame_nodes[1].spatial = SpatialNodeIndex(3);
-        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_spatial_out_of_range)).is_none());
+        let mut clip_parent_out_of_range = hostile_tree();
+        clip_parent_out_of_range.clip_nodes[1].parent = ClipNodeIndex(4);
+        rejected(&clip_parent_out_of_range);
 
-        let mut isolation_frame_out_of_range = hostile_tree();
-        isolation_frame_out_of_range.root_isolation_frame = Some(FrameNodeIndex(2));
-        assert!(VisualContextTree::from_bytes(&encode_tree(&isolation_frame_out_of_range)).is_none());
+        let mut clip_spatial_out_of_range = hostile_tree();
+        clip_spatial_out_of_range.clip_nodes[1].spatial = SpatialNodeIndex(3);
+        rejected(&clip_spatial_out_of_range);
 
-        let mut isolation_frame_is_a_clip = hostile_tree();
-        isolation_frame_is_a_clip.root_isolation_frame = Some(FrameNodeIndex(1));
-        assert!(VisualContextTree::from_bytes(&encode_tree(&isolation_frame_is_a_clip)).is_none());
+        let mut effect_parent_cycle = hostile_tree();
+        effect_parent_cycle.effect_nodes[0].parent = EffectNodeIndex(1);
+        rejected(&effect_parent_cycle);
 
-        let mut isolation_frame_is_effects = hostile_tree();
-        isolation_frame_is_effects.root_isolation_frame = Some(FrameNodeIndex(0));
-        assert!(VisualContextTree::from_bytes(&encode_tree(&isolation_frame_is_effects)).is_some());
+        let mut effect_parent_out_of_range = hostile_tree();
+        effect_parent_out_of_range.effect_nodes[1].parent = EffectNodeIndex(4);
+        rejected(&effect_parent_out_of_range);
+
+        let mut effect_spatial_out_of_range = hostile_tree();
+        effect_spatial_out_of_range.effect_nodes[1].spatial = SpatialNodeIndex(3);
+        rejected(&effect_spatial_out_of_range);
+
+        let mut output_clip_out_of_range = hostile_tree();
+        output_clip_out_of_range.effect_nodes[1].resolved_output_clip = Some(ClipNodeIndex(9));
+        rejected(&output_clip_out_of_range);
+
+        // e0's output clip moves below e1's.
+        let mut output_clip_outside_the_parents = hostile_tree();
+        output_clip_outside_the_parents.effect_nodes[0].resolved_output_clip = Some(ClipNodeIndex(1));
+        rejected(&output_clip_outside_the_parents);
+
+        let mut isolation_effect_out_of_range = hostile_tree();
+        isolation_effect_out_of_range.root_isolation_effect = Some(EffectNodeIndex(2));
+        rejected(&isolation_effect_out_of_range);
+
+        let mut isolation_effect_is_a_mask = hostile_tree();
+        isolation_effect_is_a_mask.effect_nodes[0].data = EffectNodeData::Mask(MaskData {
+            rect: IntRect::new(0, 0, 1, 1),
+            kind: MaskKind::Alpha,
+            origin: MaskLayerOrigin::CssMaskLayers,
+        });
+        isolation_effect_is_a_mask.root_isolation_effect = Some(EffectNodeIndex(0));
+        rejected(&isolation_effect_is_a_mask);
+
+        // The isolation layer must be a root effect.
+        let mut isolation_effect_has_a_parent = hostile_tree();
+        isolation_effect_has_a_parent.root_isolation_effect = Some(EffectNodeIndex(1));
+        rejected(&isolation_effect_has_a_parent);
+
+        let mut isolation_effect_at_the_root = hostile_tree();
+        isolation_effect_at_the_root.root_isolation_effect = Some(EffectNodeIndex(0));
+        assert!(VisualContextTree::from_bytes(&encode_tree(&isolation_effect_at_the_root)).is_some());
     }
 
     #[test]
     fn out_of_range_discriminants_and_absurd_counts_are_rejected() {
         let tree = hostile_tree();
         let bytes = tree.to_bytes();
-        let header_size = 4 + 4 + 8 + 1 + 4 + 4 + 4;
+        let header_size = 4 + 4 + 8 + 1 + 4 + 4 + 4 + 4;
         let root_spatial_kind_offset = header_size + 4;
         let mut bad_spatial_kind = bytes.clone();
         bad_spatial_kind[root_spatial_kind_offset] = 200;
         assert!(VisualContextTree::from_bytes(&bad_spatial_kind).is_none());
 
         let mut bad_bool = bytes.clone();
-        bad_bool[header_size - 4 - 4 - 4] = 2;
+        bad_bool[4 + 4 + 8] = 2;
         assert!(VisualContextTree::from_bytes(&bad_bool).is_none());
 
-        let mut absurd_spatial_count = bytes.clone();
-        absurd_spatial_count[header_size - 8..header_size - 4].copy_from_slice(&u32::MAX.to_ne_bytes());
-        assert!(VisualContextTree::from_bytes(&absurd_spatial_count).is_none());
+        let count_offset = |slot: usize| header_size - 12 + slot * 4;
+        for slot in 0..3 {
+            let mut absurd_count = bytes.clone();
+            absurd_count[count_offset(slot)..count_offset(slot) + 4].copy_from_slice(&u32::MAX.to_ne_bytes());
+            assert!(
+                VisualContextTree::from_bytes(&absurd_count).is_none(),
+                "an absurd count in slot {slot} decoded"
+            );
+        }
 
-        let mut absurd_frame_count = bytes;
-        absurd_frame_count[header_size - 4..header_size].copy_from_slice(&u32::MAX.to_ne_bytes());
-        assert!(VisualContextTree::from_bytes(&absurd_frame_count).is_none());
+        // The first clip node starts right after the spatial nodes; its kind byte follows its
+        // parent and spatial indices.
+        let spatial_nodes_size = {
+            let mut probe = tree.clone();
+            probe.clip_nodes.clear();
+            probe.effect_nodes.clear();
+            probe.root_isolation_effect = None;
+            probe.to_bytes().len() - header_size
+        };
+        let first_clip_kind_offset = header_size + spatial_nodes_size + 4 + 4;
+        let mut bad_clip_kind = bytes.clone();
+        bad_clip_kind[first_clip_kind_offset] = 200;
+        assert!(VisualContextTree::from_bytes(&bad_clip_kind).is_none());
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/shape.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/shape.rs
@@ -43,19 +43,31 @@ pub(crate) enum SpatialNodeShape {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum FrameShapeKind {
-    BackgroundColorAnimation,
-    Clip { mode: ClipMode },
-    ClipPath,
-    Effects,
-    Mask { origin: MaskLayerOrigin },
+pub(crate) enum ClipShapeKind {
+    Rect { mode: ClipMode },
+    Path,
     Dead,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct FrameNodeShape {
-    pub kind: FrameShapeKind,
-    pub parent: FrameNodeIndex,
+pub(crate) struct ClipNodeShape {
+    pub kind: ClipShapeKind,
+    pub parent: ClipNodeIndex,
+    pub spatial: SpatialNodeIndex,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EffectShapeKind {
+    Effects,
+    Mask { origin: MaskLayerOrigin },
+    BackgroundColorAnimation,
+    Dead,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct EffectNodeShape {
+    pub kind: EffectShapeKind,
+    pub parent: EffectNodeIndex,
     pub spatial: SpatialNodeIndex,
 }
 
@@ -97,16 +109,27 @@ pub(crate) fn spatial_node_shape(node: &SpatialNode) -> SpatialNodeShape {
     }
 }
 
-pub(crate) fn frame_node_shape(node: &FrameNode) -> FrameNodeShape {
+pub(crate) fn clip_node_shape(node: &ClipNode) -> ClipNodeShape {
     let kind = match &node.data {
-        FrameData::BackgroundColorAnimation => FrameShapeKind::BackgroundColorAnimation,
-        FrameData::Clip(clip) => FrameShapeKind::Clip { mode: clip.mode },
-        FrameData::ClipPath(_) => FrameShapeKind::ClipPath,
-        FrameData::Effects(_) => FrameShapeKind::Effects,
-        FrameData::Mask(mask) => FrameShapeKind::Mask { origin: mask.origin },
-        FrameData::Dead => FrameShapeKind::Dead,
+        ClipNodeData::Rect(clip) => ClipShapeKind::Rect { mode: clip.mode },
+        ClipNodeData::Path(_) => ClipShapeKind::Path,
+        ClipNodeData::Dead => ClipShapeKind::Dead,
     };
-    FrameNodeShape {
+    ClipNodeShape {
+        kind,
+        parent: node.parent,
+        spatial: node.spatial,
+    }
+}
+
+pub(crate) fn effect_node_shape(node: &EffectNode) -> EffectNodeShape {
+    let kind = match &node.data {
+        EffectNodeData::Effects(_) => EffectShapeKind::Effects,
+        EffectNodeData::Mask(mask) => EffectShapeKind::Mask { origin: mask.origin },
+        EffectNodeData::BackgroundColorAnimation => EffectShapeKind::BackgroundColorAnimation,
+        EffectNodeData::Dead => EffectShapeKind::Dead,
+    };
+    EffectNodeShape {
         kind,
         parent: node.parent,
         spatial: node.spatial,
@@ -134,20 +157,27 @@ pub(crate) fn spatial_payloads_are_equal(a: &SpatialData, b: &SpatialData) -> bo
     }
 }
 
-pub(crate) fn frame_payloads_are_equal(a: &FrameData, b: &FrameData) -> bool {
+pub(crate) fn clip_payloads_are_equal(a: &ClipNodeData, b: &ClipNodeData) -> bool {
     match (a, b) {
-        (FrameData::BackgroundColorAnimation, FrameData::BackgroundColorAnimation) => true,
-        (FrameData::Clip(a), FrameData::Clip(b)) => a == b,
-        (FrameData::ClipPath(a), FrameData::ClipPath(b)) => {
+        (ClipNodeData::Rect(a), ClipNodeData::Rect(b)) => a == b,
+        (ClipNodeData::Path(a), ClipNodeData::Path(b)) => {
             std::rc::Rc::ptr_eq(&a.path, &b.path) && a.bounding_rect == b.bounding_rect && a.fill_rule == b.fill_rule
         }
-        (FrameData::Effects(a), FrameData::Effects(b)) => {
+        (ClipNodeData::Dead, ClipNodeData::Dead) => true,
+        _ => false,
+    }
+}
+
+pub(crate) fn effect_payloads_are_equal(a: &EffectNodeData, b: &EffectNodeData) -> bool {
+    match (a, b) {
+        (EffectNodeData::Effects(a), EffectNodeData::Effects(b)) => {
             a.opacity == b.opacity
                 && a.blend_mode == b.blend_mode
                 && effects_filters_are_equal(a.filter.as_ref(), b.filter.as_ref())
         }
-        (FrameData::Mask(a), FrameData::Mask(b)) => a == b,
-        (FrameData::Dead, FrameData::Dead) => true,
+        (EffectNodeData::Mask(a), EffectNodeData::Mask(b)) => a == b,
+        (EffectNodeData::BackgroundColorAnimation, EffectNodeData::BackgroundColorAnimation) => true,
+        (EffectNodeData::Dead, EffectNodeData::Dead) => true,
         _ => false,
     }
 }

--- a/Tests/Compositor/TestAsyncScrollTree.cpp
+++ b/Tests/Compositor/TestAsyncScrollTree.cpp
@@ -50,7 +50,7 @@ TEST_CASE(wheel_hit_testing_rejects_a_different_visual_context_tree_structural_e
     auto visual_context_tree = make_visual_context_tree();
     Web::Compositor::AsyncScrollingState state;
     state.main_thread_wheel_event_regions.append({
-        .context = { Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Web::Painting::NO_FRAME_NODE },
+        .context = { Web::Painting::VISUAL_VIEWPORT_NODE_INDEX },
         .rect = { 0, 0, 100, 100 },
     });
 
@@ -72,7 +72,7 @@ TEST_CASE(wheel_hit_testing_ignores_invalid_visual_context_indices)
     auto visual_context_tree = make_visual_context_tree();
     Web::Compositor::AsyncScrollingState state;
     state.main_thread_wheel_event_regions.append({
-        .context = { Web::Painting::SpatialNodeIndex { 100 }, Web::Painting::NO_FRAME_NODE },
+        .context = { Web::Painting::SpatialNodeIndex { 100 } },
         .rect = { 0, 0, 100, 100 },
     });
 
@@ -94,7 +94,7 @@ TEST_CASE(wheel_hit_testing_prefilters_static_targets_but_tracks_animated_target
     auto make_scroll_tree = [](Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Web::Painting::SpatialNodeIndex spatial) {
         Web::Compositor::AsyncScrollingState state;
         state.main_thread_wheel_event_regions.append({
-            .context = { spatial, Web::Painting::NO_FRAME_NODE },
+            .context = { spatial },
             .rect = { 0, 0, 10, 10 },
         });
         Web::Compositor::AsyncScrollTree scroll_tree;
@@ -143,7 +143,7 @@ TEST_CASE(blocking_wheel_event_hit_testing_fails_closed_for_invalid_visual_conte
     Web::Compositor::AsyncScrollingState state;
     state.has_blocking_wheel_event_listeners = true;
     state.blocking_wheel_event_regions.append({
-        .context = { Web::Painting::SpatialNodeIndex { 100 }, Web::Painting::NO_FRAME_NODE },
+        .context = { Web::Painting::SpatialNodeIndex { 100 } },
         .rect = { 0, 0, 100, 100 },
     });
 

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -103,7 +103,7 @@ static NonnullRefPtr<Web::Painting::DisplayList> make_display_list(Web::Painting
 {
     ByteBuffer command_bytes;
     if (color.has_value()) {
-        auto command = Web::Painting::FillRect { { 0, 0, 4, 4 }, *color, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
+        auto command = Web::Painting::FillRect { { 0, 0, 4, 4 }, *color, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_EFFECT_NODE };
         append_display_list_command(command_bytes, command, command.rect, context);
     }
     return decode_display_list(visual_context_tree, move(command_bytes), surface_clear_color);
@@ -139,7 +139,7 @@ TEST_CASE(caret_damage_uses_the_sampled_visual_context_tree)
         .should_blink = true,
     };
     ByteBuffer command_bytes;
-    append_display_list_command(command_bytes, caret, caret.rect, { spatial, Web::Painting::NO_FRAME_NODE });
+    append_display_list_command(command_bytes, caret, caret.rect, { spatial });
 
     context.viewport_size_updated({ 100, 100 }, Web::Compositor::WindowResizingInProgress::No);
     context.install_display_list_update(
@@ -155,7 +155,8 @@ TEST_CASE(visual_context_trees_round_trip_through_ipc_and_reject_corrupted_bytes
 {
     Web::Painting::VisualContextTreeTestBuilder builder;
     auto scroll_node = builder.append_scroll(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
-    builder.append_clip_frame(Web::Painting::NO_FRAME_NODE, scroll_node, { 1, 2, 3, 4 });
+    auto clip = builder.append_clip(Web::Painting::NO_CLIP_NODE, scroll_node, { 1, 2, 3, 4 });
+    auto effect = builder.append_effects(Web::Painting::NO_EFFECT_NODE, scroll_node, clip, 0.5f);
     auto visual_context_tree = builder.finish();
 
     IPC::MessageBuffer buffer;
@@ -167,7 +168,9 @@ TEST_CASE(visual_context_trees_round_trip_through_ipc_and_reject_corrupted_bytes
     auto decoded_tree = MUST(decoder.decode<Web::Painting::AccumulatedVisualContextTree>());
     EXPECT_EQ(decoded_tree.structural_epoch(), visual_context_tree.structural_epoch());
     EXPECT_EQ(decoded_tree.spatial_node_count(), 2u);
-    EXPECT_EQ(decoded_tree.frame_node_count(), 1u);
+    EXPECT_EQ(decoded_tree.node_count(), 4u);
+    EXPECT_EQ(decoded_tree.live_node_count(), 4u);
+    EXPECT_EQ(decoded_tree.effects_opacity(effect), Optional<float> { 0.5f });
     EXPECT_EQ(decoded_tree.serialize_to_bytes(), visual_context_tree.serialize_to_bytes());
 
     auto corrupted_bytes = visual_context_tree.serialize_to_bytes();
@@ -310,7 +313,7 @@ TEST_CASE(visual_animations_advance_without_a_web_content_update)
     Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
     Web::Painting::VisualContextTreeTestBuilder builder;
     auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
-    auto frame = builder.append_effects_frame(Web::Painting::NO_FRAME_NODE, spatial);
+    auto effect = builder.append_effects(Web::Painting::NO_EFFECT_NODE, spatial);
     auto visual_context_tree = builder.finish();
     auto anchor = MonotonicTime::now();
     visual_context_tree.set_visual_animations({
@@ -327,7 +330,7 @@ TEST_CASE(visual_animations_advance_without_a_web_content_update)
         },
         {
             .target_kind = Web::Compositor::VisualAnimation::TargetKind::Opacity,
-            .visual_context_node_indices = { frame.value() },
+            .visual_context_node_indices = { effect.value() },
             .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
             .iteration_duration_ms = 1000,
             .easing = {},
@@ -342,7 +345,7 @@ TEST_CASE(visual_animations_advance_without_a_web_content_update)
     context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
     VERIFY(context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed).has_value());
     context.install_display_list_update(
-        make_display_list(visual_context_tree, Gfx::Color::Red, Gfx::Color::Transparent, { spatial, frame }),
+        make_display_list(visual_context_tree, Gfx::Color::Red, Gfx::Color::Transparent, { spatial, Web::Painting::NO_CLIP_NODE, effect }),
         visual_context_tree,
         {});
 
@@ -366,18 +369,18 @@ TEST_CASE(visual_animations_advance_without_a_web_content_update)
     auto const& updated_tree = context.sampled_visual_context_tree_for_testing();
     auto updated_translation = updated_tree.accumulated_matrix(spatial, {}, Web::Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes)[0, 3];
     EXPECT_EQ(updated_translation, 4.0f);
-    EXPECT_EQ(updated_tree.effects_opacity(frame), Optional<float> { 0.5f });
+    EXPECT_EQ(updated_tree.effects_opacity(effect), Optional<float> { 0.5f });
     EXPECT(context.has_sampled_visual_animation_values_for_testing());
 
     context.install_display_list_update(
-        make_display_list(visual_context_tree, Gfx::Color::Red, Gfx::Color::Transparent, { spatial, frame }),
+        make_display_list(visual_context_tree, Gfx::Color::Red, Gfx::Color::Transparent, { spatial, Web::Painting::NO_CLIP_NODE, effect }),
         visual_context_tree,
         {});
     EXPECT(!context.has_sampled_visual_animation_values_for_testing());
     auto const& replaced_tree = context.sampled_visual_context_tree_for_testing();
     auto replaced_translation = replaced_tree.accumulated_matrix(spatial, {}, Web::Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes)[0, 3];
     EXPECT_EQ(replaced_translation, 4.0f);
-    EXPECT_EQ(replaced_tree.effects_opacity(frame), Optional<float> { 0.5f });
+    EXPECT_EQ(replaced_tree.effects_opacity(effect), Optional<float> { 0.5f });
     EXPECT(context.has_sampled_visual_animation_values_for_testing());
 
     visual_context_tree.set_visual_animations(Vector<Web::Compositor::VisualAnimation> {});
@@ -386,7 +389,7 @@ TEST_CASE(visual_animations_advance_without_a_web_content_update)
     auto const& restored_tree = context.visual_context_tree_for_testing();
     auto restored_translation = restored_tree.accumulated_matrix(spatial, {}, Web::Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes)[0, 3];
     EXPECT_EQ(restored_translation, 0.0f);
-    EXPECT_EQ(restored_tree.effects_opacity(frame), Optional<float> { 1.0f });
+    EXPECT_EQ(restored_tree.effects_opacity(effect), Optional<float> { 1.0f });
 }
 
 TEST_CASE(wheel_hit_testing_uses_the_current_visual_animation_tree)
@@ -414,7 +417,7 @@ TEST_CASE(wheel_hit_testing_uses_the_current_visual_animation_tree)
     });
 
     context.install_display_list_update(
-        make_scrollable_viewport_display_list(visual_context_tree, false, Web::Painting::ContextRef { animated_transform, Web::Painting::NO_FRAME_NODE }),
+        make_scrollable_viewport_display_list(visual_context_tree, false, Web::Painting::ContextRef { animated_transform }),
         visual_context_tree,
         {});
 
@@ -440,13 +443,13 @@ TEST_CASE(wheel_hit_testing_ignores_targets_from_a_larger_visual_context_tree)
     auto visual_context_tree = builder.finish();
 
     context.install_display_list_update(
-        make_scrollable_viewport_display_list(visual_context_tree, false, Web::Painting::ContextRef { removed_transform, Web::Painting::NO_FRAME_NODE }),
+        make_scrollable_viewport_display_list(visual_context_tree, false, Web::Painting::ContextRef { removed_transform }),
         visual_context_tree,
         {});
 
     auto smaller_visual_context_tree = make_scrollable_viewport_visual_context_tree();
     context.install_display_list_update(
-        make_scrollable_viewport_display_list(smaller_visual_context_tree, false, Web::Painting::ContextRef { removed_transform, Web::Painting::NO_FRAME_NODE }),
+        make_scrollable_viewport_display_list(smaller_visual_context_tree, false, Web::Painting::ContextRef { removed_transform }),
         smaller_visual_context_tree,
         {});
 
@@ -492,14 +495,14 @@ TEST_CASE(culled_initial_animation_content_becomes_visible)
     };
     Web::Painting::VisualContextTreeTestBuilder builder;
     auto opacity_spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
-    auto opacity_frame = builder.append_effects_frame(Web::Painting::NO_FRAME_NODE, opacity_spatial, 0);
+    auto opacity_effect = builder.append_effects(Web::Painting::NO_EFFECT_NODE, opacity_spatial, Web::Painting::NO_CLIP_NODE, 0);
     auto scale_spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, initial_scale.to_matrix());
     auto visual_context_tree = builder.finish();
     auto anchor = MonotonicTime::now();
     visual_context_tree.set_visual_animations({
         {
             .target_kind = Web::Compositor::VisualAnimation::TargetKind::Opacity,
-            .visual_context_node_indices = { opacity_frame.value() },
+            .visual_context_node_indices = { opacity_effect.value() },
             .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
             .iteration_duration_ms = 1000,
             .iteration_count = 1,
@@ -524,10 +527,10 @@ TEST_CASE(culled_initial_animation_content_becomes_visible)
     });
 
     ByteBuffer command_bytes;
-    auto opacity_command = Web::Painting::FillRect { { 0, 0, 4, 4 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
-    append_display_list_command(command_bytes, opacity_command, opacity_command.rect, { opacity_spatial, opacity_frame });
-    auto scale_command = Web::Painting::FillRect { { 8, 0, 4, 4 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
-    append_display_list_command(command_bytes, scale_command, scale_command.rect, { scale_spatial, Web::Painting::NO_FRAME_NODE });
+    auto opacity_command = Web::Painting::FillRect { { 0, 0, 4, 4 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_EFFECT_NODE };
+    append_display_list_command(command_bytes, opacity_command, opacity_command.rect, { opacity_spatial, Web::Painting::NO_CLIP_NODE, opacity_effect });
+    auto scale_command = Web::Painting::FillRect { { 8, 0, 4, 4 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_EFFECT_NODE };
+    append_display_list_command(command_bytes, scale_command, scale_command.rect, { scale_spatial });
 
     Gfx::IntRect viewport_rect { 0, 0, 12, 4 };
     context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
@@ -556,13 +559,13 @@ TEST_CASE(background_color_animation_replaces_the_recorded_fill_color)
     Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
     Web::Painting::VisualContextTreeTestBuilder builder;
     auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
-    auto frame = builder.append_background_color_animation_frame(Web::Painting::NO_FRAME_NODE, spatial);
+    auto effect = builder.append_background_color_animation(Web::Painting::NO_EFFECT_NODE, spatial);
     auto visual_context_tree = builder.finish();
     auto anchor = MonotonicTime::now();
     visual_context_tree.set_visual_animations({
         {
             .target_kind = Web::Compositor::VisualAnimation::TargetKind::BackgroundColor,
-            .visual_context_node_indices = { frame.value() },
+            .visual_context_node_indices = { effect.value() },
             .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
             .iteration_duration_ms = 1000,
             .iteration_count = 1,
@@ -579,9 +582,9 @@ TEST_CASE(background_color_animation_replaces_the_recorded_fill_color)
         { 0, 0, 4, 4 },
         Gfx::Color::Green,
         Gfx::CompositingAndBlendingOperator::Normal,
-        frame,
+        effect,
     };
-    append_display_list_command(command_bytes, command, command.rect, { spatial, frame });
+    append_display_list_command(command_bytes, command, command.rect, { spatial, Web::Painting::NO_CLIP_NODE, effect });
 
     Gfx::IntRect viewport_rect { 0, 0, 4, 4 };
     context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
@@ -599,7 +602,7 @@ TEST_CASE(background_color_animation_replaces_the_recorded_fill_color)
     EXPECT_EQ(bitmap->get_pixel(0, 0), (Gfx::Color { 128, 0, 128 }));
 }
 
-TEST_CASE(filter_animations_replace_their_effects_frame_filters)
+TEST_CASE(filter_animations_replace_their_effect_filters)
 {
     TestWebContentClient client;
     Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
@@ -607,14 +610,14 @@ TEST_CASE(filter_animations_replace_their_effects_frame_filters)
     Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
     Web::Painting::VisualContextTreeTestBuilder builder;
     auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
-    Vector<Web::Painting::FrameNodeIndex> frames;
+    Vector<Web::Painting::EffectNodeIndex> effects;
     Vector<Web::Compositor::VisualAnimation> animations;
     for (u32 i = 0; i < 8; ++i) {
-        auto frame = builder.append_effects_frame(Web::Painting::NO_FRAME_NODE, spatial);
-        frames.append(frame);
+        auto effect = builder.append_effects(Web::Painting::NO_EFFECT_NODE, spatial);
+        effects.append(effect);
         animations.append({
             .target_kind = Web::Compositor::VisualAnimation::TargetKind::Filter,
-            .visual_context_node_indices = { frame.value() },
+            .visual_context_node_indices = { effect.value() },
             .iteration_duration_ms = 1000,
             .iteration_count = 1,
             .easing = {},
@@ -631,17 +634,17 @@ TEST_CASE(filter_animations_replace_their_effects_frame_filters)
     visual_context_tree.set_visual_animations(move(animations));
 
     ByteBuffer command_bytes;
-    for (u32 i = 0; i < frames.size(); ++i) {
+    for (u32 i = 0; i < effects.size(); ++i) {
         auto command = Web::Painting::FillRect {
             { static_cast<i32>(i), 0, 1, 1 },
             Gfx::Color::Red,
             Gfx::CompositingAndBlendingOperator::Normal,
-            Web::Painting::NO_FRAME_NODE,
+            Web::Painting::NO_EFFECT_NODE,
         };
-        append_display_list_command(command_bytes, command, command.rect, { spatial, frames[i] });
+        append_display_list_command(command_bytes, command, command.rect, { spatial, Web::Painting::NO_CLIP_NODE, effects[i] });
     }
 
-    Gfx::IntRect viewport_rect { 0, 0, static_cast<i32>(frames.size()), 1 };
+    Gfx::IntRect viewport_rect { 0, 0, static_cast<i32>(effects.size()), 1 };
     context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
     VERIFY(context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed).has_value());
     context.install_display_list_update(
@@ -654,7 +657,7 @@ TEST_CASE(filter_animations_replace_their_effects_frame_filters)
     EXPECT(context.present_synchronously(display_list_player, nullptr));
 
     auto bitmap = context.latest_rendered_surface()->snapshot_bitmap();
-    for (u32 i = 0; i < frames.size(); ++i) {
+    for (u32 i = 0; i < effects.size(); ++i) {
         auto pixel = bitmap->get_pixel(i, 0);
         EXPECT_EQ(pixel.red(), 128);
         EXPECT_EQ(pixel.alpha(), 128);
@@ -690,7 +693,7 @@ TEST_CASE(finite_visual_animations_stop_after_their_terminal_sample)
     context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
     VERIFY(context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed).has_value());
     context.install_display_list_update(
-        make_display_list(visual_context_tree, Gfx::Color::Red, Gfx::Color::Transparent, { spatial, Web::Painting::NO_FRAME_NODE }),
+        make_display_list(visual_context_tree, Gfx::Color::Red, Gfx::Color::Transparent, { spatial }),
         visual_context_tree,
         {});
 
@@ -732,7 +735,7 @@ TEST_CASE(delayed_visual_animations_remain_dormant_until_active_start)
     visual_context_tree.set_visual_animations({ animation });
 
     context.install_display_list_update(
-        make_display_list(visual_context_tree, Gfx::Color::Red, {}, { spatial, Web::Painting::NO_FRAME_NODE }),
+        make_display_list(visual_context_tree, Gfx::Color::Red, {}, { spatial }),
         visual_context_tree,
         {});
 
@@ -992,7 +995,7 @@ static NonnullRefPtr<Web::Painting::DisplayList> make_fills_display_list(Web::Pa
 {
     ByteBuffer command_bytes;
     for (auto const& fill : fills) {
-        Web::Painting::FillRect command { fill.rect, fill.color, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
+        Web::Painting::FillRect command { fill.rect, fill.color, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_EFFECT_NODE };
         append_display_list_command(command_bytes, command, fill.bounded ? Optional<Gfx::IntRect> { fill.rect } : Optional<Gfx::IntRect> {}, fill.context);
     }
     return decode_display_list(visual_context_tree, move(command_bytes), surface_clear_color, async_scrolling_metadata);
@@ -1016,7 +1019,7 @@ static Web::Painting::ScrollStateSnapshot scroll_state_snapshot_with_offset(Web:
 
 static constexpr Web::Painting::ContextRef in_spatial_node(u32 index)
 {
-    return { Web::Painting::SpatialNodeIndex { index }, Web::Painting::NO_FRAME_NODE };
+    return { Web::Painting::SpatialNodeIndex { index } };
 }
 
 static Gfx::IntRect const test_viewport_rect { 0, 0, 16, 16 };
@@ -1434,9 +1437,9 @@ TEST_CASE(async_scroll_presents_report_the_damage_of_the_scrolled_content)
         },
         {},
         in_spatial_node(viewport_scroll_node_index.value()));
-    Web::Painting::FillRect nested_content { { 10, 10, 40, 10 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
+    Web::Painting::FillRect nested_content { { 10, 10, 40, 10 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_EFFECT_NODE };
     append_display_list_command(command_bytes, nested_content, nested_content.rect, in_spatial_node(nested_scroll_node_index.value()));
-    Web::Painting::FillRect viewport_content { { 60, 60, 10, 10 }, Gfx::Color::Green, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
+    Web::Painting::FillRect viewport_content { { 60, 60, 10, 10 }, Gfx::Color::Green, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_EFFECT_NODE };
     append_display_list_command(command_bytes, viewport_content, viewport_content.rect, in_spatial_node(viewport_scroll_node_index.value()));
     fixture.install(decode_display_list(visual_context_tree, move(command_bytes), {}, Web::Painting::DisplayList::AsyncScrollingMetadata { .viewport_rect = { 0, 0, 100, 100 } }), visual_context_tree);
     fixture.present();
@@ -1454,7 +1457,7 @@ TEST_CASE(async_scroll_presents_report_the_damage_of_the_scrolled_content)
     EXPECT_EQ(viewport_scroll_frame.damage_rect, fixture.viewport_rect);
 }
 
-TEST_CASE(clip_path_frames_round_trip_through_serialized_tree_bytes)
+TEST_CASE(clip_paths_round_trip_through_serialized_tree_bytes)
 {
     Gfx::Path star;
     star.move_to({ 65, 0 });
@@ -1464,7 +1467,7 @@ TEST_CASE(clip_path_frames_round_trip_through_serialized_tree_bytes)
     star.line_to({ 95, 80 });
     star.close();
     Web::Painting::VisualContextTreeTestBuilder builder;
-    auto clip_path_frame = builder.append_clip_path_frame(Web::Painting::NO_FRAME_NODE, Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, star, { 25, 0, 80, 80 }, Gfx::WindingRule::EvenOdd);
+    auto clip_path = builder.append_clip_path(Web::Painting::NO_CLIP_NODE, Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, star, { 25, 0, 80, 80 }, Gfx::WindingRule::EvenOdd);
     auto visual_context_tree = builder.finish();
 
     auto serialized_bytes = visual_context_tree.serialize_to_bytes();
@@ -1472,7 +1475,7 @@ TEST_CASE(clip_path_frames_round_trip_through_serialized_tree_bytes)
     EXPECT_EQ(decoded_tree.serialize_to_bytes(), serialized_bytes);
 
     Web::Painting::ScrollStateSnapshot unscrolled;
-    Web::Painting::ContextRef clip_path_context { Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, clip_path_frame };
+    Web::Painting::ContextRef clip_path_context { Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, clip_path };
     EXPECT(decoded_tree.transform_point_for_hit_test(clip_path_context, Gfx::FloatPoint { 65, 5 }, unscrolled).has_value());
     EXPECT(!decoded_tree.transform_point_for_hit_test(clip_path_context, Gfx::FloatPoint { 26, 1 }, unscrolled).has_value());
     EXPECT(!decoded_tree.transform_point_for_hit_test(clip_path_context, Gfx::FloatPoint { 10, 40 }, unscrolled).has_value());
@@ -1485,7 +1488,7 @@ TEST_CASE(visual_animation_samples_derive_a_tree_and_leave_the_source_untouched)
     matrix[1, 3] = 12;
     Web::Painting::VisualContextTreeTestBuilder builder;
     auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, matrix, { 12, 12 });
-    auto frame = builder.append_effects_frame(Web::Painting::NO_FRAME_NODE, spatial, 0.75f);
+    auto effect = builder.append_effects(Web::Painting::NO_EFFECT_NODE, spatial, Web::Painting::NO_CLIP_NODE, 0.75f);
     auto tree = builder.finish();
     tree.set_visual_animations({
         {
@@ -1501,7 +1504,7 @@ TEST_CASE(visual_animation_samples_derive_a_tree_and_leave_the_source_untouched)
         },
         {
             .target_kind = Web::Compositor::VisualAnimation::TargetKind::Opacity,
-            .visual_context_node_indices = { frame.value() },
+            .visual_context_node_indices = { effect.value() },
             .local_time_at_anchor_ms = 500,
             .iteration_duration_ms = 1000,
             .easing = {},
@@ -1517,10 +1520,10 @@ TEST_CASE(visual_animation_samples_derive_a_tree_and_leave_the_source_untouched)
     EXPECT_EQ(sampled_tree.structural_epoch(), tree.structural_epoch());
     auto sampled_translation = sampled_tree.accumulated_matrix(spatial, {}, include_viewport)[0, 3];
     EXPECT_EQ(sampled_translation, 4.0f);
-    EXPECT_EQ(sampled_tree.effects_opacity(frame), Optional<float> { 0.5f });
+    EXPECT_EQ(sampled_tree.effects_opacity(effect), Optional<float> { 0.5f });
     EXPECT_EQ(sampled_tree.visual_animations().size(), 2u);
 
     auto source_translation = tree.accumulated_matrix(spatial, {}, include_viewport)[0, 3];
     EXPECT_EQ(source_translation, 12.0f);
-    EXPECT_EQ(tree.effects_opacity(frame), Optional<float> { 0.75f });
+    EXPECT_EQ(tree.effects_opacity(effect), Optional<float> { 0.75f });
 }

--- a/Tests/LibWeb/Ref/expected/visual-context/abspos-escaping-overflow-clip-inside-blend-ref.html
+++ b/Tests/LibWeb/Ref/expected/visual-context/abspos-escaping-overflow-clip-inside-blend-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    background: rgb(128, 128, 128);
+}
+.group {
+    position: relative;
+    mix-blend-mode: multiply;
+    width: 200px;
+    height: 200px;
+    background: red;
+}
+.child {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+</style>
+<div class="group">
+    <div class="child"></div>
+</div>

--- a/Tests/LibWeb/Ref/expected/visual-context/abspos-escaping-overflow-clip-inside-mask-ref.html
+++ b/Tests/LibWeb/Ref/expected/visual-context/abspos-escaping-overflow-clip-inside-mask-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.group {
+    position: relative;
+    mask-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5));
+    width: 200px;
+    height: 200px;
+    background: red;
+}
+.child {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+</style>
+<div class="group">
+    <div class="child"></div>
+</div>

--- a/Tests/LibWeb/Ref/expected/visual-context/abspos-escaping-overflow-clip-inside-opacity-ref.html
+++ b/Tests/LibWeb/Ref/expected/visual-context/abspos-escaping-overflow-clip-inside-opacity-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.group {
+    position: relative;
+    opacity: 0.5;
+    width: 200px;
+    height: 200px;
+    background: red;
+}
+.child {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+</style>
+<div class="group">
+    <div class="child"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/visual-context/abspos-escaping-overflow-clip-inside-blend.html
+++ b/Tests/LibWeb/Ref/input/visual-context/abspos-escaping-overflow-clip-inside-blend.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/visual-context/abspos-escaping-overflow-clip-inside-blend-ref.html">
+<style>
+body {
+    margin: 0;
+    background: rgb(128, 128, 128);
+}
+.containing-block {
+    position: relative;
+    width: 200px;
+    height: 200px;
+}
+.group {
+    mix-blend-mode: multiply;
+    width: 200px;
+    height: 200px;
+    background: red;
+}
+.clip {
+    overflow: hidden;
+    width: 100px;
+    height: 100px;
+}
+.escaping {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+</style>
+<!-- The absolute child skips the overflow clip but blends as part of the group: entering the group's
+     blend layer twice would multiply the child against the already blended red instead of the gray. -->
+<div class="containing-block">
+    <div class="group">
+        <div class="clip">
+            <div class="escaping"></div>
+        </div>
+    </div>
+</div>

--- a/Tests/LibWeb/Ref/input/visual-context/abspos-escaping-overflow-clip-inside-mask.html
+++ b/Tests/LibWeb/Ref/input/visual-context/abspos-escaping-overflow-clip-inside-mask.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/visual-context/abspos-escaping-overflow-clip-inside-mask-ref.html">
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.containing-block {
+    position: relative;
+    width: 200px;
+    height: 200px;
+}
+.group {
+    mask-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5));
+    width: 200px;
+    height: 200px;
+    background: red;
+}
+.clip {
+    overflow: hidden;
+    width: 100px;
+    height: 100px;
+}
+.escaping {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+</style>
+<!-- The absolute child skips the overflow clip but is masked as part of the group: applying the half
+     transparent mask to the group and to the child separately would show red through the child. -->
+<div class="containing-block">
+    <div class="group">
+        <div class="clip">
+            <div class="escaping"></div>
+        </div>
+    </div>
+</div>

--- a/Tests/LibWeb/Ref/input/visual-context/abspos-escaping-overflow-clip-inside-opacity.html
+++ b/Tests/LibWeb/Ref/input/visual-context/abspos-escaping-overflow-clip-inside-opacity.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/visual-context/abspos-escaping-overflow-clip-inside-opacity-ref.html">
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.containing-block {
+    position: relative;
+    width: 200px;
+    height: 200px;
+}
+.group {
+    opacity: 0.5;
+    width: 200px;
+    height: 200px;
+    background: red;
+}
+.clip {
+    overflow: hidden;
+    width: 100px;
+    height: 100px;
+}
+.escaping {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+</style>
+<!-- The absolute child skips the overflow clip of its parent but stays inside the opacity group, whose
+     layer must be entered once around both the group's own background and the child. -->
+<div class="containing-block">
+    <div class="group">
+        <div class="clip">
+            <div class="escaping"></div>
+        </div>
+    </div>
+</div>

--- a/Tests/LibWeb/TestDisplayListCommandRuns.cpp
+++ b/Tests/LibWeb/TestDisplayListCommandRuns.cpp
@@ -11,14 +11,14 @@
 
 using namespace Web::Painting;
 
-static ContextRef context(u32 spatial, Optional<u32> frame = {})
+static ContextRef context(u32 spatial, Optional<u32> effect = {})
 {
-    return { SpatialNodeIndex { spatial }, frame.has_value() ? FrameNodeIndex { *frame } : NO_FRAME_NODE };
+    return { SpatialNodeIndex { spatial }, NO_CLIP_NODE, effect.has_value() ? EffectNodeIndex { *effect } : NO_EFFECT_NODE };
 }
 
 static void append_fill_rect(ByteBuffer& bytes, ContextRef context, Gfx::IntRect rect)
 {
-    append_display_list_command(bytes, FillRect { rect, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, NO_FRAME_NODE }, rect, context);
+    append_display_list_command(bytes, FillRect { rect, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, NO_EFFECT_NODE }, rect, context);
 }
 
 TEST_CASE(runs_split_on_context_changes_and_cover_the_tape)
@@ -63,7 +63,7 @@ TEST_CASE(a_draw_confined_to_its_bounds_contributes_the_confined_bounds)
 {
     ByteBuffer bytes;
     auto root = context(0);
-    append_display_list_command(bytes, FillRect { { 0, 0, 100, 100 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, NO_FRAME_NODE }, Gfx::IntRect { 10, 10, 20, 20 }, root);
+    append_display_list_command(bytes, FillRect { { 0, 0, 100, 100 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, NO_EFFECT_NODE }, Gfx::IntRect { 10, 10, 20, 20 }, root);
     append_fill_rect(bytes, root, { 50, 50, 10, 10 });
 
     auto runs = compute_display_list_command_runs(bytes);
@@ -74,7 +74,7 @@ TEST_CASE(a_draw_confined_to_its_bounds_contributes_the_confined_bounds)
 TEST_CASE(a_draw_without_bounds_marks_the_run_unbounded)
 {
     ByteBuffer bytes;
-    append_display_list_command(bytes, FillRect { { 0, 0, 10, 10 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, NO_FRAME_NODE }, {}, context(0));
+    append_display_list_command(bytes, FillRect { { 0, 0, 10, 10 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, NO_EFFECT_NODE }, {}, context(0));
 
     auto runs = compute_display_list_command_runs(bytes);
     EXPECT(runs[0].has_unbounded_draw);

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
@@ -10,11 +10,12 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] transform=[1,0,0,1,100,0] origin=(20,20) (BlockContainer<DIV>#transformed)
         [s3] scroll (BlockContainer<DIV>#clip)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[20,160 100x100] (BlockContainer<DIV>#clip)
+  clips:
+    [c0 in s1] clip=[20,160 100x100] (BlockContainer<DIV>#clip)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorBlockingWheelEventRegion@s2/f0 rect=[20,20 100x100]
-CompositorBlockingWheelEventRegion@s3/f1 rect=[20,160 200x100]
+CompositorBlockingWheelEventRegion@s2/e0 rect=[20,20 100x100]
+CompositorBlockingWheelEventRegion@s3/c0/e0 rect=[20,160 200x100]
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
@@ -28,19 +28,20 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>#scroller)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[0,0 200x200] (BlockContainer<DIV>#scroller)
+  clips:
+    [c0 in s1] clip=[0,0 200x200] (BlockContainer<DIV>#scroller)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s0 rect=[0,0 800x600]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[0,0 800x213]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[0,0 800x200]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s2 rect=[0,0 200x200]
-CompositorScrollNode@s1/f0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[0,0 200x200] min_scroll_offset=[0,0] max_scroll_offset=[800,900] is_viewport=false
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s2 rect=[0,0 100x100]
-CompositorBlockingWheelEventRegion@s2/f1 rect=[0,0 100x100]
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s2 rect=[0,100 1000x1000]
-PaintScrollBar@s1/f0
-PaintScrollBar@s1/f0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s0 rect=[0,0 800x600]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[0,0 800x213]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[0,0 800x200]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s2 rect=[0,0 200x200]
+CompositorScrollNode@s1/e0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[0,0 200x200] min_scroll_offset=[0,0] max_scroll_offset=[800,900] is_viewport=false
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s2 rect=[0,0 100x100]
+CompositorBlockingWheelEventRegion@s2/c0/e0 rect=[0,0 100x100]
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s2 rect=[0,100 1000x1000]
+PaintScrollBar@s1/e0
+PaintScrollBar@s1/e0
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
@@ -5,9 +5,9 @@ display list:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorScrollNode@s0/f0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1413] is_viewport=true
+CompositorScrollNode@s0/e0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1413] is_viewport=true
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
@@ -6,11 +6,11 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorScrollNode@s0/f0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1413] is_viewport=true
-CompositorMainThreadWheelEventRegion@s1/f0 rect=[40,40 160x120]
-DrawCompositedContext@s1/f0 dst_rect=[40,40 160x120] inline_clips=[clip=[40,40 160x120]]
+CompositorScrollNode@s0/e0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1413] is_viewport=true
+CompositorMainThreadWheelEventRegion@s1/e0 rect=[40,40 160x120]
+DrawCompositedContext@s1/e0 dst_rect=[40,40 160x120] inline_clips=[clip=[40,40 160x120]]
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
@@ -6,18 +6,19 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>#scroller)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[0,0 100x100] (BlockContainer<DIV>#scroller)
+  clips:
+    [c0 in s1] clip=[0,0 100x100] (BlockContainer<DIV>#scroller)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s1 rect=[0,0 800x600]
-CompositorScrollNode@s0/f0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1513] is_viewport=true
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,0 800x2113]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,0 800x2100]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s2 rect=[0,0 100x100]
-CompositorScrollNode@s1/f0 scroll_node_index=s2 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[0,400] is_viewport=false
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s2 rect=[0,0 100x500]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,100 800x2000]
-PaintScrollBar@s1/f0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s1 rect=[0,0 800x600]
+CompositorScrollNode@s0/e0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1513] is_viewport=true
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,0 800x2113]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,0 800x2100]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s2 rect=[0,0 100x100]
+CompositorScrollNode@s1/e0 scroll_node_index=s2 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[0,400] is_viewport=false
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s2 rect=[0,0 100x500]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,100 800x2000]
+PaintScrollBar@s1/e0
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-metadata-cache-replay.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-metadata-cache-replay.txt
@@ -3,5 +3,5 @@ scroller scrollTop: 80
 wheel target near viewport top: viewport
 upward wheel target over scroller: non-viewport
 scroll metadata:
-CompositorScrollNode@s0/f0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,2491] is_viewport=true
-CompositorScrollNode@s0/f0 scroll_node_index=s2 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[0,400] is_viewport=false
+CompositorScrollNode@s0/e0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,2491] is_viewport=true
+CompositorScrollNode@s0/e0 scroll_node_index=s2 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[0,400] is_viewport=false

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
@@ -9,20 +9,21 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] sticky scroller=s1 position_relative_to_scroller=[0,0] border_box_size=[800x100] scrollport_size=[800x600] containing_block_region=[0,0 800x2100] needs_parent_offset_adjustment=true insets=[top=0] (BlockContainer<DIV>#sticky)
           [s3] scroll (BlockContainer<DIV>#scroller)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s2] clip=[0,0 100x100] (BlockContainer<DIV>#scroller)
+  clips:
+    [c0 in s2] clip=[0,0 100x100] (BlockContainer<DIV>#scroller)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s1 rect=[0,0 800x600]
-CompositorScrollNode@s0/f0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1513] is_viewport=true
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,0 800x2113]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,0 800x2100]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,100 800x2000]
-CompositorWheelHitTestTarget@s2/f0 target_scroll_node_index=s1 rect=[0,0 800x100]
-CompositorWheelHitTestTarget@s2/f0 target_scroll_node_index=s3 rect=[0,0 100x100]
-CompositorScrollNode@s2/f0 scroll_node_index=s3 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[400,400] is_viewport=false
-CompositorWheelHitTestTarget@s3/f1 target_scroll_node_index=s3 rect=[0,0 500x500]
-PaintScrollBar@s2/f0
-PaintScrollBar@s2/f0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s1 rect=[0,0 800x600]
+CompositorScrollNode@s0/e0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1513] is_viewport=true
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,0 800x2113]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,0 800x2100]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,100 800x2000]
+CompositorWheelHitTestTarget@s2/e0 target_scroll_node_index=s1 rect=[0,0 800x100]
+CompositorWheelHitTestTarget@s2/e0 target_scroll_node_index=s3 rect=[0,0 100x100]
+CompositorScrollNode@s2/e0 scroll_node_index=s3 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[400,400] is_viewport=false
+CompositorWheelHitTestTarget@s3/c0/e0 target_scroll_node_index=s3 rect=[0,0 500x500]
+PaintScrollBar@s2/e0
+PaintScrollBar@s2/e0
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
@@ -11,19 +11,20 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>#scroller)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[0,0 100x100] (BlockContainer<DIV>#scroller)
+  clips:
+    [c0 in s1] clip=[0,0 100x100] (BlockContainer<DIV>#scroller)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s1 rect=[0,0 800x600]
-CompositorScrollNode@s0/f0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1513] is_viewport=true
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,0 800x2113]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,0 800x2100]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s2 rect=[0,0 100x100]
-CompositorScrollNode@s1/f0 scroll_node_index=s2 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[400,400] is_viewport=false
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s2 rect=[0,0 500x500]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,100 800x2000]
-PaintScrollBar@s1/f0
-PaintScrollBar@s1/f0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s1 rect=[0,0 800x600]
+CompositorScrollNode@s0/e0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1513] is_viewport=true
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,0 800x2113]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,0 800x2100]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s2 rect=[0,0 100x100]
+CompositorScrollNode@s1/e0 scroll_node_index=s2 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[400,400] is_viewport=false
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s2 rect=[0,0 500x500]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,100 800x2000]
+PaintScrollBar@s1/e0
+PaintScrollBar@s1/e0
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
@@ -12,10 +12,10 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] sticky scroller=s1 position_relative_to_scroller=[0,0] border_box_size=[800x16] scrollport_size=[800x600] containing_block_region=[0,0 800x2016] needs_parent_offset_adjustment=true insets=[top=0] (BlockContainer<DIV>#outer)
           [s3] sticky scroller=s1 parent_sticky=s2 position_relative_to_scroller=[0,0] border_box_size=[800x16] scrollport_size=[800x600] containing_block_region=[0,0 800x16] needs_parent_offset_adjustment=true insets=[top=20] (BlockContainer<DIV>#inner)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorScrollNode@s0/f0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1429] is_viewport=true
-DrawGlyphRun@s3/f0 rect=[0,0 45x16] translation=[0,12.796875] color=rgb(0, 0, 0)
+CompositorScrollNode@s0/e0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1429] is_viewport=true
+DrawGlyphRun@s3/e0 rect=[0,0 45x16] translation=[0,12.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
@@ -8,18 +8,19 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>#scroller)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[0,0 100x100] (BlockContainer<DIV>#scroller)
+  clips:
+    [c0 in s1] clip=[0,0 100x100] (BlockContainer<DIV>#scroller)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s1 rect=[0,0 800x600]
-CompositorScrollNode@s0/f0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1513] is_viewport=true
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,0 800x2113]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,0 800x2100]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s2 rect=[0,0 100x100]
-CompositorScrollNode@s1/f0 scroll_node_index=s2 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[0,400] is_viewport=false
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s2 rect=[0,0 100x500]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s1 rect=[0,100 800x2000]
-PaintScrollBar@s1/f0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s1 rect=[0,0 800x600]
+CompositorScrollNode@s0/e0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1513] is_viewport=true
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,0 800x2113]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,0 800x2100]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s2 rect=[0,0 100x100]
+CompositorScrollNode@s1/e0 scroll_node_index=s2 parent_scroll_node_index=s1 scrollport_rect=[0,0 100x100] min_scroll_offset=[0,0] max_scroll_offset=[0,400] is_viewport=false
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s2 rect=[0,0 100x500]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s1 rect=[0,100 800x2000]
+PaintScrollBar@s1/e0
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
@@ -15,20 +15,21 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>#scroller)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[0,0 200x200] (BlockContainer<DIV>#scroller)
+  clips:
+    [c0 in s1] clip=[0,0 200x200] (BlockContainer<DIV>#scroller)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s0 rect=[0,0 800x600]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[0,0 800x213]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[0,0 800x200]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s2 rect=[0,0 200x200]
-CompositorScrollNode@s1/f0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[0,0 200x200] min_scroll_offset=[0,0] max_scroll_offset=[800,900] is_viewport=false
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s2 rect=[0,0 100x100]
-CompositorBlockingWheelEventRegion@s2/f1 rect=[0,0 100x100]
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s2 rect=[0,100 1000x1000]
-PaintScrollBar@s1/f0
-PaintScrollBar@s1/f0
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[250,0 100x100]
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s0 rect=[0,0 800x600]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[0,0 800x213]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[0,0 800x200]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s2 rect=[0,0 200x200]
+CompositorScrollNode@s1/e0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[0,0 200x200] min_scroll_offset=[0,0] max_scroll_offset=[800,900] is_viewport=false
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s2 rect=[0,0 100x100]
+CompositorBlockingWheelEventRegion@s2/c0/e0 rect=[0,0 100x100]
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s2 rect=[0,100 1000x1000]
+PaintScrollBar@s1/e0
+PaintScrollBar@s1/e0
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[250,0 100x100]
 

--- a/Tests/LibWeb/Text/expected/css/text-underline-position.txt
+++ b/Tests/LibWeb/Text/expected/css/text-underline-position.txt
@@ -2,13 +2,13 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawGlyphRun@s1/f0 rect=[8,8 28x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-DrawLine@s1/f0 from=[8,24] to=[35,24] color=rgb(0, 0, 0) thickness=2 style=Solid
-DrawGlyphRun@s1/f0 rect=[35,8 8x16] translation=[35.15625,20.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[43,8 28x16] translation=[43.15625,20.796875] color=rgb(0, 0, 0)
-DrawLine@s1/f0 from=[43,27] to=[71,27] color=rgb(0, 0, 0) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,8 28x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+DrawLine@s1/e0 from=[8,24] to=[35,24] color=rgb(0, 0, 0) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[35,8 8x16] translation=[35.15625,20.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[43,8 28x16] translation=[43.15625,20.796875] color=rgb(0, 0, 0)
+DrawLine@s1/e0 from=[43,27] to=[71,27] color=rgb(0, 0, 0) thickness=2 style=Solid
 

--- a/Tests/LibWeb/Text/expected/display_list/abspos-escaping-overflow-clip-inside-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-escaping-overflow-clip-inside-opacity.txt
@@ -1,0 +1,12 @@
+AccumulatedVisualContext Tree:
+  spatial:
+    [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
+      [s1] scroll (Viewport<#document>)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s1] effects=[opacity=0.5] (BlockContainer<DIV>#group)
+
+DisplayList:
+FillRect@s1/e1 rect=[0,0 200x200] color=rgb(255, 0, 0)
+FillRect@s1/e1 rect=[50,50 100x100] color=rgb(0, 0, 255)
+

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
@@ -2,12 +2,13 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,8 200x200] (BlockContainer<DIV>.relpos)
-        [f3 in s1] effects=[opacity=0.5] (BlockContainer<DIV>.outer-opacity)
-          [f6 in s1] effects=[opacity=0.3] (BlockContainer<DIV>.inner-opacity)
+  clips:
+    [c0 in s1] clip=[8,8 200x200] (BlockContainer<DIV>.relpos)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s1 out=c0] effects=[opacity=0.5] (BlockContainer<DIV>.outer-opacity)
+        [e2 in s1 out=c0] effects=[opacity=0.3] (BlockContainer<DIV>.inner-opacity)
 
 DisplayList:
-FillRect@s1/f6 rect=[8,8 100x100] color=rgb(0, 0, 0)
+FillRect@s1/c0/e2 rect=[8,8 100x100] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
@@ -2,11 +2,12 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,8 200x200] (BlockContainer<DIV>.relpos)
-        [f3 in s1] effects=[opacity=0.5] (BlockContainer<DIV>.opacity)
+  clips:
+    [c0 in s1] clip=[8,8 200x200] (BlockContainer<DIV>.relpos)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s1 out=c0] effects=[opacity=0.5] (BlockContainer<DIV>.opacity)
 
 DisplayList:
-FillRect@s1/f3 rect=[8,8 100x100] color=rgb(0, 0, 0)
+FillRect@s1/c0/e1 rect=[8,8 100x100] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/abspos-under-clipped-transformed-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-under-clipped-transformed-opacity.txt
@@ -3,10 +3,10 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] transform=[1,0,0,1,5,5] origin=(160,160) (BlockContainer<DIV>#containing-block)
-  frames:
-    [f0 in s0] effects=[]
-      [f2 in s2] effects=[opacity=0.5] (BlockContainer<DIV>#clipped)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s2] effects=[opacity=0.5] (BlockContainer<DIV>#clipped)
 
 DisplayList:
-FillRect@s2/f2 rect=[160,160 50x50] color=rgb(0, 128, 0)
+FillRect@s2/e1 rect=[160,160 50x50] color=rgb(0, 128, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/animated-clip-path-visual-context-update.txt
+++ b/Tests/LibWeb/Text/expected/display_list/animated-clip-path-visual-context-update.txt
@@ -5,10 +5,11 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip_path=[bounds: 8,8 100x100, path: M58 58L58 58L58 58L58 58Z] (BlockContainer<DIV>#box)
+  clips:
+    [c0 in s1] clip_path=[bounds: 8,8 100x100, path: M58 58L58 58L58 58L58 58Z] (BlockContainer<DIV>#box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s1/c0/e0 rect=[8,8 100x100] color=rgb(0, 128, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/animated-transform-visual-context-update.txt
+++ b/Tests/LibWeb/Text/expected/display_list/animated-transform-visual-context-update.txt
@@ -4,11 +4,11 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] transform=[1,0,0,1,10,0] origin=(58,58) (BlockContainer<DIV>#box)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f0 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s2/e0 rect=[8,8 100x100] color=rgb(0, 128, 0)
 
 After animation update:
 AccumulatedVisualContext Tree:
@@ -16,9 +16,9 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] transform=[1,0,0,1,15,0] origin=(58,58) (BlockContainer<DIV>#box)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f0 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s2/e0 rect=[8,8 100x100] color=rgb(0, 128, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-change-repaints.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-change-repaints.txt
@@ -3,19 +3,19 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-PaintLinearGradient@s1/f0 rect=[0,0 200x600] inline_clips=[clip=[0,0 200x200]]
+PaintLinearGradient@s1/e0 rect=[0,0 200x600] inline_clips=[clip=[0,0 200x200]]
 
 After background-attachment change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-PaintLinearGradient@s0/f0 rect=[0,0 800x600] inline_clips=[clip=[0,0 200x200]]
+PaintLinearGradient@s0/e0 rect=[0,0 800x600] inline_clips=[clip=[0,0 200x200]]
 

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
@@ -1,10 +1,10 @@
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorScrollNode@s0/f0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,613] is_viewport=true
-PaintLinearGradient@s0/f0 rect=[0,0 800x600]
+CompositorScrollNode@s0/e0 scroll_node_index=s1 parent_scroll_node_index=s0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,613] is_viewport=true
+PaintLinearGradient@s0/e0 rect=[0,0 800x600]
 

--- a/Tests/LibWeb/Text/expected/display_list/background-blend-mode-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-blend-mode-invalidation.txt
@@ -3,24 +3,24 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,13 100x100] color=rgb(173, 216, 230)
-PaintLinearGradient@s1/f0 rect=[8,13 100x100] inline_clips=[clip=[8,13 100x100]]
-DrawGlyphRun@s1/f0 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,13 100x100] color=rgb(173, 216, 230)
+PaintLinearGradient@s1/e0 rect=[8,13 100x100] inline_clips=[clip=[8,13 100x100]]
+DrawGlyphRun@s1/e0 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 
 After background-blend-mode change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,13 100x100] color=rgb(173, 216, 230)
-PaintLinearGradient@s1/f0 rect=[8,13 100x100] blend_mode=2 inline_clips=[clip=[8,13 100x100]]
-DrawGlyphRun@s1/f0 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,13 100x100] color=rgb(173, 216, 230)
+PaintLinearGradient@s1/e0 rect=[8,13 100x100] blend_mode=2 inline_clips=[clip=[8,13 100x100]]
+DrawGlyphRun@s1/e0 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/background-blend-mode-isolated-group.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-blend-mode-isolated-group.txt
@@ -2,11 +2,11 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawIsolatedDisplayList@s1/f0 rect=[8,8 100x50] list_size=[100x50]
+DrawIsolatedDisplayList@s1/e0 rect=[8,8 100x50] list_size=[100x50]
   PaintLinearGradient@s0 rect=[8,8 100x50] inline_clips=[clip=[8,8 100x50]]
   PaintLinearGradient@s0 rect=[8,8 100x50] blend_mode=2 inline_clips=[clip=[8,8 100x50]]
 

--- a/Tests/LibWeb/Text/expected/display_list/background-clip-text-color-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-clip-text-color-invalidation.txt
@@ -3,24 +3,24 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawGlyphRun@s1/f0 rect=[8,13 71x30] translation=[8,37] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,13 71x30] translation=[8,37] color=rgb(0, 0, 0)
 
 After background-color change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawIsolatedDisplayList@s1/f0 rect=[8,13 100x50] list_size=[100x50] has_mask=alpha
+DrawIsolatedDisplayList@s1/e0 rect=[8,13 100x50] list_size=[100x50] has_mask=alpha
   FillRect@s0 rect=[8,13 100x50] color=rgb(0, 0, 255)
   Mask:
     DrawGlyphRun@s0 rect=[8,13 71x30] translation=[8,37] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,13 71x30] translation=[8,37] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,13 71x30] translation=[8,37] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/block-in-inline-no-border-for-phantom-inline-box.txt
+++ b/Tests/LibWeb/Text/expected/display_list/block-in-inline-no-border-for-phantom-inline-box.txt
@@ -2,13 +2,13 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[0,3 8x14]
-FillPath@s1/f0 path_bounding_rect=[0,63 8x14]
-DrawGlyphRun@s1/f0 rect=[2,5 6x10] translation=[2,13] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[0,65 6x10] translation=[0,73] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[100,55 7x10] translation=[100,63] color=rgb(0, 0, 0)
+FillPath@s1/e0 path_bounding_rect=[0,3 8x14]
+FillPath@s1/e0 path_bounding_rect=[0,63 8x14]
+DrawGlyphRun@s1/e0 rect=[2,5 6x10] translation=[2,13] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[0,65 6x10] translation=[0,73] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[100,55 7x10] translation=[100,63] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/blocking-wheel-listener-cache-replay.txt
+++ b/Tests/LibWeb/Text/expected/display_list/blocking-wheel-listener-cache-replay.txt
@@ -1,1 +1,1 @@
-CompositorBlockingWheelEventRegion@s1/f0 rect=[8,8 100x100]
+CompositorBlockingWheelEventRegion@s1/e0 rect=[8,8 100x100]

--- a/Tests/LibWeb/Text/expected/display_list/border-inner-corner-right-angle-all-edges.txt
+++ b/Tests/LibWeb/Text/expected/display_list/border-inner-corner-right-angle-all-edges.txt
@@ -2,16 +2,16 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[166,12.651531 20x110.696945]
-FillPath@s1/f0 path_bounding_rect=[11.232849,113 168.56511x15]
-FillPath@s1/f0 path_bounding_rect=[8,14.061594 8x107.876816]
-FillPath@s1/f0 path_bounding_rect=[11.232849,7.999998 168.56511x15.000002]
-FillPath@s1/f0 path_bounding_rect=[173,134.20204 15.0000305x117.59592]
-FillPath@s1/f0 path_bounding_rect=[12.651531,238 170.69693x20]
-FillPath@s1/f0 path_bounding_rect=[7.9999995,134.20204 15x117.59592]
-FillPath@s1/f0 path_bounding_rect=[12.651531,127.99999 170.69693x20.000008]
+FillPath@s1/e0 path_bounding_rect=[166,12.651531 20x110.696945]
+FillPath@s1/e0 path_bounding_rect=[11.232849,113 168.56511x15]
+FillPath@s1/e0 path_bounding_rect=[8,14.061594 8x107.876816]
+FillPath@s1/e0 path_bounding_rect=[11.232849,7.999998 168.56511x15.000002]
+FillPath@s1/e0 path_bounding_rect=[173,134.20204 15.0000305x117.59592]
+FillPath@s1/e0 path_bounding_rect=[12.651531,238 170.69693x20]
+FillPath@s1/e0 path_bounding_rect=[7.9999995,134.20204 15x117.59592]
+FillPath@s1/e0 path_bounding_rect=[12.651531,127.99999 170.69693x20.000008]
 

--- a/Tests/LibWeb/Text/expected/display_list/border-radius-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/border-radius-invalidation.txt
@@ -3,24 +3,26 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,13 100x100] (BlockContainer<DIV>#box.box)
+  clips:
+    [c0 in s1] clip=[8,13 100x100] (BlockContainer<DIV>#box.box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,13 100x100] color=rgb(173, 216, 230)
-DrawGlyphRun@s1/f1 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,13 100x100] color=rgb(173, 216, 230)
+DrawGlyphRun@s1/c0/e0 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 
 After border-radius change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,13 100x100] radii=(20,20,20,20) (BlockContainer<DIV>#box.box)
+  clips:
+    [c0 in s1] clip=[8,13 100x100] radii=(20,20,20,20) (BlockContainer<DIV>#box.box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRectWithRoundedCorners@s1/f0 rect=[8,13 100x100] color=rgb(173, 216, 230)
-DrawGlyphRun@s1/f1 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
+FillRectWithRoundedCorners@s1/e0 rect=[8,13 100x100] color=rgb(173, 216, 230)
+DrawGlyphRun@s1/c0/e0 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
+++ b/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
@@ -2,12 +2,12 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 106x20] color=rgb(212, 208, 200)
-FillPath@s1/f0 path_bounding_rect=[8,8 106x20]
-DrawGlyphRun@s1/f0 rect=[13,10 96x16] translation=[13,22.796875] color=rgb(0, 0, 0)
-DrawLine@s1/f0 from=[13,26] to=[109,26] color=rgb(0, 0, 0) thickness=2 style=Solid
+FillRect@s1/e0 rect=[8,8 106x20] color=rgb(212, 208, 200)
+FillPath@s1/e0 path_bounding_rect=[8,8 106x20]
+DrawGlyphRun@s1/e0 rect=[13,10 96x16] translation=[13,22.796875] color=rgb(0, 0, 0)
+DrawLine@s1/e0 from=[13,26] to=[109,26] color=rgb(0, 0, 0) thickness=2 style=Solid
 

--- a/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
+++ b/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
@@ -2,9 +2,9 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawCanvas@s1/f0 dst_rect=[8,8 32x32] content_generation=0
+DrawCanvas@s1/e0 dst_rect=[8,8 32x32] content_generation=0
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-auto-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-auto-invalidation.txt
@@ -3,21 +3,22 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,13 100x100] color=rgb(0, 128, 0)
+FillRect@s1/e0 rect=[8,13 100x100] color=rgb(0, 128, 0)
 
 After clip change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,13 50x50] (BlockContainer<DIV>#box)
+  clips:
+    [c0 in s1] clip=[8,13 50x50] (BlockContainer<DIV>#box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,13 100x100] color=rgb(0, 128, 0)
+FillRect@s1/c0/e0 rect=[8,13 100x100] color=rgb(0, 128, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
@@ -3,24 +3,26 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,13 100x100] (BlockContainer<DIV>#box.box)
+  clips:
+    [c0 in s1] clip=[8,13 100x100] (BlockContainer<DIV>#box.box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,13 100x100] color=rgb(173, 216, 230)
-DrawGlyphRun@s1/f1 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
+FillRect@s1/c0/e0 rect=[8,13 100x100] color=rgb(173, 216, 230)
+DrawGlyphRun@s1/c0/e0 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 
 After clip change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[18,23 80x80] (BlockContainer<DIV>#box.box)
+  clips:
+    [c0 in s1] clip=[18,23 80x80] (BlockContainer<DIV>#box.box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,13 100x100] color=rgb(173, 216, 230)
-DrawGlyphRun@s1/f1 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
+FillRect@s1/c0/e0 rect=[8,13 100x100] color=rgb(173, 216, 230)
+DrawGlyphRun@s1/c0/e0 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-empty-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-empty-invalidation.txt
@@ -3,22 +3,24 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip_path=[bounds: 8,8 100x100, path: M8 8L108 8L108 108L8 108L8 8Z] (BlockContainer<DIV>#box)
+  clips:
+    [c0 in s1] clip_path=[bounds: 8,8 100x100, path: M8 8L108 8L108 108L8 108L8 8Z] (BlockContainer<DIV>#box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s1/c0/e0 rect=[8,8 100x100] color=rgb(0, 128, 0)
 
 After clip-path change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip_path=[bounds: 8,8 100x100, path: M58 58L58 58L58 58L58 58Z] (BlockContainer<DIV>#box)
+  clips:
+    [c0 in s1] clip_path=[bounds: 8,8 100x100, path: M58 58L58 58L58 58L58 58Z] (BlockContainer<DIV>#box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s1/c0/e0 rect=[8,8 100x100] color=rgb(0, 128, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
@@ -3,24 +3,26 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip_path=[bounds: 8,8 100x100, path: M8 8L108 8L108 108L8 108L8 8Z] (BlockContainer<DIV>#box.box)
+  clips:
+    [c0 in s1] clip_path=[bounds: 8,8 100x100, path: M8 8L108 8L108 108L8 108L8 8Z] (BlockContainer<DIV>#box.box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,8 100x100] color=rgb(173, 216, 230)
-DrawGlyphRun@s1/f1 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s1/c0/e0 rect=[8,8 100x100] color=rgb(173, 216, 230)
+DrawGlyphRun@s1/c0/e0 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 
 After clip-path change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip_path=[bounds: 8,8 100x100, path: M58 8L108 58L58 108L8 58L58 8Z] (BlockContainer<DIV>#box.box)
+  clips:
+    [c0 in s1] clip_path=[bounds: 8,8 100x100, path: M58 8L108 58L58 108L8 58L58 8Z] (BlockContainer<DIV>#box.box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,8 100x100] color=rgb(173, 216, 230)
-DrawGlyphRun@s1/f1 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s1/c0/e0 rect=[8,8 100x100] color=rgb(173, 216, 230)
+DrawGlyphRun@s1/c0/e0 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-positioned-descendants.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-positioned-descendants.txt
@@ -2,12 +2,13 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f2 in s1] clip_path=[bounds: 0,0 200x200, path: M50 50L150 50L150 150L50 150L50 50Z] (BlockContainer<DIV>.clip-path-ancestor)
-      [f5 in s0] clip=[220,0 100x100] (BlockContainer<DIV>.clip-ancestor)
+  clips:
+    [c0 in s1] clip_path=[bounds: 0,0 200x200, path: M50 50L150 50L150 150L50 150L50 50Z] (BlockContainer<DIV>.clip-path-ancestor)
+    [c3 in s0] clip=[220,0 100x100] (BlockContainer<DIV>.clip-ancestor)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f2 rect=[0,0 200x200] color=rgb(255, 0, 0)
-FillRect@s0/f5 rect=[220,0 200x200] color=rgb(0, 128, 0)
+FillRect@s1/c0/e0 rect=[0,0 200x200] color=rgb(255, 0, 0)
+FillRect@s0/c3/e0 rect=[220,0 200x200] color=rgb(0, 128, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
@@ -2,10 +2,10 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-PaintCaret@s1/f0 rect=[8,8 1x16] color=rgb(0, 0, 0) should_blink=false
-FillPath@s1/f0 path_bounding_rect=[6,6 104x24]
+PaintCaret@s1/e0 rect=[8,8 1x16] color=rgb(0, 0, 0) should_blink=false
+FillPath@s1/e0 path_bounding_rect=[6,6 104x24]
 

--- a/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
+++ b/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
@@ -2,12 +2,13 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[28,23 80x70] (BlockContainer<DIV>.clipped)
+  clips:
+    [c0 in s1] clip=[28,23 80x70] (BlockContainer<DIV>.clipped)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,13 150x150] color=rgb(128, 0, 128)
-DrawGlyphRun@s1/f1 rect=[8,13 71x16] translation=[8,25.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f1 rect=[8,29 72x16] translation=[8,41.796875] color=rgb(0, 0, 0)
+FillRect@s1/c0/e0 rect=[8,13 150x150] color=rgb(128, 0, 128)
+DrawGlyphRun@s1/c0/e0 rect=[8,13 71x16] translation=[8,25.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/c0/e0 rect=[8,29 72x16] translation=[8,41.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/dashed-border-with-border-radius.txt
+++ b/Tests/LibWeb/Text/expected/display_list/dashed-border-with-border-radius.txt
@@ -2,20 +2,20 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-StrokePath@s1/f0 path_bounding_rect=[8,8 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=29.63
-StrokePath@s1/f0 path_bounding_rect=[110.677666,95.322334 17.322334x65.35534] thickness=10 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=14.75 inline_clips=[clip_path=[bounds: [112,96 16x64], curved path: 68 commands]]
-StrokePath@s1/f0 path_bounding_rect=[15.322332,150.67767 105.35533x17.322327] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=12.38 inline_clips=[clip_path=[bounds: [16,152 104x17], curved path: 68 commands]]
-StrokePath@s1/f0 path_bounding_rect=[8,95.322334 17.322332x65.35534] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=14.75 inline_clips=[clip_path=[bounds: [7,96 17x64], curved path: 68 commands]]
-StrokePath@s1/f0 path_bounding_rect=[15.322332,87.99999 105.35533x17.322342] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=12.38 inline_clips=[clip_path=[bounds: [16,88 104x16], curved path: 68 commands]]
-StrokePath@s1/f0 path_bounding_rect=[8,168 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=30.92
-StrokePath@s1/f0 path_bounding_rect=[8,248 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.88
-StrokePath@s1/f0 path_bounding_rect=[110.677666,335.32233 17.322334x65.35535] thickness=10 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=9.84 inline_clips=[clip_path=[bounds: [112,336 16x64], curved path: 68 commands]]
-StrokePath@s1/f0 path_bounding_rect=[15.322332,390.67767 105.35533x17.322327] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.90 inline_clips=[clip_path=[bounds: [16,392 104x16], curved path: 68 commands]]
-StrokePath@s1/f0 path_bounding_rect=[8,335.32233 17.322332x65.35535] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.84 inline_clips=[clip_path=[bounds: [7,336 17x64], curved path: 68 commands]]
-StrokePath@s1/f0 path_bounding_rect=[15.322332,327.99997 105.35533x17.322357] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.90 inline_clips=[clip_path=[bounds: [16,328 104x16], curved path: 68 commands]]
-StrokePath@s1/f0 path_bounding_rect=[8,408 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=10.31
+StrokePath@s1/e0 path_bounding_rect=[8,8 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=29.63
+StrokePath@s1/e0 path_bounding_rect=[110.677666,95.322334 17.322334x65.35534] thickness=10 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=14.75 inline_clips=[clip_path=[bounds: [112,96 16x64], curved path: 68 commands]]
+StrokePath@s1/e0 path_bounding_rect=[15.322332,150.67767 105.35533x17.322327] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=12.38 inline_clips=[clip_path=[bounds: [16,152 104x17], curved path: 68 commands]]
+StrokePath@s1/e0 path_bounding_rect=[8,95.322334 17.322332x65.35534] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=14.75 inline_clips=[clip_path=[bounds: [7,96 17x64], curved path: 68 commands]]
+StrokePath@s1/e0 path_bounding_rect=[15.322332,87.99999 105.35533x17.322342] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=12.38 inline_clips=[clip_path=[bounds: [16,88 104x16], curved path: 68 commands]]
+StrokePath@s1/e0 path_bounding_rect=[8,168 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=30.92
+StrokePath@s1/e0 path_bounding_rect=[8,248 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.88
+StrokePath@s1/e0 path_bounding_rect=[110.677666,335.32233 17.322334x65.35535] thickness=10 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=9.84 inline_clips=[clip_path=[bounds: [112,336 16x64], curved path: 68 commands]]
+StrokePath@s1/e0 path_bounding_rect=[15.322332,390.67767 105.35533x17.322327] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.90 inline_clips=[clip_path=[bounds: [16,392 104x16], curved path: 68 commands]]
+StrokePath@s1/e0 path_bounding_rect=[8,335.32233 17.322332x65.35535] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.84 inline_clips=[clip_path=[bounds: [7,336 17x64], curved path: 68 commands]]
+StrokePath@s1/e0 path_bounding_rect=[15.322332,327.99997 105.35533x17.322357] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.90 inline_clips=[clip_path=[bounds: [16,328 104x16], curved path: 68 commands]]
+StrokePath@s1/e0 path_bounding_rect=[8,408 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=10.31
 

--- a/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
+++ b/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
@@ -6,22 +6,23 @@ AccumulatedVisualContext Tree:
         [s3] transform=[0.9,0,0,0.9,0,0] origin=(91,141) (BlockContainer<DIV>.leaf.leaf-b)
         [s4] transform=[1,0,0,1,10,0] origin=(296,56) (BlockContainer<DIV>.leaf.leaf-c)
         [s5] transform=[1,0,0,1,0,10] origin=(296,141) (BlockContainer<DIV>.leaf.leaf-d)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[10,10 400x200] (Box<DIV>.root)
-        [f2 in s1] clip=[11,11 193x198] (BlockContainer<DIV>.branch)
-        [f3 in s1] clip=[216,11 193x198] (BlockContainer<DIV>.branch)
+  clips:
+    [c0 in s1] clip=[10,10 400x200] (Box<DIV>.root)
+      [c1 in s1] clip=[11,11 193x198] (BlockContainer<DIV>.branch)
+      [c2 in s1] clip=[216,11 193x198] (BlockContainer<DIV>.branch)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[8,8 404x204]
-FillPath@s1/f1 path_bounding_rect=[10,10 195x200]
-FillPath@s1/f1 path_bounding_rect=[215,10 195x200]
-FillRect@s2/f2 rect=[16,16 150x80] color=rgb(255, 0, 0)
-DrawGlyphRun@s2/f2 rect=[16,16 15x16] translation=[16,28.796875] color=rgb(0, 0, 0)
-FillRect@s3/f2 rect=[16,101 150x80] color=rgb(0, 128, 0)
-DrawGlyphRun@s3/f2 rect=[16,101 10x16] translation=[16,113.796875] color=rgb(0, 0, 0)
-FillRect@s4/f3 rect=[221,16 150x80] color=rgb(0, 0, 255)
-DrawGlyphRun@s4/f3 rect=[221,16 11x16] translation=[221,28.796875] color=rgb(0, 0, 0)
-FillRect@s5/f3 rect=[221,101 150x80] color=rgb(255, 165, 0)
-DrawGlyphRun@s5/f3 rect=[221,101 12x16] translation=[221,113.796875] color=rgb(0, 0, 0)
+FillPath@s1/e0 path_bounding_rect=[8,8 404x204]
+FillPath@s1/c0/e0 path_bounding_rect=[10,10 195x200]
+FillPath@s1/c0/e0 path_bounding_rect=[215,10 195x200]
+FillRect@s2/c1/e0 rect=[16,16 150x80] color=rgb(255, 0, 0)
+DrawGlyphRun@s2/c1/e0 rect=[16,16 15x16] translation=[16,28.796875] color=rgb(0, 0, 0)
+FillRect@s3/c1/e0 rect=[16,101 150x80] color=rgb(0, 128, 0)
+DrawGlyphRun@s3/c1/e0 rect=[16,101 10x16] translation=[16,113.796875] color=rgb(0, 0, 0)
+FillRect@s4/c2/e0 rect=[221,16 150x80] color=rgb(0, 0, 255)
+DrawGlyphRun@s4/c2/e0 rect=[221,16 11x16] translation=[221,28.796875] color=rgb(0, 0, 0)
+FillRect@s5/c2/e0 rect=[221,101 150x80] color=rgb(255, 165, 0)
+DrawGlyphRun@s5/c2/e0 rect=[221,101 12x16] translation=[221,113.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/double-border-with-asymmetric-radii.txt
+++ b/Tests/LibWeb/Text/expected/display_list/double-border-with-asymmetric-radii.txt
@@ -2,16 +2,16 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[192.04163,10.928932 15.958389x135.35535]
-FillPath@s1/f0 path_bounding_rect=[182.14214,22 11.857864x114.38478]
-FillPath@s1/f0 path_bounding_rect=[10.928932,142.04163 185.35535x15.958389]
-FillPath@s1/f0 path_bounding_rect=[22,132.14214 164.38478x11.85788]
-FillPath@s1/f0 path_bounding_rect=[7.999997,19.715729 15.958373x135.35535]
-FillPath@s1/f0 path_bounding_rect=[22,29.615223 11.857864x114.38478]
-FillPath@s1/f0 path_bounding_rect=[19.715729,8 185.35535x15.95837]
-FillPath@s1/f0 path_bounding_rect=[29.615223,22 164.38478x11.857864]
+FillPath@s1/e0 path_bounding_rect=[192.04163,10.928932 15.958389x135.35535]
+FillPath@s1/e0 path_bounding_rect=[182.14214,22 11.857864x114.38478]
+FillPath@s1/e0 path_bounding_rect=[10.928932,142.04163 185.35535x15.958389]
+FillPath@s1/e0 path_bounding_rect=[22,132.14214 164.38478x11.85788]
+FillPath@s1/e0 path_bounding_rect=[7.999997,19.715729 15.958373x135.35535]
+FillPath@s1/e0 path_bounding_rect=[22,29.615223 11.857864x114.38478]
+FillPath@s1/e0 path_bounding_rect=[19.715729,8 185.35535x15.95837]
+FillPath@s1/e0 path_bounding_rect=[29.615223,22 164.38478x11.857864]
 

--- a/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
@@ -2,19 +2,19 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[10,8 780x50] color=rgb(0, 0, 255) inline_clips=[clip=[10,15 780x43]]
-FillPath@s1/f0 path_bounding_rect=[789,15 1x43]
-FillPath@s1/f0 path_bounding_rect=[788,14 1x43]
-FillPath@s1/f0 path_bounding_rect=[10,57 780x1]
-FillPath@s1/f0 path_bounding_rect=[11,56 778x1]
-FillPath@s1/f0 path_bounding_rect=[10,15 1x43]
-FillPath@s1/f0 path_bounding_rect=[11,14 1x43]
-FillPath@s1/f0 path_bounding_rect=[10,15 780x1] inline_clips=[clip=[10,15 780x2], clip=[24,15 57x2] mode=difference]
-FillPath@s1/f0 path_bounding_rect=[9,16 782x1] inline_clips=[clip=[10,15 780x2], clip=[24,15 57x2] mode=difference]
-DrawGlyphRun@s1/f0 rect=[26,8 54x16] translation=[26,20.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[24,29 63x16] translation=[24,42.390625] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[10,8 780x50] color=rgb(0, 0, 255) inline_clips=[clip=[10,15 780x43]]
+FillPath@s1/e0 path_bounding_rect=[789,15 1x43]
+FillPath@s1/e0 path_bounding_rect=[788,14 1x43]
+FillPath@s1/e0 path_bounding_rect=[10,57 780x1]
+FillPath@s1/e0 path_bounding_rect=[11,56 778x1]
+FillPath@s1/e0 path_bounding_rect=[10,15 1x43]
+FillPath@s1/e0 path_bounding_rect=[11,14 1x43]
+FillPath@s1/e0 path_bounding_rect=[10,15 780x1] inline_clips=[clip=[10,15 780x2], clip=[24,15 57x2] mode=difference]
+FillPath@s1/e0 path_bounding_rect=[9,16 782x1] inline_clips=[clip=[10,15 780x2], clip=[24,15 57x2] mode=difference]
+DrawGlyphRun@s1/e0 rect=[26,8 54x16] translation=[26,20.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[24,29 63x16] translation=[24,42.390625] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
@@ -2,13 +2,14 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,8 200x100] (BlockContainer<DIV>.scroll-container)
+  clips:
+    [c0 in s1] clip=[8,8 200x100] (BlockContainer<DIV>.scroll-container)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f1 rect=[8,8 150x50] color=rgb(0, 128, 0)
-DrawGlyphRun@s1/f1 rect=[8,8 56x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-FillRect@s0/f0 rect=[10,10 80x40] color=rgb(255, 0, 0)
-DrawGlyphRun@s0/f0 rect=[10,10 44x16] translation=[10,22.796875] color=rgb(0, 0, 0)
+FillRect@s1/c0/e0 rect=[8,8 150x50] color=rgb(0, 128, 0)
+DrawGlyphRun@s1/c0/e0 rect=[8,8 56x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s0/e0 rect=[10,10 80x40] color=rgb(255, 0, 0)
+DrawGlyphRun@s0/e0 rect=[10,10 44x16] translation=[10,22.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
+++ b/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
@@ -2,13 +2,13 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 29x30] color=rgb(0, 0, 0)
-FillRect@s1/f0 rect=[38,8 28x30] color=rgb(0, 0, 0)
-FillRect@s1/f0 rect=[67,8 29x30] color=rgb(0, 0, 0)
-FillRect@s1/f0 rect=[97,8 28x30] color=rgb(0, 0, 0)
-FillRect@s1/f0 rect=[126,8 29x30] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,8 29x30] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[38,8 28x30] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[67,8 29x30] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[97,8 28x30] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[126,8 29x30] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/iframe-compositor-surface.txt
+++ b/Tests/LibWeb/Text/expected/display_list/iframe-compositor-surface.txt
@@ -2,10 +2,10 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorMainThreadWheelEventRegion@s1/f0 rect=[0,0 120x80]
-DrawCompositedContext@s1/f0 dst_rect=[0,0 120x80] inline_clips=[clip=[0,0 120x80]]
+CompositorMainThreadWheelEventRegion@s1/e0 rect=[0,0 120x80]
+DrawCompositedContext@s1/e0 dst_rect=[0,0 120x80] inline_clips=[clip=[0,0 120x80]]
 

--- a/Tests/LibWeb/Text/expected/display_list/image-object-fit-cover-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/image-object-fit-cover-clip.txt
@@ -2,9 +2,9 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawScaledDecodedImageFrame@s1/f0 dst_rect=[0,-20 40x80] inline_clips=[clip=[0,0 40x40]]
+DrawScaledDecodedImageFrame@s1/e0 dst_rect=[0,-20 40x80] inline_clips=[clip=[0,0 40x40]]
 

--- a/Tests/LibWeb/Text/expected/display_list/input-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-caret.txt
@@ -2,15 +2,16 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[9,9 104x18] (TextInputBox<INPUT>)
-        [f2 in s1] clip=[11,10 100x16] (BlockContainer<DIV>)
+  clips:
+    [c0 in s1] clip=[9,9 104x18] (TextInputBox<INPUT>)
+      [c1 in s1] clip=[11,10 100x16] (BlockContainer<DIV>)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 106x20] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[8,8 106x20]
-DrawGlyphRun@s1/f2 rect=[11,10 37x16] translation=[11,22.796875] color=rgb(0, 0, 0)
-PaintCaret@s1/f2 rect=[11,10 1x16] color=rgb(0, 0, 0) should_blink=false
-FillPath@s1/f0 path_bounding_rect=[6,6 110x24]
+FillRect@s1/e0 rect=[8,8 106x20] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[8,8 106x20]
+DrawGlyphRun@s1/c1/e0 rect=[11,10 37x16] translation=[11,22.796875] color=rgb(0, 0, 0)
+PaintCaret@s1/c1/e0 rect=[11,10 1x16] color=rgb(0, 0, 0) should_blink=false
+FillPath@s1/e0 path_bounding_rect=[6,6 110x24]
 

--- a/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
@@ -2,21 +2,22 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[9,9 204x18] (TextInputBox<INPUT>#foo)
-        [f2 in s1] clip=[11,10 200x16] (BlockContainer<DIV>)
-      [f3 in s1] clip=[223,9 204x18] (TextInputBox<INPUT>#bar)
-        [f4 in s1] clip=[225,10 200x16] (BlockContainer<DIV>)
+  clips:
+    [c0 in s1] clip=[9,9 204x18] (TextInputBox<INPUT>#foo)
+      [c1 in s1] clip=[11,10 200x16] (BlockContainer<DIV>)
+    [c2 in s1] clip=[223,9 204x18] (TextInputBox<INPUT>#bar)
+      [c3 in s1] clip=[225,10 200x16] (BlockContainer<DIV>)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 206x20] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[8,8 206x20]
-FillRect@s1/f0 rect=[222,8 206x20] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[222,8 206x20]
-DrawGlyphRun@s1/f0 rect=[214,13 8x16] translation=[214,25.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f2 rect=[11,10 28x16] translation=[11,22.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f4 rect=[225,10 28x16] translation=[225,22.796875] color=rgb(0, 0, 0)
-PaintCaret@s1/f4 rect=[225,10 1x16] color=rgb(0, 0, 0) should_blink=false
-FillPath@s1/f0 path_bounding_rect=[220,6 210x24]
+FillRect@s1/e0 rect=[8,8 206x20] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[8,8 206x20]
+FillRect@s1/e0 rect=[222,8 206x20] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[222,8 206x20]
+DrawGlyphRun@s1/e0 rect=[214,13 8x16] translation=[214,25.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/c1/e0 rect=[11,10 28x16] translation=[11,22.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/c3/e0 rect=[225,10 28x16] translation=[225,22.796875] color=rgb(0, 0, 0)
+PaintCaret@s1/c3/e0 rect=[225,10 1x16] color=rgb(0, 0, 0) should_blink=false
+FillPath@s1/e0 path_bounding_rect=[220,6 210x24]
 

--- a/Tests/LibWeb/Text/expected/display_list/mask-image-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mask-image-invalidation.txt
@@ -3,18 +3,14 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] mask=[8,8 100x100] kind=alpha origin=css-mask-layers (BlockContainer<DIV>#box.box)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s1] mask=[8,8 100x100] kind=alpha origin=css-mask-layers (BlockContainer<DIV>#box.box)
 
 DisplayList:
-FillRect@s1/f1 rect=[8,8 100x100] color=rgb(173, 216, 230)
-DrawGlyphRun@s1/f1 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-MaskDisplayList for frame f1:
-  PaintLinearGradient@s0 rect=[0,0 100x100] inline_clips=[clip=[0,0 100x100]]
-MaskDisplayList for frame f2:
-  PaintLinearGradient@s0 rect=[0,0 100x100] inline_clips=[clip=[0,0 100x100]]
-MaskDisplayList for frame f3:
+FillRect@s1/e1 rect=[8,8 100x100] color=rgb(173, 216, 230)
+DrawGlyphRun@s1/e1 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+MaskDisplayList for effect e1:
   PaintLinearGradient@s0 rect=[0,0 100x100] inline_clips=[clip=[0,0 100x100]]
 
 After mask-image removal:
@@ -22,29 +18,25 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 100x100] color=rgb(173, 216, 230)
-DrawGlyphRun@s1/f0 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,8 100x100] color=rgb(173, 216, 230)
+DrawGlyphRun@s1/e0 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 
 After mask-image reinstatement:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] mask=[8,8 100x100] kind=alpha origin=css-mask-layers (BlockContainer<DIV>#box.box)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s1] mask=[8,8 100x100] kind=alpha origin=css-mask-layers (BlockContainer<DIV>#box.box)
 
 DisplayList:
-FillRect@s1/f1 rect=[8,8 100x100] color=rgb(173, 216, 230)
-DrawGlyphRun@s1/f1 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-MaskDisplayList for frame f1:
-  PaintLinearGradient@s0 rect=[0,0 100x100] inline_clips=[clip=[0,0 100x100]]
-MaskDisplayList for frame f2:
-  PaintLinearGradient@s0 rect=[0,0 100x100] inline_clips=[clip=[0,0 100x100]]
-MaskDisplayList for frame f3:
+FillRect@s1/e1 rect=[8,8 100x100] color=rgb(173, 216, 230)
+DrawGlyphRun@s1/e1 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+MaskDisplayList for effect e1:
   PaintLinearGradient@s0 rect=[0,0 100x100] inline_clips=[clip=[0,0 100x100]]
 

--- a/Tests/LibWeb/Text/expected/display_list/mask-type-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mask-type-invalidation.txt
@@ -4,18 +4,15 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] svg-viewport-transform=[1,0,0,1,8,8] origin=(0,0) (SVGSVGBox<svg>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,8 200x200] (SVGSVGBox<svg>)
-        [f2 in s2] mask=[-10,-10 120x120] kind=alpha origin=svg-mask (SVGGeometryBox<rect>)
+  clips:
+    [c0 in s1] clip=[8,8 200x200] (SVGSVGBox<svg>)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s2 out=c0] mask=[-10,-10 120x120] kind=alpha origin=svg-mask (SVGGeometryBox<rect>)
 
 DisplayList:
-FillPath@s2/f2 path_bounding_rect=[0,0 100x100]
-MaskDisplayList for frame f2:
-  FillPath@s0 path_bounding_rect=[0,0 100x50]
-MaskDisplayList for frame f3:
-  FillPath@s0 path_bounding_rect=[0,0 100x50]
-MaskDisplayList for frame f4:
+FillPath@s2/c0/e1 path_bounding_rect=[0,0 100x100]
+MaskDisplayList for effect e1:
   FillPath@s0 path_bounding_rect=[0,0 100x50]
 
 After switching to mask-type luminance:
@@ -24,17 +21,14 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] svg-viewport-transform=[1,0,0,1,8,8] origin=(0,0) (SVGSVGBox<svg>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,8 200x200] (SVGSVGBox<svg>)
-        [f2 in s2] mask=[-10,-10 120x120] kind=luminance origin=svg-mask (SVGGeometryBox<rect>)
+  clips:
+    [c0 in s1] clip=[8,8 200x200] (SVGSVGBox<svg>)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s2 out=c0] mask=[-10,-10 120x120] kind=luminance origin=svg-mask (SVGGeometryBox<rect>)
 
 DisplayList:
-FillPath@s2/f2 path_bounding_rect=[0,0 100x100]
-MaskDisplayList for frame f2:
-  FillPath@s0 path_bounding_rect=[0,0 100x50]
-MaskDisplayList for frame f3:
-  FillPath@s0 path_bounding_rect=[0,0 100x50]
-MaskDisplayList for frame f4:
+FillPath@s2/c0/e1 path_bounding_rect=[0,0 100x100]
+MaskDisplayList for effect e1:
   FillPath@s0 path_bounding_rect=[0,0 100x50]
 

--- a/Tests/LibWeb/Text/expected/display_list/mix-blend-mode-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mix-blend-mode-invalidation.txt
@@ -3,21 +3,21 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s1/e0 rect=[8,8 100x100] color=rgb(0, 128, 0)
 
 After mix-blend-mode change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] effects=[blend_mode=2] (BlockContainer<DIV>#box)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s1] effects=[blend_mode=2] (BlockContainer<DIV>#box)
 
 DisplayList:
-FillRect@s1/f1 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s1/e1 rect=[8,8 100x100] color=rgb(0, 128, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
@@ -4,14 +4,15 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s3] scroll (BlockContainer<DIV>.clipped)
         [s2] transform=[1,0,0,1,5,5] origin=(58,58) (BlockContainer<DIV>.transformed)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[119,9 100x100] (BlockContainer<DIV>.clipped)
+  clips:
+    [c0 in s1] clip=[119,9 100x100] (BlockContainer<DIV>.clipped)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[118,8 102x102]
-FillRect@s3/f1 rect=[119,9 150x150] color=rgb(173, 216, 230)
-DrawGlyphRun@s3/f1 rect=[119,9 55x16] translation=[119,21.796875] color=rgb(0, 0, 0)
-FillRect@s2/f0 rect=[8,8 100x100] color=rgb(255, 127, 80)
-DrawGlyphRun@s2/f0 rect=[8,8 88x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillPath@s1/e0 path_bounding_rect=[118,8 102x102]
+FillRect@s3/c0/e0 rect=[119,9 150x150] color=rgb(173, 216, 230)
+DrawGlyphRun@s3/c0/e0 rect=[119,9 55x16] translation=[119,21.796875] color=rgb(0, 0, 0)
+FillRect@s2/e0 rect=[8,8 100x100] color=rgb(255, 127, 80)
+DrawGlyphRun@s2/e0 rect=[8,8 88x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-color-change-inside-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-color-change-inside-opacity.txt
@@ -3,44 +3,44 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] effects=[opacity=0.5] (InlineNode<SPAN>#outer)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s1] effects=[opacity=0.5] (InlineNode<SPAN>#outer)
 
 DisplayList:
-DrawGlyphRun@s1/f0 rect=[8,85 46x13] translation=[8,95.390625] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f1 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(0, 0, 255)
-DrawGlyphRun@s1/f1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 255)
-DrawGlyphRun@s1/f1 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 255)
-DrawGlyphRun@s1/f1 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(0, 0, 255)
+DrawGlyphRun@s1/e0 rect=[8,85 46x13] translation=[8,95.390625] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e1 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(0, 0, 255)
+DrawGlyphRun@s1/e1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 255)
+DrawGlyphRun@s1/e1 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 255)
+DrawGlyphRun@s1/e1 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(0, 0, 255)
 
 After:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] effects=[opacity=0.5] (InlineNode<SPAN>#outer)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s1] effects=[opacity=0.5] (InlineNode<SPAN>#outer)
 
 DisplayList:
-DrawGlyphRun@s1/f0 rect=[8,85 46x13] translation=[8,95.390625] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,98 214x13] translation=[8,108.390625] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,111 60x13] translation=[8,121.390625] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,124 440x13] translation=[8,134.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,137 264x13] translation=[8,147.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,150 61x13] translation=[8,160.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,163 160x13] translation=[8,173.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,176 415x13] translation=[8,186.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,202 74x13] translation=[8,212.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,215 544x13] translation=[8,225.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,228 549x13] translation=[8,238.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,241 554x13] translation=[8,251.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,254 555x13] translation=[8,264.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,267 555x13] translation=[8,277.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,293 40x13] translation=[8,303.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f1 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(255, 0, 0)
-DrawGlyphRun@s1/f1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(255, 0, 0)
-DrawGlyphRun@s1/f1 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(255, 0, 0)
-DrawGlyphRun@s1/f1 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(255, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,85 46x13] translation=[8,95.390625] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,98 214x13] translation=[8,108.390625] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,111 60x13] translation=[8,121.390625] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,124 440x13] translation=[8,134.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,137 264x13] translation=[8,147.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,150 62x13] translation=[8,160.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,163 162x13] translation=[8,173.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,176 417x13] translation=[8,186.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,202 74x13] translation=[8,212.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,215 546x13] translation=[8,225.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,228 551x13] translation=[8,238.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,241 556x13] translation=[8,251.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,254 557x13] translation=[8,264.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,267 557x13] translation=[8,277.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,293 40x13] translation=[8,303.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e1 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(255, 0, 0)
+DrawGlyphRun@s1/e1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(255, 0, 0)
+DrawGlyphRun@s1/e1 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(255, 0, 0)
+DrawGlyphRun@s1/e1 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(255, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-opacity.txt
@@ -3,55 +3,55 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] effects=[opacity=0.5] (InlineNode<SPAN>#target)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s1] effects=[opacity=0.5] (InlineNode<SPAN>#target)
 
 DisplayList:
-DrawGlyphRun@s1/f0 rect=[8,85 83x13] translation=[8,95.390625] color=rgb(0, 0, 0)
-FillRect@s1/f1 rect=[8,8 81x16] color=rgb(255, 165, 0)
-FillRect@s1/f1 rect=[8,24 47x16] color=rgb(255, 165, 0)
-FillRect@s1/f1 rect=[8,40 60x16] color=rgb(255, 165, 0)
-FillRect@s1/f1 rect=[8,56 36x16] color=rgb(255, 165, 0)
-DrawGlyphRun@s1/f1 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f1 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f1 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,85 83x13] translation=[8,95.390625] color=rgb(0, 0, 0)
+FillRect@s1/e1 rect=[8,8 81x16] color=rgb(255, 165, 0)
+FillRect@s1/e1 rect=[8,24 47x16] color=rgb(255, 165, 0)
+FillRect@s1/e1 rect=[8,40 60x16] color=rgb(255, 165, 0)
+FillRect@s1/e1 rect=[8,56 36x16] color=rgb(255, 165, 0)
+DrawGlyphRun@s1/e1 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e1 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e1 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(0, 0, 0)
 
 Without opacity:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 81x16] color=rgb(255, 165, 0)
-FillRect@s1/f0 rect=[8,24 47x16] color=rgb(255, 165, 0)
-FillRect@s1/f0 rect=[8,40 60x16] color=rgb(255, 165, 0)
-FillRect@s1/f0 rect=[8,56 36x16] color=rgb(255, 165, 0)
-DrawGlyphRun@s1/f0 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,85 83x13] translation=[8,95.390625] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,98 214x13] translation=[8,108.390625] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,111 60x13] translation=[8,121.390625] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,124 440x13] translation=[8,134.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,137 264x13] translation=[8,147.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,150 61x13] translation=[8,160.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,163 160x13] translation=[8,173.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,176 418x13] translation=[8,186.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,202 74x13] translation=[8,212.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,215 546x13] translation=[8,225.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,228 346x13] translation=[8,238.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,241 352x13] translation=[8,251.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,254 354x13] translation=[8,264.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,267 354x13] translation=[8,277.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,280 536x13] translation=[8,290.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,293 541x13] translation=[8,303.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,306 542x13] translation=[8,316.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,319 542x13] translation=[8,329.39062] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,345 105x13] translation=[8,355.39062] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,8 81x16] color=rgb(255, 165, 0)
+FillRect@s1/e0 rect=[8,24 47x16] color=rgb(255, 165, 0)
+FillRect@s1/e0 rect=[8,40 60x16] color=rgb(255, 165, 0)
+FillRect@s1/e0 rect=[8,56 36x16] color=rgb(255, 165, 0)
+DrawGlyphRun@s1/e0 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,85 83x13] translation=[8,95.390625] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,98 214x13] translation=[8,108.390625] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,111 60x13] translation=[8,121.390625] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,124 440x13] translation=[8,134.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,137 264x13] translation=[8,147.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,150 62x13] translation=[8,160.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,163 162x13] translation=[8,173.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,176 419x13] translation=[8,186.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,202 74x13] translation=[8,212.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,215 548x13] translation=[8,225.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,228 348x13] translation=[8,238.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,241 354x13] translation=[8,251.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,254 356x13] translation=[8,264.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,267 356x13] translation=[8,277.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,280 538x13] translation=[8,290.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,293 543x13] translation=[8,303.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,306 544x13] translation=[8,316.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,319 544x13] translation=[8,329.39062] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,345 105x13] translation=[8,355.39062] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
@@ -3,34 +3,34 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawGlyphRun@s1/f0 rect=[8,8 70x16] translation=[8,20.796875] color=rgb(0, 0, 255)
-DrawLine@s1/f0 from=[8,24] to=[78,24] color=rgb(0, 0, 255) thickness=2 style=Solid
-DrawGlyphRun@s1/f0 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 255)
-DrawLine@s1/f0 from=[8,40] to=[55,40] color=rgb(0, 0, 255) thickness=2 style=Solid
-DrawGlyphRun@s1/f0 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 255)
-DrawLine@s1/f0 from=[8,56] to=[68,56] color=rgb(0, 0, 255) thickness=2 style=Solid
-DrawGlyphRun@s1/f0 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(0, 0, 255)
-DrawLine@s1/f0 from=[8,72] to=[44,72] color=rgb(0, 0, 255) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,8 70x16] translation=[8,20.796875] color=rgb(0, 0, 255)
+DrawLine@s1/e0 from=[8,24] to=[78,24] color=rgb(0, 0, 255) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 255)
+DrawLine@s1/e0 from=[8,40] to=[55,40] color=rgb(0, 0, 255) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 255)
+DrawLine@s1/e0 from=[8,56] to=[68,56] color=rgb(0, 0, 255) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(0, 0, 255)
+DrawLine@s1/e0 from=[8,72] to=[44,72] color=rgb(0, 0, 255) thickness=2 style=Solid
 
 After:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawGlyphRun@s1/f0 rect=[8,8 70x16] translation=[8,20.796875] color=rgb(255, 0, 0)
-DrawLine@s1/f0 from=[8,24] to=[78,24] color=rgb(255, 0, 0) thickness=2 style=Solid
-DrawGlyphRun@s1/f0 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(255, 0, 0)
-DrawLine@s1/f0 from=[8,40] to=[55,40] color=rgb(255, 0, 0) thickness=2 style=Solid
-DrawGlyphRun@s1/f0 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(255, 0, 0)
-DrawLine@s1/f0 from=[8,56] to=[68,56] color=rgb(255, 0, 0) thickness=2 style=Solid
-DrawGlyphRun@s1/f0 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(255, 0, 0)
-DrawLine@s1/f0 from=[8,72] to=[44,72] color=rgb(255, 0, 0) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,8 70x16] translation=[8,20.796875] color=rgb(255, 0, 0)
+DrawLine@s1/e0 from=[8,24] to=[78,24] color=rgb(255, 0, 0) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(255, 0, 0)
+DrawLine@s1/e0 from=[8,40] to=[55,40] color=rgb(255, 0, 0) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(255, 0, 0)
+DrawLine@s1/e0 from=[8,56] to=[68,56] color=rgb(255, 0, 0) thickness=2 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,56 37x16] translation=[8,68.796875] color=rgb(255, 0, 0)
+DrawLine@s1/e0 from=[8,72] to=[44,72] color=rgb(255, 0, 0) thickness=2 style=Solid
 

--- a/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
@@ -6,22 +6,23 @@ AccumulatedVisualContext Tree:
         [s3] transform=[0.9986295,0.05233596,-0.05233596,0.9986295,0,0] origin=(92.5,91) (BlockContainer<DIV>.level3.t2)
         [s4] transform=[0.95,0,0,0.95,0,0] origin=(247.5,46) (BlockContainer<DIV>.level3.t3)
         [s5] transform=[1.05,0,0,1.05,0,0] origin=(247.5,91) (BlockContainer<DIV>.level3.t4)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[10,10 320x270] (Box<DIV>.level1)
-        [f2 in s1] clip=[21,21 143x248] (BlockContainer<DIV>.level2)
-        [f3 in s1] clip=[176,21 143x248] (BlockContainer<DIV>.level2)
+  clips:
+    [c0 in s1] clip=[10,10 320x270] (Box<DIV>.level1)
+      [c1 in s1] clip=[21,21 143x248] (BlockContainer<DIV>.level2)
+      [c2 in s1] clip=[176,21 143x248] (BlockContainer<DIV>.level2)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[8,8 324x274]
-FillPath@s1/f1 path_bounding_rect=[20,20 145x250]
-FillPath@s1/f1 path_bounding_rect=[175,20 145x250]
-FillRect@s2/f2 rect=[26,26 133x40] color=rgb(255, 136, 136)
-DrawGlyphRun@s2/f2 rect=[26,26 20x16] translation=[26,38.796875] color=rgb(0, 0, 0)
-FillRect@s3/f2 rect=[26,71 133x40] color=rgb(136, 255, 136)
-DrawGlyphRun@s3/f2 rect=[26,71 22x16] translation=[26,83.796875] color=rgb(0, 0, 0)
-FillRect@s4/f3 rect=[181,26 133x40] color=rgb(136, 136, 255)
-DrawGlyphRun@s4/f3 rect=[181,26 22x16] translation=[181,38.796875] color=rgb(0, 0, 0)
-FillRect@s5/f3 rect=[181,71 133x40] color=rgb(255, 255, 136)
-DrawGlyphRun@s5/f3 rect=[181,71 25x16] translation=[181,83.796875] color=rgb(0, 0, 0)
+FillPath@s1/e0 path_bounding_rect=[8,8 324x274]
+FillPath@s1/c0/e0 path_bounding_rect=[20,20 145x250]
+FillPath@s1/c0/e0 path_bounding_rect=[175,20 145x250]
+FillRect@s2/c1/e0 rect=[26,26 133x40] color=rgb(255, 136, 136)
+DrawGlyphRun@s2/c1/e0 rect=[26,26 20x16] translation=[26,38.796875] color=rgb(0, 0, 0)
+FillRect@s3/c1/e0 rect=[26,71 133x40] color=rgb(136, 255, 136)
+DrawGlyphRun@s3/c1/e0 rect=[26,71 22x16] translation=[26,83.796875] color=rgb(0, 0, 0)
+FillRect@s4/c2/e0 rect=[181,26 133x40] color=rgb(136, 136, 255)
+DrawGlyphRun@s4/c2/e0 rect=[181,26 22x16] translation=[181,38.796875] color=rgb(0, 0, 0)
+FillRect@s5/c2/e0 rect=[181,71 133x40] color=rgb(255, 255, 136)
+DrawGlyphRun@s5/c2/e0 rect=[181,71 25x16] translation=[181,83.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
@@ -4,25 +4,26 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>.outer-scroll)
           [s3] scroll (BlockContainer<DIV>.inner-scroll)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[10,10 200x150] (BlockContainer<DIV>.outer-scroll)
-        [f2 in s2] clip=[11,11 300x100] (BlockContainer<DIV>.inner-scroll)
+  clips:
+    [c0 in s1] clip=[10,10 200x150] (BlockContainer<DIV>.outer-scroll)
+      [c1 in s2] clip=[11,11 300x100] (BlockContainer<DIV>.inner-scroll)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s0 rect=[0,0 800x600]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[0,0 800x175]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[8,8 784x154]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s2 rect=[8,8 204x154]
-CompositorScrollNode@s1/f0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[10,10 200x150] min_scroll_offset=[0,0] max_scroll_offset=[102,0] is_viewport=false
-FillPath@s1/f0 path_bounding_rect=[8,8 204x154]
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s3 rect=[10,10 302x102]
-CompositorScrollNode@s2/f1 scroll_node_index=s3 parent_scroll_node_index=s2 scrollport_rect=[11,11 300x100] min_scroll_offset=[0,0] max_scroll_offset=[100,0] is_viewport=false
-FillRect@s2/f1 rect=[10,10 302x102] color=rgb(255, 255, 224)
-FillPath@s2/f1 path_bounding_rect=[10,10 302x102]
-CompositorWheelHitTestTarget@s3/f2 target_scroll_node_index=s3 rect=[11,11 400x80]
-FillRect@s3/f2 rect=[11,11 400x80] color=rgb(240, 128, 128)
-DrawGlyphRun@s3/f2 rect=[11,11 178x16] translation=[11,23.796875] color=rgb(0, 0, 0)
-PaintScrollBar@s2/f1
-PaintScrollBar@s1/f0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s0 rect=[0,0 800x600]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[0,0 800x175]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[8,8 784x154]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s2 rect=[8,8 204x154]
+CompositorScrollNode@s1/e0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[10,10 200x150] min_scroll_offset=[0,0] max_scroll_offset=[102,0] is_viewport=false
+FillPath@s1/e0 path_bounding_rect=[8,8 204x154]
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s3 rect=[10,10 302x102]
+CompositorScrollNode@s2/c0/e0 scroll_node_index=s3 parent_scroll_node_index=s2 scrollport_rect=[11,11 300x100] min_scroll_offset=[0,0] max_scroll_offset=[100,0] is_viewport=false
+FillRect@s2/c0/e0 rect=[10,10 302x102] color=rgb(255, 255, 224)
+FillPath@s2/c0/e0 path_bounding_rect=[10,10 302x102]
+CompositorWheelHitTestTarget@s3/c1/e0 target_scroll_node_index=s3 rect=[11,11 400x80]
+FillRect@s3/c1/e0 rect=[11,11 400x80] color=rgb(240, 128, 128)
+DrawGlyphRun@s3/c1/e0 rect=[11,11 178x16] translation=[11,23.796875] color=rgb(0, 0, 0)
+PaintScrollBar@s2/c0/e0
+PaintScrollBar@s1/e0
 

--- a/Tests/LibWeb/Text/expected/display_list/opaque-background-image-blend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/opaque-background-image-blend.txt
@@ -2,10 +2,10 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[0,0 40x40] color=rgb(45, 22, 0)
-DrawScaledDecodedImageFrame@s1/f0 dst_rect=[0,0 40x40] src_rect=[0,0 40x40] blend_mode=2 isolated_backdrop_color=rgb(45, 22, 0) inline_clips=[clip=[0,0 40x40]]
+FillRect@s1/e0 rect=[0,0 40x40] color=rgb(45, 22, 0)
+DrawScaledDecodedImageFrame@s1/e0 dst_rect=[0,0 40x40] src_rect=[0,0 40x40] blend_mode=2 isolated_backdrop_color=rgb(45, 22, 0) inline_clips=[clip=[0,0 40x40]]
 

--- a/Tests/LibWeb/Text/expected/display_list/page-focus-rendering.txt
+++ b/Tests/LibWeb/Text/expected/display_list/page-focus-rendering.txt
@@ -3,139 +3,145 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  clips:
+    [c0 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[0,0 86x22] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[0,0 86x22]
-FillRect@s1/f1 rect=[12,3 19x16] color=rgba(101, 2, 0, 0.8)
-DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[3,3 9x15]]
-DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[12,3 19x15]]
-FillPath@s1/f0 path_bounding_rect=[-2,-2 90x26]
-DrawLine@s1/f0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-FillRect@s1/f0 rect=[0,25 23x16] color=rgba(101, 2, 0, 0.8)
-DrawGlyphRun@s1/f0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[0,0 86x22] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[0,0 86x22]
+FillRect@s1/c0/e0 rect=[12,3 19x16] color=rgba(101, 2, 0, 0.8)
+DrawGlyphRun@s1/c0/e0 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[3,3 9x15]]
+DrawGlyphRun@s1/c0/e0 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[12,3 19x15]]
+FillPath@s1/e0 path_bounding_rect=[-2,-2 90x26]
+DrawLine@s1/e0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+FillRect@s1/e0 rect=[0,25 23x16] color=rgba(101, 2, 0, 0.8)
+DrawGlyphRun@s1/e0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
 
 -- unfocused --
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  clips:
+    [c0 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[0,0 86x22] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[0,0 86x22]
-FillRect@s1/f1 rect=[12,3 19x16] color=rgba(16, 16, 16, 0.667)
-DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[3,3 9x15]]
-DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[12,3 19x15]]
-DrawLine@s1/f0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-FillRect@s1/f0 rect=[0,25 23x16] color=rgba(16, 16, 16, 0.667)
-DrawGlyphRun@s1/f0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[0,0 86x22] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[0,0 86x22]
+FillRect@s1/c0/e0 rect=[12,3 19x16] color=rgba(16, 16, 16, 0.667)
+DrawGlyphRun@s1/c0/e0 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[3,3 9x15]]
+DrawGlyphRun@s1/c0/e0 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[12,3 19x15]]
+DrawLine@s1/e0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+FillRect@s1/e0 rect=[0,25 23x16] color=rgba(16, 16, 16, 0.667)
+DrawGlyphRun@s1/e0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
 
 -- focused again --
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  clips:
+    [c0 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[0,0 86x22] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[0,0 86x22]
-FillRect@s1/f1 rect=[12,3 19x16] color=rgba(101, 2, 0, 0.8)
-DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[3,3 9x15]]
-DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[12,3 19x15]]
-FillPath@s1/f0 path_bounding_rect=[-2,-2 90x26]
-DrawLine@s1/f0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-FillRect@s1/f0 rect=[0,25 23x16] color=rgba(101, 2, 0, 0.8)
-DrawGlyphRun@s1/f0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[0,0 86x22] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[0,0 86x22]
+FillRect@s1/c0/e0 rect=[12,3 19x16] color=rgba(101, 2, 0, 0.8)
+DrawGlyphRun@s1/c0/e0 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[3,3 9x15]]
+DrawGlyphRun@s1/c0/e0 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0) inline_clips=[clip=[12,3 19x15]]
+FillPath@s1/e0 path_bounding_rect=[-2,-2 90x26]
+DrawLine@s1/e0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+FillRect@s1/e0 rect=[0,25 23x16] color=rgba(101, 2, 0, 0.8)
+DrawGlyphRun@s1/e0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
 
 -- caret, focused --
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  clips:
+    [c0 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[0,0 86x22] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[0,0 86x22]
-DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
-PaintCaret@s1/f1 rect=[22,3 1x16] color=rgb(0, 0, 0) should_blink=false
-FillPath@s1/f0 path_bounding_rect=[-2,-2 90x26]
-DrawLine@s1/f0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawGlyphRun@s1/f0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[0,0 86x22] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[0,0 86x22]
+DrawGlyphRun@s1/c0/e0 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
+PaintCaret@s1/c0/e0 rect=[22,3 1x16] color=rgb(0, 0, 0) should_blink=false
+FillPath@s1/e0 path_bounding_rect=[-2,-2 90x26]
+DrawLine@s1/e0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawGlyphRun@s1/e0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
 
 -- caret, unfocused --
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  clips:
+    [c0 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[0,0 86x22] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[0,0 86x22]
-DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
-DrawLine@s1/f0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawGlyphRun@s1/f0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[0,0 86x22] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[0,0 86x22]
+DrawGlyphRun@s1/c0/e0 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
+DrawLine@s1/e0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawGlyphRun@s1/e0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
 
 -- caret, focused again --
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  clips:
+    [c0 in s1] clip=[1,1 84x20] (TextAreaBox<TEXTAREA>#ta)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[0,0 86x22] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[0,0 86x22]
-DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
-PaintCaret@s1/f1 rect=[22,3 1x16] color=rgb(0, 0, 0) should_blink=false
-FillPath@s1/f0 path_bounding_rect=[-2,-2 90x26]
-DrawLine@s1/f0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawGlyphRun@s1/f0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[0,0 86x22] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[0,0 86x22]
+DrawGlyphRun@s1/c0/e0 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
+PaintCaret@s1/c0/e0 rect=[22,3 1x16] color=rgb(0, 0, 0) should_blink=false
+FillPath@s1/e0 path_bounding_rect=[-2,-2 90x26]
+DrawLine@s1/e0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[78,19] to=[83,14] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[77,19] to=[83,13] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[75,19] to=[83,11] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[74,19] to=[83,10] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawGlyphRun@s1/e0 rect=[0,25 24x16] translation=[0,38] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/patterned-border-on-a-short-side.txt
+++ b/Tests/LibWeb/Text/expected/display_list/patterned-border-on-a-short-side.txt
@@ -2,12 +2,12 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[8,31 40x40]
-FillPath@s1/f0 path_bounding_rect=[8,71 40x40]
-FillPath@s1/f0 path_bounding_rect=[8,8 40x20]
-FillPath@s1/f0 path_bounding_rect=[48,8 40x20]
+FillPath@s1/e0 path_bounding_rect=[8,31 40x40]
+FillPath@s1/e0 path_bounding_rect=[8,71 40x40]
+FillPath@s1/e0 path_bounding_rect=[8,8 40x20]
+FillPath@s1/e0 path_bounding_rect=[48,8 40x20]
 

--- a/Tests/LibWeb/Text/expected/display_list/patterned-border-sharing-corners.txt
+++ b/Tests/LibWeb/Text/expected/display_list/patterned-border-sharing-corners.txt
@@ -2,19 +2,19 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-StrokePath@s1/f0 path_bounding_rect=[-2,8 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,8 140x20], path: M8 8L8 8L28 28L128 28L148 8L148 8]]
-StrokePath@s1/f0 path_bounding_rect=[-2,28 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,28 140x20], path: M8 28L8 28L28 48L128 48L148 28L148 28]]
-StrokePath@s1/f0 path_bounding_rect=[128,38 20x120] thickness=20 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=25.00 inline_clips=[clip_path=[bounds: [128,48 20x100], path: M148 48L148 48L128 68L128 128L148 148L148 148]]
-StrokePath@s1/f0 path_bounding_rect=[-2,128 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,128 140x20], path: M148 148L148 148L128 128L28 128L8 148L8 148]]
-StrokePath@s1/f0 path_bounding_rect=[8,38 20x120] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=25.00 inline_clips=[clip_path=[bounds: [8,48 20x100], path: M8 148L8 148L28 128L28 68L8 48L8 48]]
-StrokePath@s1/f0 path_bounding_rect=[-2,48 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,48 140x20], path: M8 48L8 48L28 68L128 68L148 48L148 48]]
-StrokePath@s1/f0 path_bounding_rect=[128,138 20x120] thickness=20 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=16.67 inline_clips=[clip_path=[bounds: [128,148 20x100], path: M148 148L148 148L128 168L128 228L148 248L148 248]]
-StrokePath@s1/f0 path_bounding_rect=[-2,228 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,228 140x20], path: M148 248L148 248L128 228L28 228L8 248L8 248]]
-StrokePath@s1/f0 path_bounding_rect=[8,138 20x120] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=16.67 inline_clips=[clip_path=[bounds: [8,148 20x100], path: M8 248L8 248L28 228L28 168L8 148L8 148]]
-StrokePath@s1/f0 path_bounding_rect=[-2,148 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,148 140x20], path: M8 148L8 148L28 168L128 168L148 148L148 148]]
-StrokePath@s1/f0 path_bounding_rect=[-2,248 120x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=25.00
+StrokePath@s1/e0 path_bounding_rect=[-2,8 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,8 140x20], path: M8 8L8 8L28 28L128 28L148 8L148 8]]
+StrokePath@s1/e0 path_bounding_rect=[-2,28 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,28 140x20], path: M8 28L8 28L28 48L128 48L148 28L148 28]]
+StrokePath@s1/e0 path_bounding_rect=[128,38 20x120] thickness=20 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=25.00 inline_clips=[clip_path=[bounds: [128,48 20x100], path: M148 48L148 48L128 68L128 128L148 148L148 148]]
+StrokePath@s1/e0 path_bounding_rect=[-2,128 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,128 140x20], path: M148 148L148 148L128 128L28 128L8 148L8 148]]
+StrokePath@s1/e0 path_bounding_rect=[8,38 20x120] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=25.00 inline_clips=[clip_path=[bounds: [8,48 20x100], path: M8 148L8 148L28 128L28 68L8 48L8 48]]
+StrokePath@s1/e0 path_bounding_rect=[-2,48 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,48 140x20], path: M8 48L8 48L28 68L128 68L148 48L148 48]]
+StrokePath@s1/e0 path_bounding_rect=[128,138 20x120] thickness=20 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=16.67 inline_clips=[clip_path=[bounds: [128,148 20x100], path: M148 148L148 148L128 168L128 228L148 248L148 248]]
+StrokePath@s1/e0 path_bounding_rect=[-2,228 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,228 140x20], path: M148 248L148 248L128 228L28 228L8 248L8 248]]
+StrokePath@s1/e0 path_bounding_rect=[8,138 20x120] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=16.67 inline_clips=[clip_path=[bounds: [8,148 20x100], path: M8 248L8 248L28 228L28 168L8 148L8 148]]
+StrokePath@s1/e0 path_bounding_rect=[-2,148 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50 inline_clips=[clip_path=[bounds: [8,148 140x20], path: M8 148L8 148L28 168L128 168L148 148L148 148]]
+StrokePath@s1/e0 path_bounding_rect=[-2,248 120x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=25.00
 

--- a/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
@@ -4,10 +4,10 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] perspective (BlockContainer<DIV>.perspective-container)
           [s3] transform=[0.8660254,0,0,1,0,0] origin=(58,58) (BlockContainer<DIV>.rotated)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s3/f0 rect=[8,8 100x100] color=rgb(0, 0, 255)
-DrawGlyphRun@s3/f0 rect=[8,8 21x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s3/e0 rect=[8,8 100x100] color=rgb(0, 0, 255)
+DrawGlyphRun@s3/e0 rect=[8,8 21x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/perspective-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-invalidation.txt
@@ -4,11 +4,11 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] transform=[1,0,0,1,0,0] origin=(58,58) (BlockContainer<DIV>#child)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f0 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s2/e0 rect=[8,8 100x100] color=rgb(0, 128, 0)
 
 After perspective change:
 AccumulatedVisualContext Tree:
@@ -17,9 +17,9 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] perspective (BlockContainer<DIV>#box)
           [s3] transform=[1,0,0,1,0,0] origin=(58,58) (BlockContainer<DIV>#child)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s3/f0 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s3/e0 rect=[8,8 100x100] color=rgb(0, 128, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
+++ b/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
@@ -3,12 +3,12 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] transform=[1,0,0,1,10,10] origin=(108,108) (BlockContainer<DIV>.transformed-ancestor)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f0 rect=[8,8 200x200] color=rgb(211, 211, 211)
-FillRect@s2/f0 rect=[8,8 200x90] color=rgb(173, 216, 230)
-FillRect@s2/f0 rect=[33,33 100x50] color=rgb(255, 127, 80)
-DrawGlyphRun@s2/f0 rect=[33,33 84x16] translation=[33,45.796875] color=rgb(0, 0, 0)
+FillRect@s2/e0 rect=[8,8 200x200] color=rgb(211, 211, 211)
+FillRect@s2/e0 rect=[8,8 200x90] color=rgb(173, 216, 230)
+FillRect@s2/e0 rect=[33,33 100x50] color=rgb(255, 127, 80)
+DrawGlyphRun@s2/e0 rect=[33,33 84x16] translation=[33,45.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
+++ b/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
@@ -2,12 +2,12 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 300x300] color=rgb(211, 211, 211)
-FillRect@s1/f0 rect=[8,8 100x100] color=rgb(173, 216, 230)
-FillRect@s1/f0 rect=[13,13 100x100] color=rgb(255, 127, 80)
-DrawGlyphRun@s1/f0 rect=[13,13 65x16] translation=[13,25.796875] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,8 300x300] color=rgb(211, 211, 211)
+FillRect@s1/e0 rect=[8,8 100x100] color=rgb(173, 216, 230)
+FillRect@s1/e0 rect=[13,13 100x100] color=rgb(255, 127, 80)
+DrawGlyphRun@s1/e0 rect=[13,13 65x16] translation=[13,25.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
+++ b/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
@@ -2,9 +2,9 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawRepeatedDisplayList@s1/f0 dst_rect=[8,8 20x20] clip_rect=[8,8 120x80] scaling_mode=NearestNeighbor inline_clips=[clip=[8,8 120x80], clip=[8,8 120x80]]
+DrawRepeatedDisplayList@s1/e0 dst_rect=[8,8 20x20] clip_rect=[8,8 120x80] scaling_mode=NearestNeighbor inline_clips=[clip=[8,8 120x80], clip=[8,8 120x80]]
 

--- a/Tests/LibWeb/Text/expected/display_list/root-background-propagation-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/root-background-propagation-invalidation.txt
@@ -3,56 +3,56 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
 FillRect@s0 rect=[0,0 800x600] color=rgb(0, 128, 0)
-FillRect@s1/f0 rect=[0,0 800x600] color=rgb(0, 128, 0)
-PaintLinearGradient@s1/f0 rect=[0,0 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,63 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,126 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,189 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,252 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,315 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,378 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,441 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,504 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,567 800x63] blend_mode=2
+FillRect@s1/e0 rect=[0,0 800x600] color=rgb(0, 128, 0)
+PaintLinearGradient@s1/e0 rect=[0,0 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,63 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,126 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,189 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,252 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,315 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,378 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,441 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,504 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,567 800x63] blend_mode=2
 
 Painted by the body:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
 FillRect@s0 rect=[0,0 800x600] color=rgb(255, 255, 255)
-FillRect@s1/f0 rect=[0,0 800x600] color=rgb(255, 255, 255)
-FillRect@s1/f0 rect=[0,13 800x50] color=rgb(0, 128, 0)
-PaintLinearGradient@s1/f0 rect=[0,13 800x50] blend_mode=2 inline_clips=[clip=[0,13 800x50]]
+FillRect@s1/e0 rect=[0,0 800x600] color=rgb(255, 255, 255)
+FillRect@s1/e0 rect=[0,13 800x50] color=rgb(0, 128, 0)
+PaintLinearGradient@s1/e0 rect=[0,13 800x50] blend_mode=2 inline_clips=[clip=[0,13 800x50]]
 
 Propagated to the root again:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
 FillRect@s0 rect=[0,0 800x600] color=rgb(0, 128, 0)
-FillRect@s1/f0 rect=[0,0 800x600] color=rgb(0, 128, 0)
-PaintLinearGradient@s1/f0 rect=[0,0 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,63 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,126 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,189 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,252 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,315 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,378 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,441 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,504 800x63] blend_mode=2
-PaintLinearGradient@s1/f0 rect=[0,567 800x63] blend_mode=2
+FillRect@s1/e0 rect=[0,0 800x600] color=rgb(0, 128, 0)
+PaintLinearGradient@s1/e0 rect=[0,0 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,63 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,126 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,189 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,252 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,315 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,378 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,441 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,504 800x63] blend_mode=2
+PaintLinearGradient@s1/e0 rect=[0,567 800x63] blend_mode=2
 

--- a/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
@@ -3,22 +3,23 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
       [s2] scroll (BlockContainer<DIV>.scroll-container)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s0] clip=[33,33 180x100] (BlockContainer<DIV>.scroll-container)
+  clips:
+    [c0 in s0] clip=[33,33 180x100] (BlockContainer<DIV>.scroll-container)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s0 rect=[0,0 800x600]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[0,0 800x21]
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s0 rect=[20,20 204x154]
-FillRect@s0/f0 rect=[20,20 204x154] color=rgb(211, 211, 211)
-FillPath@s0/f0 path_bounding_rect=[20,20 204x154]
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s2 rect=[32,32 182x102]
-CompositorScrollNode@s0/f0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[33,33 180x100] min_scroll_offset=[0,0] max_scroll_offset=[120,100] is_viewport=false
-FillPath@s0/f0 path_bounding_rect=[32,32 182x102]
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s2 rect=[33,33 300x200]
-FillRect@s2/f1 rect=[33,33 300x200] color=rgb(240, 128, 128)
-DrawGlyphRun@s2/f1 rect=[33,33 179x16] translation=[33,45.796875] color=rgb(0, 0, 0)
-PaintScrollBar@s0/f0
-PaintScrollBar@s0/f0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s0 rect=[0,0 800x600]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[0,0 800x21]
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s0 rect=[20,20 204x154]
+FillRect@s0/e0 rect=[20,20 204x154] color=rgb(211, 211, 211)
+FillPath@s0/e0 path_bounding_rect=[20,20 204x154]
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s2 rect=[32,32 182x102]
+CompositorScrollNode@s0/e0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[33,33 180x100] min_scroll_offset=[0,0] max_scroll_offset=[120,100] is_viewport=false
+FillPath@s0/e0 path_bounding_rect=[32,32 182x102]
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s2 rect=[33,33 300x200]
+FillRect@s2/c0/e0 rect=[33,33 300x200] color=rgb(240, 128, 128)
+DrawGlyphRun@s2/c0/e0 rect=[33,33 179x16] translation=[33,45.796875] color=rgb(0, 0, 0)
+PaintScrollBar@s0/e0
+PaintScrollBar@s0/e0
 

--- a/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
@@ -4,16 +4,17 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>.scroll-box)
         [s3] scroll (BlockContainer<DIV>.scroll-box)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[9,9 100x80] (BlockContainer<DIV>.scroll-box)
-      [f2 in s1] clip=[131,9 100x80] (BlockContainer<DIV>.scroll-box)
+  clips:
+    [c0 in s1] clip=[9,9 100x80] (BlockContainer<DIV>.scroll-box)
+    [c1 in s1] clip=[131,9 100x80] (BlockContainer<DIV>.scroll-box)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[8,8 102x82]
-FillRect@s2/f1 rect=[9,9 150x120] color=rgb(240, 128, 128)
-DrawGlyphRun@s2/f1 rect=[9,9 110x16] translation=[9,21.796875] color=rgb(0, 0, 0)
-FillPath@s1/f0 path_bounding_rect=[130,8 102x82]
-FillRect@s3/f2 rect=[131,9 150x120] color=rgb(144, 238, 144)
-DrawGlyphRun@s3/f2 rect=[131,9 119x16] translation=[131,21.796875] color=rgb(0, 0, 0)
+FillPath@s1/e0 path_bounding_rect=[8,8 102x82]
+FillRect@s2/c0/e0 rect=[9,9 150x120] color=rgb(240, 128, 128)
+DrawGlyphRun@s2/c0/e0 rect=[9,9 110x16] translation=[9,21.796875] color=rgb(0, 0, 0)
+FillPath@s1/e0 path_bounding_rect=[130,8 102x82]
+FillRect@s3/c1/e0 rect=[131,9 150x120] color=rgb(144, 238, 144)
+DrawGlyphRun@s3/c1/e0 rect=[131,9 119x16] translation=[131,21.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -5,40 +5,41 @@ AccumulatedVisualContext Tree:
       [s2] scroll (BlockContainer<DIV>.scroll-container)
       [s3] scroll (BlockContainer<DIV>.scroll-container)
       [s4] scroll (BlockContainer<DIV>.scroll-container)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s0] clip=[23,23 91x150] (BlockContainer<DIV>.scroll-container)
-      [f2 in s0] clip=[126,23 92x150] (BlockContainer<DIV>.scroll-container)
-      [f3 in s0] clip=[230,23 91x150] (BlockContainer<DIV>.scroll-container)
+  clips:
+    [c0 in s0] clip=[23,23 91x150] (BlockContainer<DIV>.scroll-container)
+    [c1 in s0] clip=[126,23 92x150] (BlockContainer<DIV>.scroll-container)
+    [c2 in s0] clip=[230,23 91x150] (BlockContainer<DIV>.scroll-container)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s0 rect=[0,0 800x600]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[0,0 800x21]
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s0 rect=[10,10 324x224]
-FillRect@s0/f0 rect=[10,10 324x224] color=rgb(211, 211, 211)
-FillPath@s0/f0 path_bounding_rect=[10,10 324x224]
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s2 rect=[22,22 93.328125x152]
-CompositorScrollNode@s0/f0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[23,23 91x150] min_scroll_offset=[0,0] max_scroll_offset=[108.671875,150] is_viewport=false
-FillPath@s0/f0 path_bounding_rect=[22,22 93x152]
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s2 rect=[23,23 200x300]
-FillRect@s2/f1 rect=[23,23 200x300] color=rgb(240, 128, 128)
-DrawGlyphRun@s2/f1 rect=[23,23 71x16] translation=[23,35.796875] color=rgb(0, 0, 0)
-PaintScrollBar@s0/f0
-PaintScrollBar@s0/f0
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s3 rect=[125.328125,22 93.328125x152]
-CompositorScrollNode@s0/f0 scroll_node_index=s3 parent_scroll_node_index=s0 scrollport_rect=[126,23 92x150] min_scroll_offset=[0,0] max_scroll_offset=[108.671875,150] is_viewport=false
-FillPath@s0/f0 path_bounding_rect=[125,22 94x152]
-CompositorWheelHitTestTarget@s3/f2 target_scroll_node_index=s3 rect=[126.328125,23 200x300]
-FillRect@s3/f2 rect=[126,23 200x300] color=rgb(144, 238, 144)
-DrawGlyphRun@s3/f2 rect=[126,23 66x16] translation=[126.328125,35.796875] color=rgb(0, 0, 0)
-PaintScrollBar@s0/f0
-PaintScrollBar@s0/f0
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s4 rect=[228.65625,22 93.328125x152]
-CompositorScrollNode@s0/f0 scroll_node_index=s4 parent_scroll_node_index=s0 scrollport_rect=[230,23 91x150] min_scroll_offset=[0,0] max_scroll_offset=[108.671875,150] is_viewport=false
-FillPath@s0/f0 path_bounding_rect=[229,22 93x152]
-CompositorWheelHitTestTarget@s4/f3 target_scroll_node_index=s4 rect=[229.65625,23 200x300]
-FillRect@s4/f3 rect=[230,23 200x300] color=rgb(173, 216, 230)
-DrawGlyphRun@s4/f3 rect=[229,23 67x16] translation=[229.65625,35.796875] color=rgb(0, 0, 0)
-PaintScrollBar@s0/f0
-PaintScrollBar@s0/f0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s0 rect=[0,0 800x600]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[0,0 800x21]
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s0 rect=[10,10 324x224]
+FillRect@s0/e0 rect=[10,10 324x224] color=rgb(211, 211, 211)
+FillPath@s0/e0 path_bounding_rect=[10,10 324x224]
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s2 rect=[22,22 93.328125x152]
+CompositorScrollNode@s0/e0 scroll_node_index=s2 parent_scroll_node_index=s0 scrollport_rect=[23,23 91x150] min_scroll_offset=[0,0] max_scroll_offset=[108.671875,150] is_viewport=false
+FillPath@s0/e0 path_bounding_rect=[22,22 93x152]
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s2 rect=[23,23 200x300]
+FillRect@s2/c0/e0 rect=[23,23 200x300] color=rgb(240, 128, 128)
+DrawGlyphRun@s2/c0/e0 rect=[23,23 71x16] translation=[23,35.796875] color=rgb(0, 0, 0)
+PaintScrollBar@s0/e0
+PaintScrollBar@s0/e0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s3 rect=[125.328125,22 93.328125x152]
+CompositorScrollNode@s0/e0 scroll_node_index=s3 parent_scroll_node_index=s0 scrollport_rect=[126,23 92x150] min_scroll_offset=[0,0] max_scroll_offset=[108.671875,150] is_viewport=false
+FillPath@s0/e0 path_bounding_rect=[125,22 94x152]
+CompositorWheelHitTestTarget@s3/c1/e0 target_scroll_node_index=s3 rect=[126.328125,23 200x300]
+FillRect@s3/c1/e0 rect=[126,23 200x300] color=rgb(144, 238, 144)
+DrawGlyphRun@s3/c1/e0 rect=[126,23 66x16] translation=[126.328125,35.796875] color=rgb(0, 0, 0)
+PaintScrollBar@s0/e0
+PaintScrollBar@s0/e0
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s4 rect=[228.65625,22 93.328125x152]
+CompositorScrollNode@s0/e0 scroll_node_index=s4 parent_scroll_node_index=s0 scrollport_rect=[230,23 91x150] min_scroll_offset=[0,0] max_scroll_offset=[108.671875,150] is_viewport=false
+FillPath@s0/e0 path_bounding_rect=[229,22 93x152]
+CompositorWheelHitTestTarget@s4/c2/e0 target_scroll_node_index=s4 rect=[229.65625,23 200x300]
+FillRect@s4/c2/e0 rect=[230,23 200x300] color=rgb(173, 216, 230)
+DrawGlyphRun@s4/c2/e0 rect=[229,23 67x16] translation=[229.65625,35.796875] color=rgb(0, 0, 0)
+PaintScrollBar@s0/e0
+PaintScrollBar@s0/e0
 

--- a/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
@@ -4,12 +4,12 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] transform=[0.9848077,-0.17364818,0.17364818,0.9848077,0,0] origin=(48,48) (BlockContainer<DIV>.box.left)
         [s3] transform=[0.8,0,0,0.8,0,0] origin=(138,48) (BlockContainer<DIV>.box.right)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f0 rect=[8,8 80x80] color=rgb(255, 0, 0)
-DrawGlyphRun@s2/f0 rect=[8,8 15x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-FillRect@s3/f0 rect=[98,8 80x80] color=rgb(0, 0, 255)
-DrawGlyphRun@s3/f0 rect=[98,8 10x16] translation=[98,20.796875] color=rgb(0, 0, 0)
+FillRect@s2/e0 rect=[8,8 80x80] color=rgb(255, 0, 0)
+DrawGlyphRun@s2/e0 rect=[8,8 15x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s3/e0 rect=[98,8 80x80] color=rgb(0, 0, 255)
+DrawGlyphRun@s3/e0 rect=[98,8 10x16] translation=[98,20.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
+++ b/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
@@ -3,12 +3,13 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>.container)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[10,10 200x100] (BlockContainer<DIV>.container)
+  clips:
+    [c0 in s1] clip=[10,10 200x100] (BlockContainer<DIV>.container)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[8,8 204x104]
-FillRect@s2/f1 rect=[10,10 300x150] color=rgb(240, 128, 128)
-DrawGlyphRun@s2/f1 rect=[10,10 38x16] translation=[10,22.796875] color=rgb(0, 0, 0)
+FillPath@s1/e0 path_bounding_rect=[8,8 204x104]
+FillRect@s2/c0/e0 rect=[10,10 300x150] color=rgb(240, 128, 128)
+DrawGlyphRun@s2/c0/e0 rect=[10,10 38x16] translation=[10,22.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/solid-border-edge-before-a-groove-edge.txt
+++ b/Tests/LibWeb/Text/expected/display_list/solid-border-edge-before-a-groove-edge.txt
@@ -2,15 +2,15 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[8,8 140x20]
-FillPath@s1/f0 path_bounding_rect=[138,8 10x100]
-FillPath@s1/f0 path_bounding_rect=[128,18 10x80]
-FillPath@s1/f0 path_bounding_rect=[8,98 140x10]
-FillPath@s1/f0 path_bounding_rect=[18,88 120x10]
-FillPath@s1/f0 path_bounding_rect=[8,8 10x100]
-FillPath@s1/f0 path_bounding_rect=[18,18 10x80]
+FillPath@s1/e0 path_bounding_rect=[8,8 140x20]
+FillPath@s1/e0 path_bounding_rect=[138,8 10x100]
+FillPath@s1/e0 path_bounding_rect=[128,18 10x80]
+FillPath@s1/e0 path_bounding_rect=[8,98 140x10]
+FillPath@s1/e0 path_bounding_rect=[18,88 120x10]
+FillPath@s1/e0 path_bounding_rect=[8,8 10x100]
+FillPath@s1/e0 path_bounding_rect=[18,18 10x80]
 

--- a/Tests/LibWeb/Text/expected/display_list/solid-border-edges-with-a-dashed-edge.txt
+++ b/Tests/LibWeb/Text/expected/display_list/solid-border-edges-with-a-dashed-edge.txt
@@ -2,12 +2,12 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[8,8 120x80]
-StrokePath@s1/f0 path_bounding_rect=[8,3 10x90] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=10.00 inline_clips=[clip_path=[bounds: [8,8 10x80], path: M8 88L8 88L18 78L18 18L8 8L8 8]]
-StrokePath@s1/f0 path_bounding_rect=[3,88 130x10] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=10.00 inline_clips=[clip_path=[bounds: [8,88 120x10], path: M8 88L8 88L18 98L118 98L128 88L128 88]]
-FillPath@s1/f0 path_bounding_rect=[8,88 120x80]
+FillPath@s1/e0 path_bounding_rect=[8,8 120x80]
+StrokePath@s1/e0 path_bounding_rect=[8,3 10x90] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=10.00 inline_clips=[clip_path=[bounds: [8,8 10x80], path: M8 88L8 88L18 78L18 18L8 8L8 8]]
+StrokePath@s1/e0 path_bounding_rect=[3,88 130x10] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=10.00 inline_clips=[clip_path=[bounds: [8,88 120x10], path: M8 88L8 88L18 98L118 98L128 88L128 88]]
+FillPath@s1/e0 path_bounding_rect=[8,88 120x80]
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -4,14 +4,15 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] svg-viewport-transform=[1,0,0,1,8,8] origin=(0,0) (SVGSVGBox<svg>)
           [s3] transform=[1,0,0,1,1,0] origin=(0,0) (SVGForeignObjectBox<foreignObject>#fo)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,8 100x100] (SVGSVGBox<svg>)
-        [f2 in s3] mask=[-10,-10 120x120] kind=luminance origin=svg-mask (SVGForeignObjectBox<foreignObject>#fo)
-          [f3 in s3] clip=[0,0 100x100] (SVGForeignObjectBox<foreignObject>#fo)
+  clips:
+    [c0 in s1] clip=[8,8 100x100] (SVGSVGBox<svg>)
+      [c1 in s3] clip=[0,0 100x100] (SVGForeignObjectBox<foreignObject>#fo)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s3 out=c0] mask=[-10,-10 120x120] kind=luminance origin=svg-mask (SVGForeignObjectBox<foreignObject>#fo)
 
 DisplayList:
-FillRect@s3/f3 rect=[0,0 100x100] color=rgb(0, 0, 0)
-MaskDisplayList for frame f2:
+FillRect@s3/c1/e1 rect=[0,0 100x100] color=rgb(0, 0, 0)
+MaskDisplayList for effect e1:
   FillPath@s0 path_bounding_rect=[0,0 100x100]
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-scroller-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-scroller-after-relayout.txt
@@ -4,23 +4,24 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] svg-viewport-transform=[1,0,0,1,8,8] origin=(0,0) (SVGSVGBox<svg>)
           [s3] scroll (BlockContainer<DIV>#scroller)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,8 100x100] (SVGSVGBox<svg>)
-        [f2 in s2] clip=[0,0 100x100] (SVGForeignObjectBox<foreignObject>)
-          [f3 in s2] clip=[0,0 80x80] (BlockContainer<DIV>#scroller)
+  clips:
+    [c0 in s1] clip=[8,8 100x100] (SVGSVGBox<svg>)
+      [c1 in s2] clip=[0,0 100x100] (SVGForeignObjectBox<foreignObject>)
+        [c2 in s2] clip=[0,0 80x80] (BlockContainer<DIV>#scroller)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-CompositorWheelHitTestTarget@s0/f0 target_scroll_node_index=s0 rect=[0,0 800x600]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[0,0 800x121]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[8,8 784x100]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[8,8 784x100]
-CompositorWheelHitTestTarget@s1/f0 target_scroll_node_index=s0 rect=[8,8 100x100]
-StrokePath@s2/f1 path_bounding_rect=[9.5,9.5 81x81] thickness=1 color=rgb(0, 0, 0)
-CompositorWheelHitTestTarget@s2/f1 target_scroll_node_index=s0 rect=[0,0 100x100]
-CompositorWheelHitTestTarget@s2/f2 target_scroll_node_index=s3 rect=[0,0 80x80]
-CompositorScrollNode@s2/f2 scroll_node_index=s3 parent_scroll_node_index=s0 scrollport_rect=[0,0 80x80] min_scroll_offset=[0,0] max_scroll_offset=[0,220] is_viewport=false
-CompositorWheelHitTestTarget@s3/f3 target_scroll_node_index=s3 rect=[0,0 80x300]
-FillRect@s3/f3 rect=[0,0 80x300] color=rgb(0, 0, 0)
-PaintScrollBar@s2/f2
+CompositorWheelHitTestTarget@s0/e0 target_scroll_node_index=s0 rect=[0,0 800x600]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[0,0 800x121]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[8,8 784x100]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[8,8 784x100]
+CompositorWheelHitTestTarget@s1/e0 target_scroll_node_index=s0 rect=[8,8 100x100]
+StrokePath@s2/c0/e0 path_bounding_rect=[9.5,9.5 81x81] thickness=1 color=rgb(0, 0, 0)
+CompositorWheelHitTestTarget@s2/c0/e0 target_scroll_node_index=s0 rect=[0,0 100x100]
+CompositorWheelHitTestTarget@s2/c1/e0 target_scroll_node_index=s3 rect=[0,0 80x80]
+CompositorScrollNode@s2/c1/e0 scroll_node_index=s3 parent_scroll_node_index=s0 scrollport_rect=[0,0 80x80] min_scroll_offset=[0,0] max_scroll_offset=[0,220] is_viewport=false
+CompositorWheelHitTestTarget@s3/c2/e0 target_scroll_node_index=s3 rect=[0,0 80x300]
+FillRect@s3/c2/e0 rect=[0,0 80x300] color=rgb(0, 0, 0)
+PaintScrollBar@s2/c1/e0
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
@@ -2,15 +2,15 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-PaintNestedDisplayList@s1/f0 rect=[8,13 300x200]
-  FillPath@s6/f0 path_bounding_rect=[0,0 100x100]
-  FillPath@s6/f0 path_bounding_rect=[0,100 100x100]
-  FillPath@s7/f1 path_bounding_rect=[0,0 100x100]
-  FillPath@s7/f1 path_bounding_rect=[0,100 100x100]
-  MaskDisplayList for frame f1:
+PaintNestedDisplayList@s1/e0 rect=[8,13 300x200]
+  FillPath@s6/e0 path_bounding_rect=[0,0 100x100]
+  FillPath@s6/e0 path_bounding_rect=[0,100 100x100]
+  FillPath@s7/e1 path_bounding_rect=[0,0 100x100]
+  FillPath@s7/e1 path_bounding_rect=[0,100 100x100]
+  MaskDisplayList for effect e1:
     FillPath@s1 path_bounding_rect=[0,0 100x100]
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
@@ -3,10 +3,11 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] svg-viewport-transform=[1,0,0,1,0,0] origin=(0,0) (SVGSVGBox<svg>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[0,0 200x200] (SVGSVGBox<svg>)
+  clips:
+    [c0 in s1] clip=[0,0 200x200] (SVGSVGBox<svg>)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s2/f1 path_bounding_rect=[10,10 100x100]
+FillPath@s2/c0/e0 path_bounding_rect=[10,10 100x100]
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
@@ -4,11 +4,12 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] svg-viewport-transform=[1,0,0,1,8,8] origin=(0,0) (SVGSVGBox<svg>)
           [s3] transform=[1,0,0,1,20,20] origin=(0,0) (SVGGeometryBox<rect>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,8 200x200] (SVGSVGBox<svg>)
-        [f2 in s2] effects=[opacity=0.5] (SVGGeometryBox<rect>)
+  clips:
+    [c0 in s1] clip=[8,8 200x200] (SVGSVGBox<svg>)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s2 out=c0] effects=[opacity=0.5] (SVGGeometryBox<rect>)
 
 DisplayList:
-FillPath@s3/f2 path_bounding_rect=[0,0 100x100]
+FillPath@s3/c0/e1 path_bounding_rect=[0,0 100x100]
 

--- a/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
+++ b/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
@@ -2,17 +2,17 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[69,-17 47x100] color=rgba(101, 2, 0, 0.8)
-DrawGlyphRun@s1/f0 rect=[8,-17 169x100] translation=[8,62.984375] color=rgb(0, 0, 0) inline_clips=[clip=[9,-15 60x91]]
-DrawLine@s1/f0 from=[8,70] to=[45,70] color=rgb(0, 0, 0) thickness=10 style=Solid
-DrawLine@s1/f0 from=[57,70] to=[67,70] color=rgb(0, 0, 0) thickness=10 style=Solid
-DrawGlyphRun@s1/f0 rect=[8,-17 169x100] translation=[8,62.984375] color=rgb(0, 0, 0) inline_clips=[clip=[69,-15 47x91]]
-DrawLine@s1/f0 from=[109,70] to=[116,70] color=rgb(0, 0, 0) thickness=10 style=Solid
-DrawGlyphRun@s1/f0 rect=[8,-17 169x100] translation=[8,62.984375] color=rgb(0, 0, 0) inline_clips=[clip=[116,-15 61x91]]
-DrawLine@s1/f0 from=[116,70] to=[153,70] color=rgb(0, 0, 0) thickness=10 style=Solid
-DrawLine@s1/f0 from=[165,70] to=[177,70] color=rgb(0, 0, 0) thickness=10 style=Solid
+FillRect@s1/e0 rect=[69,-17 47x100] color=rgba(101, 2, 0, 0.8)
+DrawGlyphRun@s1/e0 rect=[8,-17 169x100] translation=[8,62.984375] color=rgb(0, 0, 0) inline_clips=[clip=[9,-15 60x91]]
+DrawLine@s1/e0 from=[8,70] to=[45,70] color=rgb(0, 0, 0) thickness=10 style=Solid
+DrawLine@s1/e0 from=[57,70] to=[67,70] color=rgb(0, 0, 0) thickness=10 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,-17 169x100] translation=[8,62.984375] color=rgb(0, 0, 0) inline_clips=[clip=[69,-15 47x91]]
+DrawLine@s1/e0 from=[109,70] to=[116,70] color=rgb(0, 0, 0) thickness=10 style=Solid
+DrawGlyphRun@s1/e0 rect=[8,-17 169x100] translation=[8,62.984375] color=rgb(0, 0, 0) inline_clips=[clip=[116,-15 61x91]]
+DrawLine@s1/e0 from=[116,70] to=[153,70] color=rgb(0, 0, 0) thickness=10 style=Solid
+DrawLine@s1/e0 from=[165,70] to=[177,70] color=rgb(0, 0, 0) thickness=10 style=Solid
 

--- a/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
@@ -2,20 +2,21 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[9,9 104x30] (TextAreaBox<TEXTAREA>)
+  clips:
+    [c0 in s1] clip=[9,9 104x30] (TextAreaBox<TEXTAREA>)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 106x32] color=rgb(255, 255, 255)
-FillPath@s1/f0 path_bounding_rect=[8,8 106x32]
-DrawGlyphRun@s1/f1 rect=[11,11 30x13] translation=[11,21.390625] color=rgb(0, 0, 0)
-PaintCaret@s1/f1 rect=[11,11 1x13] color=rgb(0, 0, 0) should_blink=false
-FillPath@s1/f0 path_bounding_rect=[6,6 110x36]
-DrawLine@s1/f0 from=[109,37] to=[111,35] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[108,37] to=[111,34] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[106,37] to=[111,32] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[105,37] to=[111,31] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[103,37] to=[111,29] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
-DrawLine@s1/f0 from=[102,37] to=[111,28] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+FillRect@s1/e0 rect=[8,8 106x32] color=rgb(255, 255, 255)
+FillPath@s1/e0 path_bounding_rect=[8,8 106x32]
+DrawGlyphRun@s1/c0/e0 rect=[11,11 30x13] translation=[11,21.390625] color=rgb(0, 0, 0)
+PaintCaret@s1/c0/e0 rect=[11,11 1x13] color=rgb(0, 0, 0) should_blink=false
+FillPath@s1/e0 path_bounding_rect=[6,6 110x36]
+DrawLine@s1/e0 from=[109,37] to=[111,35] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[108,37] to=[111,34] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[106,37] to=[111,32] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[105,37] to=[111,31] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[103,37] to=[111,29] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
+DrawLine@s1/e0 from=[102,37] to=[111,28] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
 

--- a/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
+++ b/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
@@ -5,14 +5,14 @@ AccumulatedVisualContext Tree:
         [s2] transform=[0.9659258,-0.25881904,0.25881904,0.9659258,0,0] origin=(38,38) (BlockContainer<DIV>.box.a)
         [s3] transform=[1.1,0,0,1.1,0,0] origin=(103,38) (BlockContainer<DIV>.box.b)
         [s4] transform=[1,0.17632698,0,1,0,0] origin=(168,38) (BlockContainer<DIV>.box.c)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f0 rect=[8,8 60x60] color=rgb(255, 0, 0)
-DrawGlyphRun@s2/f0 rect=[8,8 7x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-FillRect@s3/f0 rect=[73,8 60x60] color=rgb(0, 128, 0)
-DrawGlyphRun@s3/f0 rect=[73,8 9x16] translation=[73,20.796875] color=rgb(0, 0, 0)
-FillRect@s4/f0 rect=[138,8 60x60] color=rgb(0, 0, 255)
-DrawGlyphRun@s4/f0 rect=[138,8 10x16] translation=[138,20.796875] color=rgb(0, 0, 0)
+FillRect@s2/e0 rect=[8,8 60x60] color=rgb(255, 0, 0)
+DrawGlyphRun@s2/e0 rect=[8,8 7x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s3/e0 rect=[73,8 60x60] color=rgb(0, 128, 0)
+DrawGlyphRun@s3/e0 rect=[73,8 9x16] translation=[73,20.796875] color=rgb(0, 0, 0)
+FillRect@s4/e0 rect=[138,8 60x60] color=rgb(0, 0, 255)
+DrawGlyphRun@s4/e0 rect=[138,8 10x16] translation=[138,20.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
@@ -3,10 +3,10 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] transform=[1,0,0,1,50,30] origin=(58,58) (BlockContainer<DIV>.box)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f0 rect=[8,8 100x100] color=rgb(0, 0, 255)
-DrawGlyphRun@s2/f0 rect=[8,8 38x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s2/e0 rect=[8,8 100x100] color=rgb(0, 0, 255)
+DrawGlyphRun@s2/e0 rect=[8,8 38x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-invertibility-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-invertibility-invalidation.txt
@@ -11,9 +11,9 @@ AccumulatedVisualContext Tree:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
         [s2] transform=[1,0,0,1,0,0] origin=(58,58) (BlockContainer<DIV>#box)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f0 rect=[8,8 100x100] color=rgb(0, 128, 0)
+FillRect@s2/e0 rect=[8,8 100x100] color=rgb(0, 128, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
@@ -4,11 +4,11 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] transform=[0.70710677,-0.70710677,0.70710677,0.70710677,0,0] origin=(108,108) (BlockContainer<DIV>.outer)
           [s3] transform=[0.5,0,0,0.5,0,0] origin=(58,58) (BlockContainer<DIV>.inner)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f0 rect=[8,8 200x200] color=rgb(173, 216, 230)
-FillRect@s3/f0 rect=[8,8 100x100] color=rgb(255, 127, 80)
-DrawGlyphRun@s3/f0 rect=[8,8 52x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s2/e0 rect=[8,8 200x200] color=rgb(173, 216, 230)
+FillRect@s3/e0 rect=[8,8 100x100] color=rgb(255, 127, 80)
+DrawGlyphRun@s3/e0 rect=[8,8 52x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
@@ -4,12 +4,13 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>.container)
           [s3] transform=[1,0,0,1,20,20] origin=(110,110) (BlockContainer<DIV>.transformed)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[10,10 150x150] (BlockContainer<DIV>.container)
+  clips:
+    [c0 in s1] clip=[10,10 150x150] (BlockContainer<DIV>.container)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillPath@s1/f0 path_bounding_rect=[8,8 154x154]
-FillRect@s3/f1 rect=[10,10 200x200] color=rgb(144, 238, 144)
-DrawGlyphRun@s3/f1 rect=[10,10 185x16] translation=[10,22.796875] color=rgb(0, 0, 0)
+FillPath@s1/e0 path_bounding_rect=[8,8 154x154]
+FillRect@s3/c0/e0 rect=[10,10 200x200] color=rgb(144, 238, 144)
+DrawGlyphRun@s3/c0/e0 rect=[10,10 185x16] translation=[10,22.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
+++ b/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
@@ -3,20 +3,20 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 50x50] color=rgb(0, 0, 255)
+FillRect@s1/e0 rect=[8,8 50x50] color=rgb(0, 0, 255)
 
 After z-index change:
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 50x50] color=rgb(0, 0, 255)
+FillRect@s1/e0 rect=[8,8 50x50] color=rgb(0, 0, 255)
 

--- a/Tests/LibWeb/Text/expected/display_list/zero-area-clip-commands.txt
+++ b/Tests/LibWeb/Text/expected/display_list/zero-area-clip-commands.txt
@@ -4,14 +4,15 @@ AccumulatedVisualContext Tree:
       [s1] scroll (Viewport<#document>)
         [s2] scroll (BlockContainer<DIV>.zero-width)
         [s3] scroll (BlockContainer<DIV>.zero-height)
-  frames:
-    [f0 in s0] effects=[]
-      [f1 in s1] clip=[8,8 0x100] (BlockContainer<DIV>.zero-width)
-      [f2 in s1] clip=[8,108 100x0] (BlockContainer<DIV>.zero-height)
-      [f3 in s1] clip=[8,108 100x100] (BlockContainer<DIV>.visible)
+  clips:
+    [c0 in s1] clip=[8,8 0x100] (BlockContainer<DIV>.zero-width)
+    [c1 in s1] clip=[8,108 100x0] (BlockContainer<DIV>.zero-height)
+    [c2 in s1] clip=[8,108 100x100] (BlockContainer<DIV>.visible)
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s2/f1 rect=[8,8 50x50] color=rgb(255, 0, 0)
-FillRect@s3/f2 rect=[8,108 50x50] color=rgb(255, 0, 0)
-FillRect@s1/f3 rect=[8,108 50x50] color=rgb(255, 0, 0)
+FillRect@s2/c0/e0 rect=[8,8 50x50] color=rgb(255, 0, 0)
+FillRect@s3/c1/e0 rect=[8,108 50x50] color=rgb(255, 0, 0)
+FillRect@s1/c2/e0 rect=[8,108 50x50] color=rgb(255, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/text-transform-contextual-selection-offset-mapping.txt
+++ b/Tests/LibWeb/Text/expected/text-transform-contextual-selection-offset-mapping.txt
@@ -2,12 +2,12 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,48 51x16] color=rgb(1, 2, 3)
-DrawGlyphRun@s1/f0 rect=[8,16 55x16] translation=[8,28.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,32 35x16] translation=[8,44.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,48 51x16] translation=[8,60.796875] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,48 51x16] color=rgb(1, 2, 3)
+DrawGlyphRun@s1/e0 rect=[8,16 55x16] translation=[8,28.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,32 35x16] translation=[8,44.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,48 51x16] translation=[8,60.796875] color=rgb(0, 0, 0)
 

--- a/Tests/LibWeb/Text/expected/text-transform-selection-offset-mapping.txt
+++ b/Tests/LibWeb/Text/expected/text-transform-selection-offset-mapping.txt
@@ -2,27 +2,27 @@ AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 24x16] color=rgb(1, 2, 3)
-DrawGlyphRun@s1/f0 rect=[8,8 24x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-DrawGlyphRun@s1/f0 rect=[8,40 22x16] translation=[8,52.796875] color=rgb(4, 5, 6)
-DrawGlyphRun@s1/f0 rect=[29,40 28x16] translation=[29.3125,52.796875] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,8 24x16] color=rgb(1, 2, 3)
+DrawGlyphRun@s1/e0 rect=[8,8 24x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+DrawGlyphRun@s1/e0 rect=[8,40 22x16] translation=[8,52.796875] color=rgb(4, 5, 6)
+DrawGlyphRun@s1/e0 rect=[29,40 28x16] translation=[29.3125,52.796875] color=rgb(0, 0, 0)
 
 AccumulatedVisualContext Tree:
   spatial:
     [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
       [s1] scroll (Viewport<#document>)
-  frames:
-    [f0 in s0] effects=[]
+  effects:
+    [e0 in s0] effects=[]
 
 DisplayList:
-DrawGlyphRun@s1/f0 rect=[8,8 24x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-FillRect@s1/f0 rect=[8,40 21x16] color=rgb(1, 2, 3)
-FillRect@s1/f0 rect=[29,40 9x16] color=rgb(1, 2, 3)
-DrawGlyphRun@s1/f0 rect=[8,40 22x16] translation=[8,52.796875] color=rgb(4, 5, 6)
-DrawGlyphRun@s1/f0 rect=[29,40 28x16] translation=[29.3125,52.796875] color=rgb(0, 0, 0) inline_clips=[clip=[29,40 9x15]]
-DrawGlyphRun@s1/f0 rect=[29,40 28x16] translation=[29.3125,52.796875] color=rgb(0, 0, 0) inline_clips=[clip=[38,40 19x15]]
+DrawGlyphRun@s1/e0 rect=[8,8 24x16] translation=[8,20.796875] color=rgb(0, 0, 0)
+FillRect@s1/e0 rect=[8,40 21x16] color=rgb(1, 2, 3)
+FillRect@s1/e0 rect=[29,40 9x16] color=rgb(1, 2, 3)
+DrawGlyphRun@s1/e0 rect=[8,40 22x16] translation=[8,52.796875] color=rgb(4, 5, 6)
+DrawGlyphRun@s1/e0 rect=[29,40 28x16] translation=[29.3125,52.796875] color=rgb(0, 0, 0) inline_clips=[clip=[29,40 9x15]]
+DrawGlyphRun@s1/e0 rect=[29,40 28x16] translation=[29.3125,52.796875] color=rgb(0, 0, 0) inline_clips=[clip=[38,40 19x15]]
 

--- a/Tests/LibWeb/Text/expected/visual-context/anchor-page-rebuild-keeps-untouched-node-indices.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/anchor-page-rebuild-keeps-untouched-node-indices.txt
@@ -1,9 +1,9 @@
 b owns nodes: true
-clip frame swap: full builds 1, incremental updates 0
-clip frame swap: b keeps its node indices: true
-clip frame swap: c keeps its node indices: true
-clip frame swap: live nodes unchanged: false
-clip frame swap: epoch advanced: true
+clip swap: full builds 1, incremental updates 0
+clip swap: b keeps its node indices: true
+clip swap: c keeps its node indices: true
+clip swap: live nodes unchanged: false
+clip swap: epoch advanced: true
 transform swap: full builds 1, incremental updates 0
 transform swap: b keeps its node indices: true
 transform swap: c keeps its node indices: true

--- a/Tests/LibWeb/Text/expected/visual-context/resolved-effect-output-clip-updates.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/resolved-effect-output-clip-updates.txt
@@ -1,0 +1,27 @@
+new clipped effect: epoch unchanged: true
+clipped opacity update: epoch changed: false
+clipped opacity update: one effect: true
+clipped opacity update: full builds: 0
+repeated clipped opacity update: epoch changed: false
+repeated clipped opacity update: one effect: true
+repeated clipped opacity update: full builds: 0
+absolute escape: epoch changed: true
+absolute escape: one effect: true
+absolute escape: full builds: 0
+absolute child escapes: true
+escaped opacity update: epoch changed: false
+escaped opacity update: one effect: true
+escaped opacity update: full builds: 0
+absolute escape removed: epoch changed: true
+absolute escape removed: one effect: true
+absolute escape removed: full builds: 0
+fixed escape: epoch changed: true
+fixed escape: one effect: true
+fixed escape: full builds: 0
+fixed child escapes: true
+fixed escape removed: epoch changed: true
+fixed escape removed: one effect: true
+fixed escape removed: full builds: 0
+clipped opacity update after escapes: epoch changed: false
+clipped opacity update after escapes: one effect: true
+clipped opacity update after escapes: full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/shared-effect-positioned-clip-constraints.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/shared-effect-positioned-clip-constraints.txt
@@ -1,0 +1,21 @@
+both positioned children: one owned effect: true
+both positioned children: one shared layer: true
+both positioned children: layer inside overflow clip: false
+absolute escapes: true
+fixed escapes: true
+normal stays clipped: true
+fixed child remains: one owned effect: true
+fixed child remains: one shared layer: true
+fixed child remains: layer inside overflow clip: false
+no positioned children: one owned effect: true
+no positioned children: one shared layer: true
+no positioned children: layer inside overflow clip: true
+absolute child restored: one owned effect: true
+absolute child restored: one shared layer: true
+absolute child restored: layer inside overflow clip: false
+both restored: one owned effect: true
+both restored: one shared layer: true
+both restored: layer inside overflow clip: false
+fresh tree: one owned effect: true
+fresh tree: one shared layer: true
+fresh tree: layer inside overflow clip: false

--- a/Tests/LibWeb/Text/input/display_list/abspos-escaping-overflow-clip-inside-opacity.html
+++ b/Tests/LibWeb/Text/input/display_list/abspos-escaping-overflow-clip-inside-opacity.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+    #containing-block {
+        position: relative;
+        width: 200px;
+        height: 200px;
+    }
+    #group {
+        opacity: 0.5;
+        width: 200px;
+        height: 200px;
+        background: red;
+    }
+    #clip {
+        overflow: hidden;
+        width: 100px;
+        height: 100px;
+    }
+    #escaping {
+        position: absolute;
+        left: 50px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background: blue;
+    }
+</style>
+<div id="containing-block"><div id="group"><div id="clip"><div id="escaping"></div></div></div></div>
+<script>
+    test(() => {
+        println(internals.dumpDisplayList());
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/anchor-page-rebuild-keeps-untouched-node-indices.html
+++ b/Tests/LibWeb/Text/input/visual-context/anchor-page-rebuild-keeps-untouched-node-indices.html
@@ -52,11 +52,11 @@
             lines.push(`${label}: epoch advanced: ${internals.visualContextTreeStructuralEpoch() !== epoch}`);
         };
 
-        lines.push(`b owns nodes: ${internals.visualContextNodeIndices(b).frames.length > 0 && internals.visualContextNodeIndices(b).spatial.length > 0}`);
-        swap("clipped", "clip frame swap");
+        lines.push(`b owns nodes: ${internals.visualContextNodeIndices(b).clips.length > 0 && internals.visualContextNodeIndices(b).spatial.length > 0}`);
+        swap("clipped", "clip swap");
         swap("lift", "transform swap");
         lines.push(`dead nodes after the swaps: ${internals.visualContextTreeDeadNodeCount() > 0}`);
-        lines.push(`d owns the moved nodes: ${internals.visualContextNodeIndices(d).frames.length > 0 && internals.visualContextNodeIndices(d).spatial.length > 0}`);
+        lines.push(`d owns the moved nodes: ${internals.visualContextNodeIndices(d).clips.length > 0 && internals.visualContextNodeIndices(d).spatial.length > 0}`);
 
         for (const line of lines)
             println(line);

--- a/Tests/LibWeb/Text/input/visual-context/resolved-effect-output-clip-updates.html
+++ b/Tests/LibWeb/Text/input/visual-context/resolved-effect-output-clip-updates.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #containing-block { transform: translateX(0); width: 200px; height: 100px; }
+    #clipped { overflow: hidden; width: 40px; height: 40px; }
+    #layer { width: 80px; height: 60px; }
+    #child { left: 60px; top: 0; width: 20px; height: 20px; background: green; }
+</style>
+<div id="containing-block"><div id="clipped"><div id="layer"><div id="child"></div></div></div></div>
+<script>
+    test(() => {
+        const layer = document.getElementById("layer");
+        const child = document.getElementById("child");
+        const settle = () => document.elementFromPoint(0, 0);
+        settle();
+        const epoch = internals.visualContextTreeStructuralEpoch();
+        layer.style.opacity = "0.5";
+        settle();
+        println(`new clipped effect: epoch unchanged: ${internals.visualContextTreeStructuralEpoch() === epoch}`);
+        const check = (label, change) => {
+            const epoch = internals.visualContextTreeStructuralEpoch();
+            const builds = internals.accumulatedVisualContextTreeBuildCount();
+            change();
+            settle();
+            println(`${label}: epoch changed: ${internals.visualContextTreeStructuralEpoch() !== epoch}`);
+            println(`${label}: one effect: ${internals.visualContextNodeIndices(layer).effects.length === 1}`);
+            println(`${label}: full builds: ${internals.accumulatedVisualContextTreeBuildCount() - builds}`);
+        };
+
+        check("clipped opacity update", () => layer.style.opacity = "0.6");
+        check("repeated clipped opacity update", () => layer.style.opacity = "0.7");
+        check("absolute escape", () => child.style.position = "absolute");
+        println(`absolute child escapes: ${document.elementFromPoint(65, 5) === child}`);
+        check("escaped opacity update", () => layer.style.opacity = "0.8");
+        check("absolute escape removed", () => child.style.position = "static");
+        check("fixed escape", () => child.style.position = "fixed");
+        println(`fixed child escapes: ${document.elementFromPoint(65, 5) === child}`);
+        check("fixed escape removed", () => child.style.position = "static");
+        check("clipped opacity update after escapes", () => layer.style.opacity = "0.9");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/shared-effect-positioned-clip-constraints.html
+++ b/Tests/LibWeb/Text/input/visual-context/shared-effect-positioned-clip-constraints.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #containing-block { transform: translateX(0); width: 240px; height: 100px; }
+    #clipped { overflow: hidden; width: 40px; height: 40px; }
+    #layer { opacity: 0.5; }
+    #normal { width: 80px; height: 20px; background: red; }
+    .positioned { top: 0; width: 20px; height: 20px; background: green; }
+    #absolute { position: absolute; left: 60px; }
+    #fixed { position: fixed; left: 100px; }
+</style>
+<div id="containing-block"><div id="clipped"><div id="layer">
+    <div id="normal"></div>
+    <div id="absolute" class="positioned"></div>
+    <div id="fixed" class="positioned"></div>
+</div></div></div>
+<script>
+    test(() => {
+        const layer = document.getElementById("layer");
+        const absolute = document.getElementById("absolute");
+        const fixed = document.getElementById("fixed");
+        const lines = [];
+        const check = label => {
+            // Settle the incremental update before the dump requests a canonical fresh tree.
+            document.elementFromPoint(0, 0);
+            lines.push(`${label}: one owned effect: ${internals.visualContextNodeIndices(layer).effects.length === 1}`);
+            const dump = internals.dumpDisplayList();
+            const effects = dump.split("\n").filter(line => line.includes("effects=[opacity=0.5]"));
+            lines.push(`${label}: one shared layer: ${effects.length === 1}`);
+            lines.push(`${label}: layer inside overflow clip: ${effects[0].includes(" out=c")}`);
+        };
+
+        check("both positioned children");
+        lines.push(`absolute escapes: ${document.elementFromPoint(65, 5) === absolute}`);
+        lines.push(`fixed escapes: ${document.elementFromPoint(105, 5) === fixed}`);
+        lines.push(`normal stays clipped: ${document.elementFromPoint(45, 5).id !== "normal"}`);
+        absolute.remove();
+        check("fixed child remains");
+        fixed.remove();
+        check("no positioned children");
+        layer.append(absolute);
+        check("absolute child restored");
+        layer.append(fixed);
+        check("both restored");
+        internals.forceIncompatibleVisualContextTreeRebuild();
+        check("fresh tree");
+        for (const line of lines)
+            println(line);
+    });
+</script>


### PR DESCRIPTION
Clips and compositing effects shared a frame tree, which duplicated
effect nodes along the normal, absolute and fixed positioning chains.
Regression tests with positioned descendants escaping overflow clips
exposed that switching chains could close and reopen an ancestor's
layer, compositing its content separately and applying masks repeatedly.

Give spatial nodes, clips and effects independent indices and store all
three directly in ContextRef. Each positioning chain carries its spatial
node, clip, scroll ancestors and plane root, while all three chains
share one inherited effect. A context no longer needs a separate frame
identity or slot lifetime.

Record per-box clip constraints where effects start and where positioned
descendants escape. Resolve each effect's output clip from these
constraints after the tree walk, keeping layers inside clips all their
content shares. Output clips are derived state outside effect shape
comparisons. Preserve previously resolved clips during reconciliation so
finalization detects actual changes in layer placement. Newly allocated
effects receive their first clip without invalidating existing handles.