### PR TITLE
Release a navigation’s fetch the way Gecko/WebKit/Blink do (and make pages that periodically reload themselves stop leaking gigabytes of memory)

### DIFF
--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -114,8 +114,10 @@ void Request::release_transfer_lease()
     if (!m_transfer_lease.has_value())
         return;
 
+    // Releasing the lease can unregister this request from its client, which may hold the last reference to it.
+    NonnullRefPtr protector { *this };
     if (auto client = m_client.strong_ref())
-        client->release_request_transfer_lease({}, m_transfer_lease.release_value());
+        client->release_request_transfer_lease({}, *this, m_transfer_lease.release_value());
 }
 
 bool Request::has_file_backed_response_body() const
@@ -256,6 +258,8 @@ void Request::set_stop_callback(RequestStopped on_stop)
 
 void Request::did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error)
 {
+    m_finished = true;
+
     auto effective_network_error = m_body_delivery_error.has_value() ? m_body_delivery_error : network_error;
     if (on_finish)
         on_finish(total_size, timing_info, effective_network_error);
@@ -336,6 +340,8 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
             m_internal_stream_data->read_notifier->close();
             m_internal_stream_data->read_notifier = nullptr;
             m_internal_stream_data->read_stream = nullptr;
+            // The request has finished for its owner, so a stop or transfer that follows has nothing left to report.
+            m_on_stop = nullptr;
             user_on_finish(m_internal_stream_data->total_size, m_internal_stream_data->timing_info, m_internal_stream_data->network_error);
             defer_teardown();
         }

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -97,7 +97,12 @@ public:
     void resume_body_delivery();
     void resume_body_delivery_up_to(size_t);
     void release_transfer_lease();
+    [[nodiscard]] bool has_transfer_lease() const { return m_transfer_lease.has_value(); }
     [[nodiscard]] bool has_file_backed_response_body() const;
+
+    // Whether RequestServer has reported the request finished. Its response body may still be undelivered; e.g. while
+    // body delivery is paused.
+    [[nodiscard]] bool is_finished() const { return m_finished; }
 
     using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, CameFromCache came_from_cache, Core::ImmutableBytes payload)>;
 
@@ -189,6 +194,7 @@ private:
     OwnPtr<InternalStreamData> m_internal_stream_data;
     Optional<NetworkError> m_body_delivery_error;
     bool m_body_delivery_paused { false };
+    bool m_finished { false };
 };
 
 }

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -139,9 +139,13 @@ bool RequestClient::stop_request(Badge<Request>, Request& request)
     return true;
 }
 
-void RequestClient::release_request_transfer_lease(Badge<Request>, RequestTransferLeaseKey transfer_lease)
+void RequestClient::release_request_transfer_lease(Badge<Request>, Request& request, RequestTransferLeaseKey transfer_lease)
 {
     release_request_transfer_lease(transfer_lease);
+
+    // A request that has finished stays registered only for the sake of its lease — so it goes along with the lease.
+    if (request.is_finished())
+        m_requests.remove(request.id());
 }
 
 void RequestClient::release_request_transfer_lease(RequestTransferLeaseKey transfer_lease)
@@ -236,10 +240,19 @@ void RequestClient::request_cached_body_file_available(u64 request_id, IPC::File
 
 void RequestClient::request_finished(u64 request_id, u64 total_size, RequestTimingInfo timing_info, Optional<NetworkError> network_error)
 {
-    if (RefPtr<Request> request = m_requests.get(request_id).value_or(nullptr)) {
-        request->did_finish({}, total_size, timing_info, network_error);
+    RefPtr<Request> request = m_requests.get(request_id).value_or(nullptr);
+    if (!request)
+        return;
+
+    request->did_finish({}, total_size, timing_info, network_error);
+
+    // A leased request stays registered after it finishes — just as RequestServer keeps a leased request alive after
+    // completion: Another client may still adopt it — and the request_transferred that follows has to find the request
+    // here to tear it down. It's unregistered when it's transferred, when its lease is released, or when it's stopped.
+    // Gecko and WebKit work the same way: The process a navigation response is taken away from keeps its state for the
+    // request until the one notification telling it to let go — and nothing tears it down before that notification.
+    if (!request->has_transfer_lease())
         m_requests.remove(request_id);
-    }
 }
 
 void RequestClient::headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode_file, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key, CameFromCache came_from_cache)

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -47,7 +47,7 @@ public:
     RefPtr<Request> start_request(ByteString const& method, URL::URL const&, Optional<HTTP::HeaderList const&> request_headers = {}, ReadonlyBytes request_body = {}, HTTP::CacheMode = HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials = HTTP::Cookie::IncludeCredentials::Yes, Core::ProxyData const& = {}, TransferLease = TransferLease::No, Optional<u32> address_selection_hint = {});
     RefPtr<Request> adopt_request(int source_client_id, u64 source_request_id, TransferLease = TransferLease::No);
     bool stop_request(Badge<Request>, Request&);
-    void release_request_transfer_lease(Badge<Request>, RequestTransferLeaseKey);
+    void release_request_transfer_lease(Badge<Request>, Request&, RequestTransferLeaseKey);
     void release_request_transfer_lease(RequestTransferLeaseKey);
     void ensure_connection(URL::URL const&, RequestServer::CacheLevel);
     int request_server_client_id() const { return m_request_server_client_id; }

--- a/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.cpp
@@ -204,6 +204,11 @@ void IncrementalDocumentParser::process_body_chunk(ByteBuffer bytes)
 
 void IncrementalDocumentParser::process_end_of_body()
 {
+    // The body's stream lives in the realm of the document that started this navigation, and this parser stays attached
+    // to the new document until its load event. So, drop the body as soon as it's exhausted — rather than keeping the
+    // previous document alive until the new one has finished loading. Blink, WebKit, and Gecko all do this too.
+    m_body = nullptr;
+
     if (!should_continue()) {
         release_encoding_change_buffers();
         return;
@@ -270,6 +275,7 @@ void IncrementalDocumentParser::release_encoding_change_buffers()
 
 void IncrementalDocumentParser::process_body_error(JS::Value)
 {
+    m_body = nullptr;
     release_encoding_change_buffers();
     dbgln("FIXME: Load html page with an error if incremental read of body failed.");
     HTMLParser::the_end(m_document, m_parser);

--- a/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.h
+++ b/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.h
@@ -52,7 +52,7 @@ private:
     bool should_continue() const;
 
     GC::Ref<DOM::Document> m_document;
-    GC::Ref<Fetch::Infrastructure::Body> m_body;
+    GC::Ptr<Fetch::Infrastructure::Body> m_body;
     URL::URL m_url;
     Optional<MimeSniff::MimeType> m_mime_type;
     HTMLParser::AllowDeclarativeShadowRoots m_allow_declarative_shadow_roots { HTMLParser::AllowDeclarativeShadowRoots::Yes };

--- a/Tests/LibWeb/Text/expected/navigation/replaced-document-is-collectable-while-next-load-is-stalled.txt
+++ b/Tests/LibWeb/Text/expected/navigation/replaced-document-is-collectable-while-next-load-is-stalled.txt
@@ -1,0 +1,1 @@
+first document collected while the second load is stalled: true

--- a/Tests/LibWeb/Text/expected/navigation/replaced-document-is-collectable.txt
+++ b/Tests/LibWeb/Text/expected/navigation/replaced-document-is-collectable.txt
@@ -1,0 +1,1 @@
+collected 5 of 5 replaced documents

--- a/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable-while-next-load-is-stalled.html
+++ b/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable-while-next-load-is-stalled.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // A navigation's response body is read through a stream created in the realm of the document that started the
+    // navigation — and the new document's parser stays attached until its load event. So, the parser has to let go of
+    // the body as soon as the body is exhausted. Otherwise, a load that stalls on a subresource — e.g. an image that
+    // never arrives — keeps the replaced document alive for as long as the load stalls.
+    promiseTest(async () => {
+        const server = httpTestServer();
+        // Repeated runs of this test share the echo server, so its echoes and the image's unblock token are per-run.
+        const runId = crypto.randomUUID();
+        const token = `stalled-load-${runId}`;
+        const blockedImageURL = await server.createEcho("GET", `/stalled-load-image-${runId}`, {
+            status: 404,
+            headers: { "Cache-Control": "no-store" },
+            body: "",
+            wait_for_unblock: token,
+        });
+        const firstURL = await server.createEcho("GET", `/stalled-load-first-${runId}`, {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: "<!DOCTYPE html><p>first</p>",
+        });
+        const secondURL = await server.createEcho("GET", `/stalled-load-second-${runId}`, {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: `<!DOCTYPE html>
+                <img src="${blockedImageURL}">
+                <script>
+                    document.addEventListener("DOMContentLoaded", () => parent.postMessage("second document parsed", "*"));
+                <\/script>`,
+        });
+
+        const iframe = document.createElement("iframe");
+        document.body.append(iframe);
+
+        // The first document is recorded in a nested function, so that it doesn't linger in a register of this
+        // function's frame while it's expected to be collected.
+        const weakFirstDocument = await (async () => {
+            await new Promise(resolve => {
+                iframe.addEventListener("load", resolve, { once: true });
+                iframe.src = firstURL;
+            });
+            return new WeakRef(iframe.contentDocument);
+        })();
+
+        // The second document's body has been read to its end once DOMContentLoaded fires in it, while its load event
+        // still waits on the blocked image.
+        await new Promise(resolve => {
+            window.addEventListener("message", resolve, { once: true });
+            iframe.src = secondURL;
+        });
+
+        const maximumGcRoundsWhileRequestTeardownTasksDrain = 100;
+        for (let round = 0; round < maximumGcRoundsWhileRequestTeardownTasksDrain; ++round) {
+            await timeout(0);
+            await internals.gcAsync();
+            if (weakFirstDocument.deref() === undefined)
+                break;
+        }
+        println(`first document collected while the second load is stalled: ${weakFirstDocument.deref() === undefined}`);
+
+        // Let the second load finish, so the test ends with the iframe settled.
+        const secondLoaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        await fetch(new URL(`/unblock/${token}`, blockedImageURL));
+        await secondLoaded;
+        iframe.remove();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable-while-next-load-is-stalled.html.headers
+++ b/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable-while-next-load-is-stalled.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable.html
+++ b/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // A navigation fetches its response with a transfer lease, so that the UI process can adopt the response — and a
+    // small document's fetch finishes before that adoption. The fetch's network request belongs to the document that
+    // started the navigation — and has to be torn down once the response is transferred. Otherwise its callbacks keep
+    // that document's realm rooted for good — and every navigation pins the document it replaced.
+    promiseTest(async () => {
+        const server = httpTestServer();
+        const url = await server.createEcho("GET", "/replaced-document-is-collectable", {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: "<!DOCTYPE html><p>replaced</p>",
+        });
+
+        const iframe = document.createElement("iframe");
+        document.body.append(iframe);
+
+        const navigate = url =>
+            new Promise(resolve => {
+                iframe.addEventListener("load", resolve, { once: true });
+                iframe.src = url;
+            });
+
+        // Record each document, then navigate away from it. The recording runs in a nested function — so that no
+        // document lingers in a register of this function's frame while the documents are expected to be collected.
+        const weakDocuments = await (async () => {
+            const weakDocuments = [];
+            await navigate(`${url}?0`);
+            for (let i = 1; i <= 5; i++) {
+                weakDocuments.push(new WeakRef(iframe.contentDocument));
+                await navigate(`${url}?${i}`);
+            }
+            return weakDocuments;
+        })();
+
+        const maximumGcRoundsWhileRequestTeardownTasksDrain = 100;
+        for (let round = 0; round < maximumGcRoundsWhileRequestTeardownTasksDrain; ++round) {
+            await timeout(0);
+            await internals.gcAsync();
+            if (weakDocuments.every(weak => weak.deref() === undefined))
+                break;
+        }
+
+        const collected = weakDocuments.filter(weak => weak.deref() === undefined).length;
+        println(`collected ${collected} of ${weakDocuments.length} replaced documents`);
+        iframe.remove();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable.html.headers
+++ b/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/Tests/LibWebView/TestFileDownloader.cpp
+++ b/Tests/LibWebView/TestFileDownloader.cpp
@@ -14,6 +14,7 @@
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
+#include <LibCore/Timer.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibMain/Main.h>
 #include <LibRequests/Request.h>
@@ -427,6 +428,71 @@ void expect_request_can_be_released_from_finish_callback(TestHttpServer& server,
     VERIFY(delivered_size == expected_body_size);
 }
 
+void expect_leased_request_is_torn_down_when_transferred_after_finishing(TestHttpServer& server, size_t expected_body_size)
+{
+    auto& request_client = WebView::Application::request_server_client();
+
+    auto url = URL::Parser::basic_parse(ByteString::formatted("http://127.0.0.1:{}/file", server.port()));
+    VERIFY(url.has_value());
+
+    auto request = request_client.start_request("GET"sv, *url, {}, {}, HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials::Yes, {}, Requests::RequestClient::TransferLease::Yes);
+    VERIFY(request);
+
+    bool finished = false;
+    bool stopped = false;
+
+    request->set_body_delivery_paused(true);
+    request->set_unbuffered_request_callbacks(
+        [](NonnullRefPtr<HTTP::HeaderList>, Optional<u32>, Optional<String> const&, Optional<Core::ImmutableBytes>, Optional<u64>, Requests::CameFromCache) {
+        },
+        [](Requests::ResponseData) {
+        },
+        [](Core::ImmutableBytes) {
+        },
+        [&](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError>) {
+            finished = true;
+        });
+    request->set_stop_callback([&] {
+        stopped = true;
+    });
+
+    // Let RequestServer finish the request while its body stays paused. That's the state every navigation to a small or
+    // cached document is in by the time the UI process adopts its response.
+    Core::EventLoop::current().spin_until([&] { return request->is_finished(); });
+    VERIFY(!finished);
+
+    // Adopting the finished request transfers it away from its original owner — which has to be told to let go of it.
+    auto adopted_request = request_client.adopt_request(request_client.request_server_client_id(), request->id());
+    VERIFY(adopted_request);
+
+    size_t delivered_size = 0;
+    bool adopted_request_finished = false;
+
+    adopted_request->set_unbuffered_request_callbacks(
+        [](NonnullRefPtr<HTTP::HeaderList>, Optional<u32>, Optional<String> const&, Optional<Core::ImmutableBytes>, Optional<u64>, Requests::CameFromCache) {
+        },
+        [&](Requests::ResponseData data) {
+            delivered_size += data.bytes().size();
+        },
+        [](Core::ImmutableBytes) {
+        },
+        [&](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError>) {
+            adopted_request_finished = true;
+        });
+
+    bool timed_out = false;
+    auto timeout = Core::Timer::create_single_shot(10'000, [&] {
+        timed_out = true;
+    });
+    timeout->start();
+
+    // The transfer stops the original request, and drops the client's reference to it — so, this one is the last.
+    Core::EventLoop::current().spin_until([&] { return (stopped && adopted_request_finished && request->ref_count() == 1) || timed_out; });
+    VERIFY(!timed_out);
+    VERIFY(!finished);
+    VERIFY(delivered_size == expected_body_size);
+}
+
 }
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
@@ -453,6 +519,14 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
         expect_request_can_be_released_from_finish_callback(server, response_body.size());
         outln("release request from finish callback");
+    }
+
+    {
+        auto response_body = make_body(4 * KiB);
+        TestHttpServer server { response_body, RangeSupport::No };
+
+        expect_leased_request_is_torn_down_when_transferred_after_finishing(server, response_body.size());
+        outln("leased request torn down when transferred after finishing");
     }
 
     auto body = make_body(12 * MiB);


### PR DESCRIPTION
Any page that periodically reloads itself, or navigates in place, leaked every document it replaced: Every reload kept the whole previous document alive — its DOM, its ad canvases, its timers, its iframes. After 5 hours in a background tab, one such page held 13 GB, GC reclaimed none of it, and marking that heap ate most of the tab’s CPU. And navigating away from any page didn’t free it until the new page finished loading — which a page with a never-completing resource (e.g. a never-arriving ad image) never does.

So, two fixes here — both modeled on how Gecko, WebKit, and Blink avoid the same leak:

- **A navigation’s request, leased so that the UI process can adopt its response, now stays registered after it finishes** — just as RequestServer keeps it alive after completion — so the `request_transferred` that resolves the lease finds it and tears it down, releasing the GC roots that pinned the previous document.

   That’s how Gecko and WebKit work: The process a navigation response is taken away from keeps its state for it until the one notification telling it to let go. Chromium’s browser process likewise drops the loader it hands over at that handoff and nowhere else.
   
- And **the new document’s parser now drops the response body (whose stream lives in the previous document’s realm) as soon as it has read it all,** while staying attached to the document until its load event.

   That matches Blink, WebKit, and Gecko — which all release the main resource’s body loader the moment the body finishes, and keep the document’s parser until the load event.
