### PR TITLE
LibWeb: Skip unnecessary node insertion and removal work

### DIFF
--- a/Libraries/LibWeb/CSS/Invalidation/LanguageInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/LanguageInvalidator.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/CSS/PseudoClass.h>
 #include <LibWeb/CSS/StyleEngineInput.h>
 #include <LibWeb/CSS/StyleScope.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/PseudoElement.h>
 #include <LibWeb/DOM/ShadowRoot.h>
@@ -94,6 +95,9 @@ void invalidate_style_after_slot_assignment_change(HTML::HTMLSlotElement& slot)
 // resolves to, for its whole subtree, because a directionality inherits.
 void invalidate_style_after_text_change_under(DOM::Element& parent_of_text)
 {
+    if (!parent_of_text.document().has_element_with_auto_directionality())
+        return;
+
     bool ancestor_chain_has_assigned_slot = false;
     for (auto ancestor = GC::Ptr<DOM::Element> { parent_of_text }; ancestor; ancestor = ancestor->parent_element()) {
         if (ancestor->assigned_slot_internal()) {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -118,6 +118,8 @@
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/InputEventsTarget.h>
 #include <LibWeb/DOM/LiveNodeList.h>
+#include <LibWeb/DOM/MutationObserver.h>
+#include <LibWeb/DOM/MutationType.h>
 #include <LibWeb/DOM/NodeIterator.h>
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/DOM/ProcessingInstruction.h>
@@ -1344,6 +1346,27 @@ void Document::set_dir(Utf16View dir)
     // attribute must return the empty string and do nothing on setting.
     if (auto html = html_element())
         html->set_dir(dir);
+}
+
+void Document::add_mutation_observer_types(MutationObserverOptions const& options)
+{
+    if (options.child_list)
+        m_mutation_observer_types |= to_underlying(MutationObserverType::ChildList);
+    if (options.attributes.value_or(false))
+        m_mutation_observer_types |= to_underlying(MutationObserverType::Attributes);
+    if (options.character_data.value_or(false))
+        m_mutation_observer_types |= to_underlying(MutationObserverType::CharacterData);
+}
+
+bool Document::has_mutation_observers_of_type(Utf16FlyString const& type) const
+{
+    if (type == MutationType::childList)
+        return m_mutation_observer_types & to_underlying(MutationObserverType::ChildList);
+    if (type == MutationType::attributes)
+        return m_mutation_observer_types & to_underlying(MutationObserverType::Attributes);
+    if (type == MutationType::characterData)
+        return m_mutation_observer_types & to_underlying(MutationObserverType::CharacterData);
+    return true;
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2
@@ -3698,6 +3721,11 @@ void Document::adopt_node_steps(Node& node)
         node.for_each_shadow_including_inclusive_descendant([&](DOM::Node& inclusive_descendant) {
             // 1. Set inclusiveDescendant’s node document to document.
             inclusive_descendant.set_document(Badge<Document> {}, *this);
+
+            if (auto const* registered_observers = inclusive_descendant.registered_observer_list()) {
+                for (auto const& registered_observer : *registered_observers)
+                    add_mutation_observer_types(registered_observer->options());
+            }
 
             // 2. If inclusiveDescendant is a shadow root and if any of the following are true:
             //    - inclusiveDescendant’s custom element registry is null and inclusiveDescendant’s keep custom element

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -76,6 +76,8 @@ class ImageStyleValueResource;
 
 namespace Web::DOM {
 
+struct MutationObserverOptions;
+
 enum class TemporaryDocumentForFragmentParsing : u8 {
     No,
     Yes,
@@ -276,6 +278,10 @@ public:
     void unregister_valid_html_collection_cache(HTMLCollectionAttributeInvalidationType) const;
     bool has_valid_html_collection_caches() const { return m_html_collection_attribute_invalidation_types != 0; }
     HTMLCollectionAttributeInvalidationTypes html_collection_attribute_invalidation_types_for_attribute(Utf16FlyString const& local_name, Optional<Utf16FlyString> const& namespace_) const;
+
+    // The record types any observer registered in this document has ever asked for. A type stays set.
+    void add_mutation_observer_types(MutationObserverOptions const&);
+    bool has_mutation_observers_of_type(Utf16FlyString const& type) const;
 
     // Everything a style input record cannot name by an identity of its own: the viewport moving,
     // a counter style arriving, or another untracked environment input changing. A record taken under one version
@@ -1928,6 +1934,13 @@ private:
     u64 m_option_selectedness_version { 0 };
     mutable Array<u64, to_underlying(HTMLCollectionAttributeInvalidationType::Count)> m_html_collection_attribute_invalidation_type_counts {};
     mutable HTMLCollectionAttributeInvalidationTypes m_html_collection_attribute_invalidation_types { 0 };
+
+    enum class MutationObserverType : u8 {
+        ChildList = 1 << 0,
+        Attributes = 1 << 1,
+        CharacterData = 1 << 2,
+    };
+    u8 m_mutation_observer_types { 0 };
     u64 m_style_environment_version { 0 };
     u64 m_next_counter_style_environment_identity { 1 };
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -612,6 +612,13 @@ public:
     bool needs_mathml_and_svg_user_agent_style_sheets() const { return m_needs_mathml_and_svg_user_agent_style_sheets; }
     void set_needs_mathml_and_svg_user_agent_style_sheets();
 
+    // Whether an element of the kind has ever connected. Neither is cleared, so a document that never
+    // held one can skip the removal-time bookkeeping that only such an element makes necessary.
+    bool has_element_with_auto_directionality() const { return m_has_element_with_auto_directionality; }
+    void set_has_element_with_auto_directionality() { m_has_element_with_auto_directionality = true; }
+    bool has_form_or_fieldset_element() const { return m_has_form_or_fieldset_element; }
+    void set_has_form_or_fieldset_element() { m_has_form_or_fieldset_element = true; }
+
     bool parser_cannot_change_the_mode() const { return m_parser_cannot_change_the_mode; }
     void set_parser_cannot_change_the_mode(bool parser_cannot_change_the_mode) { m_parser_cannot_change_the_mode = parser_cannot_change_the_mode; }
 
@@ -1625,6 +1632,8 @@ private:
     Optional<CSS::PreferredColorScheme> m_svg_image_color_scheme;
 
     bool m_needs_mathml_and_svg_user_agent_style_sheets { false };
+    bool m_has_element_with_auto_directionality { false };
+    bool m_has_form_or_fieldset_element { false };
 
     bool m_parser_cannot_change_the_mode { false };
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1085,7 +1085,7 @@ WebIDL::ExceptionOr<GC::Ref<Attr>> Element::remove_attribute_node(GC::Ref<Attr> 
 // https://dom.spec.whatwg.org/#dom-element-hasattribute
 bool Element::has_attribute(Utf16FlyString const& name) const
 {
-    return attribute(name).has_value();
+    return find_attribute_index(name).has_value();
 }
 
 // https://dom.spec.whatwg.org/#dom-element-hasattributens

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3197,6 +3197,8 @@ void Element::inserted()
         // building their rules.
         if (namespace_uri() == Namespace::MathML || namespace_uri() == Namespace::SVG)
             document().set_needs_mathml_and_svg_user_agent_style_sheets();
+        if (has_auto_directionality())
+            document().set_has_element_with_auto_directionality();
         if (m_id.has_value())
             document().element_with_id_was_added({}, *this);
         if (m_has_name)
@@ -4108,6 +4110,11 @@ void Element::exit_fullscreen_on_element_removal()
 {
     // 1. Let document be removedNode’s node document.
     auto& document = this->document();
+
+    // OPTIMIZATION: An element with its fullscreen flag set is in the top layer, so without a fullscreen element
+    //               the document holds no such element.
+    if (!document.fullscreen_element())
+        return;
 
     // 2. Let nodes be removedNode’s shadow-including inclusive descendants that have their fullscreen flag set, in
     //    shadow-including tree order.
@@ -6203,6 +6210,8 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
                 ensure_element_rare_data().dir = dir;
             else if (auto* rare_data = element_rare_data())
                 rare_data->dir = {};
+            if (is_connected() && has_auto_directionality())
+                document().set_has_element_with_auto_directionality();
         }
         if (is_dir)
             CSS::Invalidation::invalidate_style_after_directionality_change(*this);

--- a/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Bindings/MutationRecord.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/Bindings/WrapperWorld.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/MutationObserver.h>
 #include <LibWeb/DOM/Node.h>
@@ -122,6 +123,7 @@ WebIDL::ExceptionOr<void> MutationObserver::observe(Node& target, MutationObserv
 
             // 2. Set registered’s options to options.
             registered_observer->set_options(move(options));
+            target.document().add_mutation_observer_types(registered_observer->options());
             break;
         }
     }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2526,11 +2526,8 @@ Element* Node::parent_or_shadow_host_element()
 ParentNode* Node::flat_tree_parent()
 {
     // If we're assigned to a slot, that slot is our flat tree parent.
-    if (is_slottable()) {
-        auto& slottable = as_slottable().visit([](auto& node) -> SlottableMixin& { return *node; });
-        if (auto slot = slottable.assigned_slot())
-            return slot.ptr();
-    }
+    if (auto slot = assigned_slot_for_node(*this))
+        return slot.ptr();
 
     // Otherwise, this is the parent or shadow host.
     return parent_or_shadow_host();

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -3449,6 +3449,10 @@ void Node::queue_mutation_record(Utf16FlyString const& type, Optional<Utf16FlySt
     auto& document = this->document();
     auto& page = document.page();
 
+    // OPTIMIZATION: Without an observer of this type in the document, interestedObservers stays empty.
+    if (!document.has_mutation_observers_of_type(type) && !page.listen_for_dom_mutations())
+        return;
+
     // NOTE: We defer garbage collection until the end of the scope, since we can't safely use MutationObserver* as a hashmap key otherwise.
     // FIXME: This is a total hack.
     GC::DeferGC defer_gc(heap());
@@ -4135,6 +4139,7 @@ void Node::add_registered_observer(RegisteredObserver& registered_observer)
     if (!registered_observer_list)
         registered_observer_list = make<Vector<GC::Ref<RegisteredObserver>>>();
     registered_observer_list->append(registered_observer);
+    document().add_mutation_observer_types(registered_observer.options());
 }
 
 Vector<GC::Ref<RegisteredObserver>>* Node::registered_observer_list()

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2455,8 +2455,16 @@ void Node::moved_from(IsSubtreeRoot, GC::Ptr<Node>)
 
 static bool is_root_wheel_event_target(Node const& node)
 {
+    if (node.is_document())
+        return true;
+    if (!node.is_element())
+        return false;
     auto& document = node.document();
-    return &node == &document || &node == document.document_element() || &node == document.body();
+    if (&node == document.document_element())
+        return true;
+    if (!node.is_html_body_element() && !node.is_html_frameset_element())
+        return false;
+    return &node == document.body();
 }
 
 bool Node::update_inside_blocking_wheel_event_handler_state()

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -26,10 +26,8 @@ HTMLButtonElement::HTMLButtonElement(DOM::Document& document, DOM::QualifiedName
 
 HTMLButtonElement::~HTMLButtonElement() = default;
 
-HTMLButtonElement::TypeAttributeState HTMLButtonElement::type_state() const
+HTMLButtonElement::TypeAttributeState HTMLButtonElement::parse_type_attribute(Optional<Utf16String> const& value)
 {
-    auto value = attribute(HTML::AttributeNames::type);
-
     if (value.has_value() && value->equals_ignoring_ascii_case(u"submit"sv))
         return HTMLButtonElement::TypeAttributeState::Submit;
     if (value.has_value() && value->equals_ignoring_ascii_case(u"reset"sv))
@@ -83,6 +81,9 @@ void HTMLButtonElement::set_type_for_bindings(Utf16View type)
 void HTMLButtonElement::form_associated_element_attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const&, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_)
 {
     PopoverTargetAttributes::associated_attribute_changed(name, value, namespace_);
+
+    if (name == AttributeNames::type && !namespace_.has_value())
+        m_type_state = parse_type_attribute(value);
 
     if (name.is_one_of(AttributeNames::type, AttributeNames::command, AttributeNames::commandfor)) {
         submit_button_state_changed();

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -33,7 +33,7 @@ public:
 #undef __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE
     };
 
-    TypeAttributeState type_state() const;
+    TypeAttributeState type_state() const { return m_type_state; }
     Utf16FlyString type_for_bindings() const;
     void set_type_for_bindings(Utf16View);
 
@@ -97,6 +97,9 @@ private:
     // ^DOM::Element
     virtual i32 default_tab_index_value() const override;
 
+    static TypeAttributeState parse_type_attribute(Optional<Utf16String> const&);
+
+    TypeAttributeState m_type_state { TypeAttributeState::Auto };
     GC::Ptr<DOM::Element> m_command_for_element;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -2213,7 +2213,7 @@ void HTMLElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor
 
         // The control took its constraints out of the form and fieldsets it was under, and they
         // answer for `:valid`/`:invalid` on behalf of what is left.
-        if (old_ancestor)
+        if (old_ancestor && document().has_form_or_fieldset_element())
             CSS::Invalidation::invalidate_style_after_form_control_left(*old_ancestor);
     }
 

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGC/Heap.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLButtonElement.h>
 #include <LibWeb/HTML/HTMLFieldSetElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
@@ -50,6 +51,14 @@ bool HTMLFieldSetElement::is_disabled() const
     }
 
     return false;
+}
+
+void HTMLFieldSetElement::inserted()
+{
+    Base::inserted();
+
+    if (is_connected())
+        document().set_has_form_or_fieldset_element();
 }
 
 void HTMLFieldSetElement::attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_)

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -49,6 +49,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(Utf16FlyString const&, Optional<Utf16String> const&, Optional<Utf16String> const&, Optional<Utf16FlyString> const&) override;
+    virtual void inserted() override;
 
     virtual bool is_html_fieldset_element() const override { return true; }
 

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -79,6 +79,9 @@ void HTMLFormElement::inserted()
 {
     Base::inserted();
 
+    if (is_connected())
+        document().set_has_form_or_fieldset_element();
+
     auto* default_button = this->default_button();
     m_default_button_for_style_invalidation = default_button ? &default_button->form_associated_element_to_html_element() : nullptr;
     m_default_button_for_style_invalidation_initialized = true;

--- a/Tests/LibWeb/Text/expected/css/container-query-for-element-slotted-into-closed-shadow-root.txt
+++ b/Tests/LibWeb/Text/expected/css/container-query-for-element-slotted-into-closed-shadow-root.txt
@@ -1,0 +1,4 @@
+open shadow root: slotted color rgb(0, 128, 0)
+open shadow root: slotted checkVisibility({ opacityProperty: true }) false
+closed shadow root: slotted color rgb(0, 128, 0)
+closed shadow root: slotted checkVisibility({ opacityProperty: true }) false

--- a/Tests/LibWeb/Text/input/css/container-query-for-element-slotted-into-closed-shadow-root.html
+++ b/Tests/LibWeb/Text/input/css/container-query-for-element-slotted-into-closed-shadow-root.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .slotted {
+        color: black;
+    }
+
+    @container slot-container (min-width: 100px) {
+        .slotted {
+            color: green;
+        }
+    }
+</style>
+<div id="open-host"><span class="slotted" id="open-slotted">open</span></div>
+<div id="closed-host"><span class="slotted" id="closed-slotted">closed</span></div>
+<script>
+    test(() => {
+        for (const mode of ["open", "closed"]) {
+            const host = document.getElementById(`${mode}-host`);
+            const shadowRoot = host.attachShadow({ mode });
+            shadowRoot.innerHTML = `
+                <div style="container: slot-container / inline-size; width: 200px; opacity: 0">
+                    <slot></slot>
+                </div>`;
+            const slotted = document.getElementById(`${mode}-slotted`);
+            println(`${mode} shadow root: slotted color ${getComputedStyle(slotted).color}`);
+            println(`${mode} shadow root: slotted checkVisibility({ opacityProperty: true }) ${slotted.checkVisibility({ opacityProperty: true })}`);
+        }
+    });
+</script>


### PR DESCRIPTION
These commits improve the performance of DOM node insertion and removal by avoiding repeated work or skipping provably unnecessary work.

The first commit is also a behavior change: elements slotted into a closed shadow root now see the slot's ancestors for container queries, `checkVisibility()` and `:hover`/`:focus-within` propagation, matching other engines.

See individual commits for details.

Benchmark results:

| Benchmark | Old score | New score | Score change | Old time (s) | New time (s) | Speedup |
|---|---|---|---|---|---|---|
| Speedometer 2 | 78.73 ± 0.56 | 79.24 ± 0.58 | +0.65% | 6.568 ± 0.029 | 6.545 ± 0.030 | 1.003× |
| Speedometer 3 | 5.16 ± 0.05 | 5.23 ± 0.05 | +1.36% | 4.911 ± 0.070 | 4.833 ± 0.065 | 1.016× |