### PR TITLE
LibWeb: Fix flex alignment and animations after display changes

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1199,6 +1199,16 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
     return true;
 }
 
+static bool is_in_display_none_subtree_ignoring_animations(DOM::AbstractElement abstract_element)
+{
+    if (abstract_element.pseudo_element().has_value()) {
+        auto pseudo_style = abstract_element.computed_style();
+        if (pseudo_style && pseudo_style->base_values().display().is_none())
+            return true;
+    }
+    return abstract_element.element().has_inclusive_ancestor_with_display_none_ignoring_animations();
+}
+
 void KeyframeEffect::update_computed_properties(AnimationUpdateContext& context)
 {
     auto target = this->target();
@@ -1207,12 +1217,12 @@ void KeyframeEffect::update_computed_properties(AnimationUpdateContext& context)
 
     // An effect that animates `display` can be the very thing holding its `display: none` target visible, and
     // the update being skipped is the one that applies or removes that override, so it must always run.
-    if (!target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Display))) {
-        auto style_record = target->style_record_identity();
-        auto dependency_flags = target->document().style_computer().style_engine().style_record_dependency_flags(style_record);
-        if (dependency_flags & to_underlying(CSS::StyleRecordDependencyFlag::InDisplayNoneSubtree))
-            return;
-    }
+    // NB: A descendant's retained style can still describe a display-none subtree while ancestor visibility
+    //     reactions are propagating, so inspect the current target and ancestor styles before skipping its update.
+    DOM::AbstractElement abstract_element { *target, pseudo_element_type() };
+    if (!target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Display))
+        && is_in_display_none_subtree_ignoring_animations(abstract_element))
+        return;
 
     target->update_animated_properties({}, pseudo_element_type(), *this, context);
 }

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -1789,8 +1789,10 @@ impl<'pass> FlexFormattingContext<'pass> {
 
     // https://drafts.csswg.org/css-flexbox-1/#algo-line-stretch
     fn handle_align_content_stretch(&mut self) {
-        // If the flex container has a definite cross size,
-        if !self.has_definite_cross_size_used(&self.container_used())
+        // If the flex container has a definite cross size, or its automatic
+        // cross size is increased by a minimum cross size,
+        if (!self.has_definite_cross_size_used(&self.container_used())
+            && self.computed_cross_min_size(self.flex_container).0.is_auto())
             // align-content is stretch,
             || !matches!(
                 self.style(self.flex_container).align_content(),

--- a/Tests/LibWeb/Ref/expected/flex/min-height-align-items-center-ref.html
+++ b/Tests/LibWeb/Ref/expected/flex/min-height-align-items-center-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+    .container {
+        align-items: center;
+        background: red;
+        display: flex;
+        height: 400px;
+    }
+
+    .item {
+        background: blue;
+        flex-basis: calc((100% - 16px) / 2);
+        height: 100px;
+    }
+</style>
+<div class="container">
+    <div class="item"></div>
+    <div class="item"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/flex/min-height-align-items-center.html
+++ b/Tests/LibWeb/Ref/input/flex/min-height-align-items-center.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/flex/min-height-align-items-center-ref.html" />
+<style>
+    .container {
+        align-items: center;
+        background: red;
+        display: flex;
+        flex-wrap: wrap;
+        min-height: 400px;
+    }
+
+    .item {
+        background: blue;
+        flex-basis: calc((100% - 16px) / 2);
+        height: 100px;
+    }
+</style>
+<div class="container">
+    <div class="item"></div>
+    <div class="item"></div>
+</div>

--- a/Tests/LibWeb/Text/expected/css/animation-display-none-pseudo-element.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-display-none-pseudo-element.txt
@@ -1,0 +1,2 @@
+pseudo-element is hidden: true
+hidden pseudo-element skips animation sampling: true

--- a/Tests/LibWeb/Text/expected/css/animation-revealed-from-display-none.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-revealed-from-display-none.txt
@@ -1,0 +1,2 @@
+visible descendant samples its animation: true
+animation restores the base opacity: true

--- a/Tests/LibWeb/Text/expected/css/finite-compositor-animation-completion.txt
+++ b/Tests/LibWeb/Text/expected/css/finite-compositor-animation-completion.txt
@@ -6,4 +6,5 @@ finite effects request one end frame: true
 wake-up timer leaves animation updates to frames: true
 forwards fill retains opacity: true
 no fill restores transform: true
+no fill restores opacity: true
 terminal values remain stable: true

--- a/Tests/LibWeb/Text/input/css/animation-display-none-pseudo-element.html
+++ b/Tests/LibWeb/Text/input/css/animation-display-none-pseudo-element.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #target::before {
+        content: "";
+        display: none;
+        opacity: 0.3;
+    }
+</style>
+<div id="target"></div>
+<script>
+    asyncTest(async done => {
+        const target = document.querySelector("#target");
+        println(`pseudo-element is hidden: ${getComputedStyle(target, "::before").display === "none"}`);
+        internals.resetStyleInvalidationCounters();
+        const animation = target.animate({ opacity: [0, 1] }, { duration: 1000, pseudoElement: "::before" });
+        animation.pause();
+        animation.currentTime = 500;
+        await new Promise(requestAnimationFrame);
+
+        println(`hidden pseudo-element skips animation sampling: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animation-revealed-from-display-none.html
+++ b/Tests/LibWeb/Text/input/css/animation-revealed-from-display-none.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #parent {
+        display: none;
+    }
+
+    #child {
+        width: 100px;
+        height: 100px;
+        opacity: 0.3;
+    }
+</style>
+<div id="parent"><div><div><div><div id="child"></div></div></div></div></div>
+<script>
+    asyncTest(async done => {
+        const parentElement = document.querySelector("#parent");
+        const childElement = document.querySelector("#child");
+        getComputedStyle(childElement).opacity;
+        parentElement.style.display = "block";
+        const animation = childElement.animate({ opacity: [0, 1] }, 1000);
+        animation.pause();
+        animation.currentTime = 500;
+        await new Promise(requestAnimationFrame);
+
+        println(`visible descendant samples its animation: ${getComputedStyle(childElement).opacity === "0.5"}`);
+        animation.finish();
+        await animation.finished;
+        await new Promise(requestAnimationFrame);
+        println(`animation restores the base opacity: ${getComputedStyle(childElement).opacity === "0.3"}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/finite-compositor-animation-completion.html
+++ b/Tests/LibWeb/Text/input/css/finite-compositor-animation-completion.html
@@ -20,9 +20,15 @@
         transform: translateX(7px);
         animation: finite-transform 300ms linear none;
     }
+
+    #opacity-without-fill {
+        opacity: 0.3;
+        animation: finite-opacity 300ms linear none;
+    }
 </style>
 <div id="opacity"></div>
 <div id="transform"></div>
+<div id="opacity-without-fill"></div>
 <script>
     asyncTest(async done => {
         let animationEndEvents = 0;
@@ -37,23 +43,25 @@
 
         await new Promise(requestAnimationFrame);
         await new Promise(requestAnimationFrame);
-        const animations = [...opacity.getAnimations(), ...transform.getAnimations()];
-        println(`finite effects use the compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 2}`);
+        const opacityWithoutFill = document.querySelector("#opacity-without-fill");
+        const animations = [...opacity.getAnimations(), ...transform.getAnimations(), ...opacityWithoutFill.getAnimations()];
+        println(`finite effects use the compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 3}`);
 
         internals.resetStyleInvalidationCounters();
         let finishedPromises = 0;
         await Promise.all(animations.map(animation => animation.finished.then(() => ++finishedPromises)));
         await new Promise(requestAnimationFrame);
 
-        println(`finished promises resolve: ${finishedPromises === 2}`);
+        println(`finished promises resolve: ${finishedPromises === 3}`);
         println(`animationend events fire: ${animationEndEvents === 2}`);
         println(`animationend sees terminal style: ${eventHandlerSawTerminalStyle}`);
         println(`finite effects request one end frame: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 1}`);
         println(`wake-up timer leaves animation updates to frames: ${animationUpdatesAtEndEvent === 2}`);
         println(`forwards fill retains opacity: ${getComputedStyle(opacity).opacity === "0.8"}`);
         println(`no fill restores transform: ${getComputedStyle(transform).transform === "matrix(1, 0, 0, 1, 7, 0)"}`);
+        println(`no fill restores opacity: ${getComputedStyle(opacityWithoutFill).opacity === "0.3"}`);
         await Promise.resolve();
-        println(`terminal values remain stable: ${getComputedStyle(opacity).opacity === "0.8" && getComputedStyle(transform).transform === "matrix(1, 0, 0, 1, 7, 0)"}`);
+        println(`terminal values remain stable: ${getComputedStyle(opacity).opacity === "0.8" && getComputedStyle(transform).transform === "matrix(1, 0, 0, 1, 7, 0)" && getComputedStyle(opacityWithoutFill).opacity === "0.3"}`);
         done();
     });
 </script>


### PR DESCRIPTION
Fix two rendering issues exposed by Azure pages. Flex lines now honor a container’s used minimum height when resolving cross-axis stretch, so `align-items: center` positions content against the final size.

Animation sampling now checks current ancestor styles instead of a stale `InDisplayNoneSubtree` flag. This allows descendants revealed from `display: none` to retain the correct style when compositor animations finish.

Add coverage for minimum-height flex alignment, animation sampling after hidden ancestors become visible, and opacity restoration after finite compositor animations without fill.

| Before | After |
| --- | ---- |
| <img width="1242" height="851" alt="Screenshot 2026-09-08 at 10 37 51" src="https://github.com/user-attachments/assets/209dce76-67b9-476b-9f99-992e81cc4b5f" /> | <img width="1255" height="851" alt="Screenshot 2026-09-08 at 13 02 13" src="https://github.com/user-attachments/assets/4de7b8e1-9d45-41bd-a5f0-3ad5c145bb2b" /> |

| Before | After |
| --- | ---- |
| <img width="1242" height="950" alt="Screenshot 2026-09-08 at 11 31 15" src="https://github.com/user-attachments/assets/22a6301c-7176-41c4-8f4c-d1910ab93abd" /> | <img width="1255" height="851" alt="Screenshot 2026-09-08 at 13 02 25" src="https://github.com/user-attachments/assets/4da3bd2e-5a72-46bc-a8d7-bc31dcca1870" /> |
