### PR TITLE
LibWeb: Rebuild child session history on reload

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -983,6 +983,12 @@ void LocalNavigable::continue_navigation_at_population(NavigationPopulationReque
 
 void LocalNavigable::prepare_child_navigable_history_reconstruction(SessionHistoryDocumentStateDescriptor const& document_state_descriptor)
 {
+    // INTEROP: Reloading rebuilds child frames from the new document instead of restoring their previous entries.
+    if (document_state_descriptor.reload_pending) {
+        set_child_navigable_history_reconstruction_ids({});
+        return;
+    }
+
     Vector<Optional<CrossProcessId>> child_navigable_ids;
     child_navigable_ids.ensure_capacity(document_state_descriptor.nested_histories.size());
     for (auto const& nested_history : document_state_descriptor.nested_histories)

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -1346,6 +1346,17 @@ void CanonicalTraversable::send_changing_navigable_continuation_task(HistoryOper
     VERIFY(pending_job.has_value());
     VERIFY(pending_job.value()->continuation.has_value());
 
+    auto const& target_entry = pending_job.value()->job.target_entry;
+    if (unload_displayed_document == Web::HTML::UnloadDisplayedDocument::Yes && target_entry.document_state.reload_pending) {
+        // INTEROP: Reloading rebuilds the child history tree from the replacement document, as in WebKit.
+        //          Keep the old entries until population succeeds so an abandoned reload preserves them.
+        auto navigable = find(navigable_id);
+        if (navigable.has_value()) {
+            for (auto const& nested_history : target_entry.document_state.nested_histories)
+                remove_nested_history(*navigable, target_entry.document_state.id, nested_history.id);
+        }
+    }
+
     auto continuation = *pending_job.value()->continuation;
     endpoint->client->async_apply_changing_navigable_continuation(
         endpoint->page_id, operation.operation_id, navigable_id,

--- a/Tests/LibWeb/Text/data/reload-document-written-iframe.html
+++ b/Tests/LibWeb/Text/data/reload-document-written-iframe.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reload a document-written iframe</title>
+<body>Outer page
+<p>Reload twice. The iframe should keep displaying "Editor".</p>
+<script>
+    if (window === top || window.frameElement?.id !== "editor") {
+        const editor = document.createElement("iframe");
+        editor.id = "editor";
+        editor.src = "javascript:false";
+        document.body.append(editor);
+        editor.contentDocument.open();
+        editor.contentDocument.write("<!DOCTYPE html><body contenteditable>Editor</body>");
+        editor.contentDocument.close();
+        addEventListener("load", () => {
+            parent.postMessage(editor.contentDocument.body.firstChild.textContent.trim(), "*");
+        }, { once: true });
+        addEventListener("message", event => {
+            if (event.source === parent && event.data === "reload")
+                location.reload();
+        });
+    }
+</script>

--- a/Tests/LibWeb/Text/expected/navigation/reload-document-written-iframe.txt
+++ b/Tests/LibWeb/Text/expected/navigation/reload-document-written-iframe.txt
@@ -1,0 +1,4 @@
+Initial load: Editor
+Reload: Editor
+Reload: Editor
+Child histories after reload: 1

--- a/Tests/LibWeb/Text/input/navigation/reload-document-written-iframe.html
+++ b/Tests/LibWeb/Text/input/navigation/reload-document-written-iframe.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const frame = document.createElement("iframe");
+        let loads = 0;
+        window.addEventListener("message", event => {
+            if (event.source !== frame.contentWindow)
+                return;
+            println(`${loads === 0 ? "Initial load" : "Reload"}: ${event.data}`);
+            if (++loads < 3) {
+                frame.contentWindow.postMessage("reload", "*");
+            } else {
+                const history = JSON.parse(internals.dumpUIProcessSessionHistory());
+                const entry = history.entries.find(entry => entry.current);
+                const childHistory = entry.nestedHistories[0].entries[0];
+                println(`Child histories after reload: ${childHistory.nestedHistories.length}`);
+                frame.remove();
+                done();
+            }
+        });
+        frame.src = "../../data/reload-document-written-iframe.html";
+        document.body.append(frame);
+    });
+</script>


### PR DESCRIPTION
Reloading a page could restore a document-written iframe from its old history URL, loading the containing page inside an editor. Do not adopt child history identities during reload, and discard the old child history tree once the replacement document is ready to activate. Keep the old entries when reload does not produce a replacement document.

Add a standalone document-written editor test and check that repeated reloads preserve its contents without accumulating child histories.