### PR TITLE
LibWeb: Implement the font display timeline

### DIFF
--- a/Libraries/LibGfx/Font/Font.cpp
+++ b/Libraries/LibGfx/Font/Font.cpp
@@ -67,6 +67,13 @@ Font::Font(NonnullRefPtr<Typeface const> typeface, float point_width, float poin
 
 float Font::width(Utf16View const& view) const { return measure_text_width(view, *this); }
 
+NonnullRefPtr<Font> Font::invisible_variant() const
+{
+    auto font = adopt_ref(*new Font(m_typeface, m_point_width, m_point_height, m_font_variation_settings, m_shape_features));
+    font->m_is_invisible = true;
+    return font;
+}
+
 NonnullRefPtr<Font> Font::with_size(float point_size) const
 {
     if (point_size == m_point_height && point_size == m_point_width)

--- a/Libraries/LibGfx/Font/Font.h
+++ b/Libraries/LibGfx/Font/Font.h
@@ -82,6 +82,8 @@ public:
     FlyString const& family() const { return m_typeface->family(); }
 
     NonnullRefPtr<Font> with_size(float point_size) const;
+    NonnullRefPtr<Font> invisible_variant() const;
+    bool is_invisible() const { return m_is_invisible; }
 
     Typeface const& typeface() const { return m_typeface; }
 
@@ -95,6 +97,7 @@ public:
     bool is_emoji_font() const;
 
 private:
+    bool m_is_invisible { false };
     u64 m_id { 0 };
 
 #if defined(USE_FONTCONFIG)

--- a/Libraries/LibGfx/FontCascadeList.cpp
+++ b/Libraries/LibGfx/FontCascadeList.cpp
@@ -51,8 +51,9 @@ void FontCascadeList::add(NonnullRefPtr<Font const> font, Vector<UnicodeRange> u
         } });
 }
 
-void FontCascadeList::add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<void()> start_load)
+void FontCascadeList::add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<PendingFontState()> resolve)
 {
+    m_ascii_cache.fill(nullptr);
     if (unicode_ranges.is_empty())
         return;
 
@@ -63,17 +64,16 @@ void FontCascadeList::add_pending_face(Vector<UnicodeRange> unicode_ranges, Func
         highest_code_point = max(highest_code_point, range.max_code_point());
     }
 
-    m_pending_faces.append(adopt_ref(*new PendingFace(
-        UnicodeRange { lowest_code_point, highest_code_point },
-        move(unicode_ranges),
-        move(start_load))));
+    m_pending_faces.append({ m_fonts.size(), adopt_ref(*new PendingFace(UnicodeRange { lowest_code_point, highest_code_point }, move(unicode_ranges), move(resolve))) });
 }
 
 void FontCascadeList::extend(FontCascadeList const& other)
 {
+    m_ascii_cache.fill(nullptr);
     m_first_available_font_cache = nullptr;
+    for (auto const& pending : other.m_pending_faces)
+        m_pending_faces.append({ m_fonts.size() + pending.font_index, pending.face });
     m_fonts.extend(other.m_fonts);
-    m_pending_faces.extend(other.m_pending_faces);
 }
 
 void FontCascadeList::extend_fallback(FontCascadeList const& other)
@@ -115,28 +115,24 @@ Gfx::Font const& FontCascadeList::first_available_font() const
 
 Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, EmojiPresentationResult emoji_presentation) const
 {
-    // Walk pending entries first: if this codepoint falls in an unloaded face's unicode-range we kick off the fetch
-    // and drop the entry — a fallback font that happens to cover the codepoint shouldn't prevent the real face from
-    // loading. FontComputer::clear_computed_font_cache() rebuilds the cascade once the fetch completes, so later
-    // shapes pick up the loaded face. Run before the ASCII cache lookup so a previously-cached codepoint still
-    // triggers a newly-added face.
-    m_pending_faces.remove_all_matching([code_point](auto const& pending) {
-        if (!pending->covers(code_point))
-            return false;
-        pending->start_load();
-        return true;
-    });
-
     auto use_ascii_cache = code_point < m_ascii_cache.size() && emoji_presentation.presentation == EmojiPresentation::Text && emoji_presentation.forced == ForcedPresentation::No;
     if (use_ascii_cache) {
         if (auto const* cached = m_ascii_cache[code_point])
             return *cached;
     }
 
+    bool invisible = false;
     auto cache_and_return = [&](Font const& font) -> Font const& {
+        auto const* selected_font = &font;
+        if (invisible) {
+            // https://drafts.csswg.org/css-fonts-4/#invisible-fallback
+            // Create an anonymous font face with the same metrics as the selected font face
+            // but with all glyphs "invisible" (containing no "ink"), and use that for rendering text.
+            selected_font = m_invisible_fonts.ensure(&font, [&] { return font.invisible_variant(); }).ptr();
+        }
         if (use_ascii_cache)
-            m_ascii_cache[code_point] = &font;
-        return font;
+            m_ascii_cache[code_point] = selected_font;
+        return *selected_font;
     };
 
     auto presentation_matches = [wants_emoji = emoji_presentation.presentation == EmojiPresentation::Emoji](Font const& font) {
@@ -155,8 +151,28 @@ Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, EmojiPrese
         return false;
     };
 
+    size_t pending_index = 0;
+    bool rendering_with_fallback = false;
+    auto resolve_pending_faces = [&](size_t font_index) {
+        while (!rendering_with_fallback && pending_index < m_pending_faces.size()
+            && m_pending_faces[pending_index].font_index <= font_index) {
+            auto const& pending = m_pending_faces[pending_index++].face;
+            if (!pending->covers(code_point))
+                continue;
+            auto state = pending->resolve();
+            if (state == PendingFontState::Failed)
+                continue;
+            invisible = state == PendingFontState::Invisible;
+            // https://drafts.csswg.org/css-fonts-4/#font-display-timeline
+            // Doing this must not trigger loads of any of the fallback fonts.
+            rendering_with_fallback = true;
+        }
+    };
+
     Font const* author_glyph_match = nullptr;
-    for (auto const& entry : m_fonts) {
+    for (size_t font_index = 0; font_index < m_fonts.size(); ++font_index) {
+        resolve_pending_faces(font_index);
+        auto const& entry = m_fonts[font_index];
         if (!entry_contains_glyph(entry))
             continue;
         if (emoji_presentation.forced == ForcedPresentation::No || presentation_matches(*entry.font))
@@ -164,6 +180,8 @@ Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, EmojiPrese
         if (!author_glyph_match)
             author_glyph_match = entry.font.ptr();
     }
+
+    resolve_pending_faces(m_fonts.size());
 
     Font const* fallback_glyph_match = nullptr;
     for (auto const& entry : m_fallback_fonts) {
@@ -194,6 +212,8 @@ Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, EmojiPrese
 
 bool FontCascadeList::equals(FontCascadeList const& other) const
 {
+    if (!m_pending_faces.is_empty() || !other.m_pending_faces.is_empty())
+        return false;
     if (m_fonts.size() != other.m_fonts.size())
         return false;
     for (size_t i = 0; i < m_fonts.size(); ++i) {

--- a/Libraries/LibGfx/FontCascadeList.h
+++ b/Libraries/LibGfx/FontCascadeList.h
@@ -8,6 +8,7 @@
 
 #include <AK/Array.h>
 #include <AK/Function.h>
+#include <AK/HashMap.h>
 #include <AK/RefCounted.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/UnicodeRange.h>
@@ -30,6 +31,12 @@ struct EmojiPresentationResult {
 };
 
 EmojiPresentationResult emoji_presentation_for_code_point(u32 code_point, Optional<u32> next_code_point);
+
+enum class PendingFontState : u8 {
+    Invisible,
+    Visible,
+    Failed,
+};
 
 class FontCascadeList : public RefCounted<FontCascadeList> {
 public:
@@ -54,9 +61,8 @@ public:
     void add(NonnullRefPtr<Font const> font);
     void add(NonnullRefPtr<Font const> font, Vector<UnicodeRange> unicode_ranges);
 
-    // Register an unloaded face covering `unicode_ranges`. The cascade invokes
-    // `start_load` the first time a rendered codepoint falls within one of the ranges.
-    void add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<void()> start_load);
+    // Resolve a pending face only when it is selected for a rendered code point.
+    void add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<PendingFontState()> resolve);
 
     void extend(FontCascadeList const& other);
 
@@ -80,10 +86,10 @@ public:
 
     class PendingFace : public RefCounted<PendingFace> {
     public:
-        PendingFace(UnicodeRange enclosing, Vector<UnicodeRange> ranges, Function<void()> start_load)
+        PendingFace(UnicodeRange enclosing, Vector<UnicodeRange> ranges, Function<PendingFontState()> resolve)
             : m_enclosing_range(enclosing)
             , m_unicode_ranges(move(ranges))
-            , m_start_load(move(start_load))
+            , m_resolve(move(resolve))
         {
         }
 
@@ -98,12 +104,12 @@ public:
             return false;
         }
 
-        void start_load() { m_start_load(); }
+        PendingFontState resolve() const { return m_resolve(); }
 
     private:
         UnicodeRange m_enclosing_range;
         Vector<UnicodeRange> m_unicode_ranges;
-        Function<void()> m_start_load;
+        Function<PendingFontState()> m_resolve;
     };
 
     void set_last_resort_font(NonnullRefPtr<Font> font)
@@ -117,7 +123,12 @@ private:
     RefPtr<Font const> m_last_resort_font;
     mutable Vector<Entry> m_fonts;
     mutable Vector<Entry> m_fallback_fonts;
-    mutable Vector<NonnullRefPtr<PendingFace>> m_pending_faces;
+    struct PendingEntry {
+        size_t font_index;
+        NonnullRefPtr<PendingFace> face;
+    };
+    Vector<PendingEntry> m_pending_faces;
+    mutable HashMap<Font const*, NonnullRefPtr<Font>> m_invisible_fonts;
     SystemFontFallbackCallback m_system_font_fallback_callback;
 
     // OPTIMIZATION: Cache of resolved fonts for ASCII code points. Since m_fonts only grows and the cascade returns

--- a/Libraries/LibGfx/PathSkia.cpp
+++ b/Libraries/LibGfx/PathSkia.cpp
@@ -179,6 +179,8 @@ void PathImplSkia::cubic_bezier_curve_to(FloatPoint c1, FloatPoint c2, FloatPoin
 
 void PathImplSkia::glyph_run(GlyphRun const& glyph_run)
 {
+    if (glyph_run.font().is_invisible())
+        return;
     auto sk_font = glyph_run.font().skia_font(1);
     auto& path_builder = sk_path_builder();
     path_builder.setFillType(SkPathFillType::kWinding);
@@ -208,6 +210,8 @@ NonnullOwnPtr<PathImpl> PathImplSkia::place_glyph_runs_along(ReadonlySpan<Nonnul
 
     bool reached_end_of_path = false;
     for (auto const& glyph_run : glyph_runs) {
+        if (glyph_run->font().is_invisible())
+            continue;
         auto sk_font = glyph_run->font().skia_font(1);
         for (auto const& glyph : glyph_run->glyphs()) {
             SkScalar glyph_distance = offset + glyph.position.x();

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -122,6 +122,7 @@ public:
     void set_stop_callback(RequestStopped);
 
     Function<CertificateAndKey()> on_certificate_requested;
+    Function<void()> on_requires_network;
 
     void did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error);
     void did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, CameFromCache came_from_cache);

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -80,7 +80,7 @@ void RequestClient::die()
     }
 }
 
-RefPtr<Request> RequestClient::start_request(ByteString const& method, URL::URL const& url, Optional<HTTP::HeaderList const&> request_headers, ReadonlyBytes request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData const& proxy_data, TransferLease transfer_lease, Optional<u32> address_selection_hint)
+RefPtr<Request> RequestClient::start_request(ByteString const& method, URL::URL const& url, Optional<HTTP::HeaderList const&> request_headers, ReadonlyBytes request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData const& proxy_data, TransferLease transfer_lease, Optional<u32> address_selection_hint, CacheMissNotification cache_miss_notification)
 {
     auto request_id = m_next_request_id++;
     auto headers = request_headers.map([](auto const& headers) { return headers.headers().span(); }).value_or({});
@@ -88,7 +88,7 @@ RefPtr<Request> RequestClient::start_request(ByteString const& method, URL::URL 
     auto transfer_lease_key = transfer_lease == TransferLease::Yes
         ? Optional<RequestTransferLeaseKey> { { m_request_server_client_id, request_id } }
         : Optional<RequestTransferLeaseKey> {};
-    IPCProxy::async_start_request(request_id, method, url, headers, request_body, cache_mode, include_credentials, proxy_data, transfer_lease_key.has_value(), address_selection_hint);
+    IPCProxy::async_start_request(request_id, method, url, headers, request_body, cache_mode, include_credentials, proxy_data, transfer_lease_key.has_value(), address_selection_hint, cache_miss_notification == CacheMissNotification::Yes);
     auto request = Request::create_from_id({}, *this, request_id, move(transfer_lease_key));
     m_requests.set(request_id, request);
     return request;
@@ -200,6 +200,14 @@ void RequestClient::removed_cache_entries(u64 clear_cache_request_id)
 {
     if (auto promise = m_pending_clear_cache_requests.take(clear_cache_request_id); promise.has_value())
         (*promise)->resolve({});
+}
+
+void RequestClient::request_requires_network(u64 request_id)
+{
+    if (auto request = m_requests.get(request_id); request.has_value()) {
+        if ((*request)->on_requires_network)
+            (*request)->on_requires_network();
+    }
 }
 
 void RequestClient::request_started(u64 request_id, IPC::File response_file)

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -40,11 +40,16 @@ public:
         Yes,
     };
 
+    enum class CacheMissNotification {
+        No,
+        Yes,
+    };
+
     explicit RequestClient(NonnullOwnPtr<IPC::Transport>);
     virtual ~RequestClient() override;
 
     // Best-effort index into the resolved address pool.
-    RefPtr<Request> start_request(ByteString const& method, URL::URL const&, Optional<HTTP::HeaderList const&> request_headers = {}, ReadonlyBytes request_body = {}, HTTP::CacheMode = HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials = HTTP::Cookie::IncludeCredentials::Yes, Core::ProxyData const& = {}, TransferLease = TransferLease::No, Optional<u32> address_selection_hint = {});
+    RefPtr<Request> start_request(ByteString const& method, URL::URL const&, Optional<HTTP::HeaderList const&> request_headers = {}, ReadonlyBytes request_body = {}, HTTP::CacheMode = HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials = HTTP::Cookie::IncludeCredentials::Yes, Core::ProxyData const& = {}, TransferLease = TransferLease::No, Optional<u32> address_selection_hint = {}, CacheMissNotification = CacheMissNotification::No);
     RefPtr<Request> adopt_request(int source_client_id, u64 source_request_id, TransferLease = TransferLease::No);
     bool stop_request(Badge<Request>, Request&);
     void release_request_transfer_lease(Badge<Request>, Request&, RequestTransferLeaseKey);
@@ -70,6 +75,7 @@ public:
 private:
     virtual void die() override;
 
+    virtual void request_requires_network(u64 request_id) override;
     virtual void request_started(u64 request_id, IPC::File) override;
     virtual void request_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;
     virtual void request_cached_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -118,6 +118,16 @@ bool FontLoader::is_loading() const
     return m_fetch_controller && !m_typeface;
 }
 
+bool FontLoader::may_finish_from_cache() const
+{
+    return !m_fetch_controller || !m_fetch_controller->requires_network();
+}
+
+bool FontLoader::has_started_request() const
+{
+    return m_fetch_controller && m_fetch_controller->has_started_request();
+}
+
 void FontLoader::did_request_for_rendering()
 {
     // INTEROP: Delay the document load event til the fetch for this font has settled. Blink, Gecko, and WebKit all
@@ -146,6 +156,7 @@ void FontLoader::start_loading_next_url()
     // To fetch a font given a selected <url> url for @font-face rule, fetch url, with ruleOrDeclaration being rule,
     // destination "font", CORS mode "cors", and processResponse being the following steps given response res and null,
     // failure or a byte stream stream:
+    m_has_received_font_data = false;
     m_fetch_controller = fetch_a_style_resource(m_urls.take_first(), m_rule_or_declaration, Fetch::Infrastructure::Request::Destination::Font, CorsMode::Cors,
         [loader = this](auto response, auto stream) {
             // 1. If stream is null, return.
@@ -161,6 +172,7 @@ void FontLoader::start_loading_next_url()
                 }
                 return;
             }
+            loader->m_has_received_font_data = true;
             auto bytes = immutable_bytes->copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
 
             auto mime_type_essence = loader->try_load_font_mime_type_essence(response, bytes);
@@ -814,6 +826,25 @@ void FontComputer::clear_computed_font_cache_for_families(Vector<Utf16FlyString>
 void FontComputer::clear_font_feature_values_cache(Utf16FlyString const& family_name)
 {
     m_font_feature_values_cache.remove(family_name);
+}
+
+bool FontComputer::should_defer_initial_paint()
+{
+    if (m_has_completed_initial_paint)
+        return false;
+    bool has_pending_fonts = false;
+    // OPTIMIZATION: Finish cache lookups and decode cache-resident fonts before the first paint. A cache miss
+    //               releases this wait before any network activity; subsequent paints use the font display timeline.
+    for (auto const& entry : m_font_faces) {
+        for (auto const& face : entry.value) {
+            if (face->is_pending_rendering_from_cache())
+                return true;
+            has_pending_fonts |= face->has_pending_rendering();
+        }
+    }
+    m_initial_paint_had_pending_fonts = has_pending_fonts;
+    m_has_completed_initial_paint = true;
+    return false;
 }
 
 void FontComputer::did_load_font(Utf16FlyString const& family_name)

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -81,11 +81,9 @@ struct Traits<Web::CSS::ComputedFontCacheKey> : public DefaultTraits<Web::CSS::C
 
 namespace Web::CSS {
 
-FontLoader::FontLoader(FontComputer& font_computer, RuleOrDeclaration rule_or_declaration, Utf16FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<URL> urls, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load)
+FontLoader::FontLoader(FontComputer& font_computer, RuleOrDeclaration rule_or_declaration, Vector<URL> urls, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load)
     : m_font_computer(font_computer)
     , m_rule_or_declaration(rule_or_declaration)
-    , m_family_name(move(family_name))
-    , m_unicode_ranges(move(unicode_ranges))
     , m_urls(move(urls))
 {
     if (on_load)
@@ -120,19 +118,13 @@ bool FontLoader::is_loading() const
     return m_fetch_controller && !m_typeface;
 }
 
-RefPtr<Gfx::Font const> FontLoader::font_with_point_size(float point_size, Gfx::FontVariationSettings const& variations, Gfx::ShapeFeatures const& shape_features)
+void FontLoader::did_request_for_rendering()
 {
-    if (!m_typeface) {
-        if (!m_fetch_controller)
-            start_loading_next_url();
-        // INTEROP: Delay the document load event til the fetch for this font has settled. Blink, Gecko, and WebKit all
-        //          keep the document from completing while a font load requested for rendering is pending — so pages
-        //          that measure font-dependent geometry in a load-event handler see the loaded font, not a fallback.
-        if (is_loading() && !m_document_load_event_delayer.has_value())
-            m_document_load_event_delayer.emplace(m_font_computer->document());
-        return nullptr;
-    }
-    return m_typeface->font(point_size, variations, shape_features);
+    // INTEROP: Delay the document load event til the fetch for this font has settled. Blink, Gecko, and WebKit all
+    //          keep the document from completing while a font load requested for rendering is pending — so pages
+    //          that measure font-dependent geometry in a load-event handler see the loaded font, not a fallback.
+    if (is_loading() && !m_document_load_event_delayer.has_value())
+        m_document_load_event_delayer.emplace(m_font_computer->document());
 }
 
 void FontLoader::start_loading_next_url()
@@ -319,27 +311,8 @@ struct FontComputer::MatchingFontCandidate {
 
         auto font_list = Gfx::FontCascadeList::create();
         for (auto const& face : it->value) {
-            // https://drafts.csswg.org/css-font-loading/#font-face-load
-            // User agents can initiate font loads on their own, whenever they determine that a given font face is
-            // necessary to render something on the page. When this happens, they must act as if they had called the
-            // corresponding FontFace’s load() method described here.
-            // NB: An unloaded face with no subsetting unicode-range starts loading once a style actually selects
-            //     it. Loading happens via FontFace::load(). The font_with_point_size() call below then observes the
-            //     fetch in flight — and so delays the document load event until the fetch has settled.
-            if (face->has_urls() && !face->has_non_default_unicode_range() && face->status() == FontFaceLoadStatus::Unloaded)
-                face->load();
-            if (auto face_fonts = face->font_with_point_size(point_size, variations, shape_features)) {
+            if (auto face_fonts = face->font_with_point_size(point_size, variations, shape_features))
                 font_list->extend(*face_fonts);
-                continue;
-            }
-            // Unloaded subset face: surface it as a pending entry so the fetch only
-            // fires once font_for_code_point() sees a codepoint in its unicode-range.
-            if (face->has_urls() && face->has_non_default_unicode_range()) {
-                GC::Root<FontFace> rooted_face(*face);
-                font_list->add_pending_face(face->unicode_ranges(), [rooted_face = move(rooted_face)] {
-                    const_cast<FontFace&>(*rooted_face).load();
-                });
-            }
         }
         if (font_list->is_empty())
             return {};
@@ -1023,7 +996,7 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
         return it->value;
     }
 
-    auto loader = GC::Heap::the().allocate<FontLoader>(*this, rule_or_declaration, font_face.font_family(), font_face.unicode_ranges(), move(urls), move(on_load));
+    auto loader = GC::Heap::the().allocate<FontLoader>(*this, rule_or_declaration, move(urls), move(on_load));
     m_loaders_by_url.set(move(key), loader);
     return loader;
 }

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -88,6 +88,9 @@ public:
 
     bool is_loading() const;
     void did_request_for_rendering();
+    bool may_finish_from_cache() const;
+    bool has_started_request() const;
+    bool has_received_font_data() const { return m_has_received_font_data; }
 
     void subscribe(GC::Ref<GC::Function<void(RefPtr<Gfx::Typeface const>)>>);
 
@@ -106,6 +109,7 @@ private:
     Vector<GC::Ref<GC::Function<void(RefPtr<Gfx::Typeface const>)>>> m_subscribers;
     Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer;
     bool m_has_completed { false };
+    bool m_has_received_font_data { false };
 };
 
 class WEB_API FontComputer final : public GC::Cell {
@@ -124,6 +128,9 @@ public:
     DOM::Document const& document() const { return m_document; }
 
     Gfx::Font const& initial_font() const;
+    bool should_defer_initial_paint();
+    bool has_completed_initial_paint() const { return m_has_completed_initial_paint; }
+    bool initial_paint_had_pending_fonts() const { return m_initial_paint_had_pending_fonts; }
 
     void clear_computed_font_cache(Utf16FlyString const& family_name);
     void clear_font_feature_values_cache(Utf16FlyString const& family_name);
@@ -166,6 +173,8 @@ private:
     mutable HashMap<ComputedFontCacheKey, NonnullRefPtr<Gfx::FontCascadeList const>> m_computed_font_cache;
     mutable HashMap<Utf16FlyString, HashMap<FontFeatureValueKey, Vector<u32>>> m_font_feature_values_cache;
 
+    bool m_has_completed_initial_paint { false };
+    bool m_initial_paint_had_pending_fonts { false };
     u32 m_font_face_change_batch_depth { 0 };
     u64 m_environment_generation { 1 };
     Vector<Utf16FlyString> m_batched_font_face_change_families;

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -80,18 +80,14 @@ class FontLoader final : public GC::Cell {
     GC_DECLARE_ALLOCATOR(FontLoader);
 
 public:
-    FontLoader(FontComputer&, RuleOrDeclaration, Utf16FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<URL> urls, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load = {});
+    FontLoader(FontComputer&, RuleOrDeclaration, Vector<URL> urls, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load = {});
 
     virtual ~FontLoader();
 
-    Vector<Gfx::UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
-
-    RefPtr<Gfx::Font const> font_with_point_size(float point_size, Gfx::FontVariationSettings const& variations, Gfx::ShapeFeatures const& shape_features);
     void start_loading_next_url();
 
     bool is_loading() const;
-
-    Utf16FlyString family_name() const { return m_family_name; }
+    void did_request_for_rendering();
 
     void subscribe(GC::Ref<GC::Function<void(RefPtr<Gfx::Typeface const>)>>);
 
@@ -104,8 +100,6 @@ private:
 
     GC::Ref<FontComputer> m_font_computer;
     RuleOrDeclaration m_rule_or_declaration;
-    Utf16FlyString m_family_name;
-    Vector<Gfx::UnicodeRange> m_unicode_ranges;
     RefPtr<Gfx::Typeface const> m_typeface;
     Vector<URL> m_urls;
     GC::Ptr<Fetch::Infrastructure::FetchController> m_fetch_controller;

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -517,9 +517,7 @@ void FontFace::update_font_display_period()
         break;
     }
 
-    auto elapsed = m_font_display_time_for_testing.has_value()
-        ? static_cast<i64>(*m_font_display_time_for_testing)
-        : (MonotonicTime::now() - *m_font_download_timer_start).to_milliseconds();
+    auto elapsed = font_download_elapsed_time();
     auto previous_period = m_font_display_period;
     Optional<i64> next_deadline;
     if (m_font_display_failed || (failure_period_start.has_value() && elapsed >= *failure_period_start)) {
@@ -546,6 +544,28 @@ void FontFace::update_font_display_period()
         }));
     }
     m_font_download_timer->start(static_cast<int>(*next_deadline - elapsed));
+}
+
+i64 FontFace::font_download_elapsed_time() const
+{
+    VERIFY(m_font_download_timer_start.has_value());
+    return m_font_display_time_for_testing.has_value()
+        ? static_cast<i64>(*m_font_display_time_for_testing)
+        : (MonotonicTime::now() - *m_font_download_timer_start).to_milliseconds();
+}
+
+bool FontFace::has_pending_rendering() const
+{
+    return m_font_download_timer_start.has_value() && m_status == FontFaceLoadStatus::Loading && !m_font_display_failed;
+}
+
+bool FontFace::is_pending_rendering_from_cache() const
+{
+    // OPTIMIZATION: Once RequestServer is checking the cache, wait for its result and local font decoding.
+    //               Cache misses release the wait before network activity. Bound the wait for requests that
+    //               have not reached RequestServer, including pending service worker responses.
+    return has_pending_rendering() && m_font_loader && m_font_loader->may_finish_from_cache()
+        && (m_font_loader->has_started_request() || m_font_loader->has_received_font_data() || font_download_elapsed_time() < 100);
 }
 
 void FontFace::set_font_display_time_for_testing(u32 milliseconds)

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -8,6 +8,7 @@
 #include <AK/ByteBuffer.h>
 #include <LibCore/Promise.h>
 #include <LibGC/Heap.h>
+#include <LibGC/Weak.h>
 #include <LibGfx/Font/FontSupport.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
@@ -37,6 +38,7 @@
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/Platform/Timer.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/Buffers.h>
 #include <LibWeb/WebIDL/Promise.h>
@@ -340,14 +342,14 @@ ParsedFontFace FontFace::parsed_font_face() const
         m_cached_width,
         m_urls,
         m_unicode_ranges,
-        {},                // FIXME: ascent_override
-        {},                // FIXME: descent_override
-        {},                // FIXME: line_gap_override
-        FontDisplay::Auto, // FIXME: font_display
-        {},                // font-named-instance doesn't exist in FontFace
-        {},                // font-language-override doesn't exist in FontFace
-        {},                // FIXME: feature_settings
-        {},                // FIXME: variation_settings
+        {}, // FIXME: ascent_override
+        {}, // FIXME: descent_override
+        {}, // FIXME: line_gap_override
+        m_font_display,
+        {}, // font-named-instance doesn't exist in FontFace
+        {}, // font-language-override doesn't exist in FontFace
+        {}, // FIXME: feature_settings
+        {}, // FIXME: variation_settings
     };
 }
 
@@ -362,7 +364,7 @@ FontFace::~FontFace() = default;
 
 bool FontFace::should_be_registered_with_font_computer() const
 {
-    return is_css_connected() || status() == FontFaceLoadStatus::Loaded;
+    return is_css_connected() || has_urls() || status() == FontFaceLoadStatus::Loaded;
 }
 
 void FontFace::visit_edges(GC::Cell::Visitor& visitor)
@@ -373,6 +375,7 @@ void FontFace::visit_edges(GC::Cell::Visitor& visitor)
     visitor.visit(m_font_status_promise);
     visitor.visit(m_css_font_face_rule);
     visitor.visit(m_font_loader);
+    visitor.visit(m_font_download_timer);
     for (auto const& font_face_set : m_containing_sets)
         visitor.visit(font_face_set);
 }
@@ -424,16 +427,131 @@ void FontFace::disconnect_from_css_rule()
 
 RefPtr<Gfx::FontCascadeList const> FontFace::font_with_point_size(float point_size, Gfx::FontVariationSettings const& variations, Gfx::ShapeFeatures const& shape_features) const
 {
+    if (m_font_display_failed || m_status == FontFaceLoadStatus::Error)
+        return {};
     auto font_list = Gfx::FontCascadeList::create();
-    if (m_font_loader) {
-        if (auto font = m_font_loader->font_with_point_size(point_size, variations, shape_features))
-            font_list->add(*font, m_font_loader->unicode_ranges());
-    } else if (m_parsed_font) {
+    if (m_parsed_font) {
         font_list->add(m_parsed_font->font(point_size, variations, shape_features), m_unicode_ranges);
+    } else if (has_urls()) {
+        // NB: Document-owned cascades must not root faces, which trace back to their owning document.
+        font_list->add_pending_face(m_unicode_ranges, [weak_face = GC::Weak<FontFace> { const_cast<FontFace*>(this) }] {
+            if (weak_face)
+                return weak_face->resolve_for_rendering();
+            return Gfx::PendingFontState::Failed;
+        });
     }
     if (font_list->is_empty())
         return {};
     return font_list;
+}
+
+// https://drafts.csswg.org/css-fonts-4/#font-display-timeline
+Gfx::PendingFontState FontFace::resolve_for_rendering()
+{
+    if (m_font_display_failed || m_status == FontFaceLoadStatus::Error)
+        return Gfx::PendingFontState::Failed;
+    if (m_status == FontFaceLoadStatus::Loaded)
+        return Gfx::PendingFontState::Visible;
+
+    // At the moment the user agent first attempts to use a given downloaded font face on a page,
+    // the font face's font download timer is started.
+    if (!m_font_download_timer_start.has_value()) {
+        m_font_download_timer_start = MonotonicTime::now();
+        if (m_font_display == FontDisplay::Swap)
+            m_font_display_period = FontDisplayPeriod::Swap;
+        update_font_display_period();
+    }
+
+    // https://drafts.csswg.org/css-font-loading/#font-face-load
+    // When this happens, they must act as if they had called the corresponding FontFace’s load() method described here.
+    load();
+    if (m_font_loader)
+        m_font_loader->did_request_for_rendering();
+    switch (m_font_display_period) {
+    case FontDisplayPeriod::Block:
+        // During this period, if the font face is not loaded, any element attempting to use it must instead
+        // render with an invisible fallback font face.
+        return Gfx::PendingFontState::Invisible;
+    case FontDisplayPeriod::Swap:
+        // During this period, if the font face is not loaded, any element attempting to use it must instead
+        // render with a fallback font face.
+        return Gfx::PendingFontState::Visible;
+    case FontDisplayPeriod::Failure:
+        return Gfx::PendingFontState::Failed;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+void FontFace::invalidate_font_display()
+{
+    if (auto font_computer = this->font_computer(); font_computer.has_value())
+        font_computer->did_load_font(m_family);
+}
+
+// https://drafts.csswg.org/css-fonts-4/#font-display-desc
+void FontFace::update_font_display_period()
+{
+    if (m_font_download_timer)
+        m_font_download_timer->stop();
+    if (!m_font_download_timer_start.has_value() || m_font_download_completed || m_status == FontFaceLoadStatus::Loaded || m_status == FontFaceLoadStatus::Error)
+        return;
+
+    // INTEROP: Use WebKit's timeouts: 3 seconds for auto/block, 100 milliseconds for fallback/optional,
+    //          and a further 3 seconds of swapping for fallback. Blink also uses no block period for swap.
+    i64 block_period = 0;
+    Optional<i64> failure_period_start;
+    switch (m_font_display) {
+    case FontDisplay::Auto:
+    case FontDisplay::Block:
+        block_period = 3000;
+        break;
+    case FontDisplay::Swap:
+        break;
+    case FontDisplay::Fallback:
+        block_period = 100;
+        failure_period_start = 3100;
+        break;
+    case FontDisplay::Optional:
+        block_period = 100;
+        failure_period_start = 100;
+        break;
+    }
+
+    auto elapsed = m_font_display_time_for_testing.has_value()
+        ? static_cast<i64>(*m_font_display_time_for_testing)
+        : (MonotonicTime::now() - *m_font_download_timer_start).to_milliseconds();
+    auto previous_period = m_font_display_period;
+    Optional<i64> next_deadline;
+    if (m_font_display_failed || (failure_period_start.has_value() && elapsed >= *failure_period_start)) {
+        // If the font face is not yet loaded when this period starts, it's marked as a failed load,
+        // causing normal font fallback.
+        // NB: This failure only affects rendering. The Font Loading API can still finish loading the font.
+        m_font_display_period = FontDisplayPeriod::Failure;
+        m_font_display_failed = true;
+    } else if (elapsed < block_period) {
+        m_font_display_period = FontDisplayPeriod::Block;
+        next_deadline = block_period;
+    } else {
+        m_font_display_period = FontDisplayPeriod::Swap;
+        next_deadline = failure_period_start;
+    }
+
+    if (previous_period != m_font_display_period)
+        invalidate_font_display();
+    if (!next_deadline.has_value() || m_font_display_time_for_testing.has_value())
+        return;
+    if (!m_font_download_timer) {
+        m_font_download_timer = Platform::Timer::create_single_shot(heap(), 0, GC::create_function(heap(), [this] {
+            update_font_display_period();
+        }));
+    }
+    m_font_download_timer->start(static_cast<int>(*next_deadline - elapsed));
+}
+
+void FontFace::set_font_display_time_for_testing(u32 milliseconds)
+{
+    m_font_display_time_for_testing = milliseconds;
+    update_font_display_period();
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-family
@@ -686,6 +804,8 @@ WebIDL::ExceptionOr<void> FontFace::set_display(Utf16View string)
 void FontFace::set_display_impl(NonnullRefPtr<StyleValue const> const& value)
 {
     m_display = serialize_style_value_to_utf16(*value);
+    m_font_display = keyword_to_font_display(value->to_keyword()).value_or(FontDisplay::Auto);
+    update_font_display_period();
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-ascentoverride
@@ -796,6 +916,10 @@ GC::Ref<WebIDL::Promise> FontFace::load()
 
     // 5. When the load operation completes, successfully or not, queue a task to run the following steps synchronously:
     auto on_load = GC::create_function(GC::Heap::the(), [this](RefPtr<Gfx::Typeface const> maybe_typeface) {
+        update_font_display_period();
+        m_font_download_completed = true;
+        if (m_font_download_timer)
+            m_font_download_timer->stop();
         HTML::queue_global_task(HTML::Task::Source::FontLoading, task_global_object(), GC::create_function(GC::Heap::the(), [this, maybe_typeface] {
             HTML::TemporaryExecutionContext context(*m_environment, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
             // 1. If the attempt to load fails, reject font face’s [[FontStatusPromise]] with a DOMException whose name
@@ -804,6 +928,7 @@ GC::Ref<WebIDL::Promise> FontFace::load()
                 // NB: reject_status_promise() also marks the promise as handled: A font that fails to load must not
                 //     surface an unhandled rejection on a page that never looks at the FontFace API.
                 reject_status_promise(WebIDL::NetworkError::create("Failed to load font"_utf16));
+                invalidate_font_display();
 
                 // For each FontFaceSet font face is in:
                 for (auto& font_face_set : m_containing_sets) {

--- a/Libraries/LibWeb/CSS/FontFace.h
+++ b/Libraries/LibWeb/CSS/FontFace.h
@@ -99,6 +99,8 @@ public:
     Vector<Gfx::UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
     bool has_urls() const { return !m_urls.is_empty(); }
 
+    bool is_pending_rendering_from_cache() const;
+    bool has_pending_rendering() const;
     void set_font_display_time_for_testing(u32 milliseconds);
 
     FontFaceLoadStatus status() const { return m_status; }
@@ -128,6 +130,7 @@ private:
     };
     Gfx::PendingFontState resolve_for_rendering();
     void update_font_display_period();
+    i64 font_download_elapsed_time() const;
     void invalidate_font_display();
     FontDisplay m_font_display { FontDisplay::Auto };
     FontDisplayPeriod m_font_display_period { FontDisplayPeriod::Block };

--- a/Libraries/LibWeb/CSS/FontFace.h
+++ b/Libraries/LibWeb/CSS/FontFace.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Time.h>
 #include <AK/Utf16FlyString.h>
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
@@ -98,13 +99,7 @@ public:
     Vector<Gfx::UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
     bool has_urls() const { return !m_urls.is_empty(); }
 
-    bool has_non_default_unicode_range() const
-    {
-        if (m_unicode_ranges.size() != 1)
-            return true;
-        auto const& range = m_unicode_ranges.first();
-        return range.min_code_point() != 0 || range.max_code_point() != 0x10FFFF;
-    }
+    void set_font_display_time_for_testing(u32 milliseconds);
 
     FontFaceLoadStatus status() const { return m_status; }
 
@@ -124,6 +119,23 @@ private:
     void reject_status_promise(WebIDL::Exception);
 
     Optional<FontComputer&> font_computer() const;
+
+    // https://drafts.csswg.org/css-fonts-4/#font-display-timeline
+    enum class FontDisplayPeriod : u8 {
+        Block,
+        Swap,
+        Failure,
+    };
+    Gfx::PendingFontState resolve_for_rendering();
+    void update_font_display_period();
+    void invalidate_font_display();
+    FontDisplay m_font_display { FontDisplay::Auto };
+    FontDisplayPeriod m_font_display_period { FontDisplayPeriod::Block };
+    Optional<MonotonicTime> m_font_download_timer_start;
+    GC::Ptr<Platform::Timer> m_font_download_timer;
+    Optional<u32> m_font_display_time_for_testing;
+    bool m_font_display_failed { false };
+    bool m_font_download_completed { false };
 
     [[nodiscard]] Optional<ComputationContext> computation_context() const;
 

--- a/Libraries/LibWeb/Fetch/Infrastructure/FetchController.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/FetchController.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGC/Heap.h>
+#include <LibGC/Weak.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibRequests/Request.h>
 #include <LibWeb/Fetch/Fetching/PendingResponse.h>
@@ -39,6 +40,12 @@ void FetchController::visit_edges(JS::Cell::Visitor& visitor)
 void FetchController::set_pending_request(RefPtr<Requests::Request> const& request)
 {
     m_pending_request = request;
+    m_has_started_request |= !!request;
+    if (request && m_fetch_params && m_fetch_params->request()->destination() == Request::Destination::Font) {
+        request->on_requires_network = GC::weak_callback(*this, [](auto& controller) {
+            controller.m_requires_network = true;
+        });
+    }
 }
 
 void FetchController::set_report_timing_steps(Function<void(JS::Object&)> report_timing_steps)

--- a/Libraries/LibWeb/Fetch/Infrastructure/FetchController.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/FetchController.h
@@ -63,6 +63,8 @@ public:
     void set_pending_preloaded_response(GC::Ptr<Fetching::PendingResponse> pending_preloaded_response) { m_pending_preloaded_response = pending_preloaded_response; }
 
     void set_pending_request(RefPtr<Requests::Request> const&);
+    bool requires_network() const { return m_requires_network; }
+    bool has_started_request() const { return m_has_started_request; }
     void set_inner_fetch_controller(GC::Ref<FetchController>);
 
     void stop_fetch();
@@ -108,6 +110,8 @@ private:
     GC::Ptr<Fetching::PendingResponse> m_pending_preloaded_response;
 
     WeakPtr<Requests::Request> m_pending_request;
+    bool m_requires_network { false };
+    bool m_has_started_request { false };
 
     HashMap<u64, HTML::TaskID> m_ongoing_fetch_tasks;
     u64 m_next_fetch_task_id { 0 };

--- a/Libraries/LibWeb/HTML/Canvas/Canvas2DContextBase.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/Canvas2DContextBase.cpp
@@ -24,6 +24,7 @@
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/DOMRectReadOnly.h>
+#include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/StyleValues/FilterStyleValue.h>
@@ -46,6 +47,7 @@
 #include <LibWeb/HTML/Path2D.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/TextMetrics.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Layout/ImageProvider.h>
 #include <LibWeb/Page/Page.h>
@@ -969,7 +971,20 @@ RefPtr<Gfx::FontCascadeList const> Canvas2DContextBase::font_cascade_list()
         set_font(u"10px sans-serif"sv);
     }
 
-    // Get current loaded font
+    auto* document = canvas_element().visit(
+        [](GC::Ref<HTMLCanvasElement> canvas) -> DOM::Document* { return &canvas->document(); },
+        [](GC::Ref<OffscreenCanvas> canvas) -> DOM::Document* {
+            if (auto* window = window_from_global_object(canvas->relevant_global_object()))
+                return &window->associated_document();
+            return nullptr;
+        });
+    // NB: Drawing states, including saved states, retain their cascades across font loads and font-display
+    //     transitions. Refresh them lazily so cached invisible fallback glyphs and metrics cannot outlive
+    //     the font environment that selected them.
+    if (document && drawing_state().font_environment_generation != document->font_computer().environment_generation()) {
+        auto font = drawing_state().font_style_value->to_utf16_string(CSS::SerializationMode::ResolvedValue);
+        set_font(font);
+    }
     return drawing_state().current_font_cascade_list;
 }
 

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
@@ -168,6 +168,7 @@ void CanvasTextDrawingStyles<CanvasType>::set_font(Utf16View font)
 
     auto font_list = font_source.visit(
         [&](DOM::Document* document) -> RefPtr<Gfx::FontCascadeList const> {
+            drawing_state().font_environment_generation = document->font_computer().environment_generation();
             return document->font_computer().compute_font_for_style_values(
                 font_family,
                 computed_font_size->as_length().length().absolute_length_to_px(),

--- a/Libraries/LibWeb/HTML/Canvas/DrawingState.h
+++ b/Libraries/LibWeb/HTML/Canvas/DrawingState.h
@@ -83,6 +83,7 @@ struct DrawingState {
     Gfx::CompositingAndBlendingOperator current_compositing_and_blending_operator = Gfx::CompositingAndBlendingOperator::SourceOver;
     RefPtr<CSS::StyleValue const> font_style_value { nullptr };
     RefPtr<Gfx::FontCascadeList const> current_font_cascade_list { nullptr };
+    u64 font_environment_generation { 0 };
     CanvasTextAlign text_align { CanvasTextAlign::Start };
     CanvasTextBaseline text_baseline { CanvasTextBaseline::Alphabetic };
     CanvasDirection direction { CanvasDirection::Inherit };

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -708,8 +708,11 @@ void EventLoop::update_the_rendering()
             continue;
         if (navigable->is_svg_page())
             continue;
-        if (auto document = navigable->active_document())
+        if (auto document = navigable->active_document()) {
             document->update_layout(DOM::UpdateLayoutReason::HTMLEventLoopRenderingUpdate);
+            if (document->font_computer().should_defer_initial_paint())
+                continue;
+        }
         navigable->paint_next_frame();
         ++m_rendering_scheduler_counters.paints;
         if (navigable->is_local_root())

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -748,10 +748,9 @@ void HTMLParserEndState::check_progress()
 
     case Phase::WaitingForLoadEventDelay:
         // 8. Spin the event loop until there is nothing that delays the load event in the Document.
-        // AD-HOC: Update style first — so any font fetches that the computed styles depend on get started; an in-flight
-        //         font fetch delays the load event.
+        // AD-HOC: Update layout first so font loads selected by text shaping can delay the load event.
         // INTEROP: Gecko also flushes layout before firing the load event — so lazily-started font loads hold it back.
-        m_document->update_style();
+        m_document->update_layout(DOM::UpdateLayoutReason::DocumentReadinessComplete);
         if (m_document->anything_is_delaying_the_load_event())
             return;
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -382,6 +382,16 @@ WebIDL::ExceptionOr<void> Internals::mark_as_garbage(Utf16String const& variable
     return {};
 }
 
+bool Internals::has_completed_initial_paint() const
+{
+    return window().associated_document().font_computer().has_completed_initial_paint();
+}
+
+bool Internals::initial_paint_had_pending_fonts() const
+{
+    return window().associated_document().font_computer().initial_paint_had_pending_fonts();
+}
+
 void Internals::set_font_display_time(CSS::FontFace& font_face, u32 milliseconds)
 {
     font_face.set_font_display_time_for_testing(milliseconds);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -39,6 +39,7 @@
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/CSS/FontFace.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/PseudoElement.h>
@@ -379,6 +380,11 @@ WebIDL::ExceptionOr<void> Internals::mark_as_garbage(Utf16String const& variable
     (void)TRY(reference.delete_(vm));
     vm.heap().uproot_cell(&value.as_cell());
     return {};
+}
+
+void Internals::set_font_display_time(CSS::FontFace& font_face, u32 milliseconds)
+{
+    font_face.set_font_display_time_for_testing(milliseconds);
 }
 
 WebIDL::ExceptionOr<Utf16String> Internals::set_time_zone(Utf16String const& time_zone)

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -63,6 +63,8 @@ public:
     u64 layout_tree_pre_order_relabel_count();
     WebIDL::ExceptionOr<void> load_reference_test_metadata();
 
+    bool has_completed_initial_paint() const;
+    bool initial_paint_had_pending_fonts() const;
     void set_font_display_time(CSS::FontFace&, u32 milliseconds);
     WebIDL::ExceptionOr<Utf16String> set_time_zone(Utf16String const& time_zone);
 

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -63,6 +63,7 @@ public:
     u64 layout_tree_pre_order_relabel_count();
     WebIDL::ExceptionOr<void> load_reference_test_metadata();
 
+    void set_font_display_time(CSS::FontFace&, u32 milliseconds);
     WebIDL::ExceptionOr<Utf16String> set_time_zone(Utf16String const& time_zone);
 
     void gc();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -23,6 +23,8 @@ interface Internals {
     unsigned long long layoutTreePreOrderRelabelCount();
     undefined loadReferenceTestMetadata();
 
+    // Freezes the font display clock at the given elapsed time, without starting a font load.
+    undefined setFontDisplayTime(FontFace fontFace, unsigned long milliseconds);
     DOMString setTimeZone(DOMString timeZone);
 
     undefined gc();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -23,6 +23,8 @@ interface Internals {
     unsigned long long layoutTreePreOrderRelabelCount();
     undefined loadReferenceTestMetadata();
 
+    readonly attribute boolean hasCompletedInitialPaint;
+    readonly attribute boolean initialPaintHadPendingFonts;
     // Freezes the font display clock at the given elapsed time, without starting a font load.
     undefined setFontDisplayTime(FontFace fontFace, unsigned long milliseconds);
     DOMString setTimeZone(DOMString timeZone);

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -500,7 +500,10 @@ RefPtr<Requests::Request> ResourceLoader::start_network_request(LoadRequest cons
         return nullptr;
     }
 
-    auto protocol_request = m_request_client->start_request(request.method(), request.url().value(), request.headers(), request.body(), request.cache_mode(), request.include_credentials(), proxy, transfer_lease);
+    auto cache_miss_notification = request.destination() == Fetch::Infrastructure::Request::Destination::Font
+        ? Requests::RequestClient::CacheMissNotification::Yes
+        : Requests::RequestClient::CacheMissNotification::No;
+    auto protocol_request = m_request_client->start_request(request.method(), request.url().value(), request.headers(), request.body(), request.cache_mode(), request.include_credentials(), proxy, transfer_lease, {}, cache_miss_notification);
     if (!protocol_request) {
         log_failure(request, "Failed to initiate load"sv);
         return nullptr;

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -463,6 +463,8 @@ static u64 text_blob_glyph_hash(ReadonlySpan<DisplayListGlyph> glyphs)
 
 static sk_sp<SkTextBlob> make_text_blob(Gfx::Font const& font, float scale, ReadonlySpan<DisplayListGlyph> glyphs)
 {
+    if (font.is_invisible())
+        return nullptr;
     auto sk_font = font.skia_font(scale);
     SkTextBlobBuilder builder;
     auto const& run = builder.allocRunPos(sk_font, glyphs.size());

--- a/Libraries/LibWeb/Painting/DisplayListResourceTransaction.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceTransaction.cpp
@@ -43,6 +43,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayListFontResource co
     TRY(encoder.encode(font.point_size()));
     TRY(encoder.encode(font.variation_settings()));
     TRY(encoder.encode(font.features()));
+    TRY(encoder.encode(font.is_invisible()));
     return {};
 }
 
@@ -54,10 +55,14 @@ ErrorOr<Web::Painting::DisplayListFontResource> decode(Decoder& decoder)
     auto point_size = TRY(decoder.decode<float>());
     auto variations = TRY(decoder.decode<Gfx::FontVariationSettings>());
     auto features = TRY(decoder.decode<Gfx::ShapeFeatures>());
+    auto invisible = TRY(decoder.decode<bool>());
+    auto font = typeface->font(point_size, move(variations), move(features));
+    if (invisible)
+        font = font->invisible_variant();
 
     return Web::Painting::DisplayListFontResource {
         .id = id,
-        .font = typeface->font(point_size, move(variations), move(features)),
+        .font = move(font),
     };
 }
 

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -305,7 +305,7 @@ void ConnectionFromClient::set_use_system_dns()
     m_resolver->dns.reset_connection();
 }
 
-void ConnectionFromClient::start_request(u64 request_id, ByteString method, URL::URL url, Vector<HTTP::Header> request_headers, ByteBuffer request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData proxy_data, bool create_transfer_lease, Optional<u32> address_selection_hint)
+void ConnectionFromClient::start_request(u64 request_id, ByteString method, URL::URL url, Vector<HTTP::Header> request_headers, ByteBuffer request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData proxy_data, bool create_transfer_lease, Optional<u32> address_selection_hint, bool notify_on_cache_miss)
 {
     note_event_tick("ipc-start-request"sv);
     dbgln_if(REQUESTSERVER_DEBUG, "RequestServer: start_request({}, {})", request_id, url);
@@ -327,7 +327,7 @@ void ConnectionFromClient::start_request(u64 request_id, ByteString method, URL:
     auto transfer_lease = create_transfer_lease
         ? Optional<Requests::RequestTransferLeaseKey> { { client_id(), request_id } }
         : Optional<Requests::RequestTransferLeaseKey> {};
-    auto request = Request::fetch(request_id, m_disk_cache, cache_mode, *this, m_curl_multi, m_resolver, move(url), move(method), HTTP::HeaderList::create(move(request_headers)), move(request_body), include_credentials, m_alt_svc_cache_path, proxy_data, transfer_lease, address_selection_hint);
+    auto request = Request::fetch(request_id, m_disk_cache, cache_mode, *this, m_curl_multi, m_resolver, move(url), move(method), HTTP::HeaderList::create(move(request_headers)), move(request_body), include_credentials, m_alt_svc_cache_path, proxy_data, transfer_lease, address_selection_hint, notify_on_cache_miss);
     m_active_requests.set(request_id, move(request));
 
     if (transfer_lease.has_value())

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -82,7 +82,7 @@ private:
     virtual Messages::RequestServer::GetClientIdResponse get_client_id() override;
     virtual void set_dns_server(ByteString host_or_address, u16 port, bool use_tls, bool validate_dnssec_locally) override;
     virtual void set_use_system_dns() override;
-    virtual void start_request(u64 request_id, ByteString, URL::URL, Vector<HTTP::Header>, ByteBuffer, HTTP::CacheMode, HTTP::Cookie::IncludeCredentials, Core::ProxyData, bool create_transfer_lease, Optional<u32> address_selection_hint) override;
+    virtual void start_request(u64 request_id, ByteString, URL::URL, Vector<HTTP::Header>, ByteBuffer, HTTP::CacheMode, HTTP::Cookie::IncludeCredentials, Core::ProxyData, bool create_transfer_lease, Optional<u32> address_selection_hint, bool notify_on_cache_miss) override;
     virtual void adopt_request(int source_client_id, u64 source_request_id, u64 target_request_id, bool preserve_transfer_lease) override;
     virtual void release_request_transfer_lease(int source_client_id, u64 source_request_id) override;
     virtual Messages::RequestServer::StopRequestResponse stop_request(u64 request_id) override;

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -448,10 +448,12 @@ NonnullOwnPtr<Request> Request::fetch(
     Optional<ByteString> alt_svc_cache_path,
     Core::ProxyData proxy_data,
     Optional<Requests::RequestTransferLeaseKey> transfer_lease,
-    Optional<u32> address_selection_hint)
+    Optional<u32> address_selection_hint,
+    bool notify_on_cache_miss)
 {
     auto request = adopt_own(*new Request { request_id, RequestType::Fetch, disk_cache, cache_mode, client, curl_multi, resolver, move(url), move(method), move(request_headers), move(request_body), include_credentials, move(alt_svc_cache_path), proxy_data, move(transfer_lease) });
     request->m_address_selection_hint = address_selection_hint;
+    request->m_notify_on_cache_miss = notify_on_cache_miss;
     request->process();
 
     return request;
@@ -722,6 +724,12 @@ void Request::retry_after_aia(Badge<ConnectionFromClient>)
 
 void Request::transition_to_state(State state)
 {
+    // Let clients stop waiting for a cache-only result before DNS or a stalled cache writer can delay the response.
+    if (m_notify_on_cache_miss && !m_informed_client_requires_network
+        && (state == State::DNSLookup || state == State::WaitForCache)) {
+        m_informed_client_requires_network = true;
+        m_client->async_request_requires_network(m_request_id);
+    }
     dbgln_if(REQUESTSERVER_DEBUG, "Request::Transition[{}]: {} -> {} ({} {})", m_request_id, state_name(m_state), state_name(state), m_method, m_url);
     m_state = state;
     mark_activity();

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -52,7 +52,8 @@ public:
         Optional<ByteString> alt_svc_cache_path,
         Core::ProxyData proxy_data,
         Optional<Requests::RequestTransferLeaseKey>,
-        Optional<u32> address_selection_hint);
+        Optional<u32> address_selection_hint,
+        bool notify_on_cache_miss);
 
     static NonnullOwnPtr<Request> connect(
         u64 request_id,
@@ -241,6 +242,8 @@ private:
 
     RefPtr<AIACollector> m_aia_collector;
     size_t m_aia_fetch_count { 0 };
+    bool m_notify_on_cache_miss { false };
+    bool m_informed_client_requires_network { false };
     bool m_informed_client_request_started { false };
     Optional<int> m_curl_result_code;
 

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -9,6 +9,7 @@
 
 endpoint RequestClient
 {
+    request_requires_network(u64 request_id) =|
     request_started(u64 request_id, IPC::File fd) =|
     request_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|
     request_cached_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -27,7 +27,7 @@ endpoint RequestServer
     is_supported_protocol(ByteString protocol) => (bool supported)
     get_client_id() => (int client_id)
 
-    start_request(u64 request_id, ByteString method, URL::URL url, Vector<HTTP::Header> request_headers, ByteBuffer request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData proxy_data, bool create_transfer_lease, Optional<u32> address_selection_hint) =|
+    start_request(u64 request_id, ByteString method, URL::URL url, Vector<HTTP::Header> request_headers, ByteBuffer request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData proxy_data, bool create_transfer_lease, Optional<u32> address_selection_hint, bool notify_on_cache_miss) =|
     adopt_request(int source_client_id, u64 source_request_id, u64 target_request_id, bool preserve_transfer_lease) =|
     release_request_transfer_lease(int source_client_id, u64 source_request_id) =|
     stop_request(u64 request_id) => (bool success)

--- a/Tests/LibGfx/TestFont.cpp
+++ b/Tests/LibGfx/TestFont.cpp
@@ -9,6 +9,7 @@
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
 #include <LibGfx/Font/Typeface.h>
+#include <LibGfx/FontCascadeList.h>
 #include <LibGfx/TextLayout.h>
 #include <LibTest/TestCase.h>
 #include <harfbuzz/hb.h>
@@ -150,4 +151,71 @@ TEST_CASE(glyph_run_intercepts)
 
     // A degenerate scale produces nothing.
     EXPECT(Gfx::glyph_run_glyph_intercepts(font, run->glyphs(), 0, mid_x_height - 1, mid_x_height + 1).is_empty());
+}
+
+TEST_CASE(invisible_fallback_preserves_metrics_and_shaping)
+{
+    auto font = load_text_font(16);
+    auto invisible = font->invisible_variant();
+    EXPECT(invisible->is_invisible());
+    EXPECT(!font->is_invisible());
+    EXPECT_EQ(invisible->pixel_metrics().ascent, font->pixel_metrics().ascent);
+    EXPECT_EQ(invisible->pixel_metrics().descent, font->pixel_metrics().descent);
+    EXPECT_EQ(shape(*invisible, "abc"sv)->width(), shape(*font, "abc"sv)->width());
+}
+
+TEST_CASE(pending_font_only_hides_its_unicode_range)
+{
+    auto font = load_text_font(16);
+    auto cascade = Gfx::FontCascadeList::create();
+    cascade->add_pending_face({ { 'a', 'a' } }, [] { return Gfx::PendingFontState::Invisible; });
+    cascade->add(font);
+    cascade->set_last_resort_font(font);
+    EXPECT(cascade->font_for_code_point('a').is_invisible());
+    EXPECT(!cascade->font_for_code_point('b').is_invisible());
+    EXPECT_EQ(&cascade->font_for_code_point('a'), &cascade->font_for_code_point('a'));
+    EXPECT_EQ(cascade->first_available_font().pixel_size(), font->pixel_size());
+}
+
+TEST_CASE(pending_font_does_not_load_fallback_fonts)
+{
+    auto font = load_text_font(16);
+    auto cascade = Gfx::FontCascadeList::create();
+    u32 fallback_loads = 0;
+    cascade->add_pending_face({ { 0, 0x10FFFF } }, [] { return Gfx::PendingFontState::Visible; });
+    cascade->add_pending_face({ { 0, 0x10FFFF } }, [&] {
+        ++fallback_loads;
+        return Gfx::PendingFontState::Invisible;
+    });
+    cascade->add(font);
+    cascade->set_last_resort_font(font);
+    EXPECT_EQ(&cascade->font_for_code_point('a'), font.ptr());
+    EXPECT_EQ(fallback_loads, 0u);
+}
+
+TEST_CASE(loaded_font_precedes_pending_font_after_extending_cascade)
+{
+    auto font = load_text_font(16);
+    auto cascade = Gfx::FontCascadeList::create();
+    cascade->add(font);
+    auto later_family = Gfx::FontCascadeList::create();
+    u32 loads = 0;
+    later_family->add_pending_face({ { 0, 0x10FFFF } }, [&] {
+        ++loads;
+        return Gfx::PendingFontState::Invisible;
+    });
+    cascade->extend(*later_family);
+    cascade->set_last_resort_font(font);
+    EXPECT_EQ(&cascade->font_for_code_point('a'), font.ptr());
+    EXPECT_EQ(loads, 0u);
+}
+
+TEST_CASE(failed_font_allows_loading_the_next_face)
+{
+    auto font = load_text_font(16);
+    auto cascade = Gfx::FontCascadeList::create();
+    cascade->add_pending_face({ { 0, 0x10FFFF } }, [] { return Gfx::PendingFontState::Failed; });
+    cascade->add_pending_face({ { 0, 0x10FFFF } }, [] { return Gfx::PendingFontState::Invisible; });
+    cascade->set_last_resort_font(font);
+    EXPECT(cascade->font_for_code_point('a').is_invisible());
 }

--- a/Tests/LibWeb/Ref/expected/font-display-periods-ref.html
+++ b/Tests/LibWeb/Ref/expected/font-display-periods-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+body { margin: 0; }
+.row { font: 16px/16px monospace; white-space: pre; }
+.sample { color: green; text-shadow: 1px 1px green; }
+.invisible { color: transparent; text-shadow: none; }
+</style>
+<body>
+<script>
+const token = new URLSearchParams(location.search).get("unblock");
+if (token)
+    fetch(`/unblock/${token}`);
+for (const display of ["auto", "block", "swap", "fallback", "optional"]) {
+    for (const elapsed of [0, 99, 100, 2999, 3000, 3099, 3100]) {
+        const family = `${display}-${elapsed}`;
+        const hidden = (display === "auto" || display === "block") ? elapsed < 3000
+            : (display === "fallback" || display === "optional") && elapsed < 100;
+        const row = document.createElement("div");
+        row.className = "row";
+        row.append(`${family.padEnd(14)} `);
+        const sample = document.createElement("span");
+        sample.className = "sample";
+        const first = document.createElement("span");
+        first.className = hidden ? "invisible" : "";
+        first.textContent = "A";
+        sample.append(first, "B");
+        row.append(sample);
+        document.body.append(row);
+    }
+}
+</script>

--- a/Tests/LibWeb/Ref/input/font-display-periods.html
+++ b/Tests/LibWeb/Ref/input/font-display-periods.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link id="reference" rel="match" href="../expected/font-display-periods-ref.html">
+<script src="../../Text/input/include.js"></script>
+<style>
+body { margin: 0; }
+#out { display: none; }
+.row { font: 16px/16px monospace; white-space: pre; }
+.sample { color: green; text-shadow: 1px 1px green; }
+</style>
+<body>
+<script>
+addEventListener("load", async () => {
+    const server = httpTestServer();
+    const token = crypto.randomUUID();
+    const url = await server.createEcho("GET", `/font-display-periods-${token}.woff`, {
+        status: 404,
+        headers: { "Access-Control-Allow-Origin": "*" },
+        wait_for_unblock: token,
+    });
+    document.getElementById("reference").href += `?unblock=${token}`;
+    for (const display of ["auto", "block", "swap", "fallback", "optional"]) {
+        for (const elapsed of [0, 99, 100, 2999, 3000, 3099, 3100]) {
+            const family = `${display}-${elapsed}`;
+            const style = document.createElement("style");
+            style.textContent = `@font-face { font-family: "${family}"; src: url("${url}"); font-display: ${display}; unicode-range: U+0041; }`;
+            document.head.append(style);
+            const face = [...document.fonts].find(face => face.family === family);
+            internals.setFontDisplayTime(face, 0);
+            const row = document.createElement("div");
+            row.className = "row";
+            row.append(`${family.padEnd(14)} `);
+            const sample = document.createElement("span");
+            sample.className = "sample";
+            sample.style.fontFamily = `"${family}", monospace`;
+            sample.textContent = "AB";
+            row.append(sample);
+            document.body.append(row);
+            row.getBoundingClientRect();
+            internals.setFontDisplayTime(face, elapsed);
+        }
+    }
+    document.documentElement.className = "";
+});
+</script>
+</html>

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -2,6 +2,7 @@
 Text/input/css/font-cache-first-paint.html
 Text/input/css/font-display-timeline.html
 Text/input/css/unused-font-document-collectable.html
+Text/input/css/canvas-font-display.html
 Ref/input/font-display-periods.html
 Ref/expected/font-display-periods-ref.html
 ; Tests cookies.

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,4 +1,5 @@
 [LoadFromHttpServer]
+Text/input/css/font-cache-first-paint.html
 Text/input/css/font-display-timeline.html
 Text/input/css/unused-font-document-collectable.html
 Ref/input/font-display-periods.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,4 +1,8 @@
 [LoadFromHttpServer]
+Text/input/css/font-display-timeline.html
+Text/input/css/unused-font-document-collectable.html
+Ref/input/font-display-periods.html
+Ref/expected/font-display-periods-ref.html
 ; Tests cookies.
 Text/input/cookie-cache-invalidation.html
 Text/input/cookie-working.html

--- a/Tests/LibWeb/Text/expected/css/canvas-font-display.txt
+++ b/Tests/LibWeb/Text/expected/css/canvas-font-display.txt
@@ -1,0 +1,14 @@
+0: block has ink = false
+1: block has ink = false
+0: swap has ink = true
+0: swap uses fallback = true
+1: swap has ink = true
+1: swap uses fallback = true
+0: loaded has ink = true
+0: loaded uses downloaded font = true
+0: restored has ink = true
+0: restored uses downloaded font = true
+1: loaded has ink = true
+1: loaded uses downloaded font = true
+1: restored has ink = true
+1: restored uses downloaded font = true

--- a/Tests/LibWeb/Text/expected/css/font-cache-first-paint.txt
+++ b/Tests/LibWeb/Text/expected/css/font-cache-first-paint.txt
@@ -1,0 +1,4 @@
+Warm cache: first paint had pending fonts = false, font = loaded
+Disk cache: first paint had pending fonts = false, font = loaded
+Cold cache: first paint had pending fonts = true, font = loading
+Cold font eventually loads: loaded

--- a/Tests/LibWeb/Text/expected/css/font-display-timeline.txt
+++ b/Tests/LibWeb/Text/expected/css/font-display-timeline.txt
@@ -1,0 +1,21 @@
+auto: fallback metrics = true, status = loading
+block: fallback metrics = true, status = loading
+swap: fallback metrics = true, status = loading
+fallback: fallback metrics = true, status = loading
+optional: fallback metrics = true, status = loading
+auto: loaded = loaded, uses downloaded font = true
+auto: unchanged after deadline = true
+block: loaded = loaded, uses downloaded font = true
+block: unchanged after deadline = true
+swap: loaded = loaded, uses downloaded font = true
+swap: unchanged after deadline = true
+fallback: loaded = loaded, uses downloaded font = false
+fallback: unchanged after deadline = false
+optional: loaded = loaded, uses downloaded font = false
+optional: unchanged after deadline = false
+Font loaded during block period remains usable: true
+Preloaded optional font is usable: true
+Loaded preferred face leaves fallback unloaded: unloaded
+Pending preferred face leaves fallback unloaded: unloaded
+Changing display preserves fallback metrics: true
+Network failure uses fallback: error, true

--- a/Tests/LibWeb/Text/expected/css/unused-font-document-collectable.txt
+++ b/Tests/LibWeb/Text/expected/css/unused-font-document-collectable.txt
@@ -1,0 +1,3 @@
+unused face status: unloaded
+removed document collected: true
+unused face collected: true

--- a/Tests/LibWeb/Text/input/css/canvas-font-display.html
+++ b/Tests/LibWeb/Text/input/css/canvas-font-display.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+promiseTest(async () => {
+    const server = httpTestServer();
+    const token = crypto.randomUUID();
+    const bytes = new Uint8Array(await (await fetch("../../../Assets/HashSans.woff")).arrayBuffer());
+    const url = await server.createEcho("GET", `/canvas-font-display-${token}.woff`, {
+        status: 200,
+        headers: { "Content-Type": "font/woff", "Access-Control-Allow-Origin": "*", "Cache-Control": "no-store" },
+        body: btoa(String.fromCharCode(...bytes)),
+        body_encoding: "base64",
+        wait_for_unblock: token,
+    });
+    const face = new FontFace("CanvasDisplay", `url("${url}")`, { display: "block" });
+    // Neither the blocking period nor the download can end without this test explicitly advancing them.
+    internals.setFontDisplayTime(face, 0);
+    document.fonts.add(face);
+    // Exercise both connected and detached canvas elements.
+    const contexts = [document.body.appendChild(document.createElement("canvas")), document.createElement("canvas")].map(canvas => canvas.getContext("2d"));
+    function hasInk(context) {
+        context.clearRect(0, 0, 300, 150);
+        context.fillText("AAAA", 10, 60);
+        return context.getImageData(0, 0, 300, 150).data.some((value, index) => index % 4 === 3 && value !== 0);
+    }
+    const fallbackWidths = contexts.map(context => {
+        context.font = "40px monospace";
+        const width = context.measureText("AAAA").width;
+        context.font = "40px CanvasDisplay, monospace";
+        return width;
+    });
+    for (const [index, context] of contexts.entries()) {
+        println(`${index}: block has ink = ${hasInk(context)}`);
+        // Preserve a second copy of the pending cascade in the saved drawing state.
+        context.save();
+    }
+    internals.setFontDisplayTime(face, 3000);
+    for (const [index, context] of contexts.entries()) {
+        println(`${index}: swap has ink = ${hasInk(context)}`);
+        println(`${index}: swap uses fallback = ${context.measureText("AAAA").width === fallbackWidths[index]}`);
+    }
+    await fetch(`${server.baseURL}/unblock/${token}`);
+    await face.loaded;
+    for (const [index, context] of contexts.entries()) {
+        println(`${index}: loaded has ink = ${hasInk(context)}`);
+        println(`${index}: loaded uses downloaded font = ${context.measureText("AAAA").width !== fallbackWidths[index]}`);
+        context.restore();
+        println(`${index}: restored has ink = ${hasInk(context)}`);
+        println(`${index}: restored uses downloaded font = ${context.measureText("AAAA").width !== fallbackWidths[index]}`);
+    }
+});
+</script>

--- a/Tests/LibWeb/Text/input/css/font-cache-first-paint.html
+++ b/Tests/LibWeb/Text/input/css/font-cache-first-paint.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+promiseTest(async () => {
+    const server = httpTestServer();
+    const previousCacheSetting = internals.setHttpMemoryCacheEnabled(true);
+    const bytes = new Uint8Array(await (await fetch("../../../Assets/NotoSansEthiopic.woff2")).arrayBuffer());
+    let binary = "";
+    for (const byte of bytes)
+        binary += String.fromCharCode(byte);
+    const fontBody = btoa(binary);
+    const warmToken = crypto.randomUUID();
+    const warmURL = await server.createEcho("GET", `/font-cache-warm-${warmToken}.woff2`, {
+        status: 200,
+        headers: {
+            "Content-Type": "font/woff2",
+            "Cache-Control": "max-age=3600",
+            "Access-Control-Expose-Headers": "X-Ladybird-Disk-Cache-Status",
+        },
+        body: fontBody,
+        body_encoding: "base64",
+    });
+    // Opt into the test runner's disk cache when priming it, without creating or decoding a FontFace.
+    await server.createEcho("OPTIONS", `/font-cache-warm-${warmToken}.woff2`, {
+        status: 200,
+        headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "X-Ladybird-Enable-Disk-Cache",
+        },
+    });
+    const primedResponse = await fetch(warmURL, { headers: { "X-Ladybird-Enable-Disk-Cache": "1" } });
+    await primedResponse.arrayBuffer();
+    if (primedResponse.headers.get("X-Ladybird-Disk-Cache-Status") !== "written-to-cache")
+        throw new Error("Failed to prime the disk cache");
+
+    async function checkFirstPaint(url, enableMemoryCache = true) {
+        const iframe = document.createElement("iframe");
+        const painted = new Promise(resolve => window.reportFirstPaint = resolve);
+        iframe.srcdoc = `<!DOCTYPE html>
+            <style>@font-face { font-family: Test; src: url("${url}"); font-display: swap; }
+                body { font: 40px Test, monospace; }</style>
+            <script>
+                internals.setHttpMemoryCacheEnabled(${enableMemoryCache});
+                const face = [...document.fonts][0];
+                // Freeze the clock so a slow test machine cannot exhaust the cache wait budget.
+                internals.setFontDisplayTime(face, 0);
+                requestAnimationFrame(function check() {
+                    if (internals.hasCompletedInitialPaint)
+                        parent.reportFirstPaint({ pending: internals.initialPaintHadPendingFonts, status: face.status });
+                    else
+                        requestAnimationFrame(check);
+                });
+            <\/script><body>ሀሀሀሀ`;
+        document.body.append(iframe);
+        return { iframe, result: await painted };
+    }
+    const warm = await checkFirstPaint(warmURL);
+    println(`Warm cache: first paint had pending fonts = ${warm.result.pending}, font = ${warm.result.status}`);
+    warm.iframe.remove();
+
+    internals.setHttpMemoryCacheEnabled(false);
+    const disk = await checkFirstPaint(warmURL, false);
+    println(`Disk cache: first paint had pending fonts = ${disk.result.pending}, font = ${disk.result.status}`);
+    disk.iframe.remove();
+
+    const coldToken = crypto.randomUUID();
+    const coldURL = await server.createEcho("GET", `/font-cache-cold-${coldToken}.woff2`, {
+        status: 200,
+        headers: { "Content-Type": "font/woff2", "Cache-Control": "no-store" },
+        body: fontBody,
+        body_encoding: "base64",
+        wait_for_unblock: coldToken,
+    });
+    // A cache miss must allow first paint even though the server has not sent response headers yet.
+    const cold = await checkFirstPaint(coldURL);
+    println(`Cold cache: first paint had pending fonts = ${cold.result.pending}, font = ${cold.result.status}`);
+    await fetch(`${server.baseURL}/unblock/${coldToken}`);
+    await cold.iframe.contentDocument.fonts.ready;
+    println(`Cold font eventually loads: ${[...cold.iframe.contentDocument.fonts][0].status}`);
+    cold.iframe.remove();
+    internals.setHttpMemoryCacheEnabled(previousCacheSetting);
+});
+</script>

--- a/Tests/LibWeb/Text/input/css/font-display-timeline.html
+++ b/Tests/LibWeb/Text/input/css/font-display-timeline.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+promiseTest(async () => {
+    const server = httpTestServer();
+    const token = crypto.randomUUID();
+    const bytes = new Uint8Array(await (await fetch("../../../Assets/HashSans.woff")).arrayBuffer());
+    const url = await server.createEcho("GET", `/font-display-${token}.woff`, {
+        status: 200,
+        headers: { "Content-Type": "font/woff", "Access-Control-Allow-Origin": "*" },
+        body: btoa(String.fromCharCode(...bytes)),
+        body_encoding: "base64",
+        wait_for_unblock: token,
+    });
+    const samples = [];
+    function sample(family) {
+        const element = document.createElement("span");
+        element.style.cssText = `display:inline-block;font:40px "${family}",monospace`;
+        element.textContent = "AAAA";
+        document.body.append(element);
+        return element;
+    }
+    const fallbackWidth = sample("MissingFont").getBoundingClientRect().width;
+    for (const display of ["auto", "block", "swap", "fallback", "optional"]) {
+        const face = new FontFace(`Test-${display}`, `url("${url}")`, { display });
+        internals.setFontDisplayTime(face, 0);
+        document.fonts.add(face);
+        const element = sample(face.family);
+        println(`${display}: fallback metrics = ${element.getBoundingClientRect().width === fallbackWidth}, status = ${face.status}`);
+        samples.push({ face, element });
+    }
+    const early = new FontFace("EarlyFallback", `url("${url}")`, { display: "fallback" });
+    internals.setFontDisplayTime(early, 0);
+    document.fonts.add(early);
+    const earlyElement = sample(early.family);
+    earlyElement.getBoundingClientRect();
+
+    // Each face has its own deadline despite sharing the same download.
+    for (const { face } of samples)
+        internals.setFontDisplayTime(face, 3100);
+    await fetch(`${server.baseURL}/unblock/${token}`);
+    await Promise.all(samples.map(({ face }) => face.loaded));
+    for (const { face, element } of samples) {
+        println(`${face.display}: loaded = ${face.status}, uses downloaded font = ${element.getBoundingClientRect().width !== fallbackWidth}`);
+        // Once loaded in time, a font remains usable past its deadline.
+        internals.setFontDisplayTime(face, 10000);
+        println(`${face.display}: unchanged after deadline = ${element.getBoundingClientRect().width !== fallbackWidth}`);
+    }
+
+    await early.loaded;
+    internals.setFontDisplayTime(early, 10000);
+    println(`Font loaded during block period remains usable: ${earlyElement.getBoundingClientRect().width !== fallbackWidth}`);
+
+    const preloaded = new FontFace("Preloaded", `url("${url}")`, { display: "optional" });
+    await preloaded.load();
+    internals.setFontDisplayTime(preloaded, 10000);
+    document.fonts.add(preloaded);
+    println(`Preloaded optional font is usable: ${sample(preloaded.family).getBoundingClientRect().width !== fallbackWidth}`);
+
+    const unused = new FontFace("UnusedFallback", `url("${url}?unused")`);
+    document.fonts.add(unused);
+    const preferred = document.createElement("span");
+    preferred.style.font = '40px Preloaded, UnusedFallback, monospace';
+    preferred.textContent = "AAAA";
+    document.body.append(preferred);
+    preferred.getBoundingClientRect();
+    println(`Loaded preferred face leaves fallback unloaded: ${unused.status}`);
+
+    const otherToken = crypto.randomUUID();
+    const failedURL = await server.createEcho("GET", `/font-display-error-${otherToken}.woff`, {
+        status: 404,
+        wait_for_unblock: otherToken,
+    });
+    const pending = new FontFace("Pending", `url("${failedURL}")`, { display: "block" });
+    internals.setFontDisplayTime(pending, 0);
+    document.fonts.add(pending);
+    const pendingElement = sample(pending.family);
+    pendingElement.style.fontFamily = 'Pending, UnusedFallback, monospace';
+    pendingElement.getBoundingClientRect();
+    println(`Pending preferred face leaves fallback unloaded: ${unused.status}`);
+    pending.display = "swap";
+    println(`Changing display preserves fallback metrics: ${pendingElement.getBoundingClientRect().width === fallbackWidth}`);
+    const failed = pending.loaded.catch(() => {});
+    await fetch(`${server.baseURL}/unblock/${otherToken}`);
+    await failed;
+    pendingElement.style.fontFamily = 'Pending, monospace';
+    println(`Network failure uses fallback: ${pending.status}, ${pendingElement.getBoundingClientRect().width === fallbackWidth}`);
+});
+</script>

--- a/Tests/LibWeb/Text/input/css/unused-font-document-collectable.html
+++ b/Tests/LibWeb/Text/input/css/unused-font-document-collectable.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+promiseTest(async () => {
+    const fontBytes = await (await fetch("../../../Assets/HashSans.woff")).arrayBuffer();
+    async function makeRemovedDocument() {
+        const iframe = document.createElement("iframe");
+        const loaded = new Promise(resolve => iframe.onload = resolve);
+        iframe.srcdoc = `<!DOCTYPE html>
+            <style>
+                @font-face { font-family: Unused; src: url("data:font/woff;base64,AA=="); }
+                body { font: 20px monospace; }
+            </style>
+            <body>AAAA`;
+        document.body.append(iframe);
+        await loaded;
+        iframe.onload = null;
+        const preferred = new iframe.contentWindow.FontFace("Preferred", fontBytes);
+        await preferred.load();
+        iframe.contentDocument.fonts.add(preferred);
+        iframe.contentDocument.body.style.fontFamily = "Preferred, Unused, monospace";
+        // Populate the document-owned cascade while the first family covers every character.
+        iframe.contentDocument.body.getBoundingClientRect();
+        const face = [...iframe.contentDocument.fonts][0];
+        println(`unused face status: ${face.status}`);
+        // Preserve the wrappers so collection checks the native objects, not just disposable JS wrappers.
+        iframe.contentDocument.gcSentinel = true;
+        face.gcSentinel = true;
+        const weakDocument = new WeakRef(iframe.contentDocument);
+        const weakFace = new WeakRef(face);
+        iframe.remove();
+        // Release the parent's layout references to the removed iframe before collecting it.
+        document.body.getBoundingClientRect();
+        return { weakDocument, weakFace };
+    }
+    const { weakDocument, weakFace } = await makeRemovedDocument();
+    // Collect outside the creating JS job, after its locals and WeakRef kept-alive objects are released.
+    const maximumGcRoundsWhileIframeTeardownTasksDrain = 100;
+    for (let round = 0; round < maximumGcRoundsWhileIframeTeardownTasksDrain; ++round) {
+        await timeout(0);
+        await internals.gcAsync();
+        if (weakDocument.deref() === undefined && weakFace.deref() === undefined)
+            break;
+    }
+    println(`removed document collected: ${weakDocument.deref() === undefined}`);
+    println(`unused face collected: ${weakFace.deref() === undefined}`);
+});
+</script>

--- a/Tests/RequestServer/TestCookieResponses.cpp
+++ b/Tests/RequestServer/TestCookieResponses.cpp
@@ -77,7 +77,7 @@ public:
     void start_request(u64 request_id)
     {
         auto url = URL::Parser::basic_parse("http://localhost"sv).release_value();
-        auto message = make<Messages::RequestServer::StartRequest>(request_id, ByteString { "GET" }, move(url), Vector<HTTP::Header> {}, ByteBuffer {}, HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials::Yes, Core::ProxyData {}, true, Optional<u32> {});
+        auto message = make<Messages::RequestServer::StartRequest>(request_id, ByteString { "GET" }, move(url), Vector<HTTP::Header> {}, ByteBuffer {}, HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials::Yes, Core::ProxyData {}, true, Optional<u32> {}, false);
         auto response = dispatch(move(message));
         VERIFY(!response);
     }

--- a/Tests/RequestServer/TestDiskCacheWaiters.cpp
+++ b/Tests/RequestServer/TestDiskCacheWaiters.cpp
@@ -250,7 +250,7 @@ public:
             { ByteString { HTTP::TEST_CACHE_ENABLED_HEADER }, "1"sv },
         };
 
-        auto message = make<Messages::RequestServer::StartRequest>(request_id, ByteString { "GET" }, move(url), move(request_headers), ByteBuffer {}, HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials::No, Core::ProxyData {}, false, Optional<u32> {});
+        auto message = make<Messages::RequestServer::StartRequest>(request_id, ByteString { "GET" }, move(url), move(request_headers), ByteBuffer {}, HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials::No, Core::ProxyData {}, false, Optional<u32> {}, false);
         auto response = MUST(static_cast<RequestServerEndpoint::Stub&>(*m_connection).handle(move(message)));
         VERIFY(!response);
     }


### PR DESCRIPTION
Implement the CSS font display timeline, including block, swap, and failure periods for `font-display`. Preserve fallback metrics while suppressing glyph ink during the block period, avoid loading unselected fallback fonts, and keep late downloads available through the Font Loading API.

Allow cached fonts to finish before the initial paint without waiting for network responses, refresh retained canvas font cascades when fonts change, and avoid retaining discarded documents through pending font faces.

Makes this stop when a font is in cache: 

https://github.com/user-attachments/assets/3eef59e9-a04f-47fc-afb0-d06df4c8a800

