### PR TITLE
LibWeb: Wrap events for `window` listeners in the window's own realm

### DIFF
--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -161,7 +161,7 @@ JS::Completion invoke_event_listener(WebIDL::CallbackType& callback, DOM::Event&
 {
     auto& callback_realm = callback.callback->shape().realm();
     auto this_value = current_target_wrapper(callback_realm, event);
-    auto& event_realm = this_value ? this_value->realm() : callback_realm;
+    auto& event_realm = this_value ? this_value_realm(callback_realm, this_value) : callback_realm;
     auto wrapped_event = Bindings::event(event_realm, GC::Ref { event });
 
     return WebIDL::call_user_object_operation(callback, "handleEvent"_utf16_fly_string, this_value.ptr(), { { wrapped_event } });
@@ -185,7 +185,7 @@ JS::Completion invoke_event_handler(WebIDL::CallbackType& callback, DOM::Event& 
 
     auto& callback_realm = callback.callback->shape().realm();
     auto this_value = current_target_wrapper(callback_realm, event);
-    auto& event_realm = this_value ? this_value->realm() : callback_realm;
+    auto& event_realm = this_value ? this_value_realm(callback_realm, this_value) : callback_realm;
     auto wrapped_event = Bindings::event(event_realm, GC::Ref { event });
 
     return WebIDL::invoke_callback(callback, this_value.ptr(), { { wrapped_event } });

--- a/Tests/LibWeb/Text/expected/DOM/Event-wrapper-realm-with-capturing-window-listener.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Event-wrapper-realm-with-capturing-window-listener.txt
@@ -1,0 +1,2 @@
+keydown: instanceof Event = true, instanceof KeyboardEvent = true, prototype chain ends in Object.prototype = true
+click: instanceof Event = true, instanceof PointerEvent = true, prototype chain ends in Object.prototype = true

--- a/Tests/LibWeb/Text/input/DOM/Event-wrapper-realm-with-capturing-window-listener.html
+++ b/Tests/LibWeb/Text/input/DOM/Event-wrapper-realm-with-capturing-window-listener.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<textarea id="target"></textarea>
+<script src="../include.js"></script>
+<script>
+    // Events fired by the engine are wrapped when the first listener receives them. A capturing listener on the window
+    // runs first, so the wrapper it triggers must belong to the page's realm rather than the realm the WindowProxy was
+    // created in. Otherwise, every later listener sees prototypes from the wrong realm.
+    test(() => {
+        const target = document.getElementById("target");
+        const results = [];
+
+        window.addEventListener("keydown", () => {}, true);
+        window.addEventListener("click", () => {}, true);
+
+        for (const type of ["keydown", "click"]) {
+            target.addEventListener(type, event => {
+                let chainEnd = event;
+                while (Object.getPrototypeOf(chainEnd) !== null)
+                    chainEnd = Object.getPrototypeOf(chainEnd);
+                results.push(`${type}: instanceof Event = ${event instanceof Event}, `
+                    + `instanceof ${event.constructor.name} = ${event instanceof window[event.constructor.name]}, `
+                    + `prototype chain ends in Object.prototype = ${chainEnd === Object.prototype}`);
+            });
+        }
+
+        target.focus();
+        internals.sendKey(target, "A");
+        target.click();
+
+        for (const result of results)
+            println(result);
+    });
+</script>


### PR DESCRIPTION
Previously, a capturing listener on `window` handed every later listener an event object whose prototypes belonged to the realm of the initial `about:blank` document. This meant that `event instanceof Event` evaluated to false. The `this` value of a `window` listener is the browsing context's `WindowProxy`, which keeps the realm it was created in across navigations, and the event was wrapped through that realm. We now wrap the event in the realm of the window that the proxy currently represents. Listeners in isolated worlds keep receiving wrappers from their own world.

This fixes typing on https://monkeytype.com, which regressed as of 4be9c6d3ccfd204d72809569cf09818e7593c3cf.

Advances #11648 (but doesn't close it, since 10fastfingers is still not working).