### PR TITLE
LibJS: Decouple interpreter helpers from call-frame storage

### DIFF
--- a/Libraries/LibJS/Flap/src/bin/generate-libjs-bytecode.rs
+++ b/Libraries/LibJS/Flap/src/bin/generate-libjs-bytecode.rs
@@ -5,7 +5,8 @@
  */
 
 use flapc::metadata::{
-    Field, InstructionDefinition, derive_specialized_instructions, parse_flap_metadata, parse_specializations,
+    Field, InstructionDefinition, ParameterMode, derive_specialized_instructions, parse_flap_metadata,
+    parse_specializations,
 };
 use flapc::validate_specializations;
 use std::env;
@@ -150,6 +151,27 @@ fn generate_class(output: &mut String, op: &InstructionDefinition) -> Result<(),
     }
 
     writeln!(output).unwrap();
+    writeln!(output, "    struct Values {{").unwrap();
+    for field in &op.fields {
+        if field.ty == "Operand" || field.ty == "Optional<Operand>" {
+            let name = parameter_name(&field.name);
+            let suffix = if field.is_array { "[]" } else { "" };
+            writeln!(output, "        Value {name}{suffix};").unwrap();
+        }
+    }
+    if let Some(field) = op
+        .fields
+        .iter()
+        .find(|field| field.ty == "Operand" && !field.is_array && field.mode == ParameterMode::Out)
+    {
+        writeln!(
+            output,
+            "        Value const& primary_output() const {{ return {}; }}",
+            parameter_name(&field.name)
+        )
+        .unwrap();
+    }
+    writeln!(output, "    }};").unwrap();
     writeln!(output, "private:").unwrap();
     for field in &op.fields {
         if field.is_array {
@@ -160,7 +182,84 @@ fn generate_class(output: &mut String, op: &InstructionDefinition) -> Result<(),
     }
     writeln!(output, "}};").unwrap();
     writeln!(output, "static_assert(IsTriviallyDestructible<{}>);", op.name).unwrap();
+    generate_slow_path_interface(output, op);
     Ok(())
+}
+
+fn generate_slow_path_interface(output: &mut String, op: &InstructionDefinition) {
+    let name = &op.name;
+    let layout = flapc::metadata::SlowPathLayout::new(op);
+    let scalar = layout.uses_scalar_arguments();
+    let scalar_inputs = layout.array.is_none();
+    if scalar_inputs {
+        writeln!(output, "#ifndef AK_OS_WINDOWS").unwrap();
+        let result_type = if scalar { "AsmSlowPathResult" } else { "i64" };
+        let results_parameter = if scalar {
+            String::new()
+        } else {
+            format!(", Op::{name}::Values& outputs")
+        };
+        let inputs: Vec<_> = op
+            .fields
+            .iter()
+            .filter(|field| {
+                (field.ty == "Operand" || field.ty == "Optional<Operand>") && field.mode != ParameterMode::Out
+            })
+            .collect();
+        let parameters = inputs
+            .iter()
+            .map(|field| format!(", Value {}", parameter_name(&field.name)))
+            .collect::<String>();
+        writeln!(
+            output,
+            "#define JS_DECLARE_SLOW_PATH_{name}(slow_path_function) {result_type} slow_path_function(VM*, u32, Op::{name} const*{results_parameter}{parameters})"
+        )
+        .unwrap();
+        writeln!(output, "#define JS_DEFINE_SLOW_PATH_{name}(slow_path_function) \\").unwrap();
+        writeln!(
+            output,
+            "    static ALWAYS_INLINE i64 slow_path_function##_impl(VM*, u32, Op::{name} const*, Op::{name}::Values&); \\"
+        )
+        .unwrap();
+        writeln!(
+            output,
+            "    {result_type} slow_path_function(VM* vm, u32 pc, Op::{name} const* instruction{results_parameter}{parameters}) {{ \\"
+        )
+        .unwrap();
+        writeln!(output, "        Op::{name}::Values values; \\").unwrap();
+        for field in inputs {
+            let field_name = parameter_name(&field.name);
+            writeln!(output, "        values.{field_name} = {field_name}; \\").unwrap();
+        }
+        if scalar {
+            writeln!(output, "        return make_asm_slow_path_result(slow_path_function##_impl(vm, pc, instruction, values), values); \\").unwrap();
+        } else {
+            writeln!(
+                output,
+                "        auto control = slow_path_function##_impl(vm, pc, instruction, values); \\"
+            )
+            .unwrap();
+            for field in op.fields.iter().filter(|field| {
+                (field.ty == "Operand" || field.ty == "Optional<Operand>") && field.mode != ParameterMode::In
+            }) {
+                let field_name = parameter_name(&field.name);
+                writeln!(output, "        outputs.{field_name} = values.{field_name}; \\").unwrap();
+            }
+            writeln!(output, "        return control; \\").unwrap();
+        }
+        writeln!(output, "    }} \\").unwrap();
+        writeln!(output, "    static ALWAYS_INLINE i64 slow_path_function##_impl([[maybe_unused]] VM* vm, [[maybe_unused]] u32 pc, [[maybe_unused]] Op::{name} const* instruction, [[maybe_unused]] Op::{name}::Values& values)").unwrap();
+        writeln!(output, "#else").unwrap();
+    }
+    writeln!(output, "#define JS_DECLARE_SLOW_PATH_{name}(slow_path_function) i64 slow_path_function(VM*, u32, Op::{name} const*, Op::{name}::Values&)").unwrap();
+    writeln!(
+        output,
+        "#define JS_DEFINE_SLOW_PATH_{name}(slow_path_function) DEFINE_RECORD_SLOW_PATH(slow_path_function, Op::{name})"
+    )
+    .unwrap();
+    if scalar_inputs {
+        writeln!(output, "#endif").unwrap();
+    }
 }
 
 fn generate_op_header(ops: &[InstructionDefinition]) -> Result<String, String> {
@@ -294,5 +393,76 @@ specialize Add(rhs: Int32);
         .unwrap_err();
 
         assert_eq!(error, "duplicate specialization name 'AddRhsInt32'");
+    }
+
+    #[test]
+    fn generates_named_values_only_for_operands() {
+        let op = parse_flap_metadata(
+            "test.flap",
+            "handler Call(length: u32, dst: out Operand, callee: in Operand, argument_count: u32, arguments: Operand[]) { dispatch_next; }",
+        )
+        .unwrap()
+        .remove(0);
+        let mut output = String::new();
+        generate_class(&mut output, &op).unwrap();
+        assert!(output.contains(
+            "    struct Values {\n        Value dst;\n        Value callee;\n        Value arguments[];\n        Value const& primary_output() const { return dst; }\n    };"
+        ));
+    }
+
+    #[test]
+    fn generates_scalar_arguments_with_a_windows_record_fallback() {
+        let op = parse_flap_metadata(
+            "test.flap",
+            "handler Get(dst: out Operand, base: Operand, property: Optional<Operand>) { dispatch_next; }",
+        )
+        .unwrap()
+        .remove(0);
+        let mut output = String::new();
+        generate_class(&mut output, &op).unwrap();
+        assert!(output.contains("#ifndef AK_OS_WINDOWS"));
+        assert!(
+            output
+                .contains("AsmSlowPathResult slow_path_function(VM*, u32, Op::Get const*, Value base, Value property)")
+        );
+        assert!(output.contains("values.base = base;"));
+        assert!(output.contains("values.property = property;"));
+        assert!(output.contains("i64 slow_path_function(VM*, u32, Op::Get const*, Op::Get::Values&)"));
+    }
+
+    #[test]
+    fn generates_scalar_inputs_and_record_outputs_for_multiple_results() {
+        let op = parse_flap_metadata(
+            "test.flap",
+            "handler Next(value: out Operand, done: out Operand, state: inout Operand, iterator: Operand) { dispatch_next; }",
+        )
+        .unwrap()
+        .remove(0);
+        let mut output = String::new();
+        generate_class(&mut output, &op).unwrap();
+        assert!(output.contains(
+            "i64 slow_path_function(VM*, u32, Op::Next const*, Op::Next::Values& outputs, Value state, Value iterator)"
+        ));
+        assert!(output.contains("values.state = state;"));
+        assert!(output.contains("values.iterator = iterator;"));
+        assert!(output.contains("outputs.value = values.value;"));
+        assert!(output.contains("outputs.done = values.done;"));
+        assert!(output.contains("outputs.state = values.state;"));
+        assert!(!output.contains("outputs.iterator ="));
+    }
+
+    #[test]
+    fn generates_scalar_arguments_without_outputs_or_colliding_with_name_operands() {
+        let op = parse_flap_metadata(
+            "test.flap",
+            "handler SetName(function: Operand, name: Operand) { dispatch_next; }",
+        )
+        .unwrap()
+        .remove(0);
+        let mut output = String::new();
+        generate_class(&mut output, &op).unwrap();
+        assert!(output.contains("#define JS_DEFINE_SLOW_PATH_SetName(slow_path_function)"));
+        assert!(output.contains("values.name = name;"));
+        assert!(output.contains("Value function, Value name)"));
     }
 }

--- a/Libraries/LibJS/Flap/src/bytecode.rs
+++ b/Libraries/LibJS/Flap/src/bytecode.rs
@@ -34,6 +34,7 @@ struct FieldLayout {
 #[derive(Debug)]
 pub(crate) struct HandlerLayout {
     pub(crate) size: Option<usize>,
+    pub(crate) slow_path: Option<crate::metadata::SlowPathLayout>,
     fields: Vec<FieldLayout>,
 }
 
@@ -79,6 +80,7 @@ impl HandlerLayout {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
             size: layout.and_then(|layout| layout.size),
+            slow_path: op.map(crate::metadata::SlowPathLayout::new),
             fields,
         })
     }

--- a/Libraries/LibJS/Flap/src/frontend/layout.rs
+++ b/Libraries/LibJS/Flap/src/frontend/layout.rs
@@ -63,6 +63,8 @@ define_known_layout_constants! {
     NullValue => "NULL_VALUE";
     ShiftedIsCellPattern => "SHIFTED_IS_CELL_PATTERN";
     VmRunningExecutionContext => "VM_RUNNING_EXECUTION_CONTEXT";
+    VmStackInfoBase => "VM_STACK_INFO_BASE";
+    VmStackSpaceLimit => "VM_STACK_SPACE_LIMIT";
     VmHeapRegionBase => "VM_HEAP_REGION_BASE";
     VmBreakpointController => "VM_BREAKPOINT_CONTROLLER";
     SlowPathContinuationBit => "SLOW_PATH_CONTINUATION_BIT";

--- a/Libraries/LibJS/Flap/src/frontend/layout.rs
+++ b/Libraries/LibJS/Flap/src/frontend/layout.rs
@@ -65,6 +65,7 @@ define_known_layout_constants! {
     VmRunningExecutionContext => "VM_RUNNING_EXECUTION_CONTEXT";
     VmHeapRegionBase => "VM_HEAP_REGION_BASE";
     VmBreakpointController => "VM_BREAKPOINT_CONTROLLER";
+    SlowPathContinuationBit => "SLOW_PATH_CONTINUATION_BIT";
     ExecutionContextExecutable => "EXECUTION_CONTEXT_EXECUTABLE";
     ExecutionContextProgramCounter => "EXECUTION_CONTEXT_PROGRAM_COUNTER";
     ExecutableBytecodeData => "EXECUTABLE_BYTECODE_DATA";

--- a/Libraries/LibJS/Flap/src/frontend/specialize.rs
+++ b/Libraries/LibJS/Flap/src/frontend/specialize.rs
@@ -182,10 +182,14 @@ pub(crate) fn expand_declarative_specializations(
                 span,
             }
         };
+        let temperature = match specialization.components.as_slice() {
+            [component] => handlers[&component.bytecode].temperature,
+            _ => BlockTemperature::Default,
+        };
         program.declarations.push(Declaration::Handler(HandlerDeclaration {
             name: specialization.definition.name.clone(),
             parameters,
-            temperature: BlockTemperature::Default,
+            temperature,
             body,
             span,
         }));
@@ -416,6 +420,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn preserves_single_component_handler_temperature() {
+        let source = "handler Source(src: Operand) @cold { dispatch_next; }";
+        let mut program = super::super::parser::parse("test.flap", source).unwrap();
+        let operations = crate::metadata::parse_flap_metadata("test.flap", source).unwrap();
+        let declarations =
+            crate::metadata::parse_specializations("test.flap", "specialize Source(src: Int32);").unwrap();
+        let specializations = crate::metadata::derive_specialized_instructions(&operations, &declarations).unwrap();
+
+        expand_declarative_specializations("test.flap", &mut program, &specializations).unwrap();
+
+        let Some(Declaration::Handler(specialized)) = program.declarations.last() else {
+            panic!("expected specialized handler");
+        };
+        assert_eq!(specialized.name, "SourceSrcInt32");
+        assert_eq!(specialized.temperature, BlockTemperature::Cold);
+    }
+
+    #[test]
     fn accepts_handlerless_programs_without_specializations() {
         let mut program = Program {
             declarations: Vec::new(),
@@ -460,6 +482,7 @@ mod tests {
                     name: "m_field".to_string(),
                     ty: "Operand".to_string(),
                     is_array: false,
+                    mode: crate::metadata::ParameterMode::In,
                 }],
                 is_terminator: false,
                 layout: Default::default(),

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -1938,19 +1938,27 @@ impl<'a> Checker<'a> {
                 ))
             }
             ExpressionKind::Call { callee, arguments }
-                if callee == "call_helper" && arguments.len() == 2 && expected.is_some() =>
+                if ((callee == "call_helper" && arguments.len() == 2)
+                    || (callee == "call_helper_with_two_arguments" && arguments.len() == 3))
+                    && expected.is_some() =>
             {
                 let return_type = expected.expect("guarded by expected.is_some()");
                 if !is_gpr_type(return_type) {
-                    return self.error(expression.span, format!("call_helper cannot return {return_type}"));
+                    return self.error(expression.span, format!("{callee} cannot return {return_type}"));
+                }
+                let operation = if arguments.len() == 2 {
+                    CallOperation::Helper
+                } else {
+                    CallOperation::HelperWithTwoArguments
+                };
+                let mut values = vec![self.check_value(&arguments[0], &Type::FunctionSymbol)?];
+                for argument in &arguments[1..] {
+                    values.push(self.check_materialized_gpr_value(argument)?);
                 }
                 Ok(Call::new(
-                    CallTarget::Intrinsic(Intrinsic::Call(CallOperation::Helper)),
-                    vec![
-                        self.check_value(&arguments[0], &Type::FunctionSymbol)?,
-                        self.check_materialized_gpr_value(&arguments[1])?,
-                    ],
-                    vec![ParameterMode::In, ParameterMode::In],
+                    CallTarget::Intrinsic(Intrinsic::Call(operation)),
+                    values,
+                    vec![ParameterMode::In; arguments.len()],
                     Some(return_type.clone()),
                 ))
             }

--- a/Libraries/LibJS/Flap/src/intrinsic.rs
+++ b/Libraries/LibJS/Flap/src/intrinsic.rs
@@ -824,6 +824,7 @@ define_named_intrinsic_enum! {
         JumpSlowPath => "call_jump_slow_path" signatures [signature!([In SlowPath, In Value, In Value, In BytecodeOffset, In BytecodeOffset])];
         Interpreter => "call_interp" signatures [signature!([In FunctionSymbol] -> I32), signature!([In FunctionSymbol, Out AnyGpr])];
         Helper => "call_helper" signatures [signature!([In FunctionSymbol, In AnyGpr, Out AnyGpr])];
+        HelperWithTwoArguments => "call_helper_with_two_arguments" signatures [signature!([In FunctionSymbol, In AnyGpr, In AnyGpr, Out AnyGpr])];
         RawNative => "call_raw_native" signatures [signature!([In AnyGpr] -> (Value, U64)), signature!([In AnyGpr, Out AnyGpr, Out AnyGpr])];
     }
 }
@@ -832,7 +833,7 @@ impl CallOperation {
     pub(crate) fn result_count(self) -> usize {
         match self {
             Self::SlowPath | Self::BinarySlowPath | Self::JumpSlowPath => 0,
-            Self::Interpreter | Self::Helper => 1,
+            Self::Interpreter | Self::Helper | Self::HelperWithTwoArguments => 1,
             Self::RawNative => 2,
         }
     }

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -640,6 +640,7 @@ const EXECUTION_CONTEXT_PROGRAM_COUNTER = 56
 const SIZEOF_EXECUTION_CONTEXT = 120
 const VM_RUNNING_EXECUTION_CONTEXT = 15288
 const VM_BREAKPOINT_CONTROLLER = 16664
+const SLOW_PATH_CONTINUATION_BIT = 32
 const EXECUTABLE_BYTECODE_DATA = 104
 const INT32_TAG = 0x7FFA
 const BOOLEAN_TAG = 0x7FF9
@@ -1037,7 +1038,7 @@ specialize Clear(dst: Undefined);
         assert!(
             emission_error
                 .message
-                .contains("required runtime constant 'VM_RUNNING_EXECUTION_CONTEXT'")
+                .contains("required runtime constant 'SLOW_PATH_CONTINUATION_BIT'")
         );
     }
 

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -545,6 +545,14 @@ impl Compiler {
     pub fn lower(&self, prepared: &PreparedProgram) -> Result<LowProgram, CompileError> {
         let mut program = LowProgram::new();
         program.runtime = low_ir::RuntimeConstants::from_layout(&prepared.constants);
+        for (handler, layout) in prepared.handlers.iter().zip(&prepared.bytecode.handler_layouts) {
+            if let Some(layout) = &layout.slow_path {
+                program
+                    .runtime
+                    .slow_paths
+                    .insert(handler.name().to_string(), layout.clone());
+            }
+        }
         program.dispatch_handlers = prepared.bytecode.dispatch_handlers.clone();
 
         for template in &prepared.handlers {

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -271,6 +271,43 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                 ));
             }
         }
+        if !cold.is_empty() {
+            // Blocks reached only after crossing a cold annotation belong in
+            // the cold section too. Keep whole fallthrough chains together so
+            // moving a block cannot change its implicit successor.
+            let mut states = vec![0u8; self.blocks.len()];
+            let mut pending = vec![(BlockId(0), 1u8)];
+            while let Some((block_id, mut state)) = pending.pop() {
+                let block = &self.blocks[block_id.0];
+                if block.is_cold {
+                    state = 2;
+                }
+                if states[block_id.0] & state != 0 {
+                    continue;
+                }
+                states[block_id.0] |= state;
+                pending.extend(block.successors.iter().map(|edge| (edge.target, state)));
+            }
+            let mut cold_blocks = self.blocks.iter().map(|block| block.is_cold).collect::<Vec<_>>();
+            let mut start = 0;
+            for (index, block) in self.blocks.iter().enumerate() {
+                if block.instructions.last().unwrap().opcode.description().terminal || index + 1 == self.blocks.len() {
+                    if states[start..=index].iter().all(|&state| state == 2) {
+                        cold_blocks[start..=index].fill(true);
+                    }
+                    start = index + 1;
+                }
+            }
+            hot.clear();
+            cold.clear();
+            for (index, is_cold) in cold_blocks.into_iter().enumerate() {
+                if is_cold {
+                    cold.push(BlockId(index));
+                } else {
+                    hot.push(BlockId(index));
+                }
+            }
+        }
         Ok(BlockLayout { hot, cold })
     }
 
@@ -946,6 +983,41 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![Operation::Label, Operation::Call(CallKind::SlowPath)]
         );
+    }
+
+    #[test]
+    fn propagates_coldness_without_separating_fallthrough_joins() {
+        for explicit_join in [false, true] {
+            let mut instructions = vec![
+                instruction(
+                    Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero),
+                    vec![Operand::VirtualRegister("value".into()), label(".slow")],
+                ),
+                instruction(Operation::Control(ControlOperation::JumpLabel), vec![label(".join")]),
+                instruction(Operation::Label, vec![label(".rare")]),
+            ];
+            if explicit_join {
+                instructions.push(instruction(
+                    Operation::Control(ControlOperation::JumpLabel),
+                    vec![label(".join")],
+                ));
+            }
+            instructions.extend([
+                instruction(Operation::Label, vec![label(".join")]),
+                instruction(Operation::Control(ControlOperation::DispatchNext), vec![]),
+                instruction(Operation::Cold, vec![label(".slow")]),
+                instruction(Operation::Label, vec![label(".slow")]),
+                instruction(Operation::Control(ControlOperation::JumpLabel), vec![label(".rare")]),
+            ]);
+            let graph = ControlFlowGraph::from_instructions(instructions).unwrap();
+            let layout = graph.layout_hot_and_cold().unwrap();
+            assert!(
+                layout.hot.contains(&BlockId(3)),
+                "a join reachable from hot code stays hot"
+            );
+            assert_eq!(layout.cold.contains(&BlockId(2)), explicit_join);
+            assert!(layout.cold.contains(&BlockId(4)));
+        }
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -311,16 +311,6 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         Ok(BlockLayout { hot, cold })
     }
 
-    pub(crate) fn single_instruction(&self) -> Option<&Instruction<O, C>> {
-        let [block] = self.blocks.as_slice() else {
-            return None;
-        };
-        let [instruction] = block.instructions.as_slice() else {
-            return None;
-        };
-        Some(instruction)
-    }
-
     /// Tidy the graph after an edit: thread branches through jump-only blocks,
     /// drop jump blocks nothing reaches, and drop blocks control cannot reach.
     ///
@@ -893,7 +883,8 @@ mod tests {
         }])
         .unwrap();
 
-        assert!(graph.single_instruction().is_some());
+        assert_eq!(graph.blocks.len(), 1);
+        assert_eq!(graph.blocks[0].instructions.len(), 1);
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -2465,6 +2465,7 @@ fn lower_instruction(
                 CallOperation::BinarySlowPath => 4,
                 CallOperation::JumpSlowPath => 5,
                 CallOperation::Helper => 2,
+                CallOperation::HelperWithTwoArguments => 3,
             };
             if inputs.len() != expected_inputs || results.len() != operation.result_count() {
                 return Err(format!("'{}' has invalid SSA operand arity", operation.name()));

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -504,12 +504,14 @@ pub(crate) struct Handler {
 #[derive(Clone, Default)]
 pub(crate) struct RuntimeConstants {
     values: [Option<i64>; KnownLayoutConstant::COUNT],
+    pub(crate) slow_paths: HashMap<String, crate::metadata::SlowPathLayout>,
 }
 
 impl RuntimeConstants {
     pub(crate) fn from_layout(constants: &LayoutConstants) -> Self {
         Self {
             values: KnownLayoutConstant::ALL.map(|constant| constants.known(constant).map(|value| value.value())),
+            slow_paths: HashMap::default(),
         }
     }
 

--- a/Libraries/LibJS/Flap/src/metadata.rs
+++ b/Libraries/LibJS/Flap/src/metadata.rs
@@ -19,6 +19,74 @@ pub struct Field {
     pub name: String,
     pub ty: String,
     pub is_array: bool,
+    pub mode: ParameterMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParameterMode {
+    In,
+    Out,
+    InOut,
+}
+
+#[derive(Debug, Clone)]
+pub struct SlowPathField {
+    pub instruction_offset: usize,
+    pub value_offset: usize,
+    pub mode: ParameterMode,
+    pub optional: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SlowPathLayout {
+    pub fields: Vec<SlowPathField>,
+    /// Instruction offsets of the operand array and its count, and whether its entries are optional.
+    pub array: Option<(usize, usize, bool)>,
+}
+
+impl SlowPathLayout {
+    pub fn uses_scalar_arguments(&self) -> bool {
+        self.array.is_none()
+            && self
+                .fields
+                .iter()
+                .filter(|field| field.mode == ParameterMode::Out)
+                .count()
+                <= 1
+            && self
+                .fields
+                .iter()
+                .all(|field| field.mode == ParameterMode::In || (field.mode == ParameterMode::Out && !field.optional))
+    }
+
+    pub fn new(op: &InstructionDefinition) -> Self {
+        // Match the generated Op::Values record: one Value per scalar operand,
+        // followed by the variable-length input operands. Non-value metadata
+        // remains in the instruction and is not copied into this record.
+        let mut layout = Self::default();
+        for field in &op.fields {
+            if field.ty != "Operand" && field.ty != "Optional<Operand>" {
+                continue;
+            }
+            let optional = field.ty == "Optional<Operand>";
+            if field.is_array {
+                let array = op.array.as_ref().expect("operand array has a count");
+                layout.array = Some((
+                    array.offset,
+                    op.layout.field_offsets[&op.fields[array.count_field_index].name],
+                    optional,
+                ));
+            } else {
+                layout.fields.push(SlowPathField {
+                    instruction_offset: op.layout.field_offsets[&field.name],
+                    value_offset: layout.fields.len() * 8,
+                    mode: field.mode,
+                    optional,
+                });
+            }
+        }
+        layout
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -300,6 +368,13 @@ fn parse_handler_fields(source_name: &str, line: usize, source: &str) -> Result<
                     ));
                 }
                 let ty = ty.trim();
+                let mode = if ty.starts_with("out ") {
+                    ParameterMode::Out
+                } else if ty.starts_with("inout ") {
+                    ParameterMode::InOut
+                } else {
+                    ParameterMode::In
+                };
                 let ty = ["inout ", "in ", "out "]
                     .into_iter()
                     .find_map(|mode| ty.strip_prefix(mode))
@@ -323,6 +398,7 @@ fn parse_handler_fields(source_name: &str, line: usize, source: &str) -> Result<
                     name: format!("m_{name}"),
                     ty: ty.to_string(),
                     is_array,
+                    mode,
                 });
             }
             _ => {}
@@ -713,6 +789,7 @@ pub fn derive_specialized_instructions(
                             name: format!("m_{specialized_name}"),
                             ty: ty.to_string(),
                             is_array: field.is_array,
+                            mode: field.mode,
                         });
                         SpecializedParameterBinding::Field(specialized_name)
                     }
@@ -747,6 +824,52 @@ pub fn derive_specialized_instructions(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lays_out_explicit_helper_values_with_operand_modes() {
+        let ops = parse_flap_metadata(
+            "test.flap",
+            "handler Call(length: u32, dst: out Operand, callee: in Operand, state: inout Optional<Operand>, argument_count: u32, arguments: Operand[]) = call_slow_path(call);",
+        )
+        .unwrap();
+        let op = &ops[0];
+        let layout = SlowPathLayout::new(op);
+        assert!(!layout.uses_scalar_arguments());
+        assert_eq!(layout.fields.len(), 3);
+        for (index, (name, mode)) in [
+            ("m_dst", ParameterMode::Out),
+            ("m_callee", ParameterMode::In),
+            ("m_state", ParameterMode::InOut),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            assert_eq!(layout.fields[index].instruction_offset, op.layout.field_offsets[name]);
+            assert_eq!(layout.fields[index].value_offset, index * 8);
+            assert_eq!(layout.fields[index].mode, mode);
+            assert_eq!(layout.fields[index].optional, index == 2);
+        }
+        assert_eq!(
+            layout.array,
+            Some((
+                op.array.as_ref().unwrap().offset,
+                op.layout.field_offsets["m_argument_count"],
+                false
+            ))
+        );
+    }
+
+    #[test]
+    fn uses_scalar_arguments_for_at_most_one_required_output_without_inout_operands() {
+        let ops = parse_flap_metadata(
+            "test.flap",
+            "handler Get(dst: out Operand, base: Operand, property: Optional<Operand>) { dispatch_next; }\nhandler Update(dst: out Operand, src: inout Operand) { dispatch_next; }\nhandler OptionalOutput(dst: out Optional<Operand>) { dispatch_next; }\nhandler Put(base: Operand, value: Operand) { dispatch_next; }",
+        ).unwrap();
+        assert!(SlowPathLayout::new(&ops[0]).uses_scalar_arguments());
+        assert!(!SlowPathLayout::new(&ops[1]).uses_scalar_arguments());
+        assert!(!SlowPathLayout::new(&ops[2]).uses_scalar_arguments());
+        assert!(SlowPathLayout::new(&ops[3]).uses_scalar_arguments());
+    }
 
     #[test]
     fn parses_operations_fields_and_annotations() {

--- a/Libraries/LibJS/Flap/src/target/aarch64.rs
+++ b/Libraries/LibJS/Flap/src/target/aarch64.rs
@@ -779,10 +779,7 @@ pub(crate) fn generate(program: &Program, options: &CompileOptions) -> String {
                 "//",
                 |out, _| emit_handler_alignment(out, object_format),
                 emit_instruction,
-                |out| {
-                    w!(out, ".Lexit_veneer:");
-                    w!(out, "    b .Lexit");
-                },
+                |_| {},
             )
         },
         |out| generate_exit_point(out, object_format),
@@ -1163,6 +1160,31 @@ fn shift_mnemonic(operation: ShiftOperation) -> &'static str {
 fn emit_instruction(out: &mut String, insn: &MachineInstruction, handler: &Handler) {
     let opcode = insn.opcode.aarch64();
     debug_assert!(!opcode.is_pseudo());
+    // Cold blocks follow all hot handlers and may exceed the test-bit branch's
+    // +/-32 KiB reach. Use a local inverted test followed by a full-range branch.
+    let bit_branch = match opcode {
+        Opcode::TestBitAndBranch { width, condition } => Some((width, condition, insn.immediate(1), 2)),
+        Opcode::BranchOnBit31(condition) => Some((
+            IntegerWidth::U32,
+            condition.select(TestCondition::Set, TestCondition::Clear),
+            31,
+            1,
+        )),
+        _ => None,
+    };
+    if let Some((width, condition, bit, target_index)) = bit_branch {
+        let target = &insn.operands[target_index];
+        if handler.cold_instructions.iter().any(|instruction| {
+            instruction.opcode.aarch64() == Opcode::Label && instruction.operands.first() == Some(target)
+        }) {
+            let register = insn.physical_register(0).integer_name(width);
+            let inverse = condition.select("tbz", "tbnz");
+            w!(out, "    {inverse} {register}, #{bit}, 1f");
+            w!(out, "    b {}", super::emitter::resolve_label(target, handler));
+            w!(out, "1:");
+            return;
+        }
+    }
     if emit_simple_instruction(out, insn, opcode.simple_instruction(), |operand| match operand {
         Operand::Label(_) => super::emitter::resolve_label(operand, handler),
         Operand::Address(address) => match opcode {
@@ -1186,10 +1208,9 @@ fn emit_instruction(out: &mut String, insn: &MachineInstruction, handler: &Handl
 }
 
 fn emit_branch_bit_set_to_exit(out: &mut String, register: PhysicalRegister, bit: u8) {
-    // A test-bit branch only has a +/-32 KiB range, while the shared exit point
-    // follows all interpreter handlers. Branch to the veneer between the hot
-    // and cold regions, which can reach the exit using a wider-range branch.
-    w!(out, "    tbnz {register}, #{bit}, .Lexit_veneer");
+    w!(out, "    tbz {register}, #{bit}, 1f");
+    w!(out, "    b .Lexit");
+    w!(out, "1:");
 }
 
 #[cfg(test)]
@@ -1305,7 +1326,7 @@ mod tests {
     }
 
     #[test]
-    fn bit_test_exit_branch_uses_the_shared_veneer() {
+    fn bit_test_exit_branch_uses_a_full_range_branch() {
         let program = machine_coff_program(Vec::new());
         let handler = &program.functions[0];
         let instruction = MachineInstruction {
@@ -1316,17 +1337,14 @@ mod tests {
 
         emit_instruction(&mut out, &instruction, handler);
 
-        assert_eq!(out, "    tbnz x0, #63, .Lexit_veneer\n");
+        assert_eq!(out, "    tbz x0, #63, 1f\n    b .Lexit\n1:\n");
     }
 
     #[test]
-    fn emits_one_exit_veneer_between_hot_and_cold_handlers() {
+    fn exit_branches_do_not_depend_on_a_shared_veneer() {
         let output = generate(&coff_program(Vec::new()));
 
-        assert_eq!(output.matches(".Lexit_veneer:").count(), 1);
-        assert!(output.contains("    tbnz x0, #63, .Lexit_veneer"));
-        assert!(output.contains(".Lexit_veneer:\n    b .Lexit\n"));
-        assert!(output.find(".Lexit_veneer:") < output.find("// Cold handler paths"));
+        assert!(output.contains("    tbz x0, #63, 1f\n    b .Lexit\n1:\n"));
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/target/aarch64.rs
+++ b/Libraries/LibJS/Flap/src/target/aarch64.rs
@@ -1233,6 +1233,7 @@ mod tests {
                 &crate::frontend::layout::LayoutConstants::from_values([
                     ("VM_RUNNING_EXECUTION_CONTEXT".into(), 8),
                     ("VM_BREAKPOINT_CONTROLLER".into(), 16),
+                    ("SLOW_PATH_CONTINUATION_BIT".into(), 32),
                     ("VM_HEAP_REGION_BASE".into(), 24),
                     ("CANON_NAN_BITS".into(), 0x7ff8_0000_0000_0000u64 as i64),
                     ("INT32_TAG".into(), 0xfffau64 as i64),

--- a/Libraries/LibJS/Flap/src/target/aarch64/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/aarch64/finalize.rs
@@ -888,6 +888,16 @@ fn finish_slow_path_call(
     let [execution_context, executable, _, bytecode, values_offset] = interpreter_layout(emit.runtime, emit.handler)?;
     emit!(emit.output, Aarch64; Opcode::BranchBitSetToExit(63) => [register X0];);
 
+    let transfer = emit.unique_label("slow_path_transfer");
+    let continuation_bit = emit.constant(KnownLayoutConstant::SlowPathContinuationBit)?;
+    emit!(emit.output, Aarch64;
+        Opcode::TestBitAndBranch { width: IntegerWidth::U64, condition: TestCondition::Clear } => [register X0, immediate continuation_bit, label transfer.clone()];
+        Opcode::SetInstructionPointer => [register X0];
+    );
+    dispatch_from_instruction_pointer(emit, dispatch_register, dispatch_scratch)
+        .map_err(|error| memory_address_compile_error(emit.handler, error))?;
+    emit!(emit.output, Aarch64; Opcode::Label => [label transfer];);
+
     load(
         emit,
         MemoryWidth::DoubleWord,

--- a/Libraries/LibJS/Flap/src/target/aarch64/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/aarch64/finalize.rs
@@ -878,6 +878,485 @@ fn store_slow_path_program_counter(
     .map_err(|error| memory_address_compile_error(emit.handler, error))
 }
 
+fn call_values_load(
+    emit: &mut Emit<'_>,
+    width: MemoryWidth,
+    destination: PhysicalRegister,
+    address: MachineMemoryAddress,
+) -> Result<(), CompileError> {
+    use crate::target::registers::aarch64::X15;
+    load(emit, width, false, destination, address, &[X15])
+        .map_err(|error| memory_address_compile_error(emit.handler, error))
+}
+
+fn call_values_store(
+    emit: &mut Emit<'_>,
+    width: MemoryWidth,
+    address: MachineMemoryAddress,
+    source: PhysicalRegister,
+) -> Result<(), CompileError> {
+    use crate::target::registers::aarch64::{X15, X16};
+    store(emit, width, address, StoreSource::Register(source), [X15, X16])
+        .map_err(|error| memory_address_compile_error(emit.handler, error))
+}
+
+fn call_values_add(emit: &mut Emit<'_>, destination: PhysicalRegister, source: PhysicalRegister, value: i64) {
+    emit!(emit.output, Aarch64;
+        Opcode::AddSubtractImmediate { operation: AddSubtractOperation::Add, shift: super::ImmediateShift::None, flags: FlagUpdate::Preserve } => [register destination, register source, immediate value];
+    );
+}
+
+fn call_with_scalar_values(
+    emit: &mut Emit<'_>,
+    function: crate::low_ir::Relocation,
+    layout: &crate::metadata::SlowPathLayout,
+) -> Result<(), CompileError> {
+    use crate::metadata::ParameterMode;
+    use crate::target::registers::aarch64::{SP, X0, X1, X3, X4, X5, X6, X7, X9, X10, X11, X21, X27};
+    let registers = [X3, X4, X5, X6, X7];
+    let inputs: Vec<_> = layout
+        .fields
+        .iter()
+        .filter(|field| field.mode == ParameterMode::In)
+        .collect();
+    let stack_size = (inputs.len().saturating_sub(registers.len()) as i64 * 8 + 15) & !15;
+    if stack_size != 0 {
+        emit!(emit.output, Aarch64;
+            Opcode::AddSubtractImmediate { operation: AddSubtractOperation::Subtract, shift: super::ImmediateShift::None, flags: FlagUpdate::Preserve } => [register SP, register SP, immediate stack_size];
+        );
+    }
+    for (index, field) in inputs.iter().enumerate() {
+        let ready = emit.unique_label("scalar_value_ready");
+        call_values_load(
+            emit,
+            MemoryWidth::Word,
+            X9,
+            MachineMemoryAddress::offset(X21, field.instruction_offset as i64),
+        )?;
+        if field.optional {
+            let empty = emit.constant(KnownLayoutConstant::EmptyValue)?;
+            move_immediate(emit, X10, empty, IntegerWidth::U64);
+            move_immediate(emit, X11, -1, IntegerWidth::U32);
+            emit!(emit.output, Aarch64;
+                Opcode::CompareRegister(IntegerWidth::U32) => [register X9, register X11];
+                Opcode::BranchCondition(super::Condition::Equal) => [label ready.clone()];
+            );
+        }
+        call_values_load(
+            emit,
+            MemoryWidth::DoubleWord,
+            X10,
+            MachineMemoryAddress {
+                scale: Some(8),
+                ..MachineMemoryAddress::indexed(X27, X9)
+            },
+        )?;
+        emit!(emit.output, Aarch64; Opcode::Label => [label ready];);
+        if let Some(register) = registers.get(index) {
+            emit!(emit.output, Aarch64; Opcode::MoveRegister(IntegerWidth::U64) => [register *register, register X10];);
+        } else {
+            call_values_store(
+                emit,
+                MemoryWidth::DoubleWord,
+                MachineMemoryAddress::offset(SP, (index - registers.len()) as i64 * 8),
+                X10,
+            )?;
+        }
+    }
+    interpreter_call_arguments(emit);
+    direct_call(emit, function);
+    if stack_size != 0 {
+        call_values_add(emit, SP, SP, stack_size);
+    }
+    let done = emit.unique_label("scalar_result_done");
+    let continuation_bit = emit.constant(KnownLayoutConstant::SlowPathContinuationBit)?;
+    emit!(emit.output, Aarch64;
+        Opcode::TestBitAndBranch { width: IntegerWidth::U64, condition: TestCondition::Set } => [register X0, immediate 63, label done.clone()];
+        Opcode::TestBitAndBranch { width: IntegerWidth::U64, condition: TestCondition::Clear } => [register X0, immediate continuation_bit, label done.clone()];
+    );
+    if let Some(output) = layout.fields.iter().find(|field| field.mode == ParameterMode::Out) {
+        call_values_load(
+            emit,
+            MemoryWidth::Word,
+            X9,
+            MachineMemoryAddress::offset(X21, output.instruction_offset as i64),
+        )?;
+        call_values_store(
+            emit,
+            MemoryWidth::DoubleWord,
+            MachineMemoryAddress {
+                scale: Some(8),
+                ..MachineMemoryAddress::indexed(X27, X9)
+            },
+            X1,
+        )?;
+    }
+    emit!(emit.output, Aarch64; Opcode::SetInstructionPointer => [register X0];);
+    dispatch_from_instruction_pointer(emit, X9, X10)
+        .map_err(|error| memory_address_compile_error(emit.handler, error))?;
+    emit!(emit.output, Aarch64; Opcode::Label => [label done];);
+    Ok(())
+}
+
+fn call_with_values(
+    emit: &mut Emit<'_>,
+    function: crate::low_ir::Relocation,
+    kind: crate::target::backend::HelperCallKind,
+) -> Result<(), CompileError> {
+    use super::Condition;
+    use crate::metadata::ParameterMode;
+    use crate::target::description::ShiftOperation;
+    use crate::target::registers::aarch64::{
+        SP, X0, X3, X4, X5, X6, X7, X9, X10, X11, X12, X13, X14, X20, X21, X27, X28,
+    };
+
+    let Some(layout) = emit.runtime.slow_paths.get(emit.handler).cloned() else {
+        interpreter_call_arguments(emit);
+        direct_call(emit, function);
+        return Ok(());
+    };
+    if kind == crate::target::backend::HelperCallKind::SlowPath
+        && emit.object_format != crate::ObjectFormat::Coff
+        && layout.uses_scalar_arguments()
+    {
+        return call_with_scalar_values(emit, function, &layout);
+    }
+    let scalar_inputs = kind == crate::target::backend::HelperCallKind::SlowPath
+        && emit.object_format != crate::ObjectFormat::Coff
+        && layout.array.is_none();
+    let input_registers = [X4, X5, X6, X7];
+    let input_count = layout
+        .fields
+        .iter()
+        .filter(|field| field.mode != ParameterMode::Out)
+        .count();
+    let stack_arguments_size = if scalar_inputs {
+        (input_count.saturating_sub(input_registers.len()) as i64 * 8 + 15) & !15
+    } else {
+        0
+    };
+    let values_offset = if layout.array.is_some() { 16 } else { 0 } + stack_arguments_size;
+    let fixed_size = values_offset + layout.fields.len() as i64 * 8;
+    let empty = emit.constant(KnownLayoutConstant::EmptyValue)?;
+    let done = emit.unique_label("values_call_done");
+    if let Some((_, count_offset, _)) = layout.array {
+        call_values_add(emit, X9, SP, 0);
+        let allocate = emit.unique_label("values_allocate");
+        let probe = emit.unique_label("values_probe");
+        let allocated = emit.unique_label("values_allocated");
+        let base_offset = emit.constant(KnownLayoutConstant::VmStackInfoBase)?;
+        let stack_space_limit = emit.constant(KnownLayoutConstant::VmStackSpaceLimit)?;
+        call_values_load(
+            emit,
+            MemoryWidth::Word,
+            X10,
+            MachineMemoryAddress::offset(X21, count_offset as i64),
+        )?;
+        emit!(emit.output, Aarch64;
+            Opcode::ShiftImmediate { operation: ShiftOperation::Left, width: IntegerWidth::U64 } => [register X10, register X10, immediate 3];
+        );
+        call_values_add(emit, X10, X10, fixed_size + 15);
+        emit!(emit.output, Aarch64;
+            Opcode::LogicalImmediate { operation: super::LogicalOperation::And, width: IntegerWidth::U64 } => [register X10, register X10, immediate -16];
+            Opcode::AddSubtractRegister { operation: AddSubtractOperation::Subtract, flags: FlagUpdate::Preserve } => [register X14, register X9, register X10];
+        );
+        call_values_load(
+            emit,
+            MemoryWidth::DoubleWord,
+            X12,
+            MachineMemoryAddress::offset(X20, base_offset),
+        )?;
+        move_immediate(emit, X13, stack_space_limit, IntegerWidth::U64);
+        address_add_register(emit, X12, X12, X13);
+        emit!(emit.output, Aarch64;
+            Opcode::CompareRegister(IntegerWidth::U64) => [register X14, register X12];
+            Opcode::BranchCondition(Condition::UnsignedGreaterOrEqual) => [label allocate.clone()];
+        );
+        if kind == crate::target::backend::HelperCallKind::SlowPath {
+            vm_pc_arguments(emit);
+            direct_call(
+                emit,
+                crate::low_ir::Relocation::function_call(crate::identity::ExternalSymbol::new(
+                    "asm_slow_path_stack_overflow",
+                )),
+            );
+        } else {
+            move_immediate(emit, X0, 1, IntegerWidth::U64);
+        }
+        emit!(emit.output, Aarch64;
+            Opcode::Branch => [label done.clone()];
+            Opcode::Label => [label allocate];
+            Opcode::Label => [label probe.clone()];
+            Opcode::AddSubtractImmediate { operation: AddSubtractOperation::Subtract, shift: super::ImmediateShift::Twelve, flags: FlagUpdate::Preserve } => [register X10, register SP, immediate 1];
+            Opcode::CompareRegister(IntegerWidth::U64) => [register X10, register X14];
+            Opcode::BranchCondition(Condition::UnsignedLessOrEqual) => [label allocated.clone()];
+        );
+        call_values_add(emit, SP, X10, 0);
+        call_values_store(emit, MemoryWidth::DoubleWord, MachineMemoryAddress::offset(SP, 0), XZR)?;
+        emit!(emit.output, Aarch64;
+            Opcode::Branch => [label probe];
+            Opcode::Label => [label allocated];
+        );
+        call_values_add(emit, SP, X14, 0);
+    } else {
+        emit!(emit.output, Aarch64;
+            Opcode::AddSubtractImmediate { operation: AddSubtractOperation::Subtract, shift: super::ImmediateShift::None, flags: FlagUpdate::Preserve } => [register SP, register SP, immediate (fixed_size + 15) & !15];
+        );
+    }
+    if layout.array.is_some() {
+        call_values_store(emit, MemoryWidth::DoubleWord, MachineMemoryAddress::offset(SP, 0), X9)?;
+    }
+    let mut input_index = 0;
+    for field in &layout.fields {
+        if field.mode == ParameterMode::Out {
+            continue;
+        }
+        let ready = emit.unique_label("value_ready");
+        if field.optional {
+            move_immediate(emit, X11, empty, IntegerWidth::U64);
+        }
+        call_values_load(
+            emit,
+            MemoryWidth::Word,
+            X12,
+            MachineMemoryAddress::offset(X21, field.instruction_offset as i64),
+        )?;
+        if field.optional {
+            move_immediate(emit, X13, -1, IntegerWidth::U32);
+            emit!(emit.output, Aarch64;
+                Opcode::CompareRegister(IntegerWidth::U32) => [register X12, register X13];
+                Opcode::BranchCondition(Condition::Equal) => [label ready.clone()];
+            );
+        }
+        call_values_load(
+            emit,
+            MemoryWidth::DoubleWord,
+            X11,
+            MachineMemoryAddress {
+                scale: Some(8),
+                ..MachineMemoryAddress::indexed(X27, X12)
+            },
+        )?;
+        emit!(emit.output, Aarch64; Opcode::Label => [label ready];);
+        if scalar_inputs {
+            if let Some(register) = input_registers.get(input_index) {
+                emit!(emit.output, Aarch64; Opcode::MoveRegister(IntegerWidth::U64) => [register *register, register X11];);
+            } else {
+                call_values_store(
+                    emit,
+                    MemoryWidth::DoubleWord,
+                    MachineMemoryAddress::offset(SP, (input_index - input_registers.len()) as i64 * 8),
+                    X11,
+                )?;
+            }
+        } else {
+            call_values_store(
+                emit,
+                MemoryWidth::DoubleWord,
+                MachineMemoryAddress::offset(SP, values_offset + field.value_offset as i64),
+                X11,
+            )?;
+        }
+        input_index += 1;
+    }
+    if let Some((array_offset, count_offset, optional)) = layout.array {
+        let next = emit.unique_label("array_value_next");
+        let ready = emit.unique_label("array_value_ready");
+        let end = emit.unique_label("array_values_end");
+        move_immediate(emit, X9, 0, IntegerWidth::U64);
+        call_values_load(
+            emit,
+            MemoryWidth::Word,
+            X10,
+            MachineMemoryAddress::offset(X21, count_offset as i64),
+        )?;
+        call_values_add(emit, X14, SP, fixed_size);
+        call_values_add(emit, X3, X21, array_offset as i64);
+        emit!(emit.output, Aarch64;
+            Opcode::Label => [label next.clone()];
+            Opcode::CompareRegister(IntegerWidth::U64) => [register X9, register X10];
+            Opcode::BranchCondition(Condition::UnsignedGreaterOrEqual) => [label end.clone()];
+        );
+        call_values_load(
+            emit,
+            MemoryWidth::Word,
+            X12,
+            MachineMemoryAddress {
+                scale: Some(4),
+                ..MachineMemoryAddress::indexed(X3, X9)
+            },
+        )?;
+        if optional {
+            move_immediate(emit, X11, empty, IntegerWidth::U64);
+            move_immediate(emit, X13, -1, IntegerWidth::U32);
+            emit!(emit.output, Aarch64;
+                Opcode::CompareRegister(IntegerWidth::U32) => [register X12, register X13];
+                Opcode::BranchCondition(Condition::Equal) => [label ready.clone()];
+            );
+        }
+        call_values_load(
+            emit,
+            MemoryWidth::DoubleWord,
+            X11,
+            MachineMemoryAddress {
+                scale: Some(8),
+                ..MachineMemoryAddress::indexed(X27, X12)
+            },
+        )?;
+        emit!(emit.output, Aarch64; Opcode::Label => [label ready];);
+        call_values_store(
+            emit,
+            MemoryWidth::DoubleWord,
+            MachineMemoryAddress {
+                scale: Some(8),
+                ..MachineMemoryAddress::indexed(X14, X9)
+            },
+            X11,
+        )?;
+        call_values_add(emit, X9, X9, 1);
+        emit!(emit.output, Aarch64;
+            Opcode::Branch => [label next];
+            Opcode::Label => [label end];
+        );
+    }
+    interpreter_call_arguments(emit);
+    call_values_add(emit, X3, SP, values_offset);
+    direct_call(emit, function);
+    let restore = emit.unique_label("values_restore_stack");
+    if layout.fields.iter().any(|field| field.mode != ParameterMode::In) {
+        // Normal continuation guarantees the original frame. On exceptions,
+        // only input/output operands are valid, and only while that frame lives.
+        let exceptional = emit.unique_label("values_exceptional_outputs");
+        if kind == crate::target::backend::HelperCallKind::SlowPath {
+            let continuation_bit = emit.constant(KnownLayoutConstant::SlowPathContinuationBit)?;
+            emit!(emit.output, Aarch64;
+                Opcode::TestBitAndBranch { width: IntegerWidth::U64, condition: TestCondition::Set } => [register X0, immediate 63, label exceptional.clone()];
+                Opcode::TestBitAndBranch { width: IntegerWidth::U64, condition: TestCondition::Clear } => [register X0, immediate continuation_bit, label exceptional.clone()];
+            );
+        } else {
+            let execution_context = emit.constant(KnownLayoutConstant::VmRunningExecutionContext)?;
+            call_values_load(
+                emit,
+                MemoryWidth::DoubleWord,
+                X9,
+                MachineMemoryAddress::offset(X20, execution_context),
+            )?;
+            emit!(emit.output, Aarch64;
+                Opcode::CompareRegister(IntegerWidth::U64) => [register X9, register X28];
+                Opcode::BranchCondition(Condition::NotEqual) => [label restore.clone()];
+            );
+            emit!(emit.output, Aarch64;
+                Opcode::CompareAndBranchZero { width: IntegerWidth::U64, condition: ZeroCondition::NonZero } => [register X0, label exceptional.clone()];
+            );
+        }
+        for field in &layout.fields {
+            if field.mode == ParameterMode::In {
+                continue;
+            }
+            let skip = emit.unique_label("skip_output_value");
+            call_values_load(
+                emit,
+                MemoryWidth::Word,
+                X12,
+                MachineMemoryAddress::offset(X21, field.instruction_offset as i64),
+            )?;
+            if field.optional {
+                move_immediate(emit, X13, -1, IntegerWidth::U32);
+                emit!(emit.output, Aarch64;
+                    Opcode::CompareRegister(IntegerWidth::U32) => [register X12, register X13];
+                    Opcode::BranchCondition(Condition::Equal) => [label skip.clone()];
+                );
+            }
+            call_values_load(
+                emit,
+                MemoryWidth::DoubleWord,
+                X11,
+                MachineMemoryAddress::offset(SP, values_offset + field.value_offset as i64),
+            )?;
+            call_values_store(
+                emit,
+                MemoryWidth::DoubleWord,
+                MachineMemoryAddress {
+                    scale: Some(8),
+                    ..MachineMemoryAddress::indexed(X27, X12)
+                },
+                X11,
+            )?;
+            emit!(emit.output, Aarch64; Opcode::Label => [label skip];);
+        }
+        if kind == crate::target::backend::HelperCallKind::SlowPath {
+            if layout.array.is_some() {
+                call_values_load(emit, MemoryWidth::DoubleWord, X9, MachineMemoryAddress::offset(SP, 0))?;
+                call_values_add(emit, SP, X9, 0);
+            } else {
+                call_values_add(emit, SP, SP, (fixed_size + 15) & !15);
+            }
+            emit!(emit.output, Aarch64; Opcode::SetInstructionPointer => [register X0];);
+            dispatch_from_instruction_pointer(emit, X9, X10)
+                .map_err(|error| memory_address_compile_error(emit.handler, error))?;
+        } else {
+            emit!(emit.output, Aarch64; Opcode::Branch => [label restore.clone()];);
+        }
+        emit!(emit.output, Aarch64; Opcode::Label => [label exceptional];);
+        if kind == crate::target::backend::HelperCallKind::SlowPath
+            && layout.fields.iter().any(|field| field.mode == ParameterMode::InOut)
+        {
+            let execution_context = emit.constant(KnownLayoutConstant::VmRunningExecutionContext)?;
+            call_values_load(
+                emit,
+                MemoryWidth::DoubleWord,
+                X9,
+                MachineMemoryAddress::offset(X20, execution_context),
+            )?;
+            emit!(emit.output, Aarch64;
+                Opcode::CompareRegister(IntegerWidth::U64) => [register X9, register X28];
+                Opcode::BranchCondition(Condition::NotEqual) => [label restore.clone()];
+            );
+        }
+        for field in layout.fields.iter().filter(|field| field.mode == ParameterMode::InOut) {
+            let skip = emit.unique_label("skip_exceptional_output");
+            call_values_load(
+                emit,
+                MemoryWidth::Word,
+                X12,
+                MachineMemoryAddress::offset(X21, field.instruction_offset as i64),
+            )?;
+            if field.optional {
+                move_immediate(emit, X13, -1, IntegerWidth::U32);
+                emit!(emit.output, Aarch64;
+                    Opcode::CompareRegister(IntegerWidth::U32) => [register X12, register X13];
+                    Opcode::BranchCondition(Condition::Equal) => [label skip.clone()];
+                );
+            }
+            call_values_load(
+                emit,
+                MemoryWidth::DoubleWord,
+                X11,
+                MachineMemoryAddress::offset(SP, values_offset + field.value_offset as i64),
+            )?;
+            call_values_store(
+                emit,
+                MemoryWidth::DoubleWord,
+                MachineMemoryAddress {
+                    scale: Some(8),
+                    ..MachineMemoryAddress::indexed(X27, X12)
+                },
+                X11,
+            )?;
+            emit!(emit.output, Aarch64; Opcode::Label => [label skip];);
+        }
+    }
+    emit!(emit.output, Aarch64; Opcode::Label => [label restore];);
+    if layout.array.is_some() {
+        call_values_load(emit, MemoryWidth::DoubleWord, X9, MachineMemoryAddress::offset(SP, 0))?;
+        call_values_add(emit, SP, X9, 0);
+    } else {
+        call_values_add(emit, SP, SP, (fixed_size + 15) & !15);
+    }
+    emit!(emit.output, Aarch64; Opcode::Label => [label done];);
+    Ok(())
+}
+
 fn finish_slow_path_call(
     emit: &mut Emit<'_>,
     dispatch_register: PhysicalRegister,
@@ -1186,13 +1665,12 @@ impl Backend for Aarch64Backend {
         );
     }
 
-    fn helper_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) {
+    fn helper_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation, _argument_count: usize) {
         direct_call(emit, function);
     }
 
-    fn interpreter_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) {
-        interpreter_call_arguments(emit);
-        direct_call(emit, function);
+    fn interpreter_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) -> Result<(), CompileError> {
+        call_with_values(emit, function, crate::target::backend::HelperCallKind::Try)
     }
 
     fn raw_native_call(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
@@ -1241,8 +1719,7 @@ impl Backend for Aarch64Backend {
 
         vm_pc_arguments(emit);
         store_slow_path_program_counter(emit, dispatch_register, dispatch_scratch)?;
-        instruction_argument(emit);
-        direct_call(emit, function);
+        call_with_values(emit, function, crate::target::backend::HelperCallKind::SlowPath)?;
         finish_slow_path_call(emit, dispatch_register, dispatch_scratch)
     }
 
@@ -1254,12 +1731,45 @@ impl Backend for Aarch64Backend {
             operands.physical_register(3),
         ];
         let [dispatch_register, dispatch_scratch] = [operands.physical_register(4), operands.physical_register(5)];
-        use crate::target::registers::aarch64::{X2, X3, X4};
+        use crate::target::registers::aarch64::{SP, X0, X2, X3, X4, X9, X10, X27};
 
-        push_parallel_register_moves(emit, &[(X2, destination), (X3, lhs), (X4, rhs)], dispatch_scratch);
+        emit!(emit.output, Aarch64;
+            Opcode::AddSubtractImmediate { operation: AddSubtractOperation::Subtract, shift: super::ImmediateShift::None, flags: FlagUpdate::Preserve } => [register SP, register SP, immediate 16];
+        );
+        call_values_store(
+            emit,
+            MemoryWidth::Word,
+            MachineMemoryAddress::offset(SP, 8),
+            destination,
+        )?;
+        push_parallel_register_moves(emit, &[(X3, lhs), (X4, rhs)], dispatch_scratch);
+        call_values_add(emit, X2, SP, 0);
         vm_pc_arguments(emit);
         store_slow_path_program_counter(emit, dispatch_register, dispatch_scratch)?;
         direct_call(emit, function);
+        let restore = emit.unique_label("binary_result_restore");
+        let continuation_bit = emit.constant(KnownLayoutConstant::SlowPathContinuationBit)?;
+        emit!(emit.output, Aarch64;
+            Opcode::TestBitAndBranch { width: IntegerWidth::U64, condition: TestCondition::Set } => [register X0, immediate 63, label restore.clone()];
+            Opcode::TestBitAndBranch { width: IntegerWidth::U64, condition: TestCondition::Clear } => [register X0, immediate continuation_bit, label restore.clone()];
+        );
+        call_values_load(emit, MemoryWidth::Word, X9, MachineMemoryAddress::offset(SP, 8))?;
+        call_values_load(emit, MemoryWidth::DoubleWord, X10, MachineMemoryAddress::offset(SP, 0))?;
+        call_values_store(
+            emit,
+            MemoryWidth::DoubleWord,
+            MachineMemoryAddress {
+                scale: Some(8),
+                ..MachineMemoryAddress::indexed(X27, X9)
+            },
+            X10,
+        )?;
+        call_values_add(emit, SP, SP, 16);
+        emit!(emit.output, Aarch64; Opcode::SetInstructionPointer => [register X0];);
+        dispatch_from_instruction_pointer(emit, dispatch_register, dispatch_scratch)
+            .map_err(|error| memory_address_compile_error(emit.handler, error))?;
+        emit!(emit.output, Aarch64; Opcode::Label => [label restore];);
+        call_values_add(emit, SP, SP, 16);
         finish_slow_path_call(emit, dispatch_register, dispatch_scratch)
     }
 

--- a/Libraries/LibJS/Flap/src/target/backend.rs
+++ b/Libraries/LibJS/Flap/src/target/backend.rs
@@ -27,6 +27,12 @@ use super::registers::PhysicalRegister;
 use crate::CompileError;
 use crate::low_ir::Label;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HelperCallKind {
+    Try,
+    SlowPath,
+}
+
 pub(crate) trait Backend: Sync {
     fn branch_float(
         &self,
@@ -93,9 +99,9 @@ pub(crate) trait Backend: Sync {
         failure: &Label,
     );
 
-    fn helper_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation);
+    fn helper_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation, argument_count: usize);
 
-    fn interpreter_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation);
+    fn interpreter_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) -> Result<(), CompileError>;
 
     fn raw_native_call(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]);
 

--- a/Libraries/LibJS/Flap/src/target/description.rs
+++ b/Libraries/LibJS/Flap/src/target/description.rs
@@ -814,6 +814,24 @@ fn lookup_operation(operation: Operation) -> &'static InstructionDescription {
                     .aarch64(spec().outputs(&[X0]).fixed(&[(1, X0)]))
             }
         }
+        Operation::Call(CallKind::HelperWithTwoArguments) => {
+            &const {
+                plain(&[FuncSymbol, GprIn, GprIn, GprOut])
+                    .call()
+                    .x86_64(
+                        spec()
+                            .inputs(&[RCX, RDX])
+                            .outputs(&[RAX])
+                            .fixed(&[(1, RCX), (2, RDX), (3, RAX)]),
+                    )
+                    .aarch64(
+                        spec()
+                            .inputs(&[X0, X1])
+                            .outputs(&[X0])
+                            .fixed(&[(1, X0), (2, X1), (3, X0)]),
+                    )
+            }
+        }
         Operation::Call(CallKind::RawNative) => {
             &const {
                 plain(&[GprIn, GprOut, GprOut])

--- a/Libraries/LibJS/Flap/src/target/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/finalize.rs
@@ -33,34 +33,16 @@ fn finalize_function_for_target(
 ) -> Result<MachineFunction, CompileError> {
     let backend = backend_for(options.target.architecture);
     let mut emit = Emit::new(runtime, &function.name, function.size, options);
-    let (hot_instructions, mut cold_instructions) = if function.is_cold {
-        let instruction = function
-            .cfg
-            .single_instruction()
-            .ok_or_else(|| finalization_error(&function.name, "cold handler must consist solely of call_slow_path"))?;
-        if instruction.opcode.operation() != Operation::Call(CallKind::SlowPath) {
-            return Err(finalization_error(
-                &function.name,
-                "cold handler must consist solely of call_slow_path",
-            ));
-        }
-        (
-            finalize_instructions(vec![instruction.clone()], backend, &mut emit)?,
-            Vec::new(),
-        )
-    } else {
-        let layout = function
-            .cfg
-            .layout_hot_and_cold()
-            .map_err(|message| finalization_error(&function.name, message))?;
-        // Nothing reads the graph after this, so it hands its instructions over
-        // rather than being copied out of.
-        let (hot, cold) = std::mem::take(&mut function.cfg).linearize_hot_and_cold(&layout);
-        (
-            finalize_instructions(hot, backend, &mut emit)?,
-            finalize_instructions(cold, backend, &mut emit)?,
-        )
-    };
+    let layout = function
+        .cfg
+        .layout_hot_and_cold()
+        .map_err(|message| finalization_error(&function.name, message))?;
+    // Nothing reads the graph after this, so it hands its instructions over
+    // rather than being copied out of. Whole cold handlers use the same layout;
+    // the emitter places both parts together in the cold region.
+    let (hot, cold) = std::mem::take(&mut function.cfg).linearize_hot_and_cold(&layout);
+    let hot_instructions = finalize_instructions(hot, backend, &mut emit)?;
+    let mut cold_instructions = finalize_instructions(cold, backend, &mut emit)?;
 
     cold_instructions.extend(emit.cold);
     let machine = MachineFunction {
@@ -234,8 +216,9 @@ fn finalize_call(
     operands: &[AllocatedOperand],
 ) -> Result<(), CompileError> {
     match kind {
-        CallKind::Helper => backend.helper_call(emit, operands.relocation(0)),
-        CallKind::Interpreter => backend.interpreter_call(emit, operands.relocation(0)),
+        CallKind::Helper => backend.helper_call(emit, operands.relocation(0), 1),
+        CallKind::HelperWithTwoArguments => backend.helper_call(emit, operands.relocation(0), 2),
+        CallKind::Interpreter => backend.interpreter_call(emit, operands.relocation(0))?,
         CallKind::RawNative => backend.raw_native_call(emit, operands),
         CallKind::SlowPath => backend.slow_path_call(emit, operands)?,
         CallKind::BinarySlowPath => backend.binary_slow_path_call(emit, operands)?,
@@ -539,7 +522,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_non_terminal_cold_handler() {
+    fn finalizes_cold_handlers_with_instruction_bodies() {
         let function = allocated_function(
             vec![Instruction {
                 opcode: Operation::Control(ControlOperation::DispatchNext),
@@ -548,10 +531,10 @@ mod tests {
             true,
         );
 
-        let error = finalize_function(function, &runtime()).unwrap_err();
-        assert_eq!(error.stage, CompileStage::Finalization);
-        assert_eq!(error.handler.as_deref(), Some("Test"));
-        assert_eq!(error.message, "cold handler must consist solely of call_slow_path");
+        let machine = finalize_function(function, &runtime()).unwrap();
+        assert!(machine.is_cold);
+        assert_eq!(machine.hot_instructions.len(), 3);
+        assert!(machine.cold_instructions.is_empty());
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/target/ir.rs
+++ b/Libraries/LibJS/Flap/src/target/ir.rs
@@ -343,6 +343,7 @@ impl MachineProgram {
             .iter()
             .chain(
                 [
+                    SlowPathContinuationBit,
                     VmRunningExecutionContext,
                     VmBreakpointController,
                     VmHeapRegionBase,

--- a/Libraries/LibJS/Flap/src/target/x86_64/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/x86_64/finalize.rs
@@ -642,6 +642,372 @@ fn store_slow_path_program_counter(emit: &mut Emit<'_>) -> Result<(), CompileErr
     Ok(())
 }
 
+fn call_with_scalar_values(
+    emit: &mut Emit<'_>,
+    function: crate::low_ir::Relocation,
+    layout: &crate::metadata::SlowPathLayout,
+) -> Result<(), CompileError> {
+    use crate::metadata::ParameterMode;
+    use crate::target::registers::x86_64::{R8, R9, R10, R11, R13, R14, RAX, RBX, RCX, RDX, RSP};
+    let registers = [RCX, R8, R9];
+    let inputs: Vec<_> = layout
+        .fields
+        .iter()
+        .filter(|field| field.mode == ParameterMode::In)
+        .collect();
+    let stack_size = (inputs.len().saturating_sub(registers.len()) as i64 * 8 + 15) & !15;
+    if stack_size != 0 {
+        push_stack_adjustment(emit, super::AluOperation::Subtract, stack_size);
+    }
+    emit!(emit.output, X86_64; Opcode::LoadEffectiveAddress => [register R11, address MachineMemoryAddress::indexed(R14, R13)];);
+    for (index, field) in inputs.iter().enumerate() {
+        let ready = emit.unique_label("scalar_value_ready");
+        emit!(emit.output, X86_64;
+            Opcode::Load { width: MemoryWidth::Word, signed: false } => [register R10, address MachineMemoryAddress::offset(R11, field.instruction_offset as i64)];
+        );
+        if field.optional {
+            let empty = emit.constant(KnownLayoutConstant::EmptyValue)?;
+            emit!(emit.output, X86_64;
+                Opcode::MoveAbsolute64Immediate => [register RAX, immediate empty];
+                Opcode::CompareImmediate(IntegerWidth::U32) => [register R10, immediate -1];
+                Opcode::JumpCondition(super::Condition::Equal) => [label ready.clone()];
+            );
+        }
+        push_load(
+            emit,
+            RAX,
+            MachineMemoryAddress {
+                scale: Some(8),
+                ..MachineMemoryAddress::indexed(RBX, R10)
+            },
+        );
+        emit!(emit.output, X86_64; Opcode::Label => [label ready];);
+        if let Some(register) = registers.get(index) {
+            emit!(emit.output, X86_64; Opcode::Move64Register => [register *register, register RAX];);
+        } else {
+            emit!(emit.output, X86_64; Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress::offset(RSP, (index - registers.len()) as i64 * 8), register RAX];);
+        }
+    }
+    interpreter_call_arguments(emit);
+    direct_call(emit, function);
+    if stack_size != 0 {
+        push_stack_adjustment(emit, super::AluOperation::Add, stack_size);
+    }
+    let done = emit.unique_label("scalar_result_done");
+    let continuation_bit = emit.constant(KnownLayoutConstant::SlowPathContinuationBit)?;
+    emit!(emit.output, X86_64;
+        Opcode::TestRegister(IntegerWidth::U64) => [register RAX];
+        Opcode::JumpSign(SignCondition::Negative) => [label done.clone()];
+        Opcode::BitTest64Immediate => [register RAX, immediate continuation_bit];
+        Opcode::JumpCondition(super::Condition::NotCarry) => [label done.clone()];
+    );
+    if let Some(output) = layout.fields.iter().find(|field| field.mode == ParameterMode::Out) {
+        emit!(emit.output, X86_64;
+            Opcode::LoadEffectiveAddress => [register RCX, address MachineMemoryAddress::indexed(R14, R13)];
+            Opcode::Load { width: MemoryWidth::Word, signed: false } => [register R10, address MachineMemoryAddress::offset(RCX, output.instruction_offset as i64)];
+            Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress { scale: Some(8), ..MachineMemoryAddress::indexed(RBX, R10) }, register RDX];
+        );
+    }
+    emit!(emit.output, X86_64; Opcode::Move32Register => [register R13, register RAX];);
+    dispatch_from_instruction_pointer(emit, RAX);
+    emit!(emit.output, X86_64; Opcode::Label => [label done];);
+    Ok(())
+}
+
+fn call_with_values(
+    emit: &mut Emit<'_>,
+    function: crate::low_ir::Relocation,
+    kind: crate::target::backend::HelperCallKind,
+) -> Result<(), CompileError> {
+    use super::{AluOperation, Condition};
+    use crate::metadata::ParameterMode;
+    use crate::target::registers::x86_64::{R8, R9, R10, R11, R13, R14, RAX, RBX, RCX, RDX, RSP};
+
+    let Some(layout) = emit.runtime.slow_paths.get(emit.handler).cloned() else {
+        interpreter_call_arguments(emit);
+        direct_call(emit, function);
+        return Ok(());
+    };
+    if kind == crate::target::backend::HelperCallKind::SlowPath
+        && emit.object_format != ObjectFormat::Coff
+        && layout.uses_scalar_arguments()
+    {
+        return call_with_scalar_values(emit, function, &layout);
+    }
+    let shadow = if emit.object_format == ObjectFormat::Coff {
+        32
+    } else {
+        0
+    };
+    let scalar_inputs = kind == crate::target::backend::HelperCallKind::SlowPath
+        && emit.object_format != ObjectFormat::Coff
+        && layout.array.is_none();
+    let input_registers = [R8, R9];
+    let input_count = layout
+        .fields
+        .iter()
+        .filter(|field| field.mode != ParameterMode::Out)
+        .count();
+    let stack_arguments_size = if scalar_inputs {
+        (input_count.saturating_sub(input_registers.len()) as i64 * 8 + 15) & !15
+    } else {
+        0
+    };
+    let values_offset = shadow + if layout.array.is_some() { 16 } else { 0 } + stack_arguments_size;
+    let fixed_size = values_offset + layout.fields.len() as i64 * 8;
+    let empty = emit.constant(KnownLayoutConstant::EmptyValue)?;
+    let done = emit.unique_label("values_call_done");
+    emit!(emit.output, X86_64;
+        Opcode::LoadEffectiveAddress => [register RCX, address MachineMemoryAddress::indexed(R14, R13)];
+    );
+    if let Some((_, count_offset, _)) = layout.array {
+        emit!(emit.output, X86_64; Opcode::Move64Register => [register R11, register RSP];);
+        let allocate = emit.unique_label("values_allocate");
+        let probe = emit.unique_label("values_probe");
+        let allocated = emit.unique_label("values_allocated");
+        let base_offset = emit.constant(KnownLayoutConstant::VmStackInfoBase)?;
+        let stack_space_limit = emit.constant(KnownLayoutConstant::VmStackSpaceLimit)?;
+        emit!(emit.output, X86_64;
+            Opcode::Load { width: MemoryWidth::Word, signed: false } => [register R10, address MachineMemoryAddress::offset(RCX, count_offset as i64)];
+            Opcode::ShiftImmediate { operation: ShiftOperation::Left, width: IntegerWidth::U64 } => [register R10, immediate 3];
+            Opcode::AluImmediate { operation: AluOperation::Add, width: IntegerWidth::U64 } => [register R10, immediate fixed_size + 15];
+            Opcode::AluImmediate { operation: AluOperation::And, width: IntegerWidth::U64 } => [register R10, immediate -16];
+            Opcode::Move64Register => [register RAX, register RSP];
+            Opcode::AluRegister { operation: AluOperation::Subtract, width: IntegerWidth::U64 } => [register RAX, register R10];
+        );
+        vm_load(emit, RDX);
+        push_load(emit, RDX, MachineMemoryAddress::offset(RDX, base_offset));
+        emit!(emit.output, X86_64;
+            Opcode::AluImmediate { operation: AluOperation::Add, width: IntegerWidth::U64 } => [register RDX, immediate stack_space_limit];
+            Opcode::CompareRegister(IntegerWidth::U64) => [register RAX, register RDX];
+            Opcode::JumpCondition(Condition::UnsignedGreaterOrEqual) => [label allocate.clone()];
+        );
+        if kind == crate::target::backend::HelperCallKind::SlowPath {
+            interpreter_call_arguments(emit);
+            direct_call(
+                emit,
+                crate::low_ir::Relocation::function_call(crate::identity::ExternalSymbol::new(
+                    "asm_slow_path_stack_overflow",
+                )),
+            );
+        } else {
+            emit!(emit.output, X86_64; Opcode::Move32Immediate => [register RAX, immediate 1];);
+        }
+        emit!(emit.output, X86_64;
+            Opcode::Jump => [label done.clone()];
+            Opcode::Label => [label allocate];
+            Opcode::Label => [label probe.clone()];
+            Opcode::LoadEffectiveAddress => [register R10, address MachineMemoryAddress::offset(RSP, -4096)];
+            Opcode::CompareRegister(IntegerWidth::U64) => [register R10, register RAX];
+            Opcode::JumpCondition(Condition::UnsignedLessOrEqual) => [label allocated.clone()];
+            Opcode::Move64Register => [register RSP, register R10];
+            Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress::offset(RSP, 0), immediate 0];
+            Opcode::Jump => [label probe];
+            Opcode::Label => [label allocated];
+            Opcode::Move64Register => [register RSP, register RAX];
+        );
+    } else {
+        push_stack_adjustment(emit, AluOperation::Subtract, (fixed_size + 15) & !15);
+    }
+    if layout.array.is_some() {
+        emit!(emit.output, X86_64;
+            Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress::offset(RSP, shadow), register R11];
+        );
+    }
+    let mut input_index = 0;
+    for field in &layout.fields {
+        if field.mode == ParameterMode::Out {
+            continue;
+        }
+        let ready = emit.unique_label("value_ready");
+        if field.optional {
+            emit!(emit.output, X86_64; Opcode::MoveAbsolute64Immediate => [register RAX, immediate empty];);
+        }
+        emit!(emit.output, X86_64;
+            Opcode::Load { width: MemoryWidth::Word, signed: false } => [register R10, address MachineMemoryAddress::offset(RCX, field.instruction_offset as i64)];
+        );
+        if field.optional {
+            emit!(emit.output, X86_64;
+                Opcode::CompareImmediate(IntegerWidth::U32) => [register R10, immediate -1];
+                Opcode::JumpCondition(Condition::Equal) => [label ready.clone()];
+            );
+        }
+        push_load(
+            emit,
+            RAX,
+            MachineMemoryAddress {
+                scale: Some(8),
+                ..MachineMemoryAddress::indexed(RBX, R10)
+            },
+        );
+        emit!(emit.output, X86_64;
+            Opcode::Label => [label ready];
+        );
+        if scalar_inputs {
+            if let Some(register) = input_registers.get(input_index) {
+                emit!(emit.output, X86_64; Opcode::Move64Register => [register *register, register RAX];);
+            } else {
+                emit!(emit.output, X86_64; Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress::offset(RSP, (input_index - input_registers.len()) as i64 * 8), register RAX];);
+            }
+        } else {
+            emit!(emit.output, X86_64; Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress::offset(RSP, values_offset + field.value_offset as i64), register RAX];);
+        }
+        input_index += 1;
+    }
+    if let Some((array_offset, count_offset, optional)) = layout.array {
+        let next = emit.unique_label("array_value_next");
+        let ready = emit.unique_label("array_value_ready");
+        let end = emit.unique_label("array_values_end");
+        emit!(emit.output, X86_64;
+            Opcode::Move32Immediate => [register R11, immediate 0];
+            Opcode::Load { width: MemoryWidth::Word, signed: false } => [register R10, address MachineMemoryAddress::offset(RCX, count_offset as i64)];
+            Opcode::Label => [label next.clone()];
+            Opcode::CompareRegister(IntegerWidth::U64) => [register R11, register R10];
+            Opcode::JumpCondition(Condition::UnsignedGreaterOrEqual) => [label end.clone()];
+            Opcode::Load { width: MemoryWidth::Word, signed: false } => [register RDX, address MachineMemoryAddress { scale: Some(4), ..MachineMemoryAddress::indexed_offset(RCX, R11, array_offset as i64) }];
+        );
+        if optional {
+            emit!(emit.output, X86_64;
+                Opcode::MoveAbsolute64Immediate => [register RAX, immediate empty];
+                Opcode::CompareImmediate(IntegerWidth::U32) => [register RDX, immediate -1];
+                Opcode::JumpCondition(Condition::Equal) => [label ready.clone()];
+            );
+        }
+        push_load(
+            emit,
+            RAX,
+            MachineMemoryAddress {
+                scale: Some(8),
+                ..MachineMemoryAddress::indexed(RBX, RDX)
+            },
+        );
+        emit!(emit.output, X86_64;
+            Opcode::Label => [label ready];
+            Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress { scale: Some(8), ..MachineMemoryAddress::indexed_offset(RSP, R11, fixed_size) }, register RAX];
+            Opcode::AluImmediate { operation: AluOperation::Add, width: IntegerWidth::U64 } => [register R11, immediate 1];
+            Opcode::Jump => [label next];
+            Opcode::Label => [label end];
+        );
+    }
+    interpreter_call_arguments(emit);
+    let argument = if emit.object_format == ObjectFormat::Coff {
+        R9
+    } else {
+        RCX
+    };
+    emit!(emit.output, X86_64;
+        Opcode::LoadEffectiveAddress => [register argument, address MachineMemoryAddress::offset(RSP, values_offset)];
+    );
+    direct_call(emit, function);
+    let restore = emit.unique_label("values_restore_stack");
+    if layout.fields.iter().any(|field| field.mode != ParameterMode::In) {
+        // Normal continuation guarantees the original frame. On exceptions,
+        // only input/output operands are valid, and only while that frame lives.
+        let exceptional = emit.unique_label("values_exceptional_outputs");
+        if kind == crate::target::backend::HelperCallKind::SlowPath {
+            let continuation_bit = emit.constant(KnownLayoutConstant::SlowPathContinuationBit)?;
+            emit!(emit.output, X86_64;
+                Opcode::TestRegister(IntegerWidth::U64) => [register RAX];
+                Opcode::JumpSign(SignCondition::Negative) => [label exceptional.clone()];
+                Opcode::BitTest64Immediate => [register RAX, immediate continuation_bit];
+                Opcode::JumpCondition(Condition::NotCarry) => [label exceptional.clone()];
+            );
+        } else {
+            let [execution_context, _, _, _, frame_values_offset] = interpreter_layout(emit.runtime, emit.handler)?;
+            vm_load(emit, R10);
+            push_load(emit, R10, MachineMemoryAddress::offset(R10, execution_context));
+            emit!(emit.output, X86_64;
+                Opcode::AluImmediate { operation: AluOperation::Add, width: IntegerWidth::U64 } => [register R10, immediate frame_values_offset];
+                Opcode::CompareRegister(IntegerWidth::U64) => [register R10, register RBX];
+                Opcode::JumpCondition(Condition::NotEqual) => [label restore.clone()];
+            );
+            emit!(emit.output, X86_64;
+                Opcode::TestRegister(IntegerWidth::U64) => [register RAX];
+                Opcode::JumpCondition(Condition::NotEqual) => [label exceptional.clone()];
+            );
+        }
+        emit!(emit.output, X86_64; Opcode::LoadEffectiveAddress => [register RCX, address MachineMemoryAddress::indexed(R14, R13)];);
+        for field in &layout.fields {
+            if field.mode == ParameterMode::In {
+                continue;
+            }
+            let skip = emit.unique_label("skip_output_value");
+            emit!(emit.output, X86_64;
+                Opcode::Load { width: MemoryWidth::Word, signed: false } => [register R10, address MachineMemoryAddress::offset(RCX, field.instruction_offset as i64)];
+            );
+            if field.optional {
+                emit!(emit.output, X86_64;
+                    Opcode::CompareImmediate(IntegerWidth::U32) => [register R10, immediate -1];
+                    Opcode::JumpCondition(Condition::Equal) => [label skip.clone()];
+                );
+            }
+            push_load(
+                emit,
+                R11,
+                MachineMemoryAddress::offset(RSP, values_offset + field.value_offset as i64),
+            );
+            emit!(emit.output, X86_64;
+                Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress { scale: Some(8), ..MachineMemoryAddress::indexed(RBX, R10) }, register R11];
+                Opcode::Label => [label skip];
+            );
+        }
+        if kind == crate::target::backend::HelperCallKind::SlowPath {
+            if layout.array.is_some() {
+                push_load(emit, RSP, MachineMemoryAddress::offset(RSP, shadow));
+            } else {
+                push_stack_adjustment(emit, AluOperation::Add, (fixed_size + 15) & !15);
+            }
+            emit!(emit.output, X86_64; Opcode::Move32Register => [register R13, register RAX];);
+            dispatch_from_instruction_pointer(emit, RAX);
+        } else {
+            emit!(emit.output, X86_64; Opcode::Jump => [label restore.clone()];);
+        }
+        emit!(emit.output, X86_64; Opcode::Label => [label exceptional];);
+        if kind == crate::target::backend::HelperCallKind::SlowPath
+            && layout.fields.iter().any(|field| field.mode == ParameterMode::InOut)
+        {
+            let [execution_context, _, _, _, frame_values_offset] = interpreter_layout(emit.runtime, emit.handler)?;
+            vm_load(emit, R10);
+            push_load(emit, R10, MachineMemoryAddress::offset(R10, execution_context));
+            emit!(emit.output, X86_64;
+                Opcode::AluImmediate { operation: AluOperation::Add, width: IntegerWidth::U64 } => [register R10, immediate frame_values_offset];
+                Opcode::CompareRegister(IntegerWidth::U64) => [register R10, register RBX];
+                Opcode::JumpCondition(Condition::NotEqual) => [label restore.clone()];
+            );
+        }
+        for field in layout.fields.iter().filter(|field| field.mode == ParameterMode::InOut) {
+            let skip = emit.unique_label("skip_exceptional_output");
+            emit!(emit.output, X86_64;
+                Opcode::LoadEffectiveAddress => [register RCX, address MachineMemoryAddress::indexed(R14, R13)];
+                Opcode::Load { width: MemoryWidth::Word, signed: false } => [register R10, address MachineMemoryAddress::offset(RCX, field.instruction_offset as i64)];
+            );
+            if field.optional {
+                emit!(emit.output, X86_64;
+                    Opcode::CompareImmediate(IntegerWidth::U32) => [register R10, immediate -1];
+                    Opcode::JumpCondition(Condition::Equal) => [label skip.clone()];
+                );
+            }
+            push_load(
+                emit,
+                R11,
+                MachineMemoryAddress::offset(RSP, values_offset + field.value_offset as i64),
+            );
+            emit!(emit.output, X86_64;
+                Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress { scale: Some(8), ..MachineMemoryAddress::indexed(RBX, R10) }, register R11];
+                Opcode::Label => [label skip];
+            );
+        }
+    }
+    emit!(emit.output, X86_64; Opcode::Label => [label restore];);
+    if layout.array.is_some() {
+        push_load(emit, RSP, MachineMemoryAddress::offset(RSP, shadow));
+    } else {
+        push_stack_adjustment(emit, AluOperation::Add, (fixed_size + 15) & !15);
+    }
+    emit!(emit.output, X86_64; Opcode::Label => [label done];);
+    Ok(())
+}
+
 fn finish_slow_path_call(
     emit: &mut Emit<'_>,
     result_scratch: PhysicalRegister,
@@ -893,18 +1259,20 @@ impl Backend for X86_64Backend {
         }
     }
 
-    fn helper_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) {
-        use crate::target::registers::x86_64::{RCX, RDI};
+    fn helper_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation, argument_count: usize) {
+        use crate::target::registers::x86_64::{RCX, RDI, RDX, RSI};
 
         if emit.object_format != ObjectFormat::Coff {
             emit!(emit.output, X86_64; Opcode::Move64Register => [register RDI, register RCX];);
+            if argument_count == 2 {
+                emit!(emit.output, X86_64; Opcode::Move64Register => [register RSI, register RDX];);
+            }
         }
         direct_call(emit, function);
     }
 
-    fn interpreter_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) {
-        interpreter_call_arguments(emit);
-        direct_call(emit, function);
+    fn interpreter_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) -> Result<(), CompileError> {
+        call_with_values(emit, function, crate::target::backend::HelperCallKind::Try)
     }
 
     fn raw_native_call(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
@@ -951,8 +1319,7 @@ impl Backend for X86_64Backend {
         let [result_scratch, state_scratch] = [operands.physical_register(1), operands.physical_register(2)];
 
         store_slow_path_program_counter(emit)?;
-        interpreter_call_arguments(emit);
-        direct_call(emit, function);
+        call_with_values(emit, function, crate::target::backend::HelperCallKind::SlowPath)?;
         finish_slow_path_call(emit, result_scratch, state_scratch)
     }
 
@@ -964,26 +1331,60 @@ impl Backend for X86_64Backend {
             operands.physical_register(3),
         ];
         let [result_scratch, state_scratch] = [operands.physical_register(4), operands.physical_register(5)];
-        use crate::target::registers::x86_64::{R8, R9, R13, RBP, RCX, RDI, RDX, RSI};
+        use crate::target::registers::x86_64::{R8, R9, R10, R11, R13, RAX, RBX, RCX, RDI, RDX, RSI, RSP};
 
         store_slow_path_program_counter(emit)?;
+        let result_offset = if emit.object_format == ObjectFormat::Coff {
+            48
+        } else {
+            0
+        };
+        let stack_size = result_offset + 16;
+        push_stack_adjustment(emit, super::AluOperation::Subtract, stack_size);
+        store(
+            emit,
+            MemoryWidth::Word,
+            MachineMemoryAddress::offset(RSP, result_offset + 8),
+            StoreSource::Register(destination),
+            None,
+        );
         if emit.object_format == ObjectFormat::Coff {
             store(
                 emit,
                 MemoryWidth::DoubleWord,
-                MachineMemoryAddress::offset(RBP, super::WIN64_RAW_NATIVE_RETURN_SLOT),
+                MachineMemoryAddress::offset(RSP, 32),
                 StoreSource::Register(rhs),
                 None,
             );
-            push_parallel_register_moves(emit, &[(R8, destination), (R9, lhs)], state_scratch);
+            push_parallel_register_moves(emit, &[(R9, lhs)], state_scratch);
+            emit!(emit.output, X86_64; Opcode::LoadEffectiveAddress => [register R8, address MachineMemoryAddress::offset(RSP, result_offset)];);
             vm_load(emit, RCX);
             emit!(emit.output, X86_64; Opcode::Move32Register => [register RDX, register R13];);
         } else {
-            push_parallel_register_moves(emit, &[(RDX, destination), (RCX, lhs), (R8, rhs)], state_scratch);
+            push_parallel_register_moves(emit, &[(RCX, lhs), (R8, rhs)], state_scratch);
+            emit!(emit.output, X86_64; Opcode::LoadEffectiveAddress => [register RDX, address MachineMemoryAddress::offset(RSP, result_offset)];);
             vm_load(emit, RDI);
             emit!(emit.output, X86_64; Opcode::Move32Register => [register RSI, register R13];);
         }
         direct_call(emit, function);
+        let restore = emit.unique_label("binary_result_restore");
+        let continuation_bit = emit.constant(KnownLayoutConstant::SlowPathContinuationBit)?;
+        emit!(emit.output, X86_64;
+            Opcode::TestRegister(IntegerWidth::U64) => [register RAX];
+            Opcode::JumpSign(SignCondition::Negative) => [label restore.clone()];
+            Opcode::BitTest64Immediate => [register RAX, immediate continuation_bit];
+            Opcode::JumpCondition(super::Condition::NotCarry) => [label restore.clone()];
+            Opcode::Load { width: MemoryWidth::Word, signed: false } => [register R10, address MachineMemoryAddress::offset(RSP, result_offset + 8)];
+        );
+        push_load(emit, R11, MachineMemoryAddress::offset(RSP, result_offset));
+        emit!(emit.output, X86_64;
+            Opcode::Store(MemoryWidth::DoubleWord) => [address MachineMemoryAddress { scale: Some(8), ..MachineMemoryAddress::indexed(RBX, R10) }, register R11];
+        );
+        push_stack_adjustment(emit, super::AluOperation::Add, stack_size);
+        emit!(emit.output, X86_64; Opcode::Move32Register => [register R13, register RAX];);
+        dispatch_from_instruction_pointer(emit, RAX);
+        emit!(emit.output, X86_64; Opcode::Label => [label restore];);
+        push_stack_adjustment(emit, super::AluOperation::Add, stack_size);
         finish_slow_path_call(emit, result_scratch, state_scratch)
     }
 

--- a/Libraries/LibJS/Flap/src/target/x86_64/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/x86_64/finalize.rs
@@ -655,6 +655,16 @@ fn finish_slow_path_call(
         Opcode::JumpNegativeToExit => [];
     );
 
+    let transfer = emit.unique_label("slow_path_transfer");
+    let continuation_bit = emit.constant(crate::frontend::layout::KnownLayoutConstant::SlowPathContinuationBit)?;
+    emit!(emit.output, X86_64;
+        Opcode::BitTest64Immediate => [register result_scratch, immediate continuation_bit];
+        Opcode::JumpCondition(super::Condition::NotCarry) => [label transfer.clone()];
+    );
+    emit!(emit.output, X86_64; Opcode::Move32Register => [register R13, register result_scratch];);
+    dispatch_from_instruction_pointer(emit, result_scratch);
+    emit!(emit.output, X86_64; Opcode::Label => [label transfer];);
+
     vm_load(emit, state_scratch);
     push_load(
         emit,

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
@@ -11,6 +11,7 @@
 .section .data.rel.ro
 .p2align 3
 asm_dispatch_table:
+    .quad asm_handler_Enter
     .quad asm_handler_Mov
     .quad asm_handler_Add
     .quad asm_handler_Sub
@@ -227,7 +228,6 @@ asm_dispatch_table:
     .quad asm_handler_JumpStrictlyInequalsRhsInt32
     .quad asm_handler_JumpLooselyEqualsRhsInt32
     .quad asm_handler_JumpLooselyInequalsRhsInt32
-    .quad asm_handler_fallback
     .quad asm_handler_fallback
     .quad asm_handler_fallback
     .quad asm_handler_fallback
@@ -529,6 +529,10 @@ asm_debug_dispatch_table:
 .globl CSYM(js_interpreter_handler_ranges)
 .p2align 3
 CSYM(js_interpreter_handler_ranges):
+    .quad asm_handler_Enter
+    .quad asm_handler_Enter_hot_end
+    .quad asm_handler_Enter_cold
+    .quad asm_handler_Enter_cold_end
     .quad asm_handler_Mov
     .quad asm_handler_Mov_hot_end
     .quad asm_handler_Mov_cold
@@ -1549,10 +1553,6 @@ CSYM(js_interpreter_handler_ranges):
     .quad asm_handler_fallback_hot_end
     .quad asm_handler_fallback_cold
     .quad asm_handler_fallback_cold_end
-    .quad asm_handler_fallback
-    .quad asm_handler_fallback_hot_end
-    .quad asm_handler_fallback_cold
-    .quad asm_handler_fallback_cold_end
 
 .text
 
@@ -1636,7 +1636,9 @@ asm_handler_fallback:
     str w1, [x28, #64]
     mov x2, x21
     bl CSYM(asm_fallback_handler)
-    tbnz x0, #63, .Lexit_veneer
+    tbz x0, #63, 1f
+    b .Lexit
+1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -1649,6 +1651,44 @@ asm_handler_fallback_hot_end:
 asm_handler_fallback_cold:
 asm_handler_fallback_cold_end:
 
+
+.p2align 4
+asm_handler_Enter:
+    ldr x1, [x28, #88]
+    ldr w2, [x1, #364]
+    movz x3, #0x7ffb, lsl #48
+    mov w0, #5
+.Lasm_Enter.ssa_block_3:
+    add x4, x0, #1
+    cmp x4, x2
+    b.hs .Lasm_Enter.ssa_block_2
+    add x10, x27, x0, lsl #3
+    stp x3, x3, [x10]
+    add x0, x0, #2
+    b .Lasm_Enter.ssa_block_3
+.Lasm_Enter.ssa_block_2:
+    cmp x0, x2
+    b.hs .Lasm_Enter.ssa_block_5
+    str x3, [x27, x0, lsl #3]
+.Lasm_Enter.ssa_block_5:
+    ldp x3, x1, [x1, #376]
+    mov x0, #0
+.Lasm_Enter.ssa_block_8:
+    cmp x0, x3
+    b.hs .Lasm_Enter.ssa_block_7
+    ldr x4, [x1, x0, lsl #3]
+    str x4, [x27, x2, lsl #3]
+    add x0, x0, #1
+    add x2, x2, #1
+    b .Lasm_Enter.ssa_block_8
+.Lasm_Enter.ssa_block_7:
+    mov w9, #1
+    strb w9, [x28, #79]
+    ldrb w9, [x21, #8]
+    add x21, x21, #8
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+asm_handler_Enter_hot_end:
 
 .p2align 4
 asm_handler_Mov:
@@ -1723,7 +1763,9 @@ asm_handler_Mul:
     mov w2, w2
     cbnz w2, .Lasm_Mul.ssa_block_13
     orr w0, w1, w0
-    tbnz w0, #31, .Lasm_Mul.ssa_block_3
+    tbz w0, #31, 1f
+    b .Lasm_Mul.ssa_block_3
+1:
 .Lasm_Mul.ssa_block_13:
     movk x2, #0x7ffa, lsl #48
     ldr w9, [x21, #4]
@@ -1733,35 +1775,6 @@ asm_handler_Mul:
     ldr x10, [x19, x9, lsl #3]
     br x10
 asm_handler_Mul_hot_end:
-
-.p2align 4
-asm_handler_Exp:
-    ldp w0, w1, [x21, #8]
-    ldr x0, [x27, x0, lsl #3]
-    ldr x1, [x27, x1, lsl #3]
-    ldr w2, [x21, #4]
-    mov x3, x0
-    mov x4, x1
-    mov x0, x20
-    sub w1, w21, w26
-    str w1, [x28, #64]
-    bl CSYM(asm_slow_path_exp_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Exp.slow_path_transfer_0
-    add x21, x26, w0, uxtw
-    ldrb w9, [x21]
-    ldr x10, [x19, x9, lsl #3]
-    br x10
-.Lasm_Exp.slow_path_transfer_0:
-    ldr x28, [x20, #15288]
-    ldr x9, [x28, #88]
-    ldr x26, [x9, #80]
-    add x27, x28, #128
-    add x21, x26, w0, uxtw
-    ldrb w9, [x21]
-    ldr x10, [x19, x9, lsl #3]
-    br x10
-asm_handler_Exp_hot_end:
 
 .p2align 4
 asm_handler_Jump:
@@ -2856,7 +2869,9 @@ asm_handler_SetLexicalBinding:
     ldr x1, [x3, #56]
     ldrb w1, [x1, x0]
 .Lasm_SetLexicalBinding.ssa_block_10:
-    tbz x1, #1, .Lasm_SetLexicalBinding.ssa_block_1
+    tbnz x1, #1, 1f
+    b .Lasm_SetLexicalBinding.ssa_block_1
+1:
     ldr w1, [x21, #8]
     ldr x1, [x27, x1, lsl #3]
     str x1, [x2, x0, lsl #3]
@@ -2902,7 +2917,9 @@ asm_handler_SetVariableBinding:
     ldr x1, [x3, #56]
     ldrb w1, [x1, x0]
 .Lasm_SetVariableBinding.ssa_block_10:
-    tbz x1, #1, .Lasm_SetVariableBinding.ssa_block_1
+    tbnz x1, #1, 1f
+    b .Lasm_SetVariableBinding.ssa_block_1
+1:
     ldr w1, [x21, #8]
     ldr x1, [x27, x1, lsl #3]
     str x1, [x2, x0, lsl #3]
@@ -2963,7 +2980,9 @@ asm_handler_DynamicSetLexicalBinding:
     ldr x0, [x3, #56]
     ldrb w0, [x0, x1]
 .Lasm_DynamicSetLexicalBinding.ssa_block_16:
-    tbz x0, #1, .Lasm_DynamicSetLexicalBinding.ssa_block_1
+    tbnz x0, #1, 1f
+    b .Lasm_DynamicSetLexicalBinding.ssa_block_1
+1:
     ldr w0, [x21, #8]
     ldr x0, [x27, x0, lsl #3]
     str x0, [x2, x1, lsl #3]
@@ -3024,7 +3043,9 @@ asm_handler_DynamicSetVariableBinding:
     ldr x0, [x3, #56]
     ldrb w0, [x0, x1]
 .Lasm_DynamicSetVariableBinding.ssa_block_16:
-    tbz x0, #1, .Lasm_DynamicSetVariableBinding.ssa_block_1
+    tbnz x0, #1, 1f
+    b .Lasm_DynamicSetVariableBinding.ssa_block_1
+1:
     ldr w0, [x21, #8]
     ldr x0, [x27, x0, lsl #3]
     str x0, [x2, x1, lsl #3]
@@ -3437,7 +3458,9 @@ asm_handler_UnsignedRightShift:
     cmp x9, x22
     b.ne .Lasm_UnsignedRightShift.ssa_block_1
     lsr w0, w0, w1
-    tbnz x0, #31, .Lasm_UnsignedRightShift.ssa_block_2
+    tbz x0, #31, 1f
+    b .Lasm_UnsignedRightShift.ssa_block_2
+1:
     movk x0, #0x7ffa, lsl #48
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
@@ -3460,7 +3483,9 @@ asm_handler_Mod:
     cmp x9, x22
     b.ne .Lasm_Mod.ssa_block_2
     cbz w1, .Lasm_Mod.ssa_block_1
-    tbnz w0, #31, .Lasm_Mod.ssa_block_2
+    tbz w0, #31, 1f
+    b .Lasm_Mod.ssa_block_2
+1:
     sdiv w9, w0, w1
     msub w0, w9, w1, w0
     movk x0, #0x7ffa, lsl #48
@@ -3982,7 +4007,9 @@ asm_handler_PutByValue:
     add x3, x3, x24
     ldrh w1, [x3, #10]
     tbnz x1, #3, .Lasm_PutByValue.ssa_block_7
-    tbnz x1, #4, .Lasm_PutByValue.ssa_block_1
+    tbz x1, #4, 1f
+    b .Lasm_PutByValue.ssa_block_1
+1:
     ldrb w1, [x3, #12]
     cmp x1, #1
     b.ne .Lasm_PutByValue.ssa_switch_6_after_preferred
@@ -4225,42 +4252,42 @@ asm_handler_PutByValue_hot_end:
 .p2align 4
 asm_handler_GetById:
     ldr w0, [x21, #8]
-    ldr x2, [x27, x0, lsl #3]
-    lsr x9, x2, #48
+    ldr x0, [x27, x0, lsl #3]
+    lsr x9, x0, #48
     mov w10, #65529
     cmp x9, x10
     b.ne .Lasm_GetById.ssa_block_1
-    and x2, x2, #0x3ffffffffff
-    add x2, x2, x24
-    ldr x1, [x2, #24]
-    ldr x0, [x28, #88]
-    ldr x0, [x0, #112]
-    ldr w3, [x21, #20]
-    ldr x0, [x0, x3, lsl #3]
-    cbz x0, .Lasm_GetById.ssa_block_1
-    and x0, x0, #0xfffffffffffffffc
-    ldr x9, [x0, #24]
-    cmp x9, x1
+    and x1, x0, #0x3ffffffffff
+    add x1, x1, x24
+    ldr x2, [x1, #24]
+    ldr x3, [x28, #88]
+    ldr x3, [x3, #112]
+    ldr w4, [x21, #20]
+    ldr x3, [x3, x4, lsl #3]
+    cbz x3, .Lasm_GetById.ssa_block_1
+    and x3, x3, #0xfffffffffffffffc
+    ldr x9, [x3, #24]
+    cmp x9, x2
     b.ne .Lasm_GetById.ssa_block_1
-    ldr w3, [x0]
-    cmp w3, #6
+    ldr w4, [x3]
+    cmp w4, #6
     b.eq .Lasm_GetById.ssa_block_1
-    ldr x3, [x0, #32]
-    cbnz x3, .Lasm_GetById.ssa_block_10
-    mov x3, x2
+    ldr x4, [x3, #32]
+    cbnz x4, .Lasm_GetById.ssa_block_10
+    mov x4, x1
 .Lasm_GetById.ssa_block_8:
-    ldp w4, w5, [x0, #4]
-    ldr w9, [x1, #92]
-    cmp w9, w5
+    ldp w5, w6, [x3, #4]
+    ldr w9, [x2, #92]
+    cmp w9, w6
     b.ne .Lasm_GetById.ssa_block_1
-    ldr x1, [x3, #32]
-    ldr x1, [x1, x4, lsl #3]
-    lsr x9, x1, #48
+    ldr x0, [x4, #32]
+    ldr x0, [x0, x5, lsl #3]
+    lsr x9, x0, #48
     mov w10, #65532
     cmp x9, x10
     b.eq .Lasm_GetById.ssa_block_9
     ldr w9, [x21, #4]
-    str x1, [x27, x9, lsl #3]
+    str x0, [x27, x9, lsl #3]
     ldrb w9, [x21, #24]
     add x21, x21, #24
     ldr x10, [x19, x9, lsl #3]
@@ -4325,7 +4352,9 @@ asm_handler_GetByValue:
     add x3, x3, x24
     ldrh w1, [x3, #10]
     tbnz x1, #3, .Lasm_GetByValue.ssa_block_13
-    tbnz x1, #4, .Lasm_GetByValue.ssa_block_1
+    tbz x1, #4, 1f
+    b .Lasm_GetByValue.ssa_block_1
+1:
     ldrb w1, [x3, #12]
     cmp x1, #1
     b.ne .Lasm_GetByValue.ssa_switch_14_after_preferred
@@ -4429,7 +4458,9 @@ asm_handler_GetByValue:
     and x0, x0, #0x3ffffffffff
     adds x0, x0, x1
     ldr w0, [x0]
-    tbnz x0, #31, .Lasm_GetByValue.ssa_block_6
+    tbz x0, #31, 1f
+    b .Lasm_GetByValue.ssa_block_6
+1:
 .Lasm_GetByValue.ssa_block_5:
     movk x0, #0x7ffa, lsl #48
     ldr w9, [x21, #4]
@@ -4500,7 +4531,9 @@ asm_handler_GetLength:
     ldrh w0, [x1, #10]
     tbz x0, #2, .Lasm_GetLength.ssa_block_5
     ldr w0, [x1, #16]
-    tbnz x0, #31, .Lasm_GetLength.ssa_block_2
+    tbz x0, #31, 1f
+    b .Lasm_GetLength.ssa_block_2
+1:
     movk x0, #0x7ffa, lsl #48
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
@@ -4655,7 +4688,9 @@ asm_handler_SetGlobal:
     ldr x1, [x3, #56]
     ldrb w1, [x1, x0]
 .Lasm_SetGlobal.ssa_block_8:
-    tbz x1, #1, .Lasm_SetGlobal.ssa_block_2
+    tbnz x1, #1, 1f
+    b .Lasm_SetGlobal.ssa_block_2
+1:
     ldr w1, [x21, #8]
     ldr x1, [x27, x1, lsl #3]
     str x1, [x2, x0, lsl #3]
@@ -4676,52 +4711,57 @@ asm_handler_Call:
     and x1, x1, #0x3ffffffffff
     add x1, x1, x24
     ldrh w0, [x1, #10]
-    tbz x0, #7, .Lasm_Call.ssa_block_1
+    tbnz x0, #7, 1f
+    b .Lasm_Call.ssa_block_1
+1:
     tbz x0, #6, .Lasm_Call.ssa_block_3
     ldr x0, [x1, #80]
-    ldp x2, x0, [x0, #48]
-    tbz x0, #32, .Lasm_Call.ssa_block_1
+    ldp x4, x0, [x0, #48]
+    tbnz x0, #32, 1f
+    b .Lasm_Call.ssa_block_1
+1:
     tbnz x0, #33, .Lasm_Call.ssa_block_2
     movz x6, #0x7ffb, lsl #48
     tbz x0, #34, .Lasm_Call.ssa_block_9
-    ldr w3, [x21, #16]
-    ldr x6, [x27, x3, lsl #3]
+    ldr w2, [x21, #16]
+    ldr x6, [x27, x2, lsl #3]
     tbnz x0, #35, .Lasm_Call.ssa_block_9
-    lsr x3, x6, #48
-    mov x4, x3
-    and w4, w4, #0xfffe
+    lsr x2, x6, #48
+    mov x3, x2
+    and w3, w3, #0xfffe
     mov w9, #32766
-    cmp w4, w9
+    cmp w3, w9
     b.ne .Lasm_Call.ssa_block_13
-    ldr x3, [x1, #24]
-    ldr x3, [x3, #16]
-    ldr x3, [x3, #40]
-    ldr x6, [x3, #32]
+    ldr x2, [x1, #24]
+    ldr x2, [x2, #16]
+    ldr x2, [x2, #40]
+    ldr x6, [x2, #32]
     and x6, x6, #0x3ffffffffff
-    movz x3, #0xfff9, lsl #48
-    orr x6, x6, x3
+    movz x2, #0xfff9, lsl #48
+    orr x6, x6, x2
     b .Lasm_Call.ssa_block_9
 .Lasm_Call.ssa_block_13:
     mov w9, #65529
-    cmp w3, w9
+    cmp w2, w9
     b.ne .Lasm_Call.ssa_block_2
 .Lasm_Call.ssa_block_9:
-    ldr w4, [x21, #20]
-    mov w3, w0
-    cmp x3, x4
-    b.hs .Lasm_Call.ssa_block_35
-    mov x3, x4
-.Lasm_Call.ssa_block_35:
-    ldr w4, [x2, #364]
-    ldr w7, [x2, #368]
+    ldr w3, [x21, #20]
+    mov w2, w0
+    cmp x2, x3
+    b.hs .Lasm_Call.ssa_block_27
+    mov x2, x3
+.Lasm_Call.ssa_block_27:
+    ldr w0, [x4, #364]
+    ldr w3, [x4, #368]
     movn w0, #0
-    subs x0, x0, x7
-    cmp x0, x3
+    subs x0, x0, x3
+    cmp x0, x2
     b.lo .Lasm_Call.ssa_block_1
     mov x0, x20
     ldr x8, [x0, #15376]
     ldr x0, [x0, #15368]
-    adds x7, x7, x3
+    mov x7, x3
+    adds x7, x7, x2
     lsl x5, x7, #3
     add x5, x5, #128
     adds x5, x5, x0
@@ -4729,7 +4769,7 @@ asm_handler_Call:
     b.hi .Lasm_Call.ssa_block_1
     mov x8, x20
     str x5, [x8, #15368]
-    stp w7, w3, [x0, #116]
+    stp w7, w2, [x0, #116]
     ldr w5, [x21, #20]
     str w5, [x0, #104]
     ldr x5, [x1, #24]
@@ -4738,85 +4778,58 @@ asm_handler_Call:
     ldp x5, x7, [x1, #104]
     stp x5, x5, [x0, #32]
     str x7, [x0, #48]
-    stp x6, x2, [x0, #80]
-    movz x2, #0x7ffb, lsl #48
-    stp x2, x2, [x0, #128]
+    stp x6, x4, [x0, #80]
+    movz x4, #0x7ffb, lsl #48
+    stp x4, x4, [x0, #128]
     str x6, [x0, #144]
-    stp x2, x2, [x0, #152]
-    add x5, x0, #16
+    stp x4, x4, [x0, #152]
+    add x4, x0, #16
     add x1, x1, #120
-    ldp x1, x6, [x1, #0]
-    stp x1, x6, [x5, #0]
+    ldp x1, x5, [x1, #0]
+    stp x1, x5, [x4, #0]
     str wzr, [x0, #64]
-    mov x5, x20
-    ldr x1, [x5, #15384]
+    mov x4, x20
+    ldr x1, [x4, #15384]
     str x1, [x0, #56]
     add x1, x1, #1
-    str x1, [x5, #15384]
+    str x1, [x4, #15384]
     str wzr, [x0, #68]
     movn w9, #0
     str w9, [x0, #72]
     strb wzr, [x0, #76]
     strb wzr, [x0, #77]
     strb wzr, [x0, #78]
+    strb wzr, [x0, #79]
     str x28, [x0, #96]
-    ldp w6, w5, [x21, #4]
+    ldp w5, w4, [x21, #4]
     sub w1, w21, w26
-    adds x1, x1, x6
-    stp w1, w5, [x0, #108]
-    mov w1, #5
+    adds x1, x1, x5
+    stp w1, w4, [x0, #108]
+    ldr w4, [x21, #20]
+    mov x1, #0
     add x5, x0, #128
-.Lasm_Call.ssa_block_17:
-    add x6, x1, #1
-    cmp x6, x4
-    b.hs .Lasm_Call.ssa_block_16
-    add x10, x5, x1, lsl #3
-    stp x2, x2, [x10]
-    add x1, x1, #2
-    b .Lasm_Call.ssa_block_17
-.Lasm_Call.ssa_block_16:
-    cmp x1, x4
-    b.hs .Lasm_Call.ssa_block_19
-    str x2, [x5, x1, lsl #3]
-.Lasm_Call.ssa_block_19:
-    ldr x1, [x0, #88]
-    ldp x6, x7, [x1, #376]
-    mov x1, #0
-    mov x2, x4
-.Lasm_Call.ssa_block_22:
-    cmp x1, x6
-    b.hs .Lasm_Call.ssa_block_21
-    ldr x8, [x7, x1, lsl #3]
-    str x8, [x5, x2, lsl #3]
-    add x1, x1, #1
-    add x2, x2, #1
-    b .Lasm_Call.ssa_block_22
-.Lasm_Call.ssa_block_21:
-    ldr w2, [x21, #20]
-    mov x1, #0
-    adds x4, x4, x6
     add x6, x28, #128
     add x7, x21, #28
-.Lasm_Call.ssa_block_25:
-    cmp x1, x2
-    b.hs .Lasm_Call.ssa_block_24
+.Lasm_Call.ssa_block_17:
+    cmp x1, x4
+    b.hs .Lasm_Call.ssa_block_16
     ldr w8, [x7, x1, lsl #2]
     ldr x8, [x6, x8, lsl #3]
-    str x8, [x5, x4, lsl #3]
+    str x8, [x5, x3, lsl #3]
     add x1, x1, #1
-    add x4, x4, #1
-    b .Lasm_Call.ssa_block_25
-.Lasm_Call.ssa_block_24:
+    add x3, x3, #1
+    b .Lasm_Call.ssa_block_17
+.Lasm_Call.ssa_block_16:
     movz x1, #0x7ffe, lsl #48
-    adds x3, x3, x4
-    subs x3, x3, x2
-.Lasm_Call.ssa_block_28:
-    cmp x4, x3
-    b.hs .Lasm_Call.ssa_block_27
-    str x1, [x5, x4, lsl #3]
-    add x4, x4, #1
-    b .Lasm_Call.ssa_block_28
-.Lasm_Call.ssa_block_27:
+    adds x2, x2, x3
+    subs x2, x2, x4
+.Lasm_Call.ssa_block_20:
+    cmp x3, x2
+    b.hs .Lasm_Call.ssa_block_19
+    str x1, [x5, x3, lsl #3]
+    add x3, x3, #1
+    b .Lasm_Call.ssa_block_20
+.Lasm_Call.ssa_block_19:
     ldr x1, [x0, #88]
     ldr x26, [x1, #80]
     mov x1, x20
@@ -4829,7 +4842,9 @@ asm_handler_Call:
     ldr x10, [x19, x9, lsl #3]
     br x10
 .Lasm_Call.ssa_block_3:
-    tbz x0, #1, .Lasm_Call.ssa_block_1
+    tbnz x0, #1, 1f
+    b .Lasm_Call.ssa_block_1
+1:
     ldr w2, [x21, #20]
     mov x0, x20
     ldr x4, [x0, #15376]
@@ -4875,6 +4890,7 @@ asm_handler_Call:
     strb wzr, [x0, #76]
     strb wzr, [x0, #77]
     strb wzr, [x0, #78]
+    strb wzr, [x0, #79]
     ldp w3, w5, [x21, #4]
     sub w4, w21, w26
     adds x3, x3, x4
@@ -4885,15 +4901,15 @@ asm_handler_Call:
     add x4, x28, #128
     add x5, x21, #28
     add x6, x0, #128
-.Lasm_Call.ssa_block_31:
+.Lasm_Call.ssa_block_23:
     cmp x3, x2
-    b.hs .Lasm_Call.ssa_block_30
+    b.hs .Lasm_Call.ssa_block_22
     ldr w7, [x5, x3, lsl #2]
     ldr x7, [x4, x7, lsl #3]
     str x7, [x6, x3, lsl #3]
     add x3, x3, #1
-    b .Lasm_Call.ssa_block_31
-.Lasm_Call.ssa_block_30:
+    b .Lasm_Call.ssa_block_23
+.Lasm_Call.ssa_block_22:
     mov x2, x20
     str x0, [x2, #15288]
     mov x28, x0
@@ -4923,10 +4939,71 @@ asm_handler_Call:
     ldr x10, [x19, x9, lsl #3]
     br x10
 .Lasm_Call.ssa_block_2:
+    add x9, sp, #0
+    ldr w10, [x21, #20]
+    lsl x10, x10, #3
+    add x10, x10, #55
+    and x10, x10, #0xfffffffffffffff0
+    sub x14, x9, x10
+    ldr x12, [x20, #15336]
+    mov w13, #32768
+    add x12, x12, x13
+    cmp x14, x12
+    b.hs .Lasm_Call.values_allocate_1
+    mov w0, #1
+    b .Lasm_Call.values_call_done_0
+.Lasm_Call.values_allocate_1:
+.Lasm_Call.values_probe_2:
+    sub x10, sp, #1, lsl #12
+    cmp x10, x14
+    b.ls .Lasm_Call.values_allocated_3
+    add sp, x10, #0
+    str xzr, [sp]
+    b .Lasm_Call.values_probe_2
+.Lasm_Call.values_allocated_3:
+    add sp, x14, #0
+    str x9, [sp]
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_Call.value_ready_4:
+    str x11, [sp, #24]
+    ldr w12, [x21, #16]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_Call.value_ready_5:
+    str x11, [sp, #32]
+    mov w9, #0
+    ldr w10, [x21, #20]
+    add x14, sp, #40
+    add x3, x21, #28
+.Lasm_Call.array_value_next_6:
+    cmp x9, x10
+    b.hs .Lasm_Call.array_values_end_8
+    ldr w12, [x3, x9, lsl #2]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_Call.array_value_ready_7:
+    str x11, [x14, x9, lsl #3]
+    add x9, x9, #1
+    b .Lasm_Call.array_value_next_6
+.Lasm_Call.array_values_end_8:
     mov x0, x20
     sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #16
     bl CSYM(asm_try_inline_call)
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_Call.values_restore_stack_9
+    cbnz x0, .Lasm_Call.values_exceptional_outputs_10
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #16]
+    str x11, [x27, x12, lsl #3]
+.Lasm_Call.skip_output_value_11:
+    b .Lasm_Call.values_restore_stack_9
+.Lasm_Call.values_exceptional_outputs_10:
+.Lasm_Call.values_restore_stack_9:
+    ldr x9, [sp]
+    add sp, x9, #0
+.Lasm_Call.values_call_done_0:
     cbnz w0, .Lasm_Call.ssa_block_1
     mov x0, x20
     ldr x28, [x0, #15288]
@@ -4951,7 +5028,9 @@ asm_handler_CallBuiltinMathAbs:
     and x0, x0, #0x3ffffffffff
     add x0, x0, x24
     ldrh w1, [x0, #10]
-    tbz x1, #7, .Lasm_CallBuiltinMathAbs.ssa_block_1
+    tbnz x1, #7, 1f
+    b .Lasm_CallBuiltinMathAbs.ssa_block_1
+1:
     ldrb w9, [x0, #73]
     cbz w9, .Lasm_CallBuiltinMathAbs.ssa_block_1
     ldrb w9, [x0, #72]
@@ -4999,7 +5078,9 @@ asm_handler_CallBuiltinMathFloor:
     and x0, x0, #0x3ffffffffff
     add x0, x0, x24
     ldrh w1, [x0, #10]
-    tbz x1, #7, .Lasm_CallBuiltinMathFloor.ssa_block_1
+    tbnz x1, #7, 1f
+    b .Lasm_CallBuiltinMathFloor.ssa_block_1
+1:
     ldrb w9, [x0, #73]
     cbz w9, .Lasm_CallBuiltinMathFloor.ssa_block_1
     ldrb w9, [x0, #72]
@@ -5053,7 +5134,9 @@ asm_handler_CallBuiltinMathCeil:
     and x0, x0, #0x3ffffffffff
     add x0, x0, x24
     ldrh w1, [x0, #10]
-    tbz x1, #7, .Lasm_CallBuiltinMathCeil.ssa_block_1
+    tbnz x1, #7, 1f
+    b .Lasm_CallBuiltinMathCeil.ssa_block_1
+1:
     ldrb w9, [x0, #73]
     cbz w9, .Lasm_CallBuiltinMathCeil.ssa_block_1
     ldrb w9, [x0, #72]
@@ -5107,7 +5190,9 @@ asm_handler_CallBuiltinMathSqrt:
     and x0, x0, #0x3ffffffffff
     add x0, x0, x24
     ldrh w1, [x0, #10]
-    tbz x1, #7, .Lasm_CallBuiltinMathSqrt.ssa_block_1
+    tbnz x1, #7, 1f
+    b .Lasm_CallBuiltinMathSqrt.ssa_block_1
+1:
     ldrb w9, [x0, #73]
     cbz w9, .Lasm_CallBuiltinMathSqrt.ssa_block_1
     ldrb w9, [x0, #72]
@@ -5161,7 +5246,9 @@ asm_handler_CallBuiltinMathExp:
     and x0, x0, #0x3ffffffffff
     add x0, x0, x24
     ldrh w1, [x0, #10]
-    tbz x1, #7, .Lasm_CallBuiltinMathExp.ssa_block_1
+    tbnz x1, #7, 1f
+    b .Lasm_CallBuiltinMathExp.ssa_block_1
+1:
     ldrb w9, [x0, #73]
     cbz w9, .Lasm_CallBuiltinMathExp.ssa_block_1
     ldrb w9, [x0, #72]
@@ -5194,7 +5281,9 @@ asm_handler_CallBuiltinStringFromCharCode:
     and x0, x0, #0x3ffffffffff
     add x0, x0, x24
     ldrh w1, [x0, #10]
-    tbz x1, #7, .Lasm_CallBuiltinStringFromCharCode.ssa_block_1
+    tbnz x1, #7, 1f
+    b .Lasm_CallBuiltinStringFromCharCode.ssa_block_1
+1:
     ldrb w9, [x0, #73]
     cbz w9, .Lasm_CallBuiltinStringFromCharCode.ssa_block_1
     ldrb w9, [x0, #72]
@@ -5238,7 +5327,9 @@ asm_handler_CallBuiltinStringPrototypeCharCodeAt:
     and x0, x0, #0x3ffffffffff
     add x0, x0, x24
     ldrh w1, [x0, #10]
-    tbz x1, #7, .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_2
+    tbnz x1, #7, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_2
+1:
     ldrb w9, [x0, #73]
     cbz w9, .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_2
     ldrb w9, [x0, #72]
@@ -5256,7 +5347,9 @@ asm_handler_CallBuiltinStringPrototypeCharCodeAt:
     cmp x9, x22
     b.ne .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_2
     sxtw x0, w0
-    tbnz w0, #31, .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_1
+    tbz w0, #31, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_1
+1:
     and x2, x2, #0x3ffffffffff
     add x2, x2, x24
     ldrb w9, [x2, #10]
@@ -5304,7 +5397,9 @@ asm_handler_CallBuiltinStringPrototypeCharAt:
     and x0, x0, #0x3ffffffffff
     add x0, x0, x24
     ldrh w1, [x0, #10]
-    tbz x1, #7, .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_1
+    tbnz x1, #7, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_1
+1:
     ldrb w9, [x0, #73]
     cbz w9, .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_1
     ldrb w9, [x0, #72]
@@ -5322,7 +5417,9 @@ asm_handler_CallBuiltinStringPrototypeCharAt:
     cmp x9, x22
     b.ne .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_1
     sxtw x0, w0
-    tbnz w0, #31, .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_2
+    tbz w0, #31, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_2
+1:
     and x2, x2, #0x3ffffffffff
     add x2, x2, x24
     ldrb w9, [x2, #10]
@@ -5652,7 +5749,9 @@ asm_handler_MulRhsInt32:
     mov w2, w2
     cbnz w2, .Lasm_MulRhsInt32.ssa_block_11
     orr w0, w0, w1
-    tbnz w0, #31, .Lasm_MulRhsInt32.ssa_block_3
+    tbz w0, #31, 1f
+    b .Lasm_MulRhsInt32.ssa_block_3
+1:
 .Lasm_MulRhsInt32.ssa_block_11:
     movk x2, #0x7ffa, lsl #48
     ldr w9, [x21, #4]
@@ -5662,36 +5761,6 @@ asm_handler_MulRhsInt32:
     ldr x10, [x19, x9, lsl #3]
     br x10
 asm_handler_MulRhsInt32_hot_end:
-
-.p2align 4
-asm_handler_ExpRhsInt32:
-    ldr w0, [x21, #8]
-    ldr x0, [x27, x0, lsl #3]
-    ldr w1, [x21, #12]
-    movk x1, #0x7ffa, lsl #48
-    ldr w2, [x21, #4]
-    mov x3, x0
-    mov x4, x1
-    mov x0, x20
-    sub w1, w21, w26
-    str w1, [x28, #64]
-    bl CSYM(asm_slow_path_exp_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ExpRhsInt32.slow_path_transfer_0
-    add x21, x26, w0, uxtw
-    ldrb w9, [x21]
-    ldr x10, [x19, x9, lsl #3]
-    br x10
-.Lasm_ExpRhsInt32.slow_path_transfer_0:
-    ldr x28, [x20, #15288]
-    ldr x9, [x28, #88]
-    ldr x26, [x9, #80]
-    add x27, x28, #128
-    add x21, x26, w0, uxtw
-    ldrb w9, [x21]
-    ldr x10, [x19, x9, lsl #3]
-    br x10
-asm_handler_ExpRhsInt32_hot_end:
 
 .p2align 4
 asm_handler_DivRhsInt32:
@@ -5841,7 +5910,9 @@ asm_handler_UnsignedRightShiftRhsInt32:
     cmp x9, x22
     b.ne .Lasm_UnsignedRightShiftRhsInt32.ssa_block_1
     lsr w0, w0, w1
-    tbnz x0, #31, .Lasm_UnsignedRightShiftRhsInt32.ssa_block_2
+    tbz x0, #31, 1f
+    b .Lasm_UnsignedRightShiftRhsInt32.ssa_block_2
+1:
     movk x0, #0x7ffa, lsl #48
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
@@ -5860,7 +5931,9 @@ asm_handler_ModRhsInt32:
     b.ne .Lasm_ModRhsInt32.ssa_block_2
     ldr w1, [x21, #12]
     cbz w1, .Lasm_ModRhsInt32.ssa_block_1
-    tbnz w0, #31, .Lasm_ModRhsInt32.ssa_block_2
+    tbz w0, #31, 1f
+    b .Lasm_ModRhsInt32.ssa_block_2
+1:
     sdiv w9, w0, w1
     msub w0, w9, w1, w0
     movk x0, #0x7ffa, lsl #48
@@ -6780,10 +6853,10 @@ asm_handler_JumpLooselyInequalsRhsInt32:
     br x10
 asm_handler_JumpLooselyInequalsRhsInt32_hot_end:
 
-.Lexit_veneer:
-    b .Lexit
 // Cold handler paths
 asm_cold_handler_paths:
+asm_handler_Enter_cold:
+asm_handler_Enter_cold_end:
 asm_handler_Mov_cold:
 asm_handler_Mov_cold_end:
 asm_handler_Add_cold:
@@ -6841,7 +6914,9 @@ asm_handler_Add_cold:
     b .Lasm_Add.ssa_box_number_37_done
 .Lasm_Add.ssa_box_number_37_check_negative_zero:
     fmov x0, d0
-    tbnz x0, #63, .Lasm_Add.ssa_box_number_37_not_integer
+    tbz x0, #63, 1f
+    b .Lasm_Add.ssa_box_number_37_not_integer
+1:
     mov w0, w1
     movk x0, #0x7ffa, lsl #48
     b .Lasm_Add.ssa_box_number_37_done
@@ -6859,19 +6934,42 @@ asm_handler_Add_cold:
     br x10
 .Lasm_Add.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_add_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Add.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_Add.binary_result_restore_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Add.binary_result_restore_1
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Add.slow_path_transfer_1:
+.Lasm_Add.binary_result_restore_1:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Add.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Add.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -6939,7 +7037,9 @@ asm_handler_Sub_cold:
     b .Lasm_Sub.ssa_box_number_37_done
 .Lasm_Sub.ssa_box_number_37_check_negative_zero:
     fmov x0, d0
-    tbnz x0, #63, .Lasm_Sub.ssa_box_number_37_not_integer
+    tbz x0, #63, 1f
+    b .Lasm_Sub.ssa_box_number_37_not_integer
+1:
     mov w0, w1
     movk x0, #0x7ffa, lsl #48
     b .Lasm_Sub.ssa_box_number_37_done
@@ -6957,19 +7057,42 @@ asm_handler_Sub_cold:
     br x10
 .Lasm_Sub.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_sub_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Sub.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_Sub.binary_result_restore_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Sub.binary_result_restore_1
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Sub.slow_path_transfer_1:
+.Lasm_Sub.binary_result_restore_1:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Sub.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Sub.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7036,7 +7159,9 @@ asm_handler_Mul_cold:
     b .Lasm_Mul.ssa_box_number_41_done
 .Lasm_Mul.ssa_box_number_41_check_negative_zero:
     fmov x0, d0
-    tbnz x0, #63, .Lasm_Mul.ssa_box_number_41_not_integer
+    tbz x0, #63, 1f
+    b .Lasm_Mul.ssa_box_number_41_not_integer
+1:
     mov w0, w1
     movk x0, #0x7ffa, lsl #48
     b .Lasm_Mul.ssa_box_number_41_done
@@ -7054,19 +7179,42 @@ asm_handler_Mul_cold:
     br x10
 .Lasm_Mul.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_mul_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Mul.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_Mul.binary_result_restore_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Mul.binary_result_restore_1
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Mul.slow_path_transfer_1:
+.Lasm_Mul.binary_result_restore_1:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Mul.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Mul.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7087,22 +7235,104 @@ asm_handler_Mul_cold:
     fmov x0, d8
     b .Lasm_Mul.canon_nan_0_ret
 asm_handler_Mul_cold_end:
+.p2align 4
+asm_handler_Exp:
+    ldp w0, w1, [x21, #8]
+    ldr x0, [x27, x0, lsl #3]
+    ldr x1, [x27, x1, lsl #3]
+    ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
+    mov x3, x0
+    mov x4, x1
+    add x2, sp, #0
+    mov x0, x20
+    sub w1, w21, w26
+    str w1, [x28, #64]
+    bl CSYM(asm_slow_path_exp_values)
+    tbnz x0, #63, .Lasm_Exp.binary_result_restore_0
+    tbz x0, #32, .Lasm_Exp.binary_result_restore_0
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Exp.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_Exp.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Exp.slow_path_transfer_1:
+    ldr x28, [x20, #15288]
+    ldr x9, [x28, #88]
+    ldr x26, [x9, #80]
+    add x27, x28, #128
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+asm_handler_Exp_hot_end:
 asm_handler_Exp_cold:
 asm_handler_Exp_cold_end:
+
 .p2align 4
 asm_handler_ConcatString:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #16
+    ldr w12, [x21, #4]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_ConcatString.value_ready_1:
+    mov x4, x11
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_ConcatString.value_ready_2:
+    mov x5, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_concat_string)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ConcatString.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ConcatString.values_exceptional_outputs_4
+    tbz x0, #32, .Lasm_ConcatString.values_exceptional_outputs_4
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_ConcatString.skip_output_value_5:
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ConcatString.slow_path_transfer_0:
+.Lasm_ConcatString.values_exceptional_outputs_4:
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_ConcatString.values_restore_stack_3
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_ConcatString.skip_exceptional_output_6:
+.Lasm_ConcatString.values_restore_stack_3:
+    add sp, sp, #16
+.Lasm_ConcatString.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ConcatString.slow_path_transfer_7
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ConcatString.slow_path_transfer_7:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7120,15 +7350,81 @@ asm_handler_CopyObjectExcludingProperties:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    add x9, sp, #0
+    ldr w10, [x21, #16]
+    lsl x10, x10, #3
+    add x10, x10, #47
+    and x10, x10, #0xfffffffffffffff0
+    sub x14, x9, x10
+    ldr x12, [x20, #15336]
+    mov w13, #32768
+    add x12, x12, x13
+    cmp x14, x12
+    b.hs .Lasm_CopyObjectExcludingProperties.values_allocate_1
+    mov x0, x20
+    sub w1, w21, w26
+    bl CSYM(asm_slow_path_stack_overflow)
+    b .Lasm_CopyObjectExcludingProperties.values_call_done_0
+.Lasm_CopyObjectExcludingProperties.values_allocate_1:
+.Lasm_CopyObjectExcludingProperties.values_probe_2:
+    sub x10, sp, #1, lsl #12
+    cmp x10, x14
+    b.ls .Lasm_CopyObjectExcludingProperties.values_allocated_3
+    add sp, x10, #0
+    str xzr, [sp]
+    b .Lasm_CopyObjectExcludingProperties.values_probe_2
+.Lasm_CopyObjectExcludingProperties.values_allocated_3:
+    add sp, x14, #0
+    str x9, [sp]
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_CopyObjectExcludingProperties.value_ready_4:
+    str x11, [sp, #24]
+    mov w9, #0
+    ldr w10, [x21, #16]
+    add x14, sp, #32
+    add x3, x21, #20
+.Lasm_CopyObjectExcludingProperties.array_value_next_5:
+    cmp x9, x10
+    b.hs .Lasm_CopyObjectExcludingProperties.array_values_end_7
+    ldr w12, [x3, x9, lsl #2]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_CopyObjectExcludingProperties.array_value_ready_6:
+    str x11, [x14, x9, lsl #3]
+    add x9, x9, #1
+    b .Lasm_CopyObjectExcludingProperties.array_value_next_5
+.Lasm_CopyObjectExcludingProperties.array_values_end_7:
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #16
     bl CSYM(asm_slow_path_copy_object_excluding_properties)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CopyObjectExcludingProperties.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CopyObjectExcludingProperties.values_exceptional_outputs_9
+    tbz x0, #32, .Lasm_CopyObjectExcludingProperties.values_exceptional_outputs_9
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #16]
+    str x11, [x27, x12, lsl #3]
+.Lasm_CopyObjectExcludingProperties.skip_output_value_10:
+    ldr x9, [sp]
+    add sp, x9, #0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CopyObjectExcludingProperties.slow_path_transfer_0:
+.Lasm_CopyObjectExcludingProperties.values_exceptional_outputs_9:
+.Lasm_CopyObjectExcludingProperties.values_restore_stack_8:
+    ldr x9, [sp]
+    add sp, x9, #0
+.Lasm_CopyObjectExcludingProperties.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CopyObjectExcludingProperties.slow_path_transfer_11
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CopyObjectExcludingProperties.slow_path_transfer_11:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7146,15 +7442,36 @@ asm_handler_ImportCall:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ImportCall.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ImportCall.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_import_call)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ImportCall.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ImportCall.scalar_result_done_2
+    tbz x0, #32, .Lasm_ImportCall.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ImportCall.slow_path_transfer_0:
+.Lasm_ImportCall.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ImportCall.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ImportCall.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7172,15 +7489,93 @@ asm_handler_NewClass:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    add x9, sp, #0
+    ldr w10, [x21, #28]
+    lsl x10, x10, #3
+    add x10, x10, #55
+    and x10, x10, #0xfffffffffffffff0
+    sub x14, x9, x10
+    ldr x12, [x20, #15336]
+    mov w13, #32768
+    add x12, x12, x13
+    cmp x14, x12
+    b.hs .Lasm_NewClass.values_allocate_1
+    mov x0, x20
+    sub w1, w21, w26
+    bl CSYM(asm_slow_path_stack_overflow)
+    b .Lasm_NewClass.values_call_done_0
+.Lasm_NewClass.values_allocate_1:
+.Lasm_NewClass.values_probe_2:
+    sub x10, sp, #1, lsl #12
+    cmp x10, x14
+    b.ls .Lasm_NewClass.values_allocated_3
+    add sp, x10, #0
+    str xzr, [sp]
+    b .Lasm_NewClass.values_probe_2
+.Lasm_NewClass.values_allocated_3:
+    add sp, x14, #0
+    str x9, [sp]
+    movz x11, #0x7ffb, lsl #48
+    ldr w12, [x21, #12]
+    movn w13, #0
+    cmp w12, w13
+    b.eq .Lasm_NewClass.value_ready_4
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_NewClass.value_ready_4:
+    str x11, [sp, #24]
+    ldr w12, [x21, #16]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_NewClass.value_ready_5:
+    str x11, [sp, #32]
+    mov w9, #0
+    ldr w10, [x21, #28]
+    add x14, sp, #40
+    add x3, x21, #32
+.Lasm_NewClass.array_value_next_6:
+    cmp x9, x10
+    b.hs .Lasm_NewClass.array_values_end_8
+    ldr w12, [x3, x9, lsl #2]
+    movz x11, #0x7ffb, lsl #48
+    movn w13, #0
+    cmp w12, w13
+    b.eq .Lasm_NewClass.array_value_ready_7
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_NewClass.array_value_ready_7:
+    str x11, [x14, x9, lsl #3]
+    add x9, x9, #1
+    b .Lasm_NewClass.array_value_next_6
+.Lasm_NewClass.array_values_end_8:
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #16
     bl CSYM(asm_slow_path_new_class)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewClass.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewClass.values_exceptional_outputs_10
+    tbz x0, #32, .Lasm_NewClass.values_exceptional_outputs_10
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #16]
+    str x11, [x27, x12, lsl #3]
+.Lasm_NewClass.skip_output_value_11:
+    ldr x9, [sp]
+    add sp, x9, #0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewClass.slow_path_transfer_0:
+.Lasm_NewClass.values_exceptional_outputs_10:
+.Lasm_NewClass.values_restore_stack_9:
+    ldr x9, [sp]
+    add sp, x9, #0
+.Lasm_NewClass.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewClass.slow_path_transfer_12
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewClass.slow_path_transfer_12:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7249,8 +7644,12 @@ asm_handler_JumpLessThan_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_less_than_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpLessThan.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpLessThan.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -7309,8 +7708,12 @@ asm_handler_JumpGreaterThan_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_greater_than_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpGreaterThan.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpGreaterThan.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -7369,8 +7772,12 @@ asm_handler_JumpLessThanEquals_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_less_than_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpLessThanEquals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpLessThanEquals.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -7429,8 +7836,12 @@ asm_handler_JumpGreaterThanEquals_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_greater_than_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpGreaterThanEquals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpGreaterThanEquals.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -7469,8 +7880,12 @@ asm_handler_JumpLooselyEquals_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_loosely_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpLooselyEquals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpLooselyEquals.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -7509,8 +7924,12 @@ asm_handler_JumpLooselyInequals_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_loosely_inequals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpLooselyInequals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpLooselyInequals.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -7549,8 +7968,12 @@ asm_handler_JumpStrictlyEquals_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_strictly_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpStrictlyEquals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpStrictlyEquals.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -7589,8 +8012,12 @@ asm_handler_JumpStrictlyInequals_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_strictly_inequals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpStrictlyInequals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpStrictlyInequals.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -7625,15 +8052,53 @@ asm_handler_Increment_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #16
+    ldr w12, [x21, #4]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_Increment.value_ready_1:
+    mov x4, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_increment)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Increment.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_Increment.values_exceptional_outputs_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Increment.values_exceptional_outputs_3
+1:
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_Increment.skip_output_value_4:
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Increment.slow_path_transfer_0:
+.Lasm_Increment.values_exceptional_outputs_3:
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_Increment.values_restore_stack_2
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_Increment.skip_exceptional_output_5:
+.Lasm_Increment.values_restore_stack_2:
+    add sp, sp, #16
+.Lasm_Increment.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Increment.slow_path_transfer_6
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Increment.slow_path_transfer_6:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7663,15 +8128,53 @@ asm_handler_Decrement_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #16
+    ldr w12, [x21, #4]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_Decrement.value_ready_1:
+    mov x4, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_decrement)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Decrement.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_Decrement.values_exceptional_outputs_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Decrement.values_exceptional_outputs_3
+1:
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_Decrement.skip_output_value_4:
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Decrement.slow_path_transfer_0:
+.Lasm_Decrement.values_exceptional_outputs_3:
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_Decrement.values_restore_stack_2
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_Decrement.skip_exceptional_output_5:
+.Lasm_Decrement.values_restore_stack_2:
+    add sp, sp, #16
+.Lasm_Decrement.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Decrement.slow_path_transfer_6
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Decrement.slow_path_transfer_6:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7698,15 +8201,28 @@ asm_handler_GetImportMeta:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_import_meta)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetImportMeta.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetImportMeta.scalar_result_done_0
+    tbz x0, #32, .Lasm_GetImportMeta.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetImportMeta.slow_path_transfer_0:
+.Lasm_GetImportMeta.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetImportMeta.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetImportMeta.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7724,15 +8240,28 @@ asm_handler_GetNewTarget:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_new_target)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetNewTarget.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetNewTarget.scalar_result_done_0
+    tbz x0, #32, .Lasm_GetNewTarget.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetNewTarget.slow_path_transfer_0:
+.Lasm_GetNewTarget.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetNewTarget.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetNewTarget.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7750,15 +8279,28 @@ asm_handler_GetSuperConstructor:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_super_constructor)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetSuperConstructor.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetSuperConstructor.scalar_result_done_0
+    tbz x0, #32, .Lasm_GetSuperConstructor.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetSuperConstructor.slow_path_transfer_0:
+.Lasm_GetSuperConstructor.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetSuperConstructor.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetSuperConstructor.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7779,15 +8321,34 @@ asm_handler_GetBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_GetBinding.scalar_result_done_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetBinding.scalar_result_done_0
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetBinding.slow_path_transfer_0:
+.Lasm_GetBinding.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetBinding.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetBinding.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7803,15 +8364,34 @@ asm_handler_DynamicGetBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_get_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DynamicGetBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_DynamicGetBinding.scalar_result_done_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicGetBinding.scalar_result_done_0
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DynamicGetBinding.slow_path_transfer_0:
+.Lasm_DynamicGetBinding.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicGetBinding.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicGetBinding.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7829,15 +8409,34 @@ asm_handler_DynamicGetInitializedBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_get_initialized_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DynamicGetInitializedBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_DynamicGetInitializedBinding.scalar_result_done_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicGetInitializedBinding.scalar_result_done_0
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DynamicGetInitializedBinding.slow_path_transfer_0:
+.Lasm_DynamicGetInitializedBinding.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicGetInitializedBinding.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicGetInitializedBinding.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7857,15 +8456,36 @@ asm_handler_DynamicInitializeLexicalBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_DynamicInitializeLexicalBinding.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_initialize_lexical_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_DynamicInitializeLexicalBinding.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicInitializeLexicalBinding.scalar_result_done_1
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_0:
+.Lasm_DynamicInitializeLexicalBinding.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7881,15 +8501,36 @@ asm_handler_DynamicInitializeVariableBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_DynamicInitializeVariableBinding.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_initialize_variable_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DynamicInitializeVariableBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_DynamicInitializeVariableBinding.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicInitializeVariableBinding.scalar_result_done_1
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DynamicInitializeVariableBinding.slow_path_transfer_0:
+.Lasm_DynamicInitializeVariableBinding.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicInitializeVariableBinding.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicInitializeVariableBinding.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7905,15 +8546,36 @@ asm_handler_SetLexicalBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SetLexicalBinding.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_set_lexical_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_SetLexicalBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_SetLexicalBinding.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_SetLexicalBinding.scalar_result_done_1
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_SetLexicalBinding.slow_path_transfer_0:
+.Lasm_SetLexicalBinding.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_SetLexicalBinding.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetLexicalBinding.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7929,15 +8591,36 @@ asm_handler_SetVariableBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SetVariableBinding.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_set_variable_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_SetVariableBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_SetVariableBinding.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_SetVariableBinding.scalar_result_done_1
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_SetVariableBinding.slow_path_transfer_0:
+.Lasm_SetVariableBinding.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_SetVariableBinding.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetVariableBinding.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7953,15 +8636,36 @@ asm_handler_DynamicSetLexicalBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_DynamicSetLexicalBinding.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_set_lexical_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DynamicSetLexicalBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_DynamicSetLexicalBinding.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicSetLexicalBinding.scalar_result_done_1
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DynamicSetLexicalBinding.slow_path_transfer_0:
+.Lasm_DynamicSetLexicalBinding.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicSetLexicalBinding.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicSetLexicalBinding.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7977,15 +8681,36 @@ asm_handler_DynamicSetVariableBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_DynamicSetVariableBinding.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_set_variable_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DynamicSetVariableBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_DynamicSetVariableBinding.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicSetVariableBinding.scalar_result_done_1
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DynamicSetVariableBinding.slow_path_transfer_0:
+.Lasm_DynamicSetVariableBinding.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicSetVariableBinding.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicSetVariableBinding.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8000,15 +8725,28 @@ asm_handler_ResolveBinding:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_resolve_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ResolveBinding.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ResolveBinding.scalar_result_done_0
+    tbz x0, #32, .Lasm_ResolveBinding.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ResolveBinding.slow_path_transfer_0:
+.Lasm_ResolveBinding.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ResolveBinding.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ResolveBinding.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8026,15 +8764,28 @@ asm_handler_ResolveSuperBase:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_resolve_super_base)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ResolveSuperBase.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ResolveSuperBase.scalar_result_done_0
+    tbz x0, #32, .Lasm_ResolveSuperBase.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ResolveSuperBase.slow_path_transfer_0:
+.Lasm_ResolveSuperBase.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ResolveSuperBase.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ResolveSuperBase.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8052,15 +8803,34 @@ asm_handler_SetResolvedBinding:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SetResolvedBinding.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SetResolvedBinding.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_set_resolved_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_SetResolvedBinding.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_SetResolvedBinding.scalar_result_done_2
+    tbz x0, #32, .Lasm_SetResolvedBinding.scalar_result_done_2
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_SetResolvedBinding.slow_path_transfer_0:
+.Lasm_SetResolvedBinding.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_SetResolvedBinding.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetResolvedBinding.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8078,15 +8848,28 @@ asm_handler_TypeofBinding:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_typeof_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_TypeofBinding.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_TypeofBinding.scalar_result_done_0
+    tbz x0, #32, .Lasm_TypeofBinding.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_TypeofBinding.slow_path_transfer_0:
+.Lasm_TypeofBinding.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_TypeofBinding.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_TypeofBinding.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8104,15 +8887,28 @@ asm_handler_DynamicTypeofBinding:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_typeof_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DynamicTypeofBinding.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_DynamicTypeofBinding.scalar_result_done_0
+    tbz x0, #32, .Lasm_DynamicTypeofBinding.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DynamicTypeofBinding.slow_path_transfer_0:
+.Lasm_DynamicTypeofBinding.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_DynamicTypeofBinding.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicTypeofBinding.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8130,15 +8926,32 @@ asm_handler_HasPrivateId:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_HasPrivateId.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_has_private_id)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_HasPrivateId.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_HasPrivateId.scalar_result_done_1
+    tbz x0, #32, .Lasm_HasPrivateId.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_HasPrivateId.slow_path_transfer_0:
+.Lasm_HasPrivateId.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_HasPrivateId.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_HasPrivateId.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8156,15 +8969,34 @@ asm_handler_SetFunctionName:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SetFunctionName.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SetFunctionName.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_set_function_name)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_SetFunctionName.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_SetFunctionName.scalar_result_done_2
+    tbz x0, #32, .Lasm_SetFunctionName.scalar_result_done_2
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_SetFunctionName.slow_path_transfer_0:
+.Lasm_SetFunctionName.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_SetFunctionName.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetFunctionName.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8182,15 +9014,32 @@ asm_handler_NewArrayWithLength:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_NewArrayWithLength.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_new_array_with_length)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewArrayWithLength.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewArrayWithLength.scalar_result_done_1
+    tbz x0, #32, .Lasm_NewArrayWithLength.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewArrayWithLength.slow_path_transfer_0:
+.Lasm_NewArrayWithLength.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewArrayWithLength.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewArrayWithLength.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8208,15 +9057,34 @@ asm_handler_ArrayAppend:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ArrayAppend.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ArrayAppend.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_array_append)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ArrayAppend.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ArrayAppend.scalar_result_done_2
+    tbz x0, #32, .Lasm_ArrayAppend.scalar_result_done_2
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ArrayAppend.slow_path_transfer_0:
+.Lasm_ArrayAppend.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ArrayAppend.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ArrayAppend.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8234,15 +9102,26 @@ asm_handler_CreateVariable:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_create_variable)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreateVariable.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreateVariable.scalar_result_done_0
+    tbz x0, #32, .Lasm_CreateVariable.scalar_result_done_0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreateVariable.slow_path_transfer_0:
+.Lasm_CreateVariable.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreateVariable.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateVariable.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8260,15 +9139,32 @@ asm_handler_EnterObjectEnvironment:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_EnterObjectEnvironment.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_enter_object_environment)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_EnterObjectEnvironment.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_EnterObjectEnvironment.scalar_result_done_1
+    tbz x0, #32, .Lasm_EnterObjectEnvironment.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_EnterObjectEnvironment.slow_path_transfer_0:
+.Lasm_EnterObjectEnvironment.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_EnterObjectEnvironment.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_EnterObjectEnvironment.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8301,15 +9197,57 @@ asm_handler_PostfixIncrement_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #16
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PostfixIncrement.value_ready_1:
+    mov x4, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_postfix_increment)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_PostfixIncrement.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_PostfixIncrement.values_exceptional_outputs_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_PostfixIncrement.values_exceptional_outputs_3
+1:
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_PostfixIncrement.skip_output_value_4:
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_PostfixIncrement.skip_output_value_5:
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_PostfixIncrement.slow_path_transfer_0:
+.Lasm_PostfixIncrement.values_exceptional_outputs_3:
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_PostfixIncrement.values_restore_stack_2
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_PostfixIncrement.skip_exceptional_output_6:
+.Lasm_PostfixIncrement.values_restore_stack_2:
+    add sp, sp, #16
+.Lasm_PostfixIncrement.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_PostfixIncrement.slow_path_transfer_7
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PostfixIncrement.slow_path_transfer_7:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8323,19 +9261,42 @@ asm_handler_Div_cold:
 // Cold paths for Div
 .Lasm_Div.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_div_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Div.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_Div.binary_result_restore_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Div.binary_result_restore_1
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Div.slow_path_transfer_1:
+.Lasm_Div.binary_result_restore_1:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Div.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Div.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8383,19 +9344,42 @@ asm_handler_LessThan_cold:
     b .Lasm_LessThan.ssa_block_2
 .Lasm_LessThan.ssa_block_3:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_less_than_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LessThan.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LessThan.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LessThan.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LessThan.slow_path_transfer_0:
+.Lasm_LessThan.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LessThan.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LessThan.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8440,19 +9424,42 @@ asm_handler_LessThanEquals_cold:
     b .Lasm_LessThanEquals.ssa_block_2
 .Lasm_LessThanEquals.ssa_block_3:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_less_than_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LessThanEquals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LessThanEquals.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LessThanEquals.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LessThanEquals.slow_path_transfer_0:
+.Lasm_LessThanEquals.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LessThanEquals.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LessThanEquals.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8497,19 +9504,42 @@ asm_handler_GreaterThan_cold:
     b .Lasm_GreaterThan.ssa_block_2
 .Lasm_GreaterThan.ssa_block_3:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_greater_than_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GreaterThan.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_GreaterThan.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GreaterThan.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GreaterThan.slow_path_transfer_0:
+.Lasm_GreaterThan.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GreaterThan.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GreaterThan.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8554,19 +9584,42 @@ asm_handler_GreaterThanEquals_cold:
     b .Lasm_GreaterThanEquals.ssa_block_2
 .Lasm_GreaterThanEquals.ssa_block_3:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_greater_than_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GreaterThanEquals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_GreaterThanEquals.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GreaterThanEquals.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GreaterThanEquals.slow_path_transfer_0:
+.Lasm_GreaterThanEquals.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GreaterThanEquals.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GreaterThanEquals.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8611,19 +9664,42 @@ asm_handler_BitwiseXor_cold:
     b .Lasm_BitwiseXor.ssa_block_13
 .Lasm_BitwiseXor.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_xor_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_BitwiseXor.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_BitwiseXor.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseXor.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_BitwiseXor.slow_path_transfer_0:
+.Lasm_BitwiseXor.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseXor.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseXor.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8654,15 +9730,38 @@ asm_handler_UnaryPlus_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_UnaryPlus.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_unary_plus)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_UnaryPlus.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_UnaryPlus.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_UnaryPlus.scalar_result_done_1
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_UnaryPlus.slow_path_transfer_0:
+.Lasm_UnaryPlus.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_UnaryPlus.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_UnaryPlus.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8685,15 +9784,36 @@ asm_handler_ThrowIfTDZ_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ThrowIfTDZ.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_throw_if_tdz)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ThrowIfTDZ.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_ThrowIfTDZ.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ThrowIfTDZ.scalar_result_done_1
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ThrowIfTDZ.slow_path_transfer_0:
+.Lasm_ThrowIfTDZ.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ThrowIfTDZ.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ThrowIfTDZ.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8709,15 +9829,36 @@ asm_handler_ThrowIfNotObject_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ThrowIfNotObject.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_throw_if_not_object)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ThrowIfNotObject.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_ThrowIfNotObject.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ThrowIfNotObject.scalar_result_done_1
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ThrowIfNotObject.slow_path_transfer_0:
+.Lasm_ThrowIfNotObject.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ThrowIfNotObject.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ThrowIfNotObject.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8733,15 +9874,36 @@ asm_handler_ThrowIfNullish_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ThrowIfNullish.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_throw_if_nullish)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ThrowIfNullish.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_ThrowIfNullish.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ThrowIfNullish.scalar_result_done_1
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ThrowIfNullish.slow_path_transfer_0:
+.Lasm_ThrowIfNullish.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ThrowIfNullish.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ThrowIfNullish.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8756,15 +9918,26 @@ asm_handler_ThrowConstAssignment:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_throw_const_assignment)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ThrowConstAssignment.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ThrowConstAssignment.scalar_result_done_0
+    tbz x0, #32, .Lasm_ThrowConstAssignment.scalar_result_done_0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ThrowConstAssignment.slow_path_transfer_0:
+.Lasm_ThrowConstAssignment.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ThrowConstAssignment.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ThrowConstAssignment.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8782,15 +9955,30 @@ asm_handler_Throw:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_Throw.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_throw)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Throw.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_Throw.scalar_result_done_1
+    tbz x0, #32, .Lasm_Throw.scalar_result_done_1
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Throw.slow_path_transfer_0:
+.Lasm_Throw.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_Throw.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Throw.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8808,15 +9996,26 @@ asm_handler_Debugger:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_debugger)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Debugger.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_Debugger.scalar_result_done_0
+    tbz x0, #32, .Lasm_Debugger.scalar_result_done_0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Debugger.slow_path_transfer_0:
+.Lasm_Debugger.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_Debugger.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Debugger.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8834,15 +10033,30 @@ asm_handler_Await:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_Await.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_await)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Await.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_Await.scalar_result_done_1
+    tbz x0, #32, .Lasm_Await.scalar_result_done_1
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Await.slow_path_transfer_0:
+.Lasm_Await.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_Await.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Await.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8860,15 +10074,30 @@ asm_handler_Yield:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_Yield.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_yield)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Yield.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_Yield.scalar_result_done_1
+    tbz x0, #32, .Lasm_Yield.scalar_result_done_1
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Yield.slow_path_transfer_0:
+.Lasm_Yield.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_Yield.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Yield.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8886,15 +10115,30 @@ asm_handler_YieldIteratorResult:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_YieldIteratorResult.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_yield_iterator_result)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_YieldIteratorResult.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_YieldIteratorResult.scalar_result_done_1
+    tbz x0, #32, .Lasm_YieldIteratorResult.scalar_result_done_1
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_YieldIteratorResult.slow_path_transfer_0:
+.Lasm_YieldIteratorResult.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_YieldIteratorResult.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_YieldIteratorResult.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8912,15 +10156,32 @@ asm_handler_ToString:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ToString.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_to_string)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ToString.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ToString.scalar_result_done_1
+    tbz x0, #32, .Lasm_ToString.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ToString.slow_path_transfer_0:
+.Lasm_ToString.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ToString.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToString.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8938,15 +10199,32 @@ asm_handler_ToPrimitiveWithStringHint:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ToPrimitiveWithStringHint.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_to_primitive_with_string_hint)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ToPrimitiveWithStringHint.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ToPrimitiveWithStringHint.scalar_result_done_1
+    tbz x0, #32, .Lasm_ToPrimitiveWithStringHint.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ToPrimitiveWithStringHint.slow_path_transfer_0:
+.Lasm_ToPrimitiveWithStringHint.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ToPrimitiveWithStringHint.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToPrimitiveWithStringHint.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8964,15 +10242,32 @@ asm_handler_ToObject:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ToObject.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_to_object)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ToObject.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ToObject.scalar_result_done_1
+    tbz x0, #32, .Lasm_ToObject.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ToObject.slow_path_transfer_0:
+.Lasm_ToObject.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ToObject.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToObject.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8990,15 +10285,32 @@ asm_handler_ToLength:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ToLength.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_to_length)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ToLength.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_ToLength.scalar_result_done_1
+    tbz x0, #32, .Lasm_ToLength.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ToLength.slow_path_transfer_0:
+.Lasm_ToLength.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ToLength.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToLength.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9017,15 +10329,38 @@ asm_handler_BitwiseNot_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_BitwiseNot.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_bitwise_not)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_BitwiseNot.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_BitwiseNot.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseNot.scalar_result_done_1
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_BitwiseNot.slow_path_transfer_0:
+.Lasm_BitwiseNot.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseNot.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseNot.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9070,19 +10405,42 @@ asm_handler_BitwiseAnd_cold:
     b .Lasm_BitwiseAnd.ssa_block_13
 .Lasm_BitwiseAnd.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_and_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_BitwiseAnd.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_BitwiseAnd.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseAnd.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_BitwiseAnd.slow_path_transfer_0:
+.Lasm_BitwiseAnd.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseAnd.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseAnd.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9138,19 +10496,42 @@ asm_handler_BitwiseOr_cold:
     b .Lasm_BitwiseOr.ssa_block_13
 .Lasm_BitwiseOr.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_or_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_BitwiseOr.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_BitwiseOr.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseOr.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_BitwiseOr.slow_path_transfer_0:
+.Lasm_BitwiseOr.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseOr.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseOr.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9175,19 +10556,42 @@ asm_handler_LeftShift_cold:
 // Cold paths for LeftShift
 .Lasm_LeftShift.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_left_shift_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LeftShift.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LeftShift.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LeftShift.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LeftShift.slow_path_transfer_0:
+.Lasm_LeftShift.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LeftShift.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LeftShift.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9201,19 +10605,42 @@ asm_handler_RightShift_cold:
 // Cold paths for RightShift
 .Lasm_RightShift.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_right_shift_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_RightShift.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_RightShift.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_RightShift.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_RightShift.slow_path_transfer_0:
+.Lasm_RightShift.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_RightShift.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_RightShift.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9236,19 +10663,42 @@ asm_handler_UnsignedRightShift_cold:
     br x10
 .Lasm_UnsignedRightShift.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_unsigned_right_shift_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_UnsignedRightShift.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_UnsignedRightShift.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_UnsignedRightShift.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_UnsignedRightShift.slow_path_transfer_0:
+.Lasm_UnsignedRightShift.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_UnsignedRightShift.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_UnsignedRightShift.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9330,8 +10780,12 @@ asm_handler_Mod_cold:
     ldr x10, [x19, x9, lsl #3]
     br x10
 .Lasm_Mod.ssa_block_3:
-    tbnz x2, #63, .Lasm_Mod.ssa_block_4
-    tbnz x0, #63, .Lasm_Mod.ssa_block_4
+    tbz x2, #63, 1f
+    b .Lasm_Mod.ssa_block_4
+1:
+    tbz x0, #63, 1f
+    b .Lasm_Mod.ssa_block_4
+1:
     movz x0, #0x7ffa, lsl #48
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
@@ -9351,19 +10805,42 @@ asm_handler_Mod_cold:
     ldr w1, [x21, #12]
     ldr x1, [x27, x1, lsl #3]
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_mod_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Mod.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_Mod.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Mod.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Mod.slow_path_transfer_0:
+.Lasm_Mod.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Mod.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Mod.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9388,19 +10865,42 @@ asm_handler_StrictlyEquals_cold:
     b .Lasm_StrictlyEquals.ssa_block_3
 .Lasm_StrictlyEquals.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_strictly_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_StrictlyEquals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_StrictlyEquals.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_StrictlyEquals.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_StrictlyEquals.slow_path_transfer_0:
+.Lasm_StrictlyEquals.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_StrictlyEquals.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_StrictlyEquals.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9425,19 +10925,42 @@ asm_handler_StrictlyInequals_cold:
     b .Lasm_StrictlyInequals.ssa_block_2
 .Lasm_StrictlyInequals.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_strictly_inequals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_StrictlyInequals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_StrictlyInequals.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_StrictlyInequals.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_StrictlyInequals.slow_path_transfer_0:
+.Lasm_StrictlyInequals.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_StrictlyInequals.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_StrictlyInequals.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9453,15 +10976,46 @@ asm_handler_GetCalleeAndThisFromEnvironment_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #16
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_get_callee_and_this)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_GetCalleeAndThisFromEnvironment.values_exceptional_outputs_2
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetCalleeAndThisFromEnvironment.values_exceptional_outputs_2
+1:
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetCalleeAndThisFromEnvironment.skip_output_value_3:
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetCalleeAndThisFromEnvironment.skip_output_value_4:
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_0:
+.Lasm_GetCalleeAndThisFromEnvironment.values_exceptional_outputs_2:
+.Lasm_GetCalleeAndThisFromEnvironment.values_restore_stack_1:
+    add sp, sp, #16
+.Lasm_GetCalleeAndThisFromEnvironment.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_5
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9477,15 +11031,46 @@ asm_handler_DynamicGetCalleeAndThisFromEnvironment_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #16
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_dynamic_get_callee_and_this)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_DynamicGetCalleeAndThisFromEnvironment.values_exceptional_outputs_2
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicGetCalleeAndThisFromEnvironment.values_exceptional_outputs_2
+1:
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.skip_output_value_3:
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.skip_output_value_4:
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_0:
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.values_exceptional_outputs_2:
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.values_restore_stack_1:
+    add sp, sp, #16
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_5
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9510,20 +11095,42 @@ asm_handler_LooselyEquals_cold:
     b .Lasm_LooselyEquals.ssa_block_3
 .Lasm_LooselyEquals.ssa_block_1:
     ldr w1, [x21, #4]
+    sub sp, sp, #16
+    str w1, [sp, #8]
     mov x3, x0
     mov x4, x2
-    mov x2, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_loosely_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LooselyEquals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LooselyEquals.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LooselyEquals.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LooselyEquals.slow_path_transfer_0:
+.Lasm_LooselyEquals.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LooselyEquals.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LooselyEquals.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9548,20 +11155,42 @@ asm_handler_LooselyInequals_cold:
     b .Lasm_LooselyInequals.ssa_block_2
 .Lasm_LooselyInequals.ssa_block_1:
     ldr w1, [x21, #4]
+    sub sp, sp, #16
+    str w1, [sp, #8]
     mov x3, x0
     mov x4, x2
-    mov x2, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_loosely_inequals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LooselyInequals.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LooselyInequals.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LooselyInequals.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LooselyInequals.slow_path_transfer_0:
+.Lasm_LooselyInequals.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LooselyInequals.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LooselyInequals.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9600,15 +11229,38 @@ asm_handler_UnaryMinus_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_UnaryMinus.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_unary_minus)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_UnaryMinus.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_UnaryMinus.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_UnaryMinus.scalar_result_done_1
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_UnaryMinus.slow_path_transfer_0:
+.Lasm_UnaryMinus.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_UnaryMinus.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_UnaryMinus.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9646,15 +11298,57 @@ asm_handler_PostfixDecrement_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #16
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PostfixDecrement.value_ready_1:
+    mov x4, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_postfix_decrement)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_PostfixDecrement.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_PostfixDecrement.values_exceptional_outputs_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_PostfixDecrement.values_exceptional_outputs_3
+1:
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_PostfixDecrement.skip_output_value_4:
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_PostfixDecrement.skip_output_value_5:
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_PostfixDecrement.slow_path_transfer_0:
+.Lasm_PostfixDecrement.values_exceptional_outputs_3:
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_PostfixDecrement.values_restore_stack_2
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_PostfixDecrement.skip_exceptional_output_6:
+.Lasm_PostfixDecrement.values_restore_stack_2:
+    add sp, sp, #16
+.Lasm_PostfixDecrement.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_PostfixDecrement.slow_path_transfer_7
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PostfixDecrement.slow_path_transfer_7:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9685,15 +11379,38 @@ asm_handler_ToInt32_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_ToInt32.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_to_int32)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ToInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_ToInt32.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ToInt32.scalar_result_done_1
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ToInt32.slow_path_transfer_0:
+.Lasm_ToInt32.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ToInt32.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToInt32.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9716,10 +11433,27 @@ asm_handler_ToInt32_cold_end:
 asm_handler_PutByValue_cold:
 // Cold paths for PutByValue
 .Lasm_PutByValue.ssa_block_3:
+    sub sp, sp, #32
+    ldr w12, [x21, #4]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PutByValue.value_ready_1:
+    str x11, [sp]
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PutByValue.value_ready_2:
+    str x11, [sp, #8]
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PutByValue.value_ready_3:
+    str x11, [sp, #16]
     mov x0, x20
     sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_try_put_by_value_typed_array)
+.Lasm_PutByValue.values_restore_stack_4:
+    add sp, sp, #32
+.Lasm_PutByValue.values_call_done_0:
     cbnz w0, .Lasm_PutByValue.ssa_block_1
     ldrb w9, [x21, #24]
     add x21, x21, #24
@@ -9750,15 +11484,44 @@ asm_handler_PutByValue_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByValue.scalar_value_ready_5:
+    mov x3, x10
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByValue.scalar_value_ready_6:
+    mov x4, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByValue.scalar_value_ready_7:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_value)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_PutByValue.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_PutByValue.scalar_result_done_8
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_PutByValue.scalar_result_done_8
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_PutByValue.slow_path_transfer_0:
+.Lasm_PutByValue.scalar_result_done_8:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_PutByValue.slow_path_transfer_9
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutByValue.slow_path_transfer_9:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9768,10 +11531,27 @@ asm_handler_PutByValue_cold:
     ldr x10, [x19, x9, lsl #3]
     br x10
 .Lasm_PutByValue.ssa_block_2:
+    sub sp, sp, #32
+    ldr w12, [x21, #4]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PutByValue.value_ready_11:
+    str x11, [sp]
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PutByValue.value_ready_12:
+    str x11, [sp, #8]
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PutByValue.value_ready_13:
+    str x11, [sp, #16]
     mov x0, x20
     sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_try_put_by_value_holey_array)
+.Lasm_PutByValue.values_restore_stack_14:
+    add sp, sp, #32
+.Lasm_PutByValue.values_call_done_10:
     cbnz w0, .Lasm_PutByValue.ssa_block_1
     ldrb w9, [x21, #24]
     add x21, x21, #24
@@ -9780,43 +11560,45 @@ asm_handler_PutByValue_cold:
 asm_handler_PutByValue_cold_end:
 asm_handler_GetById_cold:
 // Cold paths for GetById
-.Lasm_GetById.ssa_block_13:
-    ldrb w9, [x0, #12]
+.Lasm_GetById.ssa_block_15:
+    ldrb w9, [x3, #12]
     cbz w9, .Lasm_GetById.ssa_block_3
-    ldr w0, [x1, #108]
-    ldr x0, [x2, x0, lsl #3]
+    ldr w0, [x2, #108]
+    ldr x0, [x1, x0, lsl #3]
     cbz x0, .Lasm_GetById.ssa_block_3
-    ldr w3, [x1, #116]
+    ldr w3, [x2, #116]
     ldr x5, [x0, x3, lsl #3]
     cbz x5, .Lasm_GetById.ssa_block_3
-    ldr w4, [x1, #120]
+    ldr w4, [x2, #120]
     ldr x5, [x5, x4, lsl #3]
-    cmp x5, x2
+    cmp x5, x1
     b.ne .Lasm_GetById.ssa_block_3
-    ldr w1, [x1, #112]
+    ldr w1, [x2, #112]
     ldr x0, [x0, x1, lsl #3]
-    cbnz x0, .Lasm_GetById.ssa_block_26
+    cbnz x0, .Lasm_GetById.ssa_block_31
     movz x0, #0x7fff, lsl #48
-    b .Lasm_GetById.ssa_block_27
-.Lasm_GetById.ssa_block_26:
+    b .Lasm_GetById.ssa_block_32
+.Lasm_GetById.ssa_block_31:
     ldr x0, [x0, x3, lsl #3]
     cbz x0, .Lasm_GetById.ssa_block_3
     ldr x0, [x0, x4, lsl #3]
     cbz x0, .Lasm_GetById.ssa_block_3
     ldrh w1, [x0, #10]
-    tbnz x1, #11, .Lasm_GetById.ssa_block_3
+    tbz x1, #11, 1f
+    b .Lasm_GetById.ssa_block_3
+1:
     and x0, x0, #0x3ffffffffff
     movz x1, #0xfff9, lsl #48
     orr x0, x0, x1
-.Lasm_GetById.ssa_block_27:
+.Lasm_GetById.ssa_block_32:
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
     ldrb w9, [x21, #24]
     add x21, x21, #24
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetById.ssa_block_14:
-    ldr w3, [x1, #104]
+.Lasm_GetById.ssa_block_16:
+    ldr w3, [x2, #104]
     mov x0, x20
     ldr x0, [x0, #16704]
     lsl x3, x3, #4
@@ -9838,17 +11620,17 @@ asm_handler_GetById_cold:
     str x5, [x6, #15368]
     stp w4, w4, [x0, #116]
     str wzr, [x0, #104]
-    ldr x4, [x1, #24]
+    ldr x4, [x2, #24]
     ldr x4, [x4, #16]
-    stp x1, x4, [x0, #0]
-    ldp x1, x4, [x28, #32]
-    stp x1, x4, [x0, #32]
-    ldr x1, [x28, #48]
-    str x1, [x0, #48]
-    and x2, x2, #0x3ffffffffff
-    movz x1, #0xfff9, lsl #48
-    orr x2, x2, x1
-    str x2, [x0, #80]
+    stp x2, x4, [x0, #0]
+    ldp x2, x4, [x28, #32]
+    stp x2, x4, [x0, #32]
+    ldr x2, [x28, #48]
+    str x2, [x0, #48]
+    and x1, x1, #0x3ffffffffff
+    movz x2, #0xfff9, lsl #48
+    orr x1, x1, x2
+    str x1, [x0, #80]
     mov x1, #0
     add x2, x0, #16
     stp x1, x1, [x2, #0]
@@ -9860,6 +11642,7 @@ asm_handler_GetById_cold:
     strb wzr, [x0, #76]
     strb wzr, [x0, #77]
     strb wzr, [x0, #78]
+    strb wzr, [x0, #79]
     sub w1, w21, w26
     ldp w2, w4, [x21, #4]
     str w1, [x28, #64]
@@ -9892,15 +11675,38 @@ asm_handler_GetById_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetById.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_id_cached_accessor)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetById.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_GetById.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetById.scalar_result_done_1
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetById.slow_path_transfer_0:
+.Lasm_GetById.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetById.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetById.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9918,25 +11724,48 @@ asm_handler_GetById_cold:
     ldr x10, [x19, x9, lsl #3]
     br x10
 .Lasm_GetById.ssa_block_10:
-    ldr x4, [x0, #40]
-    cbz x4, .Lasm_GetById.ssa_block_1
-    ldrb w9, [x4, #10]
+    ldr x5, [x3, #40]
+    cbz x5, .Lasm_GetById.ssa_block_1
+    ldrb w9, [x5, #10]
     cbz w9, .Lasm_GetById.ssa_block_1
     b .Lasm_GetById.ssa_block_8
 .Lasm_GetById.ssa_block_9:
-    and x1, x1, #0x3ffffffffff
-    add x1, x1, x24
-    ldr x1, [x1, #16]
-    cbz x1, .Lasm_GetById.ssa_block_5
-    ldrh w3, [x1, #10]
-    tbz x3, #1, .Lasm_GetById.ssa_block_3
-    tbz x3, #10, .Lasm_GetById.ssa_block_14
-    b .Lasm_GetById.ssa_block_13
+    and x0, x0, #0x3ffffffffff
+    add x0, x0, x24
+    ldr x2, [x0, #16]
+    cbz x2, .Lasm_GetById.ssa_block_5
+    ldrh w0, [x2, #10]
+    tbnz x0, #1, 1f
+    b .Lasm_GetById.ssa_block_3
+1:
+    tbnz x0, #10, 1f
+    b .Lasm_GetById.ssa_block_16
+1:
+    b .Lasm_GetById.ssa_block_15
 .Lasm_GetById.ssa_block_3:
+    sub sp, sp, #16
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_GetById.value_ready_4:
+    str x11, [sp, #8]
     mov x0, x20
     sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_try_inline_get_by_id_accessor)
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_GetById.values_restore_stack_5
+    cbnz x0, .Lasm_GetById.values_exceptional_outputs_6
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetById.skip_output_value_7:
+    b .Lasm_GetById.values_restore_stack_5
+.Lasm_GetById.values_exceptional_outputs_6:
+.Lasm_GetById.values_restore_stack_5:
+    add sp, sp, #16
+.Lasm_GetById.values_call_done_3:
     cbnz w0, .Lasm_GetById.ssa_block_4
     mov x0, x20
     ldr x28, [x0, #15288]
@@ -9950,7 +11779,9 @@ asm_handler_GetById_cold:
     br x10
 .Lasm_GetById.ssa_block_6:
     bl CSYM(asm_helper_handle_raw_native_exception)
-    tbnz w0, #31, .Lasm_GetById.ssa_block_7
+    tbz w0, #31, 1f
+    b .Lasm_GetById.ssa_block_7
+1:
     mov x0, x20
     ldr x28, [x0, #15288]
     add x27, x28, #128
@@ -9962,11 +11793,17 @@ asm_handler_GetById_cold:
     ldr x10, [x19, x9, lsl #3]
     br x10
 .Lasm_GetById.ssa_block_1:
-    mov x0, x20
-    sub w1, w21, w26
-    mov x2, x21
+    ldr x1, [x28, #88]
+    ldr x1, [x1, #112]
+    ldr w2, [x21, #20]
+    lsl x2, x2, #3
+    adds x1, x1, x2
     bl CSYM(asm_try_get_by_id_cache)
-    cbnz w0, .Lasm_GetById.ssa_block_2
+    movz x9, #0x7ffb, lsl #48
+    cmp x0, x9
+    b.eq .Lasm_GetById.ssa_block_2
+    ldr w9, [x21, #4]
+    str x0, [x27, x9, lsl #3]
     ldrb w9, [x21, #24]
     add x21, x21, #24
     ldr x10, [x19, x9, lsl #3]
@@ -9975,15 +11812,38 @@ asm_handler_GetById_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetById.scalar_value_ready_8:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_id)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetById.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_GetById.scalar_result_done_9
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetById.scalar_result_done_9
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetById.slow_path_transfer_1:
+.Lasm_GetById.scalar_result_done_9:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetById.slow_path_transfer_10
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetById.slow_path_transfer_10:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10000,15 +11860,36 @@ asm_handler_GetByIdWithThis:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetByIdWithThis.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetByIdWithThis.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_id_with_this)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetByIdWithThis.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetByIdWithThis.scalar_result_done_2
+    tbz x0, #32, .Lasm_GetByIdWithThis.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetByIdWithThis.slow_path_transfer_0:
+.Lasm_GetByIdWithThis.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetByIdWithThis.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetByIdWithThis.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10024,10 +11905,23 @@ asm_handler_GetByIdWithThis_cold_end:
 asm_handler_PutById_cold:
 // Cold paths for PutById
 .Lasm_PutById.ssa_block_2:
+    sub sp, sp, #16
+    ldr w12, [x21, #4]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PutById.value_ready_1:
+    str x11, [sp]
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_PutById.value_ready_2:
+    str x11, [sp, #8]
     mov x0, x20
     sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_try_put_by_id_cache)
+.Lasm_PutById.values_restore_stack_3:
+    add sp, sp, #16
+.Lasm_PutById.values_call_done_0:
     cbnz w0, .Lasm_PutById.ssa_block_1
     ldrb w9, [x21, #32]
     add x21, x21, #32
@@ -10037,15 +11931,40 @@ asm_handler_PutById_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutById.scalar_value_ready_4:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutById.scalar_value_ready_5:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_id)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_PutById.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_PutById.scalar_result_done_6
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_PutById.scalar_result_done_6
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_PutById.slow_path_transfer_0:
+.Lasm_PutById.scalar_result_done_6:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_PutById.slow_path_transfer_7
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutById.slow_path_transfer_7:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10060,15 +11979,38 @@ asm_handler_PutByIdWithThis:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByIdWithThis.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByIdWithThis.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByIdWithThis.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_id_with_this)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_PutByIdWithThis.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_PutByIdWithThis.scalar_result_done_3
+    tbz x0, #32, .Lasm_PutByIdWithThis.scalar_result_done_3
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_PutByIdWithThis.slow_path_transfer_0:
+.Lasm_PutByIdWithThis.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_PutByIdWithThis.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutByIdWithThis.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10093,10 +12035,33 @@ asm_handler_GetByValue_cold:
     ldr x10, [x19, x9, lsl #3]
     br x10
 .Lasm_GetByValue.ssa_block_2:
+    sub sp, sp, #32
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_GetByValue.value_ready_2:
+    str x11, [sp, #8]
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_GetByValue.value_ready_3:
+    str x11, [sp, #16]
     mov x0, x20
     sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_try_get_by_value_typed_array)
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_GetByValue.values_restore_stack_4
+    cbnz x0, .Lasm_GetByValue.values_exceptional_outputs_5
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetByValue.skip_output_value_6:
+    b .Lasm_GetByValue.values_restore_stack_4
+.Lasm_GetByValue.values_exceptional_outputs_5:
+.Lasm_GetByValue.values_restore_stack_4:
+    add sp, sp, #32
+.Lasm_GetByValue.values_call_done_1:
     cbnz w0, .Lasm_GetByValue.ssa_block_1
     ldrb w9, [x21, #24]
     add x21, x21, #24
@@ -10106,15 +12071,42 @@ asm_handler_GetByValue_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetByValue.scalar_value_ready_7:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetByValue.scalar_value_ready_8:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_value)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetByValue.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_GetByValue.scalar_result_done_9
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetByValue.scalar_result_done_9
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetByValue.slow_path_transfer_1:
+.Lasm_GetByValue.scalar_result_done_9:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetByValue.slow_path_transfer_10
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetByValue.slow_path_transfer_10:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10132,15 +12124,40 @@ asm_handler_GetByValueWithThis:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetByValueWithThis.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetByValueWithThis.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetByValueWithThis.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_value_with_this)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetByValueWithThis.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetByValueWithThis.scalar_result_done_3
+    tbz x0, #32, .Lasm_GetByValueWithThis.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetByValueWithThis.slow_path_transfer_0:
+.Lasm_GetByValueWithThis.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetByValueWithThis.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetByValueWithThis.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10158,15 +12175,42 @@ asm_handler_PutByValueWithThis:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByValueWithThis.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByValueWithThis.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByValueWithThis.scalar_value_ready_2:
+    mov x5, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutByValueWithThis.scalar_value_ready_3:
+    mov x6, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_value_with_this)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_PutByValueWithThis.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_PutByValueWithThis.scalar_result_done_4
+    tbz x0, #32, .Lasm_PutByValueWithThis.scalar_result_done_4
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_PutByValueWithThis.slow_path_transfer_0:
+.Lasm_PutByValueWithThis.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_PutByValueWithThis.slow_path_transfer_5
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutByValueWithThis.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10184,15 +12228,34 @@ asm_handler_PutBySpread:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutBySpread.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutBySpread.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_spread)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_PutBySpread.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_PutBySpread.scalar_result_done_2
+    tbz x0, #32, .Lasm_PutBySpread.scalar_result_done_2
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_PutBySpread.slow_path_transfer_0:
+.Lasm_PutBySpread.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_PutBySpread.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutBySpread.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10220,15 +12283,38 @@ asm_handler_GetLength_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetLength.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_length)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetLength.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_GetLength.scalar_result_done_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetLength.scalar_result_done_1
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetLength.slow_path_transfer_0:
+.Lasm_GetLength.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetLength.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetLength.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10243,15 +12329,36 @@ asm_handler_GetLengthWithThis:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetLengthWithThis.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetLengthWithThis.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_length_with_this)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetLengthWithThis.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetLengthWithThis.scalar_result_done_2
+    tbz x0, #32, .Lasm_GetLengthWithThis.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetLengthWithThis.slow_path_transfer_0:
+.Lasm_GetLengthWithThis.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetLengthWithThis.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetLengthWithThis.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10269,15 +12376,32 @@ asm_handler_GetMethod:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetMethod.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_method)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetMethod.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetMethod.scalar_result_done_1
+    tbz x0, #32, .Lasm_GetMethod.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetMethod.slow_path_transfer_0:
+.Lasm_GetMethod.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetMethod.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetMethod.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10295,15 +12419,48 @@ asm_handler_GetIterator:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #32
+    ldr w12, [x21, #16]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_GetIterator.value_ready_1:
+    mov x4, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_get_iterator)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetIterator.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetIterator.values_exceptional_outputs_3
+    tbz x0, #32, .Lasm_GetIterator.values_exceptional_outputs_3
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetIterator.skip_output_value_4:
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetIterator.skip_output_value_5:
+    ldr w12, [x21, #12]
+    ldr x11, [sp, #16]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetIterator.skip_output_value_6:
+    add sp, sp, #32
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetIterator.slow_path_transfer_0:
+.Lasm_GetIterator.values_exceptional_outputs_3:
+.Lasm_GetIterator.values_restore_stack_2:
+    add sp, sp, #32
+.Lasm_GetIterator.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetIterator.slow_path_transfer_7
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetIterator.slow_path_transfer_7:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10322,15 +12479,34 @@ asm_handler_GetGlobal_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_global)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetGlobal.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_GetGlobal.scalar_result_done_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetGlobal.scalar_result_done_0
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetGlobal.slow_path_transfer_0:
+.Lasm_GetGlobal.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GetGlobal.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetGlobal.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10340,10 +12516,25 @@ asm_handler_GetGlobal_cold:
     ldr x10, [x19, x9, lsl #3]
     br x10
 .Lasm_GetGlobal.ssa_block_1:
+    sub sp, sp, #16
     mov x0, x20
     sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_try_get_global_env_binding)
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_GetGlobal.values_restore_stack_3
+    cbnz x0, .Lasm_GetGlobal.values_exceptional_outputs_4
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetGlobal.skip_output_value_5:
+    b .Lasm_GetGlobal.values_restore_stack_3
+.Lasm_GetGlobal.values_exceptional_outputs_4:
+.Lasm_GetGlobal.values_restore_stack_3:
+    add sp, sp, #16
+.Lasm_GetGlobal.values_call_done_2:
     cbnz w0, .Lasm_GetGlobal.ssa_block_2
     ldrb w9, [x21, #16]
     add x21, x21, #16
@@ -10353,10 +12544,19 @@ asm_handler_GetGlobal_cold_end:
 asm_handler_SetGlobal_cold:
 // Cold paths for SetGlobal
 .Lasm_SetGlobal.ssa_block_1:
+    sub sp, sp, #16
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_SetGlobal.value_ready_1:
+    str x11, [sp]
     mov x0, x20
     sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_try_set_global_env_binding)
+.Lasm_SetGlobal.values_restore_stack_2:
+    add sp, sp, #16
+.Lasm_SetGlobal.values_call_done_0:
     cbnz w0, .Lasm_SetGlobal.ssa_block_2
     ldrb w9, [x21, #16]
     add x21, x21, #16
@@ -10366,15 +12566,36 @@ asm_handler_SetGlobal_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SetGlobal.scalar_value_ready_3:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_set_global)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_SetGlobal.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_SetGlobal.scalar_result_done_4
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_SetGlobal.scalar_result_done_4
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_SetGlobal.slow_path_transfer_0:
+.Lasm_SetGlobal.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_SetGlobal.slow_path_transfer_5
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetGlobal.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10388,7 +12609,9 @@ asm_handler_Call_cold:
 // Cold paths for Call
 .Lasm_Call.ssa_block_4:
     bl CSYM(asm_helper_handle_raw_native_exception)
-    tbnz w0, #31, .Lasm_Call.ssa_block_5
+    tbz w0, #31, 1f
+    b .Lasm_Call.ssa_block_5
+1:
     mov x0, x20
     ldr x28, [x0, #15288]
     add x27, x28, #128
@@ -10403,15 +12626,91 @@ asm_handler_Call_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    add x9, sp, #0
+    ldr w10, [x21, #20]
+    lsl x10, x10, #3
+    add x10, x10, #55
+    and x10, x10, #0xfffffffffffffff0
+    sub x14, x9, x10
+    ldr x12, [x20, #15336]
+    mov w13, #32768
+    add x12, x12, x13
+    cmp x14, x12
+    b.hs .Lasm_Call.values_allocate_13
+    mov x0, x20
+    sub w1, w21, w26
+    bl CSYM(asm_slow_path_stack_overflow)
+    b .Lasm_Call.values_call_done_12
+.Lasm_Call.values_allocate_13:
+.Lasm_Call.values_probe_14:
+    sub x10, sp, #1, lsl #12
+    cmp x10, x14
+    b.ls .Lasm_Call.values_allocated_15
+    add sp, x10, #0
+    str xzr, [sp]
+    b .Lasm_Call.values_probe_14
+.Lasm_Call.values_allocated_15:
+    add sp, x14, #0
+    str x9, [sp]
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_Call.value_ready_16:
+    str x11, [sp, #24]
+    ldr w12, [x21, #16]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_Call.value_ready_17:
+    str x11, [sp, #32]
+    mov w9, #0
+    ldr w10, [x21, #20]
+    add x14, sp, #40
+    add x3, x21, #28
+.Lasm_Call.array_value_next_18:
+    cmp x9, x10
+    b.hs .Lasm_Call.array_values_end_20
+    ldr w12, [x3, x9, lsl #2]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_Call.array_value_ready_19:
+    str x11, [x14, x9, lsl #3]
+    add x9, x9, #1
+    b .Lasm_Call.array_value_next_18
+.Lasm_Call.array_values_end_20:
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #16
     bl CSYM(asm_slow_path_call)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Call.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_Call.values_exceptional_outputs_22
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Call.values_exceptional_outputs_22
+1:
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #16]
+    str x11, [x27, x12, lsl #3]
+.Lasm_Call.skip_output_value_23:
+    ldr x9, [sp]
+    add sp, x9, #0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Call.slow_path_transfer_0:
+.Lasm_Call.values_exceptional_outputs_22:
+.Lasm_Call.values_restore_stack_21:
+    ldr x9, [sp]
+    add sp, x9, #0
+.Lasm_Call.values_call_done_12:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_Call.slow_path_transfer_24
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Call.slow_path_transfer_24:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10440,15 +12739,46 @@ asm_handler_CallBuiltinMathAbs_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathAbs.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathAbs.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathAbs.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_abs)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathAbs.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_CallBuiltinMathAbs.scalar_result_done_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathAbs.scalar_result_done_3
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathAbs.slow_path_transfer_0:
+.Lasm_CallBuiltinMathAbs.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathAbs.slow_path_transfer_4
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathAbs.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10464,15 +12794,46 @@ asm_handler_CallBuiltinMathFloor_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathFloor.scalar_value_ready_1:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathFloor.scalar_value_ready_2:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathFloor.scalar_value_ready_3:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_floor)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathFloor.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_CallBuiltinMathFloor.scalar_result_done_4
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathFloor.scalar_result_done_4
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathFloor.slow_path_transfer_1:
+.Lasm_CallBuiltinMathFloor.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathFloor.slow_path_transfer_5
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathFloor.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10491,15 +12852,46 @@ asm_handler_CallBuiltinMathCeil_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathCeil.scalar_value_ready_1:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathCeil.scalar_value_ready_2:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathCeil.scalar_value_ready_3:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_ceil)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathCeil.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_CallBuiltinMathCeil.scalar_result_done_4
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathCeil.scalar_result_done_4
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathCeil.slow_path_transfer_1:
+.Lasm_CallBuiltinMathCeil.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathCeil.slow_path_transfer_5
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathCeil.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10518,15 +12910,46 @@ asm_handler_CallBuiltinMathSqrt_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathSqrt.scalar_value_ready_1:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathSqrt.scalar_value_ready_2:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathSqrt.scalar_value_ready_3:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_sqrt)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathSqrt.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_CallBuiltinMathSqrt.scalar_result_done_4
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathSqrt.scalar_result_done_4
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathSqrt.slow_path_transfer_1:
+.Lasm_CallBuiltinMathSqrt.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathSqrt.slow_path_transfer_5
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathSqrt.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10545,15 +12968,46 @@ asm_handler_CallBuiltinMathExp_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathExp.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathExp.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathExp.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_exp)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathExp.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_CallBuiltinMathExp.scalar_result_done_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathExp.scalar_result_done_3
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathExp.slow_path_transfer_0:
+.Lasm_CallBuiltinMathExp.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinMathExp.slow_path_transfer_4
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathExp.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10568,15 +13022,40 @@ asm_handler_CallBuiltinMathLog:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathLog.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathLog.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathLog.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_log)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathLog.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinMathLog.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallBuiltinMathLog.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathLog.slow_path_transfer_0:
+.Lasm_CallBuiltinMathLog.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinMathLog.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathLog.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10594,15 +13073,44 @@ asm_handler_CallBuiltinMathPow:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathPow.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathPow.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathPow.scalar_value_ready_2:
+    mov x5, x10
+    ldr w9, [x21, #20]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathPow.scalar_value_ready_3:
+    mov x6, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_pow)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathPow.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinMathPow.scalar_result_done_4
+    tbz x0, #32, .Lasm_CallBuiltinMathPow.scalar_result_done_4
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathPow.slow_path_transfer_0:
+.Lasm_CallBuiltinMathPow.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinMathPow.slow_path_transfer_5
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathPow.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10620,15 +13128,44 @@ asm_handler_CallBuiltinMathImul:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathImul.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathImul.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathImul.scalar_value_ready_2:
+    mov x5, x10
+    ldr w9, [x21, #20]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathImul.scalar_value_ready_3:
+    mov x6, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_imul)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathImul.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinMathImul.scalar_result_done_4
+    tbz x0, #32, .Lasm_CallBuiltinMathImul.scalar_result_done_4
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathImul.slow_path_transfer_0:
+.Lasm_CallBuiltinMathImul.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinMathImul.slow_path_transfer_5
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathImul.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10646,15 +13183,36 @@ asm_handler_CallBuiltinMathRandom:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathRandom.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathRandom.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_random)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathRandom.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinMathRandom.scalar_result_done_2
+    tbz x0, #32, .Lasm_CallBuiltinMathRandom.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathRandom.slow_path_transfer_0:
+.Lasm_CallBuiltinMathRandom.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinMathRandom.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathRandom.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10672,15 +13230,40 @@ asm_handler_CallBuiltinMathRound:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathRound.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathRound.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathRound.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_round)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathRound.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinMathRound.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallBuiltinMathRound.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathRound.slow_path_transfer_0:
+.Lasm_CallBuiltinMathRound.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinMathRound.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathRound.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10698,15 +13281,40 @@ asm_handler_CallBuiltinMathSin:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathSin.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathSin.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathSin.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_sin)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathSin.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinMathSin.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallBuiltinMathSin.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathSin.slow_path_transfer_0:
+.Lasm_CallBuiltinMathSin.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinMathSin.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathSin.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10724,15 +13332,40 @@ asm_handler_CallBuiltinMathCos:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathCos.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathCos.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathCos.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_cos)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathCos.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinMathCos.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallBuiltinMathCos.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathCos.slow_path_transfer_0:
+.Lasm_CallBuiltinMathCos.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinMathCos.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathCos.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10750,15 +13383,40 @@ asm_handler_CallBuiltinMathTan:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathTan.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathTan.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMathTan.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_tan)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMathTan.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinMathTan.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallBuiltinMathTan.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMathTan.slow_path_transfer_0:
+.Lasm_CallBuiltinMathTan.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinMathTan.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathTan.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10776,15 +13434,40 @@ asm_handler_CallBuiltinRegExpPrototypeExec:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeExec.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeExec.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeExec.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_regexp_prototype_exec)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinRegExpPrototypeExec.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeExec.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_0:
+.Lasm_CallBuiltinRegExpPrototypeExec.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10802,15 +13485,44 @@ asm_handler_CallBuiltinRegExpPrototypeReplace:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_value_ready_2:
+    mov x5, x10
+    ldr w9, [x21, #20]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_value_ready_3:
+    mov x6, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_regexp_prototype_replace)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinRegExpPrototypeReplace.scalar_result_done_4
+    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeReplace.scalar_result_done_4
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_0:
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_5
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10828,15 +13540,44 @@ asm_handler_CallBuiltinRegExpPrototypeSplit:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_value_ready_2:
+    mov x5, x10
+    ldr w9, [x21, #20]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_value_ready_3:
+    mov x6, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_regexp_prototype_split)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinRegExpPrototypeSplit.scalar_result_done_4
+    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeSplit.scalar_result_done_4
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_0:
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_5
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10854,15 +13595,40 @@ asm_handler_CallBuiltinOrdinaryHasInstance:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinOrdinaryHasInstance.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinOrdinaryHasInstance.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinOrdinaryHasInstance.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_ordinary_has_instance)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinOrdinaryHasInstance.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallBuiltinOrdinaryHasInstance.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_0:
+.Lasm_CallBuiltinOrdinaryHasInstance.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10880,15 +13646,36 @@ asm_handler_CallBuiltinArrayIteratorPrototypeNext:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_array_iterator_prototype_next)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_result_done_2
+    tbz x0, #32, .Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_0:
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10906,15 +13693,36 @@ asm_handler_CallBuiltinMapIteratorPrototypeNext:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_map_iterator_prototype_next)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_result_done_2
+    tbz x0, #32, .Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_0:
+.Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10932,15 +13740,36 @@ asm_handler_CallBuiltinSetIteratorPrototypeNext:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_set_iterator_prototype_next)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_result_done_2
+    tbz x0, #32, .Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_0:
+.Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10958,15 +13787,36 @@ asm_handler_CallBuiltinStringIteratorPrototypeNext:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_string_iterator_prototype_next)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_result_done_2
+    tbz x0, #32, .Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_0:
+.Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10985,15 +13835,46 @@ asm_handler_CallBuiltinStringFromCharCode_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringFromCharCode.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringFromCharCode.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringFromCharCode.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_string_from_char_code)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_CallBuiltinStringFromCharCode.scalar_result_done_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinStringFromCharCode.scalar_result_done_3
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_0:
+.Lasm_CallBuiltinStringFromCharCode.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_4
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11017,15 +13898,46 @@ asm_handler_CallBuiltinStringPrototypeCharCodeAt_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_string_prototype_char_code_at)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_result_done_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_result_done_3
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_0:
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_4
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11050,15 +13962,46 @@ asm_handler_CallBuiltinStringPrototypeCharAt_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringPrototypeCharAt.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringPrototypeCharAt.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallBuiltinStringPrototypeCharAt.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_string_prototype_char_at)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharAt.scalar_result_done_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharAt.scalar_result_done_3
+1:
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_0:
+.Lasm_CallBuiltinStringPrototypeCharAt.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_4
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11073,15 +14016,32 @@ asm_handler_GetObjectPropertyIterator:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetObjectPropertyIterator.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_object_property_iterator)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetObjectPropertyIterator.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetObjectPropertyIterator.scalar_result_done_1
+    tbz x0, #32, .Lasm_GetObjectPropertyIterator.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetObjectPropertyIterator.slow_path_transfer_0:
+.Lasm_GetObjectPropertyIterator.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetObjectPropertyIterator.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetObjectPropertyIterator.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11100,15 +14060,50 @@ asm_handler_ObjectPropertyIteratorNext_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #32
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_ObjectPropertyIteratorNext.value_ready_1:
+    mov x4, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_object_property_iterator_next)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ObjectPropertyIteratorNext.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_ObjectPropertyIteratorNext.values_exceptional_outputs_3
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ObjectPropertyIteratorNext.values_exceptional_outputs_3
+1:
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_ObjectPropertyIteratorNext.skip_output_value_4:
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_ObjectPropertyIteratorNext.skip_output_value_5:
+    add sp, sp, #32
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ObjectPropertyIteratorNext.slow_path_transfer_0:
+.Lasm_ObjectPropertyIteratorNext.values_exceptional_outputs_3:
+.Lasm_ObjectPropertyIteratorNext.values_restore_stack_2:
+    add sp, sp, #32
+.Lasm_ObjectPropertyIteratorNext.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ObjectPropertyIteratorNext.slow_path_transfer_6
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ObjectPropertyIteratorNext.slow_path_transfer_6:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11123,15 +14118,42 @@ asm_handler_IteratorClose:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_IteratorClose.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_IteratorClose.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_IteratorClose.scalar_value_ready_2:
+    mov x5, x10
+    ldr w9, [x21, #20]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_IteratorClose.scalar_value_ready_3:
+    mov x6, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_iterator_close)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_IteratorClose.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_IteratorClose.scalar_result_done_4
+    tbz x0, #32, .Lasm_IteratorClose.scalar_result_done_4
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_IteratorClose.slow_path_transfer_0:
+.Lasm_IteratorClose.scalar_result_done_4:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_IteratorClose.slow_path_transfer_5
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IteratorClose.slow_path_transfer_5:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11149,15 +14171,59 @@ asm_handler_IteratorNext:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #32
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_IteratorNext.value_ready_1:
+    mov x4, x11
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_IteratorNext.value_ready_2:
+    mov x5, x11
+    ldr w12, [x21, #16]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_IteratorNext.value_ready_3:
+    mov x6, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_iterator_next)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_IteratorNext.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_IteratorNext.values_exceptional_outputs_5
+    tbz x0, #32, .Lasm_IteratorNext.values_exceptional_outputs_5
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorNext.skip_output_value_6:
+    ldr w12, [x21, #16]
+    ldr x11, [sp, #24]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorNext.skip_output_value_7:
+    add sp, sp, #32
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_IteratorNext.slow_path_transfer_0:
+.Lasm_IteratorNext.values_exceptional_outputs_5:
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_IteratorNext.values_restore_stack_4
+    ldr w12, [x21, #16]
+    ldr x11, [sp, #24]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorNext.skip_exceptional_output_8:
+.Lasm_IteratorNext.values_restore_stack_4:
+    add sp, sp, #32
+.Lasm_IteratorNext.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_IteratorNext.slow_path_transfer_9
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IteratorNext.slow_path_transfer_9:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11175,15 +14241,63 @@ asm_handler_IteratorNextUnpack:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #48
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_IteratorNextUnpack.value_ready_1:
+    mov x4, x11
+    ldr w12, [x21, #16]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_IteratorNextUnpack.value_ready_2:
+    mov x5, x11
+    ldr w12, [x21, #20]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_IteratorNextUnpack.value_ready_3:
+    mov x6, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_iterator_next_unpack)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_IteratorNextUnpack.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_IteratorNextUnpack.values_exceptional_outputs_5
+    tbz x0, #32, .Lasm_IteratorNextUnpack.values_exceptional_outputs_5
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorNextUnpack.skip_output_value_6:
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorNextUnpack.skip_output_value_7:
+    ldr w12, [x21, #20]
+    ldr x11, [sp, #32]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorNextUnpack.skip_output_value_8:
+    add sp, sp, #48
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_IteratorNextUnpack.slow_path_transfer_0:
+.Lasm_IteratorNextUnpack.values_exceptional_outputs_5:
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_IteratorNextUnpack.values_restore_stack_4
+    ldr w12, [x21, #20]
+    ldr x11, [sp, #32]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorNextUnpack.skip_exceptional_output_9:
+.Lasm_IteratorNextUnpack.values_restore_stack_4:
+    add sp, sp, #48
+.Lasm_IteratorNextUnpack.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_IteratorNextUnpack.slow_path_transfer_10
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IteratorNextUnpack.slow_path_transfer_10:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11201,15 +14315,59 @@ asm_handler_IteratorToArray:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #32
+    ldr w12, [x21, #8]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_IteratorToArray.value_ready_1:
+    mov x4, x11
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_IteratorToArray.value_ready_2:
+    mov x5, x11
+    ldr w12, [x21, #16]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_IteratorToArray.value_ready_3:
+    mov x6, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_iterator_to_array)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_IteratorToArray.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_IteratorToArray.values_exceptional_outputs_5
+    tbz x0, #32, .Lasm_IteratorToArray.values_exceptional_outputs_5
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorToArray.skip_output_value_6:
+    ldr w12, [x21, #16]
+    ldr x11, [sp, #24]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorToArray.skip_output_value_7:
+    add sp, sp, #32
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_IteratorToArray.slow_path_transfer_0:
+.Lasm_IteratorToArray.values_exceptional_outputs_5:
+    ldr x9, [x20, #15288]
+    cmp x9, x28
+    b.ne .Lasm_IteratorToArray.values_restore_stack_4
+    ldr w12, [x21, #16]
+    ldr x11, [sp, #24]
+    str x11, [x27, x12, lsl #3]
+.Lasm_IteratorToArray.skip_exceptional_output_8:
+.Lasm_IteratorToArray.values_restore_stack_4:
+    add sp, sp, #32
+.Lasm_IteratorToArray.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_IteratorToArray.slow_path_transfer_9
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IteratorToArray.slow_path_transfer_9:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11227,15 +14385,81 @@ asm_handler_CallConstruct:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    add x9, sp, #0
+    ldr w10, [x21, #16]
+    lsl x10, x10, #3
+    add x10, x10, #47
+    and x10, x10, #0xfffffffffffffff0
+    sub x14, x9, x10
+    ldr x12, [x20, #15336]
+    mov w13, #32768
+    add x12, x12, x13
+    cmp x14, x12
+    b.hs .Lasm_CallConstruct.values_allocate_1
+    mov x0, x20
+    sub w1, w21, w26
+    bl CSYM(asm_slow_path_stack_overflow)
+    b .Lasm_CallConstruct.values_call_done_0
+.Lasm_CallConstruct.values_allocate_1:
+.Lasm_CallConstruct.values_probe_2:
+    sub x10, sp, #1, lsl #12
+    cmp x10, x14
+    b.ls .Lasm_CallConstruct.values_allocated_3
+    add sp, x10, #0
+    str xzr, [sp]
+    b .Lasm_CallConstruct.values_probe_2
+.Lasm_CallConstruct.values_allocated_3:
+    add sp, x14, #0
+    str x9, [sp]
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_CallConstruct.value_ready_4:
+    str x11, [sp, #24]
+    mov w9, #0
+    ldr w10, [x21, #16]
+    add x14, sp, #32
+    add x3, x21, #24
+.Lasm_CallConstruct.array_value_next_5:
+    cmp x9, x10
+    b.hs .Lasm_CallConstruct.array_values_end_7
+    ldr w12, [x3, x9, lsl #2]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_CallConstruct.array_value_ready_6:
+    str x11, [x14, x9, lsl #3]
+    add x9, x9, #1
+    b .Lasm_CallConstruct.array_value_next_5
+.Lasm_CallConstruct.array_values_end_7:
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #16
     bl CSYM(asm_slow_path_call_construct)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallConstruct.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallConstruct.values_exceptional_outputs_9
+    tbz x0, #32, .Lasm_CallConstruct.values_exceptional_outputs_9
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #16]
+    str x11, [x27, x12, lsl #3]
+.Lasm_CallConstruct.skip_output_value_10:
+    ldr x9, [sp]
+    add sp, x9, #0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallConstruct.slow_path_transfer_0:
+.Lasm_CallConstruct.values_exceptional_outputs_9:
+.Lasm_CallConstruct.values_restore_stack_8:
+    ldr x9, [sp]
+    add sp, x9, #0
+.Lasm_CallConstruct.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallConstruct.slow_path_transfer_11
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallConstruct.slow_path_transfer_11:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11253,15 +14477,85 @@ asm_handler_CallDirectEval:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    add x9, sp, #0
+    ldr w10, [x21, #20]
+    lsl x10, x10, #3
+    add x10, x10, #55
+    and x10, x10, #0xfffffffffffffff0
+    sub x14, x9, x10
+    ldr x12, [x20, #15336]
+    mov w13, #32768
+    add x12, x12, x13
+    cmp x14, x12
+    b.hs .Lasm_CallDirectEval.values_allocate_1
+    mov x0, x20
+    sub w1, w21, w26
+    bl CSYM(asm_slow_path_stack_overflow)
+    b .Lasm_CallDirectEval.values_call_done_0
+.Lasm_CallDirectEval.values_allocate_1:
+.Lasm_CallDirectEval.values_probe_2:
+    sub x10, sp, #1, lsl #12
+    cmp x10, x14
+    b.ls .Lasm_CallDirectEval.values_allocated_3
+    add sp, x10, #0
+    str xzr, [sp]
+    b .Lasm_CallDirectEval.values_probe_2
+.Lasm_CallDirectEval.values_allocated_3:
+    add sp, x14, #0
+    str x9, [sp]
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_CallDirectEval.value_ready_4:
+    str x11, [sp, #24]
+    ldr w12, [x21, #16]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_CallDirectEval.value_ready_5:
+    str x11, [sp, #32]
+    mov w9, #0
+    ldr w10, [x21, #20]
+    add x14, sp, #40
+    add x3, x21, #28
+.Lasm_CallDirectEval.array_value_next_6:
+    cmp x9, x10
+    b.hs .Lasm_CallDirectEval.array_values_end_8
+    ldr w12, [x3, x9, lsl #2]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_CallDirectEval.array_value_ready_7:
+    str x11, [x14, x9, lsl #3]
+    add x9, x9, #1
+    b .Lasm_CallDirectEval.array_value_next_6
+.Lasm_CallDirectEval.array_values_end_8:
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #16
     bl CSYM(asm_slow_path_call_direct_eval)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallDirectEval.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallDirectEval.values_exceptional_outputs_10
+    tbz x0, #32, .Lasm_CallDirectEval.values_exceptional_outputs_10
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #16]
+    str x11, [x27, x12, lsl #3]
+.Lasm_CallDirectEval.skip_output_value_11:
+    ldr x9, [sp]
+    add sp, x9, #0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallDirectEval.slow_path_transfer_0:
+.Lasm_CallDirectEval.values_exceptional_outputs_10:
+.Lasm_CallDirectEval.values_restore_stack_9:
+    ldr x9, [sp]
+    add sp, x9, #0
+.Lasm_CallDirectEval.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallDirectEval.slow_path_transfer_12
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallDirectEval.slow_path_transfer_12:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11279,15 +14573,40 @@ asm_handler_CallWithArgumentArray:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallWithArgumentArray.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallWithArgumentArray.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallWithArgumentArray.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_with_argument_array)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallWithArgumentArray.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallWithArgumentArray.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallWithArgumentArray.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallWithArgumentArray.slow_path_transfer_0:
+.Lasm_CallWithArgumentArray.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallWithArgumentArray.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallWithArgumentArray.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11305,15 +14624,40 @@ asm_handler_CallDirectEvalWithArgumentArray:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallDirectEvalWithArgumentArray.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallDirectEvalWithArgumentArray.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallDirectEvalWithArgumentArray.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_direct_eval_with_argument_array)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallDirectEvalWithArgumentArray.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallDirectEvalWithArgumentArray.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_0:
+.Lasm_CallDirectEvalWithArgumentArray.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11331,15 +14675,40 @@ asm_handler_CallConstructWithArgumentArray:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallConstructWithArgumentArray.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallConstructWithArgumentArray.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CallConstructWithArgumentArray.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_call_construct_with_argument_array)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CallConstructWithArgumentArray.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CallConstructWithArgumentArray.scalar_result_done_3
+    tbz x0, #32, .Lasm_CallConstructWithArgumentArray.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CallConstructWithArgumentArray.slow_path_transfer_0:
+.Lasm_CallConstructWithArgumentArray.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CallConstructWithArgumentArray.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallConstructWithArgumentArray.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11357,15 +14726,36 @@ asm_handler_SuperCallWithArgumentArray:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SuperCallWithArgumentArray.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SuperCallWithArgumentArray.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_super_call_with_argument_array)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_SuperCallWithArgumentArray.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_SuperCallWithArgumentArray.scalar_result_done_2
+    tbz x0, #32, .Lasm_SuperCallWithArgumentArray.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_SuperCallWithArgumentArray.slow_path_transfer_0:
+.Lasm_SuperCallWithArgumentArray.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_SuperCallWithArgumentArray.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SuperCallWithArgumentArray.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11383,15 +14773,28 @@ asm_handler_NewObject:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_new_object)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewObject.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewObject.scalar_result_done_0
+    tbz x0, #32, .Lasm_NewObject.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewObject.slow_path_transfer_0:
+.Lasm_NewObject.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewObject.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewObject.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11409,15 +14812,28 @@ asm_handler_NewObjectWithNoPrototype:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_new_object_with_no_prototype)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewObjectWithNoPrototype.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewObjectWithNoPrototype.scalar_result_done_0
+    tbz x0, #32, .Lasm_NewObjectWithNoPrototype.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewObjectWithNoPrototype.slow_path_transfer_0:
+.Lasm_NewObjectWithNoPrototype.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewObjectWithNoPrototype.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewObjectWithNoPrototype.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11435,15 +14851,30 @@ asm_handler_CacheObjectShape:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CacheObjectShape.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_cache_object_shape)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CacheObjectShape.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CacheObjectShape.scalar_result_done_1
+    tbz x0, #32, .Lasm_CacheObjectShape.scalar_result_done_1
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CacheObjectShape.slow_path_transfer_0:
+.Lasm_CacheObjectShape.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CacheObjectShape.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CacheObjectShape.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11461,15 +14892,34 @@ asm_handler_InitObjectLiteralProperty:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_InitObjectLiteralProperty.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_InitObjectLiteralProperty.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_init_object_literal_property)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_InitObjectLiteralProperty.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_InitObjectLiteralProperty.scalar_result_done_2
+    tbz x0, #32, .Lasm_InitObjectLiteralProperty.scalar_result_done_2
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_InitObjectLiteralProperty.slow_path_transfer_0:
+.Lasm_InitObjectLiteralProperty.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_InitObjectLiteralProperty.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_InitObjectLiteralProperty.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11487,15 +14937,77 @@ asm_handler_NewArray:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    add x9, sp, #0
+    ldr w10, [x21, #12]
+    lsl x10, x10, #3
+    add x10, x10, #39
+    and x10, x10, #0xfffffffffffffff0
+    sub x14, x9, x10
+    ldr x12, [x20, #15336]
+    mov w13, #32768
+    add x12, x12, x13
+    cmp x14, x12
+    b.hs .Lasm_NewArray.values_allocate_1
+    mov x0, x20
+    sub w1, w21, w26
+    bl CSYM(asm_slow_path_stack_overflow)
+    b .Lasm_NewArray.values_call_done_0
+.Lasm_NewArray.values_allocate_1:
+.Lasm_NewArray.values_probe_2:
+    sub x10, sp, #1, lsl #12
+    cmp x10, x14
+    b.ls .Lasm_NewArray.values_allocated_3
+    add sp, x10, #0
+    str xzr, [sp]
+    b .Lasm_NewArray.values_probe_2
+.Lasm_NewArray.values_allocated_3:
+    add sp, x14, #0
+    str x9, [sp]
+    mov w9, #0
+    ldr w10, [x21, #12]
+    add x14, sp, #24
+    add x3, x21, #16
+.Lasm_NewArray.array_value_next_4:
+    cmp x9, x10
+    b.hs .Lasm_NewArray.array_values_end_6
+    ldr w12, [x3, x9, lsl #2]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_NewArray.array_value_ready_5:
+    str x11, [x14, x9, lsl #3]
+    add x9, x9, #1
+    b .Lasm_NewArray.array_value_next_4
+.Lasm_NewArray.array_values_end_6:
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #16
     bl CSYM(asm_slow_path_new_array)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewArray.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewArray.values_exceptional_outputs_8
+    tbz x0, #32, .Lasm_NewArray.values_exceptional_outputs_8
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #16]
+    str x11, [x27, x12, lsl #3]
+.Lasm_NewArray.skip_output_value_9:
+    ldr x9, [sp]
+    add sp, x9, #0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewArray.slow_path_transfer_0:
+.Lasm_NewArray.values_exceptional_outputs_8:
+.Lasm_NewArray.values_restore_stack_7:
+    ldr x9, [sp]
+    add sp, x9, #0
+.Lasm_NewArray.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewArray.slow_path_transfer_10
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewArray.slow_path_transfer_10:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11513,15 +15025,28 @@ asm_handler_NewPrimitiveArray:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_new_primitive_array)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewPrimitiveArray.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewPrimitiveArray.scalar_result_done_0
+    tbz x0, #32, .Lasm_NewPrimitiveArray.scalar_result_done_0
+    ldr w9, [x21, #8]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewPrimitiveArray.slow_path_transfer_0:
+.Lasm_NewPrimitiveArray.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewPrimitiveArray.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewPrimitiveArray.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11539,15 +15064,28 @@ asm_handler_NewRegExp:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_new_regexp)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewRegExp.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewRegExp.scalar_result_done_0
+    tbz x0, #32, .Lasm_NewRegExp.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewRegExp.slow_path_transfer_0:
+.Lasm_NewRegExp.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewRegExp.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewRegExp.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11565,15 +15103,28 @@ asm_handler_NewReferenceError:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_new_reference_error)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewReferenceError.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewReferenceError.scalar_result_done_0
+    tbz x0, #32, .Lasm_NewReferenceError.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewReferenceError.slow_path_transfer_0:
+.Lasm_NewReferenceError.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewReferenceError.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewReferenceError.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11591,15 +15142,28 @@ asm_handler_NewTypeError:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_new_type_error)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewTypeError.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewTypeError.scalar_result_done_0
+    tbz x0, #32, .Lasm_NewTypeError.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewTypeError.slow_path_transfer_0:
+.Lasm_NewTypeError.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewTypeError.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewTypeError.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11617,15 +15181,36 @@ asm_handler_InstanceOf:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_InstanceOf.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_InstanceOf.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_instance_of)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_InstanceOf.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_InstanceOf.scalar_result_done_2
+    tbz x0, #32, .Lasm_InstanceOf.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_InstanceOf.slow_path_transfer_0:
+.Lasm_InstanceOf.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_InstanceOf.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_InstanceOf.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11643,15 +15228,36 @@ asm_handler_In:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_In.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_In.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_in)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_In.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_In.scalar_result_done_2
+    tbz x0, #32, .Lasm_In.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_In.slow_path_transfer_0:
+.Lasm_In.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_In.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_In.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11671,15 +15277,32 @@ asm_handler_IsConstructor:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_IsConstructor.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_is_constructor)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_IsConstructor.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_IsConstructor.scalar_result_done_1
+    tbz x0, #32, .Lasm_IsConstructor.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_IsConstructor.slow_path_transfer_0:
+.Lasm_IsConstructor.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_IsConstructor.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IsConstructor.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11697,15 +15320,26 @@ asm_handler_AddPrivateName:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_add_private_name)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_AddPrivateName.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_AddPrivateName.scalar_result_done_0
+    tbz x0, #32, .Lasm_AddPrivateName.scalar_result_done_0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_AddPrivateName.slow_path_transfer_0:
+.Lasm_AddPrivateName.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_AddPrivateName.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_AddPrivateName.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11723,15 +15357,40 @@ asm_handler_CreateAsyncFromSyncIterator:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CreateAsyncFromSyncIterator.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CreateAsyncFromSyncIterator.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #16]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CreateAsyncFromSyncIterator.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_create_async_from_sync_iterator)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreateAsyncFromSyncIterator.scalar_result_done_3
+    tbz x0, #32, .Lasm_CreateAsyncFromSyncIterator.scalar_result_done_3
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_0:
+.Lasm_CreateAsyncFromSyncIterator.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11749,15 +15408,38 @@ asm_handler_CreateDataPropertyOrThrow:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CreateDataPropertyOrThrow.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CreateDataPropertyOrThrow.scalar_value_ready_1:
+    mov x4, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CreateDataPropertyOrThrow.scalar_value_ready_2:
+    mov x5, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_create_data_property_or_throw)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreateDataPropertyOrThrow.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreateDataPropertyOrThrow.scalar_result_done_3
+    tbz x0, #32, .Lasm_CreateDataPropertyOrThrow.scalar_result_done_3
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreateDataPropertyOrThrow.slow_path_transfer_0:
+.Lasm_CreateDataPropertyOrThrow.scalar_result_done_3:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreateDataPropertyOrThrow.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateDataPropertyOrThrow.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11775,15 +15457,30 @@ asm_handler_CreateImmutableBinding:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CreateImmutableBinding.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_create_immutable_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreateImmutableBinding.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreateImmutableBinding.scalar_result_done_1
+    tbz x0, #32, .Lasm_CreateImmutableBinding.scalar_result_done_1
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreateImmutableBinding.slow_path_transfer_0:
+.Lasm_CreateImmutableBinding.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreateImmutableBinding.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateImmutableBinding.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11801,15 +15498,30 @@ asm_handler_CreateMutableBinding:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CreateMutableBinding.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_create_mutable_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreateMutableBinding.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreateMutableBinding.scalar_result_done_1
+    tbz x0, #32, .Lasm_CreateMutableBinding.scalar_result_done_1
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreateMutableBinding.slow_path_transfer_0:
+.Lasm_CreateMutableBinding.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreateMutableBinding.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateMutableBinding.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11827,15 +15539,28 @@ asm_handler_CreateRestParams:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_create_rest_params)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreateRestParams.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreateRestParams.scalar_result_done_0
+    tbz x0, #32, .Lasm_CreateRestParams.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreateRestParams.slow_path_transfer_0:
+.Lasm_CreateRestParams.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreateRestParams.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateRestParams.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11853,15 +15578,39 @@ asm_handler_CreateArguments:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #16
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_create_arguments)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreateArguments.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreateArguments.values_exceptional_outputs_2
+    tbz x0, #32, .Lasm_CreateArguments.values_exceptional_outputs_2
+    ldr w12, [x21, #4]
+    movn w13, #0
+    cmp w12, w13
+    b.eq .Lasm_CreateArguments.skip_output_value_3
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_CreateArguments.skip_output_value_3:
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreateArguments.slow_path_transfer_0:
+.Lasm_CreateArguments.values_exceptional_outputs_2:
+.Lasm_CreateArguments.values_restore_stack_1:
+    add sp, sp, #16
+.Lasm_CreateArguments.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreateArguments.slow_path_transfer_4
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateArguments.slow_path_transfer_4:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11879,15 +15628,32 @@ asm_handler_CreateLexicalEnvironment:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_CreateLexicalEnvironment.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_create_lexical_environment)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreateLexicalEnvironment.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreateLexicalEnvironment.scalar_result_done_1
+    tbz x0, #32, .Lasm_CreateLexicalEnvironment.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreateLexicalEnvironment.slow_path_transfer_0:
+.Lasm_CreateLexicalEnvironment.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreateLexicalEnvironment.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateLexicalEnvironment.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11905,15 +15671,26 @@ asm_handler_CreatePrivateEnvironment:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_create_private_environment)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreatePrivateEnvironment.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreatePrivateEnvironment.scalar_result_done_0
+    tbz x0, #32, .Lasm_CreatePrivateEnvironment.scalar_result_done_0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreatePrivateEnvironment.slow_path_transfer_0:
+.Lasm_CreatePrivateEnvironment.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreatePrivateEnvironment.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreatePrivateEnvironment.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11931,15 +15708,26 @@ asm_handler_CreateVariableEnvironment:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_create_variable_environment)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_CreateVariableEnvironment.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_CreateVariableEnvironment.scalar_result_done_0
+    tbz x0, #32, .Lasm_CreateVariableEnvironment.scalar_result_done_0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_CreateVariableEnvironment.slow_path_transfer_0:
+.Lasm_CreateVariableEnvironment.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_CreateVariableEnvironment.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateVariableEnvironment.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11957,15 +15745,32 @@ asm_handler_DeleteById:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_DeleteById.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_delete_by_id)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DeleteById.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_DeleteById.scalar_result_done_1
+    tbz x0, #32, .Lasm_DeleteById.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DeleteById.slow_path_transfer_0:
+.Lasm_DeleteById.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_DeleteById.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DeleteById.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11983,15 +15788,36 @@ asm_handler_DeleteByValue:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_DeleteByValue.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_DeleteByValue.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_delete_by_value)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DeleteByValue.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_DeleteByValue.scalar_result_done_2
+    tbz x0, #32, .Lasm_DeleteByValue.scalar_result_done_2
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DeleteByValue.slow_path_transfer_0:
+.Lasm_DeleteByValue.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_DeleteByValue.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DeleteByValue.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12009,15 +15835,28 @@ asm_handler_DeleteVariable:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_delete_variable)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DeleteVariable.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_DeleteVariable.scalar_result_done_0
+    tbz x0, #32, .Lasm_DeleteVariable.scalar_result_done_0
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DeleteVariable.slow_path_transfer_0:
+.Lasm_DeleteVariable.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_DeleteVariable.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DeleteVariable.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12035,15 +15874,44 @@ asm_handler_GetCompletionFields:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    sub sp, sp, #32
+    ldr w12, [x21, #12]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_GetCompletionFields.value_ready_1:
+    mov x4, x11
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #0
     bl CSYM(asm_slow_path_get_completion_fields)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetCompletionFields.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetCompletionFields.values_exceptional_outputs_3
+    tbz x0, #32, .Lasm_GetCompletionFields.values_exceptional_outputs_3
+    ldr w12, [x21, #4]
+    ldr x11, [sp]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetCompletionFields.skip_output_value_4:
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #8]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetCompletionFields.skip_output_value_5:
+    add sp, sp, #32
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetCompletionFields.slow_path_transfer_0:
+.Lasm_GetCompletionFields.values_exceptional_outputs_3:
+.Lasm_GetCompletionFields.values_restore_stack_2:
+    add sp, sp, #32
+.Lasm_GetCompletionFields.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetCompletionFields.slow_path_transfer_6
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetCompletionFields.slow_path_transfer_6:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12061,15 +15929,30 @@ asm_handler_SetCompletionType:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_SetCompletionType.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_set_completion_type)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_SetCompletionType.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_SetCompletionType.scalar_result_done_1
+    tbz x0, #32, .Lasm_SetCompletionType.scalar_result_done_1
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_SetCompletionType.slow_path_transfer_0:
+.Lasm_SetCompletionType.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_SetCompletionType.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetCompletionType.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12087,15 +15970,77 @@ asm_handler_GetTemplateObject:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    add x9, sp, #0
+    ldr w10, [x21, #12]
+    lsl x10, x10, #3
+    add x10, x10, #39
+    and x10, x10, #0xfffffffffffffff0
+    sub x14, x9, x10
+    ldr x12, [x20, #15336]
+    mov w13, #32768
+    add x12, x12, x13
+    cmp x14, x12
+    b.hs .Lasm_GetTemplateObject.values_allocate_1
+    mov x0, x20
+    sub w1, w21, w26
+    bl CSYM(asm_slow_path_stack_overflow)
+    b .Lasm_GetTemplateObject.values_call_done_0
+.Lasm_GetTemplateObject.values_allocate_1:
+.Lasm_GetTemplateObject.values_probe_2:
+    sub x10, sp, #1, lsl #12
+    cmp x10, x14
+    b.ls .Lasm_GetTemplateObject.values_allocated_3
+    add sp, x10, #0
+    str xzr, [sp]
+    b .Lasm_GetTemplateObject.values_probe_2
+.Lasm_GetTemplateObject.values_allocated_3:
+    add sp, x14, #0
+    str x9, [sp]
+    mov w9, #0
+    ldr w10, [x21, #12]
+    add x14, sp, #24
+    add x3, x21, #20
+.Lasm_GetTemplateObject.array_value_next_4:
+    cmp x9, x10
+    b.hs .Lasm_GetTemplateObject.array_values_end_6
+    ldr w12, [x3, x9, lsl #2]
+    ldr x11, [x27, x12, lsl #3]
+.Lasm_GetTemplateObject.array_value_ready_5:
+    str x11, [x14, x9, lsl #3]
+    add x9, x9, #1
+    b .Lasm_GetTemplateObject.array_value_next_4
+.Lasm_GetTemplateObject.array_values_end_6:
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
+    add x3, sp, #16
     bl CSYM(asm_slow_path_get_template_object)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetTemplateObject.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetTemplateObject.values_exceptional_outputs_8
+    tbz x0, #32, .Lasm_GetTemplateObject.values_exceptional_outputs_8
+    ldr w12, [x21, #8]
+    ldr x11, [sp, #16]
+    str x11, [x27, x12, lsl #3]
+.Lasm_GetTemplateObject.skip_output_value_9:
+    ldr x9, [sp]
+    add sp, x9, #0
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetTemplateObject.slow_path_transfer_0:
+.Lasm_GetTemplateObject.values_exceptional_outputs_8:
+.Lasm_GetTemplateObject.values_restore_stack_7:
+    ldr x9, [sp]
+    add sp, x9, #0
+.Lasm_GetTemplateObject.values_call_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetTemplateObject.slow_path_transfer_10
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetTemplateObject.slow_path_transfer_10:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12113,15 +16058,36 @@ asm_handler_NewFunction:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #16]
+    movz x10, #0x7ffb, lsl #48
+    movn w11, #0
+    cmp w9, w11
+    b.eq .Lasm_NewFunction.scalar_value_ready_0
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_NewFunction.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_new_function)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_NewFunction.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_NewFunction.scalar_result_done_1
+    tbz x0, #32, .Lasm_NewFunction.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_NewFunction.slow_path_transfer_0:
+.Lasm_NewFunction.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_NewFunction.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewFunction.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12139,15 +16105,32 @@ asm_handler_Typeof:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_Typeof.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_typeof)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_Typeof.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_Typeof.scalar_result_done_1
+    tbz x0, #32, .Lasm_Typeof.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_Typeof.slow_path_transfer_0:
+.Lasm_Typeof.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_Typeof.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Typeof.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12168,15 +16151,32 @@ asm_handler_ResolveThisBinding_cold:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_resolve_this_binding)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ResolveThisBinding.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_ResolveThisBinding.scalar_result_done_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ResolveThisBinding.scalar_result_done_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ResolveThisBinding.slow_path_transfer_0:
+.Lasm_ResolveThisBinding.scalar_result_done_0:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ResolveThisBinding.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ResolveThisBinding.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12191,15 +16191,32 @@ asm_handler_GetPrivateById:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #8]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_GetPrivateById.scalar_value_ready_0:
+    mov x3, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_get_private_by_id)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GetPrivateById.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_GetPrivateById.scalar_result_done_1
+    tbz x0, #32, .Lasm_GetPrivateById.scalar_result_done_1
+    ldr w9, [x21, #4]
+    str x1, [x27, x9, lsl #3]
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetPrivateById.slow_path_transfer_0:
+.Lasm_GetPrivateById.scalar_result_done_1:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_GetPrivateById.slow_path_transfer_2
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetPrivateById.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12217,15 +16234,34 @@ asm_handler_PutPrivateById:
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
+    ldr w9, [x21, #4]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutPrivateById.scalar_value_ready_0:
+    mov x3, x10
+    ldr w9, [x21, #12]
+    ldr x10, [x27, x9, lsl #3]
+.Lasm_PutPrivateById.scalar_value_ready_1:
+    mov x4, x10
+    mov x0, x20
+    sub w1, w21, w26
     mov x2, x21
     bl CSYM(asm_slow_path_put_private_by_id)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_PutPrivateById.slow_path_transfer_0
+    tbnz x0, #63, .Lasm_PutPrivateById.scalar_result_done_2
+    tbz x0, #32, .Lasm_PutPrivateById.scalar_result_done_2
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_PutPrivateById.slow_path_transfer_0:
+.Lasm_PutPrivateById.scalar_result_done_2:
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_PutPrivateById.slow_path_transfer_3
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutPrivateById.slow_path_transfer_3:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12258,19 +16294,42 @@ asm_handler_AddLhsInt32_cold:
     ldr w1, [x21, #8]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x1
     mov x4, x0
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_add_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_AddLhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_AddLhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_AddLhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_AddLhsInt32.slow_path_transfer_0:
+.Lasm_AddLhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_AddLhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_AddLhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12294,15 +16353,17 @@ asm_handler_AddLhsInt32_cold:
     b .Lasm_AddLhsInt32.ssa_box_number_6_done
 .Lasm_AddLhsInt32.ssa_box_number_6_check_negative_zero:
     fmov x0, d0
-    tbnz x0, #63, .Lasm_AddLhsInt32.ssa_box_number_6_not_integer
+    tbz x0, #63, 1f
+    b .Lasm_AddLhsInt32.ssa_box_number_6_not_integer
+1:
     mov w0, w1
     movk x0, #0x7ffa, lsl #48
     b .Lasm_AddLhsInt32.ssa_box_number_6_done
 .Lasm_AddLhsInt32.ssa_box_number_6_not_integer:
     fmov x0, d0
     fcmp d0, d0
-    b.vs .Lasm_AddLhsInt32.canon_nan_1
-.Lasm_AddLhsInt32.canon_nan_1_ret:
+    b.vs .Lasm_AddLhsInt32.canon_nan_2
+.Lasm_AddLhsInt32.canon_nan_2_ret:
 .Lasm_AddLhsInt32.ssa_box_number_6_done:
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
@@ -12323,9 +16384,9 @@ asm_handler_AddLhsInt32_cold:
     add x21, x21, #16
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_AddLhsInt32.canon_nan_1:
+.Lasm_AddLhsInt32.canon_nan_2:
     fmov x0, d8
-    b .Lasm_AddLhsInt32.canon_nan_1_ret
+    b .Lasm_AddLhsInt32.canon_nan_2_ret
 asm_handler_AddLhsInt32_cold_end:
 asm_handler_AddRhsInt32_cold:
 // Cold paths for AddRhsInt32
@@ -12363,7 +16424,9 @@ asm_handler_AddRhsInt32_cold:
     b .Lasm_AddRhsInt32.ssa_box_number_8_done
 .Lasm_AddRhsInt32.ssa_box_number_8_check_negative_zero:
     fmov x0, d0
-    tbnz x0, #63, .Lasm_AddRhsInt32.ssa_box_number_8_not_integer
+    tbz x0, #63, 1f
+    b .Lasm_AddRhsInt32.ssa_box_number_8_not_integer
+1:
     mov w0, w1
     movk x0, #0x7ffa, lsl #48
     b .Lasm_AddRhsInt32.ssa_box_number_8_done
@@ -12383,19 +16446,42 @@ asm_handler_AddRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_add_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_AddRhsInt32.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_AddRhsInt32.binary_result_restore_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_AddRhsInt32.binary_result_restore_1
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_AddRhsInt32.slow_path_transfer_1:
+.Lasm_AddRhsInt32.binary_result_restore_1:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_AddRhsInt32.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_AddRhsInt32.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12444,7 +16530,9 @@ asm_handler_SubRhsInt32_cold:
     b .Lasm_SubRhsInt32.ssa_box_number_8_done
 .Lasm_SubRhsInt32.ssa_box_number_8_check_negative_zero:
     fmov x0, d0
-    tbnz x0, #63, .Lasm_SubRhsInt32.ssa_box_number_8_not_integer
+    tbz x0, #63, 1f
+    b .Lasm_SubRhsInt32.ssa_box_number_8_not_integer
+1:
     mov w0, w1
     movk x0, #0x7ffa, lsl #48
     b .Lasm_SubRhsInt32.ssa_box_number_8_done
@@ -12464,19 +16552,42 @@ asm_handler_SubRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_sub_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_SubRhsInt32.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_SubRhsInt32.binary_result_restore_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_SubRhsInt32.binary_result_restore_1
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_SubRhsInt32.slow_path_transfer_1:
+.Lasm_SubRhsInt32.binary_result_restore_1:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_SubRhsInt32.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SubRhsInt32.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12499,19 +16610,42 @@ asm_handler_MulRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_mul_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_MulRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_MulRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_MulRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_MulRhsInt32.slow_path_transfer_0:
+.Lasm_MulRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_MulRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_MulRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12535,15 +16669,17 @@ asm_handler_MulRhsInt32_cold:
     b .Lasm_MulRhsInt32.ssa_box_number_8_done
 .Lasm_MulRhsInt32.ssa_box_number_8_check_negative_zero:
     fmov x0, d0
-    tbnz x0, #63, .Lasm_MulRhsInt32.ssa_box_number_8_not_integer
+    tbz x0, #63, 1f
+    b .Lasm_MulRhsInt32.ssa_box_number_8_not_integer
+1:
     mov w0, w1
     movk x0, #0x7ffa, lsl #48
     b .Lasm_MulRhsInt32.ssa_box_number_8_done
 .Lasm_MulRhsInt32.ssa_box_number_8_not_integer:
     fmov x0, d0
     fcmp d0, d0
-    b.vs .Lasm_MulRhsInt32.canon_nan_1
-.Lasm_MulRhsInt32.canon_nan_1_ret:
+    b.vs .Lasm_MulRhsInt32.canon_nan_2
+.Lasm_MulRhsInt32.canon_nan_2_ret:
 .Lasm_MulRhsInt32.ssa_box_number_8_done:
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
@@ -12572,31 +16708,101 @@ asm_handler_MulRhsInt32_cold:
     add x21, x21, #16
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_MulRhsInt32.canon_nan_1:
+.Lasm_MulRhsInt32.canon_nan_2:
     fmov x0, d8
-    b .Lasm_MulRhsInt32.canon_nan_1_ret
+    b .Lasm_MulRhsInt32.canon_nan_2_ret
 asm_handler_MulRhsInt32_cold_end:
+.p2align 4
+asm_handler_ExpRhsInt32:
+    ldr w0, [x21, #8]
+    ldr x0, [x27, x0, lsl #3]
+    ldr w1, [x21, #12]
+    movk x1, #0x7ffa, lsl #48
+    ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
+    mov x3, x0
+    mov x4, x1
+    add x2, sp, #0
+    mov x0, x20
+    sub w1, w21, w26
+    str w1, [x28, #64]
+    bl CSYM(asm_slow_path_exp_values)
+    tbnz x0, #63, .Lasm_ExpRhsInt32.binary_result_restore_0
+    tbz x0, #32, .Lasm_ExpRhsInt32.binary_result_restore_0
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ExpRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbz x0, #32, .Lasm_ExpRhsInt32.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ExpRhsInt32.slow_path_transfer_1:
+    ldr x28, [x20, #15288]
+    ldr x9, [x28, #88]
+    ldr x26, [x9, #80]
+    add x27, x28, #128
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+asm_handler_ExpRhsInt32_hot_end:
 asm_handler_ExpRhsInt32_cold:
 asm_handler_ExpRhsInt32_cold_end:
+
 asm_handler_DivRhsInt32_cold:
 // Cold paths for DivRhsInt32
 .Lasm_DivRhsInt32.ssa_block_1:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_div_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_DivRhsInt32.slow_path_transfer_1
+    tbz x0, #63, 1f
+    b .Lasm_DivRhsInt32.binary_result_restore_1
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DivRhsInt32.binary_result_restore_1
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_DivRhsInt32.slow_path_transfer_1:
+.Lasm_DivRhsInt32.binary_result_restore_1:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_DivRhsInt32.slow_path_transfer_2
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DivRhsInt32.slow_path_transfer_2:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12647,19 +16853,42 @@ asm_handler_BitwiseXorRhsInt32_cold:
     b .Lasm_BitwiseXorRhsInt32.ssa_block_13
 .Lasm_BitwiseXorRhsInt32.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_xor_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_BitwiseXorRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_BitwiseXorRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseXorRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_BitwiseXorRhsInt32.slow_path_transfer_0:
+.Lasm_BitwiseXorRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseXorRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseXorRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12718,19 +16947,42 @@ asm_handler_BitwiseAndRhsInt32_cold:
     b .Lasm_BitwiseAndRhsInt32.ssa_block_13
 .Lasm_BitwiseAndRhsInt32.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_and_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_BitwiseAndRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_BitwiseAndRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseAndRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_BitwiseAndRhsInt32.slow_path_transfer_0:
+.Lasm_BitwiseAndRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseAndRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseAndRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12789,19 +17041,42 @@ asm_handler_BitwiseOrRhsInt32_cold:
     b .Lasm_BitwiseOrRhsInt32.ssa_block_13
 .Lasm_BitwiseOrRhsInt32.ssa_block_1:
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_or_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_BitwiseOrRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_BitwiseOrRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseOrRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_BitwiseOrRhsInt32.slow_path_transfer_0:
+.Lasm_BitwiseOrRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_BitwiseOrRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseOrRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12828,19 +17103,42 @@ asm_handler_LeftShiftRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_left_shift_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LeftShiftRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LeftShiftRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LeftShiftRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LeftShiftRhsInt32.slow_path_transfer_0:
+.Lasm_LeftShiftRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LeftShiftRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LeftShiftRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12856,19 +17154,42 @@ asm_handler_RightShiftRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_right_shift_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_RightShiftRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_RightShiftRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_RightShiftRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_RightShiftRhsInt32.slow_path_transfer_0:
+.Lasm_RightShiftRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_RightShiftRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_RightShiftRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12893,19 +17214,42 @@ asm_handler_UnsignedRightShiftRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_unsigned_right_shift_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_UnsignedRightShiftRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_UnsignedRightShiftRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_0:
+.Lasm_UnsignedRightShiftRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12968,8 +17312,12 @@ asm_handler_ModRhsInt32_cold:
     ldr x10, [x19, x9, lsl #3]
     br x10
 .Lasm_ModRhsInt32.ssa_block_3:
-    tbnz x2, #63, .Lasm_ModRhsInt32.ssa_block_4
-    tbnz x0, #63, .Lasm_ModRhsInt32.ssa_block_4
+    tbz x2, #63, 1f
+    b .Lasm_ModRhsInt32.ssa_block_4
+1:
+    tbz x0, #63, 1f
+    b .Lasm_ModRhsInt32.ssa_block_4
+1:
     movz x0, #0x7ffa, lsl #48
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
@@ -12989,19 +17337,42 @@ asm_handler_ModRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_mod_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_ModRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_ModRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ModRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_ModRhsInt32.slow_path_transfer_0:
+.Lasm_ModRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_ModRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ModRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -13021,19 +17392,42 @@ asm_handler_LessThanRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_less_than_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LessThanRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LessThanRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LessThanRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LessThanRhsInt32.slow_path_transfer_0:
+.Lasm_LessThanRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LessThanRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LessThanRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -13061,19 +17455,42 @@ asm_handler_LessThanEqualsRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_less_than_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LessThanEqualsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LessThanEqualsRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LessThanEqualsRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LessThanEqualsRhsInt32.slow_path_transfer_0:
+.Lasm_LessThanEqualsRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LessThanEqualsRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LessThanEqualsRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -13101,19 +17518,42 @@ asm_handler_GreaterThanRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_greater_than_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GreaterThanRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_GreaterThanRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GreaterThanRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GreaterThanRhsInt32.slow_path_transfer_0:
+.Lasm_GreaterThanRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GreaterThanRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GreaterThanRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -13141,19 +17581,42 @@ asm_handler_GreaterThanEqualsRhsInt32_cold:
     ldr w1, [x21, #12]
     movk x1, #0x7ffa, lsl #48
     ldr w2, [x21, #4]
+    sub sp, sp, #16
+    str w2, [sp, #8]
     mov x3, x0
     mov x4, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_greater_than_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_GreaterThanEqualsRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GreaterThanEqualsRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_0:
+.Lasm_GreaterThanEqualsRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -13190,8 +17653,12 @@ asm_handler_JumpLessThanRhsInt32_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_less_than_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpLessThanRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpLessThanRhsInt32.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -13233,8 +17700,12 @@ asm_handler_JumpLessThanEqualsRhsInt32_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_less_than_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpLessThanEqualsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpLessThanEqualsRhsInt32.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -13276,8 +17747,12 @@ asm_handler_JumpGreaterThanRhsInt32_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_greater_than_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpGreaterThanRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpGreaterThanRhsInt32.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -13319,8 +17794,12 @@ asm_handler_JumpGreaterThanEqualsRhsInt32_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_greater_than_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpGreaterThanEqualsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpGreaterThanEqualsRhsInt32.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -13358,20 +17837,42 @@ asm_handler_StrictlyEqualsRhsInt32_cold:
     b .Lasm_StrictlyEqualsRhsInt32.ssa_block_3
 .Lasm_StrictlyEqualsRhsInt32.ssa_block_1:
     ldr w1, [x21, #4]
+    sub sp, sp, #16
+    str w1, [sp, #8]
     mov x3, x0
     mov x4, x2
-    mov x2, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_strictly_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_StrictlyEqualsRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_StrictlyEqualsRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_0:
+.Lasm_StrictlyEqualsRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -13396,20 +17897,42 @@ asm_handler_StrictlyInequalsRhsInt32_cold:
     b .Lasm_StrictlyInequalsRhsInt32.ssa_block_2
 .Lasm_StrictlyInequalsRhsInt32.ssa_block_1:
     ldr w1, [x21, #4]
+    sub sp, sp, #16
+    str w1, [sp, #8]
     mov x3, x0
     mov x4, x2
-    mov x2, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_strictly_inequals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_StrictlyInequalsRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_StrictlyInequalsRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_0:
+.Lasm_StrictlyInequalsRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -13434,20 +17957,42 @@ asm_handler_LooselyEqualsRhsInt32_cold:
     b .Lasm_LooselyEqualsRhsInt32.ssa_block_3
 .Lasm_LooselyEqualsRhsInt32.ssa_block_1:
     ldr w1, [x21, #4]
+    sub sp, sp, #16
+    str w1, [sp, #8]
     mov x3, x0
     mov x4, x2
-    mov x2, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_loosely_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LooselyEqualsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LooselyEqualsRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LooselyEqualsRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LooselyEqualsRhsInt32.slow_path_transfer_0:
+.Lasm_LooselyEqualsRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LooselyEqualsRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LooselyEqualsRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -13472,20 +18017,42 @@ asm_handler_LooselyInequalsRhsInt32_cold:
     b .Lasm_LooselyInequalsRhsInt32.ssa_block_2
 .Lasm_LooselyInequalsRhsInt32.ssa_block_1:
     ldr w1, [x21, #4]
+    sub sp, sp, #16
+    str w1, [sp, #8]
     mov x3, x0
     mov x4, x2
-    mov x2, x1
+    add x2, sp, #0
     mov x0, x20
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_loosely_inequals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_LooselyInequalsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lasm_LooselyInequalsRhsInt32.binary_result_restore_0
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LooselyInequalsRhsInt32.binary_result_restore_0
+1:
+    ldr w9, [sp, #8]
+    ldr x10, [sp]
+    str x10, [x27, x9, lsl #3]
+    add sp, sp, #16
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_LooselyInequalsRhsInt32.slow_path_transfer_0:
+.Lasm_LooselyInequalsRhsInt32.binary_result_restore_0:
+    add sp, sp, #16
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_LooselyInequalsRhsInt32.slow_path_transfer_1
+1:
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LooselyInequalsRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -13519,8 +18086,12 @@ asm_handler_JumpStrictlyEqualsRhsInt32_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_strictly_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpStrictlyEqualsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpStrictlyEqualsRhsInt32.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -13559,8 +18130,12 @@ asm_handler_JumpStrictlyInequalsRhsInt32_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_strictly_inequals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpStrictlyInequalsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpStrictlyInequalsRhsInt32.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -13599,8 +18174,12 @@ asm_handler_JumpLooselyEqualsRhsInt32_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_loosely_equals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpLooselyEqualsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpLooselyEqualsRhsInt32.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]
@@ -13639,8 +18218,12 @@ asm_handler_JumpLooselyInequalsRhsInt32_cold:
     sub w1, w21, w26
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_loosely_inequals_values)
-    tbnz x0, #63, .Lexit_veneer
-    tbz x0, #32, .Lasm_JumpLooselyInequalsRhsInt32.slow_path_transfer_0
+    tbz x0, #63, 1f
+    b .Lexit
+1:
+    tbnz x0, #32, 1f
+    b .Lasm_JumpLooselyInequalsRhsInt32.slow_path_transfer_0
+1:
     add x21, x26, w0, uxtw
     ldrb w9, [x21]
     ldr x10, [x19, x9, lsl #3]

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
@@ -1747,6 +1747,12 @@ asm_handler_Exp:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_exp_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Exp.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Exp.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -5655,6 +5661,12 @@ asm_handler_ExpRhsInt32:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_exp_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ExpRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ExpRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -6838,6 +6850,12 @@ asm_handler_Add_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_add_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Add.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Add.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -6930,6 +6948,12 @@ asm_handler_Sub_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_sub_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Sub.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Sub.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7021,6 +7045,12 @@ asm_handler_Mul_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_mul_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Mul.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Mul.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7051,6 +7081,12 @@ asm_handler_ConcatString:
     mov x2, x21
     bl CSYM(asm_slow_path_concat_string)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ConcatString.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ConcatString.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7071,6 +7107,12 @@ asm_handler_CopyObjectExcludingProperties:
     mov x2, x21
     bl CSYM(asm_slow_path_copy_object_excluding_properties)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CopyObjectExcludingProperties.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CopyObjectExcludingProperties.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7091,6 +7133,12 @@ asm_handler_ImportCall:
     mov x2, x21
     bl CSYM(asm_slow_path_import_call)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ImportCall.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ImportCall.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7111,6 +7159,12 @@ asm_handler_NewClass:
     mov x2, x21
     bl CSYM(asm_slow_path_new_class)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewClass.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewClass.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7180,6 +7234,12 @@ asm_handler_JumpLessThan_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_less_than_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpLessThan.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpLessThan.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7234,6 +7294,12 @@ asm_handler_JumpGreaterThan_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_greater_than_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpGreaterThan.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpGreaterThan.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7288,6 +7354,12 @@ asm_handler_JumpLessThanEquals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_less_than_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpLessThanEquals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpLessThanEquals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7342,6 +7414,12 @@ asm_handler_JumpGreaterThanEquals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_greater_than_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpGreaterThanEquals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpGreaterThanEquals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7376,6 +7454,12 @@ asm_handler_JumpLooselyEquals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_loosely_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpLooselyEquals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpLooselyEquals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7410,6 +7494,12 @@ asm_handler_JumpLooselyInequals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_loosely_inequals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpLooselyInequals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpLooselyInequals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7444,6 +7534,12 @@ asm_handler_JumpStrictlyEquals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_strictly_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpStrictlyEquals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpStrictlyEquals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7478,6 +7574,12 @@ asm_handler_JumpStrictlyInequals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_strictly_inequals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpStrictlyInequals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpStrictlyInequals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7510,6 +7612,12 @@ asm_handler_Increment_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_increment)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Increment.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Increment.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7542,6 +7650,12 @@ asm_handler_Decrement_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_decrement)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Decrement.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Decrement.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7571,6 +7685,12 @@ asm_handler_GetImportMeta:
     mov x2, x21
     bl CSYM(asm_slow_path_get_import_meta)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetImportMeta.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetImportMeta.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7591,6 +7711,12 @@ asm_handler_GetNewTarget:
     mov x2, x21
     bl CSYM(asm_slow_path_get_new_target)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetNewTarget.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetNewTarget.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7611,6 +7737,12 @@ asm_handler_GetSuperConstructor:
     mov x2, x21
     bl CSYM(asm_slow_path_get_super_constructor)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetSuperConstructor.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetSuperConstructor.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7634,6 +7766,12 @@ asm_handler_GetBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_get_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7652,6 +7790,12 @@ asm_handler_DynamicGetBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_get_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DynamicGetBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicGetBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7672,6 +7816,12 @@ asm_handler_DynamicGetInitializedBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_get_initialized_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DynamicGetInitializedBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicGetInitializedBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7694,6 +7844,12 @@ asm_handler_DynamicInitializeLexicalBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_initialize_lexical_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7712,6 +7868,12 @@ asm_handler_DynamicInitializeVariableBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_initialize_variable_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DynamicInitializeVariableBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicInitializeVariableBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7730,6 +7892,12 @@ asm_handler_SetLexicalBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_set_lexical_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_SetLexicalBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetLexicalBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7748,6 +7916,12 @@ asm_handler_SetVariableBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_set_variable_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_SetVariableBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetVariableBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7766,6 +7940,12 @@ asm_handler_DynamicSetLexicalBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_set_lexical_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DynamicSetLexicalBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicSetLexicalBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7784,6 +7964,12 @@ asm_handler_DynamicSetVariableBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_set_variable_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DynamicSetVariableBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicSetVariableBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7801,6 +7987,12 @@ asm_handler_ResolveBinding:
     mov x2, x21
     bl CSYM(asm_slow_path_resolve_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ResolveBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ResolveBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7821,6 +8013,12 @@ asm_handler_ResolveSuperBase:
     mov x2, x21
     bl CSYM(asm_slow_path_resolve_super_base)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ResolveSuperBase.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ResolveSuperBase.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7841,6 +8039,12 @@ asm_handler_SetResolvedBinding:
     mov x2, x21
     bl CSYM(asm_slow_path_set_resolved_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_SetResolvedBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetResolvedBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7861,6 +8065,12 @@ asm_handler_TypeofBinding:
     mov x2, x21
     bl CSYM(asm_slow_path_typeof_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_TypeofBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_TypeofBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7881,6 +8091,12 @@ asm_handler_DynamicTypeofBinding:
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_typeof_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DynamicTypeofBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicTypeofBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7901,6 +8117,12 @@ asm_handler_HasPrivateId:
     mov x2, x21
     bl CSYM(asm_slow_path_has_private_id)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_HasPrivateId.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_HasPrivateId.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7921,6 +8143,12 @@ asm_handler_SetFunctionName:
     mov x2, x21
     bl CSYM(asm_slow_path_set_function_name)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_SetFunctionName.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetFunctionName.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7941,6 +8169,12 @@ asm_handler_NewArrayWithLength:
     mov x2, x21
     bl CSYM(asm_slow_path_new_array_with_length)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewArrayWithLength.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewArrayWithLength.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7961,6 +8195,12 @@ asm_handler_ArrayAppend:
     mov x2, x21
     bl CSYM(asm_slow_path_array_append)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ArrayAppend.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ArrayAppend.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -7981,6 +8221,12 @@ asm_handler_CreateVariable:
     mov x2, x21
     bl CSYM(asm_slow_path_create_variable)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreateVariable.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateVariable.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8001,6 +8247,12 @@ asm_handler_EnterObjectEnvironment:
     mov x2, x21
     bl CSYM(asm_slow_path_enter_object_environment)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_EnterObjectEnvironment.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_EnterObjectEnvironment.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8036,6 +8288,12 @@ asm_handler_PostfixIncrement_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_postfix_increment)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_PostfixIncrement.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PostfixIncrement.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8056,6 +8314,12 @@ asm_handler_Div_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_div_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Div.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Div.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8110,6 +8374,12 @@ asm_handler_LessThan_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_less_than_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LessThan.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LessThan.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8161,6 +8431,12 @@ asm_handler_LessThanEquals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_less_than_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LessThanEquals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LessThanEquals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8212,6 +8488,12 @@ asm_handler_GreaterThan_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_greater_than_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GreaterThan.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GreaterThan.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8263,6 +8545,12 @@ asm_handler_GreaterThanEquals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_greater_than_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GreaterThanEquals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GreaterThanEquals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8314,6 +8602,12 @@ asm_handler_BitwiseXor_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_xor_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_BitwiseXor.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseXor.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8347,6 +8641,12 @@ asm_handler_UnaryPlus_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_unary_plus)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_UnaryPlus.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_UnaryPlus.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8372,6 +8672,12 @@ asm_handler_ThrowIfTDZ_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_throw_if_tdz)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ThrowIfTDZ.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ThrowIfTDZ.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8390,6 +8696,12 @@ asm_handler_ThrowIfNotObject_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_throw_if_not_object)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ThrowIfNotObject.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ThrowIfNotObject.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8408,6 +8720,12 @@ asm_handler_ThrowIfNullish_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_throw_if_nullish)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ThrowIfNullish.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ThrowIfNullish.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8425,6 +8743,12 @@ asm_handler_ThrowConstAssignment:
     mov x2, x21
     bl CSYM(asm_slow_path_throw_const_assignment)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ThrowConstAssignment.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ThrowConstAssignment.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8445,6 +8769,12 @@ asm_handler_Throw:
     mov x2, x21
     bl CSYM(asm_slow_path_throw)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Throw.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Throw.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8465,6 +8795,12 @@ asm_handler_Debugger:
     mov x2, x21
     bl CSYM(asm_slow_path_debugger)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Debugger.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Debugger.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8485,6 +8821,12 @@ asm_handler_Await:
     mov x2, x21
     bl CSYM(asm_slow_path_await)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Await.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Await.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8505,6 +8847,12 @@ asm_handler_Yield:
     mov x2, x21
     bl CSYM(asm_slow_path_yield)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Yield.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Yield.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8525,6 +8873,12 @@ asm_handler_YieldIteratorResult:
     mov x2, x21
     bl CSYM(asm_slow_path_yield_iterator_result)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_YieldIteratorResult.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_YieldIteratorResult.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8545,6 +8899,12 @@ asm_handler_ToString:
     mov x2, x21
     bl CSYM(asm_slow_path_to_string)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ToString.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToString.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8565,6 +8925,12 @@ asm_handler_ToPrimitiveWithStringHint:
     mov x2, x21
     bl CSYM(asm_slow_path_to_primitive_with_string_hint)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ToPrimitiveWithStringHint.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToPrimitiveWithStringHint.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8585,6 +8951,12 @@ asm_handler_ToObject:
     mov x2, x21
     bl CSYM(asm_slow_path_to_object)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ToObject.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToObject.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8605,6 +8977,12 @@ asm_handler_ToLength:
     mov x2, x21
     bl CSYM(asm_slow_path_to_length)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ToLength.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToLength.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8626,6 +9004,12 @@ asm_handler_BitwiseNot_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_bitwise_not)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_BitwiseNot.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseNot.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8677,6 +9061,12 @@ asm_handler_BitwiseAnd_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_and_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_BitwiseAnd.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseAnd.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8739,6 +9129,12 @@ asm_handler_BitwiseOr_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_or_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_BitwiseOr.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseOr.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8770,6 +9166,12 @@ asm_handler_LeftShift_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_left_shift_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LeftShift.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LeftShift.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8790,6 +9192,12 @@ asm_handler_RightShift_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_right_shift_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_RightShift.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_RightShift.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8819,6 +9227,12 @@ asm_handler_UnsignedRightShift_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_unsigned_right_shift_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_UnsignedRightShift.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_UnsignedRightShift.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8928,6 +9342,12 @@ asm_handler_Mod_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_mod_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Mod.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Mod.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8959,6 +9379,12 @@ asm_handler_StrictlyEquals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_strictly_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_StrictlyEquals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_StrictlyEquals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -8990,6 +9416,12 @@ asm_handler_StrictlyInequals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_strictly_inequals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_StrictlyInequals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_StrictlyInequals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9008,6 +9440,12 @@ asm_handler_GetCalleeAndThisFromEnvironment_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_get_callee_and_this)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9026,6 +9464,12 @@ asm_handler_DynamicGetCalleeAndThisFromEnvironment_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_dynamic_get_callee_and_this)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9058,6 +9502,12 @@ asm_handler_LooselyEquals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_loosely_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LooselyEquals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LooselyEquals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9090,6 +9540,12 @@ asm_handler_LooselyInequals_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_loosely_inequals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LooselyInequals.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LooselyInequals.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9131,6 +9587,12 @@ asm_handler_UnaryMinus_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_unary_minus)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_UnaryMinus.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_UnaryMinus.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9171,6 +9633,12 @@ asm_handler_PostfixDecrement_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_postfix_decrement)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_PostfixDecrement.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PostfixDecrement.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9204,6 +9672,12 @@ asm_handler_ToInt32_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_to_int32)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ToInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ToInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9263,6 +9737,12 @@ asm_handler_PutByValue_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_value)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_PutByValue.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutByValue.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9399,6 +9879,12 @@ asm_handler_GetById_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_id_cached_accessor)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetById.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetById.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9476,6 +9962,12 @@ asm_handler_GetById_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_id)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetById.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetById.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9495,6 +9987,12 @@ asm_handler_GetByIdWithThis:
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_id_with_this)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetByIdWithThis.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetByIdWithThis.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9526,6 +10024,12 @@ asm_handler_PutById_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_id)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_PutById.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutById.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9543,6 +10047,12 @@ asm_handler_PutByIdWithThis:
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_id_with_this)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_PutByIdWithThis.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutByIdWithThis.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9583,6 +10093,12 @@ asm_handler_GetByValue_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_value)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetByValue.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetByValue.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9603,6 +10119,12 @@ asm_handler_GetByValueWithThis:
     mov x2, x21
     bl CSYM(asm_slow_path_get_by_value_with_this)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetByValueWithThis.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetByValueWithThis.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9623,6 +10145,12 @@ asm_handler_PutByValueWithThis:
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_value_with_this)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_PutByValueWithThis.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutByValueWithThis.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9643,6 +10171,12 @@ asm_handler_PutBySpread:
     mov x2, x21
     bl CSYM(asm_slow_path_put_by_spread)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_PutBySpread.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutBySpread.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9673,6 +10207,12 @@ asm_handler_GetLength_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_get_length)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetLength.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetLength.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9690,6 +10230,12 @@ asm_handler_GetLengthWithThis:
     mov x2, x21
     bl CSYM(asm_slow_path_get_length_with_this)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetLengthWithThis.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetLengthWithThis.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9710,6 +10256,12 @@ asm_handler_GetMethod:
     mov x2, x21
     bl CSYM(asm_slow_path_get_method)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetMethod.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetMethod.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9730,6 +10282,12 @@ asm_handler_GetIterator:
     mov x2, x21
     bl CSYM(asm_slow_path_get_iterator)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetIterator.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetIterator.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9751,6 +10309,12 @@ asm_handler_GetGlobal_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_get_global)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetGlobal.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetGlobal.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9789,6 +10353,12 @@ asm_handler_SetGlobal_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_set_global)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_SetGlobal.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetGlobal.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9820,6 +10390,12 @@ asm_handler_Call_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_call)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Call.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Call.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9851,6 +10427,12 @@ asm_handler_CallBuiltinMathAbs_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_abs)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathAbs.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathAbs.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9869,6 +10451,12 @@ asm_handler_CallBuiltinMathFloor_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_floor)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathFloor.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathFloor.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9890,6 +10478,12 @@ asm_handler_CallBuiltinMathCeil_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_ceil)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathCeil.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathCeil.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9911,6 +10505,12 @@ asm_handler_CallBuiltinMathSqrt_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_sqrt)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathSqrt.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathSqrt.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9932,6 +10532,12 @@ asm_handler_CallBuiltinMathExp_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_exp)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathExp.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathExp.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9949,6 +10555,12 @@ asm_handler_CallBuiltinMathLog:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_log)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathLog.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathLog.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9969,6 +10581,12 @@ asm_handler_CallBuiltinMathPow:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_pow)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathPow.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathPow.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -9989,6 +10607,12 @@ asm_handler_CallBuiltinMathImul:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_imul)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathImul.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathImul.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10009,6 +10633,12 @@ asm_handler_CallBuiltinMathRandom:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_random)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathRandom.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathRandom.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10029,6 +10659,12 @@ asm_handler_CallBuiltinMathRound:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_round)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathRound.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathRound.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10049,6 +10685,12 @@ asm_handler_CallBuiltinMathSin:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_sin)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathSin.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathSin.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10069,6 +10711,12 @@ asm_handler_CallBuiltinMathCos:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_cos)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathCos.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathCos.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10089,6 +10737,12 @@ asm_handler_CallBuiltinMathTan:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_math_tan)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMathTan.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMathTan.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10109,6 +10763,12 @@ asm_handler_CallBuiltinRegExpPrototypeExec:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_regexp_prototype_exec)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10129,6 +10789,12 @@ asm_handler_CallBuiltinRegExpPrototypeReplace:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_regexp_prototype_replace)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10149,6 +10815,12 @@ asm_handler_CallBuiltinRegExpPrototypeSplit:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_regexp_prototype_split)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10169,6 +10841,12 @@ asm_handler_CallBuiltinOrdinaryHasInstance:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_ordinary_has_instance)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10189,6 +10867,12 @@ asm_handler_CallBuiltinArrayIteratorPrototypeNext:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_array_iterator_prototype_next)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10209,6 +10893,12 @@ asm_handler_CallBuiltinMapIteratorPrototypeNext:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_map_iterator_prototype_next)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10229,6 +10919,12 @@ asm_handler_CallBuiltinSetIteratorPrototypeNext:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_set_iterator_prototype_next)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10249,6 +10945,12 @@ asm_handler_CallBuiltinStringIteratorPrototypeNext:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_string_iterator_prototype_next)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10270,6 +10972,12 @@ asm_handler_CallBuiltinStringFromCharCode_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_string_from_char_code)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10296,6 +11004,12 @@ asm_handler_CallBuiltinStringPrototypeCharCodeAt_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_string_prototype_char_code_at)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10323,6 +11037,12 @@ asm_handler_CallBuiltinStringPrototypeCharAt_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_call_builtin_string_prototype_char_at)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10340,6 +11060,12 @@ asm_handler_GetObjectPropertyIterator:
     mov x2, x21
     bl CSYM(asm_slow_path_get_object_property_iterator)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetObjectPropertyIterator.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetObjectPropertyIterator.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10361,6 +11087,12 @@ asm_handler_ObjectPropertyIteratorNext_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_object_property_iterator_next)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ObjectPropertyIteratorNext.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ObjectPropertyIteratorNext.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10378,6 +11110,12 @@ asm_handler_IteratorClose:
     mov x2, x21
     bl CSYM(asm_slow_path_iterator_close)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_IteratorClose.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IteratorClose.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10398,6 +11136,12 @@ asm_handler_IteratorNext:
     mov x2, x21
     bl CSYM(asm_slow_path_iterator_next)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_IteratorNext.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IteratorNext.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10418,6 +11162,12 @@ asm_handler_IteratorNextUnpack:
     mov x2, x21
     bl CSYM(asm_slow_path_iterator_next_unpack)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_IteratorNextUnpack.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IteratorNextUnpack.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10438,6 +11188,12 @@ asm_handler_IteratorToArray:
     mov x2, x21
     bl CSYM(asm_slow_path_iterator_to_array)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_IteratorToArray.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IteratorToArray.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10458,6 +11214,12 @@ asm_handler_CallConstruct:
     mov x2, x21
     bl CSYM(asm_slow_path_call_construct)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallConstruct.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallConstruct.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10478,6 +11240,12 @@ asm_handler_CallDirectEval:
     mov x2, x21
     bl CSYM(asm_slow_path_call_direct_eval)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallDirectEval.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallDirectEval.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10498,6 +11266,12 @@ asm_handler_CallWithArgumentArray:
     mov x2, x21
     bl CSYM(asm_slow_path_call_with_argument_array)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallWithArgumentArray.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallWithArgumentArray.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10518,6 +11292,12 @@ asm_handler_CallDirectEvalWithArgumentArray:
     mov x2, x21
     bl CSYM(asm_slow_path_call_direct_eval_with_argument_array)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10538,6 +11318,12 @@ asm_handler_CallConstructWithArgumentArray:
     mov x2, x21
     bl CSYM(asm_slow_path_call_construct_with_argument_array)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CallConstructWithArgumentArray.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CallConstructWithArgumentArray.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10558,6 +11344,12 @@ asm_handler_SuperCallWithArgumentArray:
     mov x2, x21
     bl CSYM(asm_slow_path_super_call_with_argument_array)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_SuperCallWithArgumentArray.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SuperCallWithArgumentArray.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10578,6 +11370,12 @@ asm_handler_NewObject:
     mov x2, x21
     bl CSYM(asm_slow_path_new_object)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewObject.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewObject.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10598,6 +11396,12 @@ asm_handler_NewObjectWithNoPrototype:
     mov x2, x21
     bl CSYM(asm_slow_path_new_object_with_no_prototype)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewObjectWithNoPrototype.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewObjectWithNoPrototype.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10618,6 +11422,12 @@ asm_handler_CacheObjectShape:
     mov x2, x21
     bl CSYM(asm_slow_path_cache_object_shape)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CacheObjectShape.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CacheObjectShape.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10638,6 +11448,12 @@ asm_handler_InitObjectLiteralProperty:
     mov x2, x21
     bl CSYM(asm_slow_path_init_object_literal_property)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_InitObjectLiteralProperty.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_InitObjectLiteralProperty.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10658,6 +11474,12 @@ asm_handler_NewArray:
     mov x2, x21
     bl CSYM(asm_slow_path_new_array)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewArray.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewArray.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10678,6 +11500,12 @@ asm_handler_NewPrimitiveArray:
     mov x2, x21
     bl CSYM(asm_slow_path_new_primitive_array)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewPrimitiveArray.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewPrimitiveArray.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10698,6 +11526,12 @@ asm_handler_NewRegExp:
     mov x2, x21
     bl CSYM(asm_slow_path_new_regexp)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewRegExp.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewRegExp.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10718,6 +11552,12 @@ asm_handler_NewReferenceError:
     mov x2, x21
     bl CSYM(asm_slow_path_new_reference_error)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewReferenceError.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewReferenceError.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10738,6 +11578,12 @@ asm_handler_NewTypeError:
     mov x2, x21
     bl CSYM(asm_slow_path_new_type_error)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewTypeError.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewTypeError.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10758,6 +11604,12 @@ asm_handler_InstanceOf:
     mov x2, x21
     bl CSYM(asm_slow_path_instance_of)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_InstanceOf.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_InstanceOf.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10778,6 +11630,12 @@ asm_handler_In:
     mov x2, x21
     bl CSYM(asm_slow_path_in)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_In.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_In.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10800,6 +11658,12 @@ asm_handler_IsConstructor:
     mov x2, x21
     bl CSYM(asm_slow_path_is_constructor)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_IsConstructor.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_IsConstructor.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10820,6 +11684,12 @@ asm_handler_AddPrivateName:
     mov x2, x21
     bl CSYM(asm_slow_path_add_private_name)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_AddPrivateName.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_AddPrivateName.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10840,6 +11710,12 @@ asm_handler_CreateAsyncFromSyncIterator:
     mov x2, x21
     bl CSYM(asm_slow_path_create_async_from_sync_iterator)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10860,6 +11736,12 @@ asm_handler_CreateDataPropertyOrThrow:
     mov x2, x21
     bl CSYM(asm_slow_path_create_data_property_or_throw)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreateDataPropertyOrThrow.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateDataPropertyOrThrow.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10880,6 +11762,12 @@ asm_handler_CreateImmutableBinding:
     mov x2, x21
     bl CSYM(asm_slow_path_create_immutable_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreateImmutableBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateImmutableBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10900,6 +11788,12 @@ asm_handler_CreateMutableBinding:
     mov x2, x21
     bl CSYM(asm_slow_path_create_mutable_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreateMutableBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateMutableBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10920,6 +11814,12 @@ asm_handler_CreateRestParams:
     mov x2, x21
     bl CSYM(asm_slow_path_create_rest_params)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreateRestParams.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateRestParams.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10940,6 +11840,12 @@ asm_handler_CreateArguments:
     mov x2, x21
     bl CSYM(asm_slow_path_create_arguments)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreateArguments.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateArguments.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10960,6 +11866,12 @@ asm_handler_CreateLexicalEnvironment:
     mov x2, x21
     bl CSYM(asm_slow_path_create_lexical_environment)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreateLexicalEnvironment.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateLexicalEnvironment.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -10980,6 +11892,12 @@ asm_handler_CreatePrivateEnvironment:
     mov x2, x21
     bl CSYM(asm_slow_path_create_private_environment)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreatePrivateEnvironment.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreatePrivateEnvironment.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11000,6 +11918,12 @@ asm_handler_CreateVariableEnvironment:
     mov x2, x21
     bl CSYM(asm_slow_path_create_variable_environment)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_CreateVariableEnvironment.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_CreateVariableEnvironment.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11020,6 +11944,12 @@ asm_handler_DeleteById:
     mov x2, x21
     bl CSYM(asm_slow_path_delete_by_id)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DeleteById.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DeleteById.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11040,6 +11970,12 @@ asm_handler_DeleteByValue:
     mov x2, x21
     bl CSYM(asm_slow_path_delete_by_value)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DeleteByValue.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DeleteByValue.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11060,6 +11996,12 @@ asm_handler_DeleteVariable:
     mov x2, x21
     bl CSYM(asm_slow_path_delete_variable)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DeleteVariable.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DeleteVariable.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11080,6 +12022,12 @@ asm_handler_GetCompletionFields:
     mov x2, x21
     bl CSYM(asm_slow_path_get_completion_fields)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetCompletionFields.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetCompletionFields.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11100,6 +12048,12 @@ asm_handler_SetCompletionType:
     mov x2, x21
     bl CSYM(asm_slow_path_set_completion_type)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_SetCompletionType.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SetCompletionType.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11120,6 +12074,12 @@ asm_handler_GetTemplateObject:
     mov x2, x21
     bl CSYM(asm_slow_path_get_template_object)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetTemplateObject.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetTemplateObject.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11140,6 +12100,12 @@ asm_handler_NewFunction:
     mov x2, x21
     bl CSYM(asm_slow_path_new_function)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_NewFunction.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_NewFunction.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11160,6 +12126,12 @@ asm_handler_Typeof:
     mov x2, x21
     bl CSYM(asm_slow_path_typeof)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_Typeof.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_Typeof.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11183,6 +12155,12 @@ asm_handler_ResolveThisBinding_cold:
     mov x2, x21
     bl CSYM(asm_slow_path_resolve_this_binding)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ResolveThisBinding.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ResolveThisBinding.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11200,6 +12178,12 @@ asm_handler_GetPrivateById:
     mov x2, x21
     bl CSYM(asm_slow_path_get_private_by_id)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GetPrivateById.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetPrivateById.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11220,6 +12204,12 @@ asm_handler_PutPrivateById:
     mov x2, x21
     bl CSYM(asm_slow_path_put_private_by_id)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_PutPrivateById.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_PutPrivateById.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11259,6 +12249,12 @@ asm_handler_AddLhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_add_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_AddLhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_AddLhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11289,8 +12285,8 @@ asm_handler_AddLhsInt32_cold:
 .Lasm_AddLhsInt32.ssa_box_number_6_not_integer:
     fmov x0, d0
     fcmp d0, d0
-    b.vs .Lasm_AddLhsInt32.canon_nan_0
-.Lasm_AddLhsInt32.canon_nan_0_ret:
+    b.vs .Lasm_AddLhsInt32.canon_nan_1
+.Lasm_AddLhsInt32.canon_nan_1_ret:
 .Lasm_AddLhsInt32.ssa_box_number_6_done:
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
@@ -11311,9 +12307,9 @@ asm_handler_AddLhsInt32_cold:
     add x21, x21, #16
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_AddLhsInt32.canon_nan_0:
+.Lasm_AddLhsInt32.canon_nan_1:
     fmov x0, d8
-    b .Lasm_AddLhsInt32.canon_nan_0_ret
+    b .Lasm_AddLhsInt32.canon_nan_1_ret
 asm_handler_AddLhsInt32_cold_end:
 asm_handler_AddRhsInt32_cold:
 // Cold paths for AddRhsInt32
@@ -11378,6 +12374,12 @@ asm_handler_AddRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_add_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_AddRhsInt32.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_AddRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11453,6 +12455,12 @@ asm_handler_SubRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_sub_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_SubRhsInt32.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_SubRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11482,6 +12490,12 @@ asm_handler_MulRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_mul_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_MulRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_MulRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11512,8 +12526,8 @@ asm_handler_MulRhsInt32_cold:
 .Lasm_MulRhsInt32.ssa_box_number_8_not_integer:
     fmov x0, d0
     fcmp d0, d0
-    b.vs .Lasm_MulRhsInt32.canon_nan_0
-.Lasm_MulRhsInt32.canon_nan_0_ret:
+    b.vs .Lasm_MulRhsInt32.canon_nan_1
+.Lasm_MulRhsInt32.canon_nan_1_ret:
 .Lasm_MulRhsInt32.ssa_box_number_8_done:
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
@@ -11542,9 +12556,9 @@ asm_handler_MulRhsInt32_cold:
     add x21, x21, #16
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_MulRhsInt32.canon_nan_0:
+.Lasm_MulRhsInt32.canon_nan_1:
     fmov x0, d8
-    b .Lasm_MulRhsInt32.canon_nan_0_ret
+    b .Lasm_MulRhsInt32.canon_nan_1_ret
 asm_handler_MulRhsInt32_cold_end:
 asm_handler_ExpRhsInt32_cold:
 asm_handler_ExpRhsInt32_cold_end:
@@ -11561,6 +12575,12 @@ asm_handler_DivRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_div_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_DivRhsInt32.slow_path_transfer_1
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_DivRhsInt32.slow_path_transfer_1:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11618,6 +12638,12 @@ asm_handler_BitwiseXorRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_xor_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_BitwiseXorRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseXorRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11683,6 +12709,12 @@ asm_handler_BitwiseAndRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_and_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_BitwiseAndRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseAndRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11748,6 +12780,12 @@ asm_handler_BitwiseOrRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_bitwise_or_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_BitwiseOrRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_BitwiseOrRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11781,6 +12819,12 @@ asm_handler_LeftShiftRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_left_shift_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LeftShiftRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LeftShiftRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11803,6 +12847,12 @@ asm_handler_RightShiftRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_right_shift_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_RightShiftRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_RightShiftRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11834,6 +12884,12 @@ asm_handler_UnsignedRightShiftRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_unsigned_right_shift_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11924,6 +12980,12 @@ asm_handler_ModRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_mod_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_ModRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_ModRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11950,6 +13012,12 @@ asm_handler_LessThanRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_less_than_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LessThanRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LessThanRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -11984,6 +13052,12 @@ asm_handler_LessThanEqualsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_less_than_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LessThanEqualsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LessThanEqualsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12018,6 +13092,12 @@ asm_handler_GreaterThanRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_greater_than_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GreaterThanRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GreaterThanRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12052,6 +13132,12 @@ asm_handler_GreaterThanEqualsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_greater_than_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12089,6 +13175,12 @@ asm_handler_JumpLessThanRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_less_than_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpLessThanRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpLessThanRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12126,6 +13218,12 @@ asm_handler_JumpLessThanEqualsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_less_than_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpLessThanEqualsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpLessThanEqualsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12163,6 +13261,12 @@ asm_handler_JumpGreaterThanRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_greater_than_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpGreaterThanRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpGreaterThanRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12200,6 +13304,12 @@ asm_handler_JumpGreaterThanEqualsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_greater_than_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpGreaterThanEqualsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpGreaterThanEqualsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12240,6 +13350,12 @@ asm_handler_StrictlyEqualsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_strictly_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12272,6 +13388,12 @@ asm_handler_StrictlyInequalsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_strictly_inequals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12304,6 +13426,12 @@ asm_handler_LooselyEqualsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_loosely_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LooselyEqualsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LooselyEqualsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12336,6 +13464,12 @@ asm_handler_LooselyInequalsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_loosely_inequals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_LooselyInequalsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_LooselyInequalsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12370,6 +13504,12 @@ asm_handler_JumpStrictlyEqualsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_strictly_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpStrictlyEqualsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpStrictlyEqualsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12404,6 +13544,12 @@ asm_handler_JumpStrictlyInequalsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_strictly_inequals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpStrictlyInequalsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpStrictlyInequalsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12438,6 +13584,12 @@ asm_handler_JumpLooselyEqualsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_loosely_equals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpLooselyEqualsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpLooselyEqualsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]
@@ -12472,6 +13624,12 @@ asm_handler_JumpLooselyInequalsRhsInt32_cold:
     str w1, [x28, #64]
     bl CSYM(asm_slow_path_jump_loosely_inequals_values)
     tbnz x0, #63, .Lexit_veneer
+    tbz x0, #32, .Lasm_JumpLooselyInequalsRhsInt32.slow_path_transfer_0
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_JumpLooselyInequalsRhsInt32.slow_path_transfer_0:
     ldr x28, [x20, #15288]
     ldr x9, [x28, #88]
     ldr x26, [x9, #80]

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
@@ -4248,137 +4248,6 @@ asm_handler_GetById:
     add x21, x21, #24
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetById.ssa_block_13:
-    ldrb w9, [x0, #12]
-    cbz w9, .Lasm_GetById.ssa_block_3
-    ldr w0, [x1, #108]
-    ldr x0, [x2, x0, lsl #3]
-    cbz x0, .Lasm_GetById.ssa_block_3
-    ldr w3, [x1, #116]
-    ldr x5, [x0, x3, lsl #3]
-    cbz x5, .Lasm_GetById.ssa_block_3
-    ldr w4, [x1, #120]
-    ldr x5, [x5, x4, lsl #3]
-    cmp x5, x2
-    b.ne .Lasm_GetById.ssa_block_3
-    ldr w1, [x1, #112]
-    ldr x0, [x0, x1, lsl #3]
-    cbnz x0, .Lasm_GetById.ssa_block_25
-    movz x0, #0x7fff, lsl #48
-    b .Lasm_GetById.ssa_block_26
-.Lasm_GetById.ssa_block_25:
-    ldr x0, [x0, x3, lsl #3]
-    cbz x0, .Lasm_GetById.ssa_block_3
-    ldr x0, [x0, x4, lsl #3]
-    cbz x0, .Lasm_GetById.ssa_block_3
-    ldrh w1, [x0, #10]
-    tbnz x1, #11, .Lasm_GetById.ssa_block_3
-    and x0, x0, #0x3ffffffffff
-    movz x1, #0xfff9, lsl #48
-    orr x0, x0, x1
-.Lasm_GetById.ssa_block_26:
-    ldr w9, [x21, #4]
-    str x0, [x27, x9, lsl #3]
-    ldrb w9, [x21, #24]
-    add x21, x21, #24
-    ldr x10, [x19, x9, lsl #3]
-    br x10
-.Lasm_GetById.ssa_block_14:
-    ldr w3, [x1, #104]
-    mov x0, x20
-    ldr x0, [x0, #16704]
-    lsl x3, x3, #4
-    adds x3, x3, x0
-    ldr w4, [x3, #8]
-    mov x0, x20
-    ldr x6, [x0, #15376]
-    ldr x0, [x0, #15368]
-    add x5, x0, #128
-    cmp x5, x6
-    b.hi .Lasm_GetById.ssa_block_3
-    mov x6, x20
-    ldr x7, [x6, #15336]
-    mov x6, x7
-    add x6, x6, #8, lsl #12
-    cmp x6, x29
-    b.hi .Lasm_GetById.ssa_block_3
-    mov x6, x20
-    str x5, [x6, #15368]
-    stp w4, w4, [x0, #116]
-    str wzr, [x0, #104]
-    ldr x4, [x1, #24]
-    ldr x4, [x4, #16]
-    stp x1, x4, [x0, #0]
-    ldp x1, x4, [x28, #32]
-    stp x1, x4, [x0, #32]
-    ldr x1, [x28, #48]
-    str x1, [x0, #48]
-    and x2, x2, #0x3ffffffffff
-    movz x1, #0xfff9, lsl #48
-    orr x2, x2, x1
-    str x2, [x0, #80]
-    mov x1, #0
-    add x2, x0, #16
-    stp x1, x1, [x2, #0]
-    str xzr, [x0, #88]
-    str wzr, [x0, #64]
-    str wzr, [x0, #68]
-    movn w9, #0
-    str w9, [x0, #72]
-    strb wzr, [x0, #76]
-    strb wzr, [x0, #77]
-    strb wzr, [x0, #78]
-    sub w1, w21, w26
-    ldp w2, w4, [x21, #4]
-    str w1, [x28, #64]
-    str x28, [x0, #96]
-    add x1, x1, #1
-    stp w1, w2, [x0, #108]
-    mov x1, x20
-    str x0, [x1, #15288]
-    mov x28, x0
-    add x27, x28, #128
-    ldr x2, [x3]
-    mov x9, x2
-    mov x0, x20
-    blr x9
-    and x1, x1, #0xff
-    cbnz x1, .Lasm_GetById.ssa_block_6
-    ldr x1, [x28, #96]
-    mov x2, x20
-    str x1, [x2, #15288]
-    str x28, [x2, #15368]
-    mov x28, x1
-    add x27, x28, #128
-    ldr w9, [x21, #4]
-    str x0, [x27, x9, lsl #3]
-    ldrb w9, [x21, #24]
-    add x21, x21, #24
-    ldr x10, [x19, x9, lsl #3]
-    br x10
-.Lasm_GetById.ssa_block_4:
-    mov x0, x20
-    sub w1, w21, w26
-    str w1, [x28, #64]
-    mov x2, x21
-    bl CSYM(asm_slow_path_get_by_id_cached_accessor)
-    tbnz x0, #63, .Lexit_veneer
-    ldr x28, [x20, #15288]
-    ldr x9, [x28, #88]
-    ldr x26, [x9, #80]
-    add x27, x28, #128
-    add x21, x26, w0, uxtw
-    ldrb w9, [x21]
-    ldr x10, [x19, x9, lsl #3]
-    br x10
-.Lasm_GetById.ssa_block_5:
-    ldr w9, [x21, #4]
-    movz x10, #0x7ffe, lsl #48
-    str x10, [x27, x9, lsl #3]
-    ldrb w9, [x21, #24]
-    add x21, x21, #24
-    ldr x10, [x19, x9, lsl #3]
-    br x10
 asm_handler_GetById_hot_end:
 
 .p2align 4
@@ -9420,6 +9289,137 @@ asm_handler_PutByValue_cold:
 asm_handler_PutByValue_cold_end:
 asm_handler_GetById_cold:
 // Cold paths for GetById
+.Lasm_GetById.ssa_block_13:
+    ldrb w9, [x0, #12]
+    cbz w9, .Lasm_GetById.ssa_block_3
+    ldr w0, [x1, #108]
+    ldr x0, [x2, x0, lsl #3]
+    cbz x0, .Lasm_GetById.ssa_block_3
+    ldr w3, [x1, #116]
+    ldr x5, [x0, x3, lsl #3]
+    cbz x5, .Lasm_GetById.ssa_block_3
+    ldr w4, [x1, #120]
+    ldr x5, [x5, x4, lsl #3]
+    cmp x5, x2
+    b.ne .Lasm_GetById.ssa_block_3
+    ldr w1, [x1, #112]
+    ldr x0, [x0, x1, lsl #3]
+    cbnz x0, .Lasm_GetById.ssa_block_25
+    movz x0, #0x7fff, lsl #48
+    b .Lasm_GetById.ssa_block_26
+.Lasm_GetById.ssa_block_25:
+    ldr x0, [x0, x3, lsl #3]
+    cbz x0, .Lasm_GetById.ssa_block_3
+    ldr x0, [x0, x4, lsl #3]
+    cbz x0, .Lasm_GetById.ssa_block_3
+    ldrh w1, [x0, #10]
+    tbnz x1, #11, .Lasm_GetById.ssa_block_3
+    and x0, x0, #0x3ffffffffff
+    movz x1, #0xfff9, lsl #48
+    orr x0, x0, x1
+.Lasm_GetById.ssa_block_26:
+    ldr w9, [x21, #4]
+    str x0, [x27, x9, lsl #3]
+    ldrb w9, [x21, #24]
+    add x21, x21, #24
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetById.ssa_block_14:
+    ldr w3, [x1, #104]
+    mov x0, x20
+    ldr x0, [x0, #16704]
+    lsl x3, x3, #4
+    adds x3, x3, x0
+    ldr w4, [x3, #8]
+    mov x0, x20
+    ldr x6, [x0, #15376]
+    ldr x0, [x0, #15368]
+    add x5, x0, #128
+    cmp x5, x6
+    b.hi .Lasm_GetById.ssa_block_3
+    mov x6, x20
+    ldr x7, [x6, #15336]
+    mov x6, x7
+    add x6, x6, #8, lsl #12
+    cmp x6, x29
+    b.hi .Lasm_GetById.ssa_block_3
+    mov x6, x20
+    str x5, [x6, #15368]
+    stp w4, w4, [x0, #116]
+    str wzr, [x0, #104]
+    ldr x4, [x1, #24]
+    ldr x4, [x4, #16]
+    stp x1, x4, [x0, #0]
+    ldp x1, x4, [x28, #32]
+    stp x1, x4, [x0, #32]
+    ldr x1, [x28, #48]
+    str x1, [x0, #48]
+    and x2, x2, #0x3ffffffffff
+    movz x1, #0xfff9, lsl #48
+    orr x2, x2, x1
+    str x2, [x0, #80]
+    mov x1, #0
+    add x2, x0, #16
+    stp x1, x1, [x2, #0]
+    str xzr, [x0, #88]
+    str wzr, [x0, #64]
+    str wzr, [x0, #68]
+    movn w9, #0
+    str w9, [x0, #72]
+    strb wzr, [x0, #76]
+    strb wzr, [x0, #77]
+    strb wzr, [x0, #78]
+    sub w1, w21, w26
+    ldp w2, w4, [x21, #4]
+    str w1, [x28, #64]
+    str x28, [x0, #96]
+    add x1, x1, #1
+    stp w1, w2, [x0, #108]
+    mov x1, x20
+    str x0, [x1, #15288]
+    mov x28, x0
+    add x27, x28, #128
+    ldr x2, [x3]
+    mov x9, x2
+    mov x0, x20
+    blr x9
+    and x1, x1, #0xff
+    cbnz x1, .Lasm_GetById.ssa_block_6
+    ldr x1, [x28, #96]
+    mov x2, x20
+    str x1, [x2, #15288]
+    str x28, [x2, #15368]
+    mov x28, x1
+    add x27, x28, #128
+    ldr w9, [x21, #4]
+    str x0, [x27, x9, lsl #3]
+    ldrb w9, [x21, #24]
+    add x21, x21, #24
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetById.ssa_block_4:
+    mov x0, x20
+    sub w1, w21, w26
+    str w1, [x28, #64]
+    mov x2, x21
+    bl CSYM(asm_slow_path_get_by_id_cached_accessor)
+    tbnz x0, #63, .Lexit_veneer
+    ldr x28, [x20, #15288]
+    ldr x9, [x28, #88]
+    ldr x26, [x9, #80]
+    add x27, x28, #128
+    add x21, x26, w0, uxtw
+    ldrb w9, [x21]
+    ldr x10, [x19, x9, lsl #3]
+    br x10
+.Lasm_GetById.ssa_block_5:
+    ldr w9, [x21, #4]
+    movz x10, #0x7ffe, lsl #48
+    str x10, [x27, x9, lsl #3]
+    ldrb w9, [x21, #24]
+    add x21, x21, #24
+    ldr x10, [x19, x9, lsl #3]
+    br x10
 .Lasm_GetById.ssa_block_8:
     and x1, x1, #0x3ffffffffff
     add x1, x1, x24

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
@@ -2486,6 +2486,14 @@ asm_handler_Return:
 .Lasm_Return.ssa_block_3:
     ldr x0, [x28, #96]
     cbz x0, .Lasm_Return.ssa_block_1
+    ldrb w9, [x28, #78]
+    cbz w9, .Lasm_Return.ssa_block_7
+    lsr x9, x1, #48
+    mov w10, #65529
+    cmp x9, x10
+    b.eq .Lasm_Return.ssa_block_7
+    ldr x1, [x28, #80]
+.Lasm_Return.ssa_block_7:
     ldp w2, w3, [x28, #108]
     str w2, [x0, #64]
     add x9, x0, #128
@@ -2518,6 +2526,14 @@ asm_handler_End:
     ldr x1, [x27, x0, lsl #3]
     ldr x0, [x28, #96]
     cbz x0, .Lasm_End.ssa_block_1
+    ldrb w9, [x28, #78]
+    cbz w9, .Lasm_End.ssa_block_5
+    lsr x9, x1, #48
+    mov w10, #65529
+    cmp x9, x10
+    b.eq .Lasm_End.ssa_block_5
+    ldr x1, [x28, #80]
+.Lasm_End.ssa_block_5:
     ldp w2, w3, [x28, #108]
     str w2, [x0, #64]
     add x9, x0, #128

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
@@ -4217,21 +4217,16 @@ asm_handler_GetById:
     ldr x0, [x0, x3, lsl #3]
     cbz x0, .Lasm_GetById.ssa_block_1
     and x0, x0, #0xfffffffffffffffc
-    ldp x4, x3, [x0, #24]
-    cmp x4, x1
+    ldr x9, [x0, #24]
+    cmp x9, x1
     b.ne .Lasm_GetById.ssa_block_1
-    ldr w4, [x0]
-    cmp w4, #6
+    ldr w3, [x0]
+    cmp w3, #6
     b.eq .Lasm_GetById.ssa_block_1
+    ldr x3, [x0, #32]
     cbnz x3, .Lasm_GetById.ssa_block_10
     mov x3, x2
-    b .Lasm_GetById.ssa_block_11
-.Lasm_GetById.ssa_block_10:
-    ldr x4, [x0, #40]
-    cbz x4, .Lasm_GetById.ssa_block_1
-    ldrb w9, [x4, #10]
-    cbz w9, .Lasm_GetById.ssa_block_1
-.Lasm_GetById.ssa_block_11:
+.Lasm_GetById.ssa_block_8:
     ldp w4, w5, [x0, #4]
     ldr w9, [x1, #92]
     cmp w9, w5
@@ -4241,7 +4236,7 @@ asm_handler_GetById:
     lsr x9, x1, #48
     mov w10, #65532
     cmp x9, x10
-    b.eq .Lasm_GetById.ssa_block_8
+    b.eq .Lasm_GetById.ssa_block_9
     ldr w9, [x21, #4]
     str x1, [x27, x9, lsl #3]
     ldrb w9, [x21, #24]
@@ -9304,10 +9299,10 @@ asm_handler_GetById_cold:
     b.ne .Lasm_GetById.ssa_block_3
     ldr w1, [x1, #112]
     ldr x0, [x0, x1, lsl #3]
-    cbnz x0, .Lasm_GetById.ssa_block_25
+    cbnz x0, .Lasm_GetById.ssa_block_26
     movz x0, #0x7fff, lsl #48
-    b .Lasm_GetById.ssa_block_26
-.Lasm_GetById.ssa_block_25:
+    b .Lasm_GetById.ssa_block_27
+.Lasm_GetById.ssa_block_26:
     ldr x0, [x0, x3, lsl #3]
     cbz x0, .Lasm_GetById.ssa_block_3
     ldr x0, [x0, x4, lsl #3]
@@ -9317,7 +9312,7 @@ asm_handler_GetById_cold:
     and x0, x0, #0x3ffffffffff
     movz x1, #0xfff9, lsl #48
     orr x0, x0, x1
-.Lasm_GetById.ssa_block_26:
+.Lasm_GetById.ssa_block_27:
     ldr w9, [x21, #4]
     str x0, [x27, x9, lsl #3]
     ldrb w9, [x21, #24]
@@ -9420,7 +9415,13 @@ asm_handler_GetById_cold:
     add x21, x21, #24
     ldr x10, [x19, x9, lsl #3]
     br x10
-.Lasm_GetById.ssa_block_8:
+.Lasm_GetById.ssa_block_10:
+    ldr x4, [x0, #40]
+    cbz x4, .Lasm_GetById.ssa_block_1
+    ldrb w9, [x4, #10]
+    cbz w9, .Lasm_GetById.ssa_block_1
+    b .Lasm_GetById.ssa_block_8
+.Lasm_GetById.ssa_block_9:
     and x1, x1, #0x3ffffffffff
     add x1, x1, x24
     ldr x1, [x1, #16]

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
@@ -1736,6 +1736,12 @@ asm_handler_Exp:
     call CSYM(asm_slow_path_exp_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Exp.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Exp.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -5754,6 +5760,12 @@ asm_handler_ExpRhsInt32:
     call CSYM(asm_slow_path_exp_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ExpRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ExpRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -6893,6 +6905,12 @@ asm_handler_Add_cold:
     call CSYM(asm_slow_path_add_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Add.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Add.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -6989,6 +7007,12 @@ asm_handler_Sub_cold:
     call CSYM(asm_slow_path_sub_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Sub.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Sub.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7084,6 +7108,12 @@ asm_handler_Mul_cold:
     call CSYM(asm_slow_path_mul_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Mul.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Mul.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7114,6 +7144,12 @@ asm_handler_ConcatString:
     call CSYM(asm_slow_path_concat_string)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ConcatString.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ConcatString.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7135,6 +7171,12 @@ asm_handler_CopyObjectExcludingProperties:
     call CSYM(asm_slow_path_copy_object_excluding_properties)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CopyObjectExcludingProperties.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CopyObjectExcludingProperties.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7156,6 +7198,12 @@ asm_handler_ImportCall:
     call CSYM(asm_slow_path_import_call)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ImportCall.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ImportCall.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7177,6 +7225,12 @@ asm_handler_NewClass:
     call CSYM(asm_slow_path_new_class)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewClass.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewClass.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7243,6 +7297,12 @@ asm_handler_JumpLessThan_cold:
     call CSYM(asm_slow_path_jump_less_than_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpLessThan.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpLessThan.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7294,6 +7354,12 @@ asm_handler_JumpGreaterThan_cold:
     call CSYM(asm_slow_path_jump_greater_than_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpGreaterThan.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpGreaterThan.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7345,6 +7411,12 @@ asm_handler_JumpLessThanEquals_cold:
     call CSYM(asm_slow_path_jump_less_than_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpLessThanEquals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpLessThanEquals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7396,6 +7468,12 @@ asm_handler_JumpGreaterThanEquals_cold:
     call CSYM(asm_slow_path_jump_greater_than_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpGreaterThanEquals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpGreaterThanEquals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7431,6 +7509,12 @@ asm_handler_JumpLooselyEquals_cold:
     call CSYM(asm_slow_path_jump_loosely_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpLooselyEquals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpLooselyEquals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7466,6 +7550,12 @@ asm_handler_JumpLooselyInequals_cold:
     call CSYM(asm_slow_path_jump_loosely_inequals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpLooselyInequals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpLooselyInequals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7501,6 +7591,12 @@ asm_handler_JumpStrictlyEquals_cold:
     call CSYM(asm_slow_path_jump_strictly_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpStrictlyEquals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpStrictlyEquals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7536,6 +7632,12 @@ asm_handler_JumpStrictlyInequals_cold:
     call CSYM(asm_slow_path_jump_strictly_inequals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpStrictlyInequals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpStrictlyInequals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7568,6 +7670,12 @@ asm_handler_Increment_cold:
     call CSYM(asm_slow_path_increment)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Increment.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Increment.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7600,6 +7708,12 @@ asm_handler_Decrement_cold:
     call CSYM(asm_slow_path_decrement)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Decrement.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Decrement.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7630,6 +7744,12 @@ asm_handler_GetImportMeta:
     call CSYM(asm_slow_path_get_import_meta)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetImportMeta.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetImportMeta.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7651,6 +7771,12 @@ asm_handler_GetNewTarget:
     call CSYM(asm_slow_path_get_new_target)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetNewTarget.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetNewTarget.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7672,6 +7798,12 @@ asm_handler_GetSuperConstructor:
     call CSYM(asm_slow_path_get_super_constructor)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetSuperConstructor.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetSuperConstructor.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7696,6 +7828,12 @@ asm_handler_GetBinding_cold:
     call CSYM(asm_slow_path_get_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7715,6 +7853,12 @@ asm_handler_DynamicGetBinding_cold:
     call CSYM(asm_slow_path_dynamic_get_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicGetBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicGetBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7736,6 +7880,12 @@ asm_handler_DynamicGetInitializedBinding_cold:
     call CSYM(asm_slow_path_dynamic_get_initialized_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicGetInitializedBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicGetInitializedBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7759,6 +7909,12 @@ asm_handler_DynamicInitializeLexicalBinding_cold:
     call CSYM(asm_slow_path_dynamic_initialize_lexical_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7778,6 +7934,12 @@ asm_handler_DynamicInitializeVariableBinding_cold:
     call CSYM(asm_slow_path_dynamic_initialize_variable_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicInitializeVariableBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicInitializeVariableBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7797,6 +7959,12 @@ asm_handler_SetLexicalBinding_cold:
     call CSYM(asm_slow_path_set_lexical_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetLexicalBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetLexicalBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7816,6 +7984,12 @@ asm_handler_SetVariableBinding_cold:
     call CSYM(asm_slow_path_set_variable_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetVariableBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetVariableBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7835,6 +8009,12 @@ asm_handler_DynamicSetLexicalBinding_cold:
     call CSYM(asm_slow_path_dynamic_set_lexical_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicSetLexicalBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicSetLexicalBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7854,6 +8034,12 @@ asm_handler_DynamicSetVariableBinding_cold:
     call CSYM(asm_slow_path_dynamic_set_variable_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicSetVariableBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicSetVariableBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7872,6 +8058,12 @@ asm_handler_ResolveBinding:
     call CSYM(asm_slow_path_resolve_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ResolveBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ResolveBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7893,6 +8085,12 @@ asm_handler_ResolveSuperBase:
     call CSYM(asm_slow_path_resolve_super_base)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ResolveSuperBase.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ResolveSuperBase.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7914,6 +8112,12 @@ asm_handler_SetResolvedBinding:
     call CSYM(asm_slow_path_set_resolved_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetResolvedBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetResolvedBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7935,6 +8139,12 @@ asm_handler_TypeofBinding:
     call CSYM(asm_slow_path_typeof_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_TypeofBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_TypeofBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7956,6 +8166,12 @@ asm_handler_DynamicTypeofBinding:
     call CSYM(asm_slow_path_dynamic_typeof_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicTypeofBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicTypeofBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7977,6 +8193,12 @@ asm_handler_HasPrivateId:
     call CSYM(asm_slow_path_has_private_id)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_HasPrivateId.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_HasPrivateId.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7998,6 +8220,12 @@ asm_handler_SetFunctionName:
     call CSYM(asm_slow_path_set_function_name)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetFunctionName.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetFunctionName.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8019,6 +8247,12 @@ asm_handler_NewArrayWithLength:
     call CSYM(asm_slow_path_new_array_with_length)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewArrayWithLength.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewArrayWithLength.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8040,6 +8274,12 @@ asm_handler_ArrayAppend:
     call CSYM(asm_slow_path_array_append)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ArrayAppend.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ArrayAppend.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8061,6 +8301,12 @@ asm_handler_CreateVariable:
     call CSYM(asm_slow_path_create_variable)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateVariable.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateVariable.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8082,6 +8328,12 @@ asm_handler_EnterObjectEnvironment:
     call CSYM(asm_slow_path_enter_object_environment)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_EnterObjectEnvironment.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_EnterObjectEnvironment.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8117,6 +8369,12 @@ asm_handler_PostfixIncrement_cold:
     call CSYM(asm_slow_path_postfix_increment)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_PostfixIncrement.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PostfixIncrement.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8139,6 +8397,12 @@ asm_handler_Div_cold:
     call CSYM(asm_slow_path_div_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Div.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Div.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8193,6 +8457,12 @@ asm_handler_LessThan_cold:
     call CSYM(asm_slow_path_less_than_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LessThan.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LessThan.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8244,6 +8514,12 @@ asm_handler_LessThanEquals_cold:
     call CSYM(asm_slow_path_less_than_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LessThanEquals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LessThanEquals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8295,6 +8571,12 @@ asm_handler_GreaterThan_cold:
     call CSYM(asm_slow_path_greater_than_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GreaterThan.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GreaterThan.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8346,6 +8628,12 @@ asm_handler_GreaterThanEquals_cold:
     call CSYM(asm_slow_path_greater_than_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GreaterThanEquals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GreaterThanEquals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8402,6 +8690,12 @@ asm_handler_BitwiseXor_cold:
     call CSYM(asm_slow_path_bitwise_xor_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseXor.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseXor.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8435,6 +8729,12 @@ asm_handler_UnaryPlus_cold:
     call CSYM(asm_slow_path_unary_plus)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_UnaryPlus.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_UnaryPlus.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8460,6 +8760,12 @@ asm_handler_ThrowIfTDZ_cold:
     call CSYM(asm_slow_path_throw_if_tdz)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ThrowIfTDZ.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ThrowIfTDZ.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8479,6 +8785,12 @@ asm_handler_ThrowIfNotObject_cold:
     call CSYM(asm_slow_path_throw_if_not_object)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ThrowIfNotObject.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ThrowIfNotObject.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8498,6 +8810,12 @@ asm_handler_ThrowIfNullish_cold:
     call CSYM(asm_slow_path_throw_if_nullish)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ThrowIfNullish.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ThrowIfNullish.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8516,6 +8834,12 @@ asm_handler_ThrowConstAssignment:
     call CSYM(asm_slow_path_throw_const_assignment)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ThrowConstAssignment.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ThrowConstAssignment.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8537,6 +8861,12 @@ asm_handler_Throw:
     call CSYM(asm_slow_path_throw)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Throw.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Throw.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8558,6 +8888,12 @@ asm_handler_Debugger:
     call CSYM(asm_slow_path_debugger)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Debugger.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Debugger.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8579,6 +8915,12 @@ asm_handler_Await:
     call CSYM(asm_slow_path_await)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Await.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Await.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8600,6 +8942,12 @@ asm_handler_Yield:
     call CSYM(asm_slow_path_yield)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Yield.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Yield.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8621,6 +8969,12 @@ asm_handler_YieldIteratorResult:
     call CSYM(asm_slow_path_yield_iterator_result)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_YieldIteratorResult.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_YieldIteratorResult.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8642,6 +8996,12 @@ asm_handler_ToString:
     call CSYM(asm_slow_path_to_string)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToString.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToString.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8663,6 +9023,12 @@ asm_handler_ToPrimitiveWithStringHint:
     call CSYM(asm_slow_path_to_primitive_with_string_hint)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToPrimitiveWithStringHint.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToPrimitiveWithStringHint.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8684,6 +9050,12 @@ asm_handler_ToObject:
     call CSYM(asm_slow_path_to_object)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToObject.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToObject.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8705,6 +9077,12 @@ asm_handler_ToLength:
     call CSYM(asm_slow_path_to_length)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToLength.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToLength.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8727,6 +9105,12 @@ asm_handler_BitwiseNot_cold:
     call CSYM(asm_slow_path_bitwise_not)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseNot.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseNot.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8783,6 +9167,12 @@ asm_handler_BitwiseAnd_cold:
     call CSYM(asm_slow_path_bitwise_and_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseAnd.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseAnd.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8850,6 +9240,12 @@ asm_handler_BitwiseOr_cold:
     call CSYM(asm_slow_path_bitwise_or_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseOr.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseOr.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8883,6 +9279,12 @@ asm_handler_LeftShift_cold:
     call CSYM(asm_slow_path_left_shift_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LeftShift.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LeftShift.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8905,6 +9307,12 @@ asm_handler_RightShift_cold:
     call CSYM(asm_slow_path_right_shift_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_RightShift.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_RightShift.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8935,6 +9343,12 @@ asm_handler_UnsignedRightShift_cold:
     call CSYM(asm_slow_path_unsigned_right_shift_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_UnsignedRightShift.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_UnsignedRightShift.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9045,6 +9459,12 @@ asm_handler_Mod_cold:
     call CSYM(asm_slow_path_mod_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Mod.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Mod.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9076,6 +9496,12 @@ asm_handler_StrictlyEquals_cold:
     call CSYM(asm_slow_path_strictly_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_StrictlyEquals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_StrictlyEquals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9107,6 +9533,12 @@ asm_handler_StrictlyInequals_cold:
     call CSYM(asm_slow_path_strictly_inequals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_StrictlyInequals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_StrictlyInequals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9126,6 +9558,12 @@ asm_handler_GetCalleeAndThisFromEnvironment_cold:
     call CSYM(asm_slow_path_get_callee_and_this)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9145,6 +9583,12 @@ asm_handler_DynamicGetCalleeAndThisFromEnvironment_cold:
     call CSYM(asm_slow_path_dynamic_get_callee_and_this)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9176,6 +9620,12 @@ asm_handler_LooselyEquals_cold:
     call CSYM(asm_slow_path_loosely_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LooselyEquals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LooselyEquals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9207,6 +9657,12 @@ asm_handler_LooselyInequals_cold:
     call CSYM(asm_slow_path_loosely_inequals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LooselyInequals.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LooselyInequals.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9246,6 +9702,12 @@ asm_handler_UnaryMinus_cold:
     call CSYM(asm_slow_path_unary_minus)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_UnaryMinus.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_UnaryMinus.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9285,6 +9747,12 @@ asm_handler_PostfixDecrement_cold:
     call CSYM(asm_slow_path_postfix_decrement)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_PostfixDecrement.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PostfixDecrement.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9321,6 +9789,12 @@ asm_handler_ToInt32_cold:
     call CSYM(asm_slow_path_to_int32)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToInt32.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9384,6 +9858,12 @@ asm_handler_PutByValue_cold:
     call CSYM(asm_slow_path_put_by_value)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutByValue.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutByValue.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9536,6 +10016,12 @@ asm_handler_GetById_cold:
     call CSYM(asm_slow_path_get_by_id_cached_accessor)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetById.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetById.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9618,6 +10104,12 @@ asm_handler_GetById_cold:
     call CSYM(asm_slow_path_get_by_id)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetById.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetById.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9638,6 +10130,12 @@ asm_handler_GetByIdWithThis:
     call CSYM(asm_slow_path_get_by_id_with_this)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetByIdWithThis.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetByIdWithThis.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9670,6 +10168,12 @@ asm_handler_PutById_cold:
     call CSYM(asm_slow_path_put_by_id)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutById.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutById.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9688,6 +10192,12 @@ asm_handler_PutByIdWithThis:
     call CSYM(asm_slow_path_put_by_id_with_this)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutByIdWithThis.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutByIdWithThis.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9728,6 +10238,12 @@ asm_handler_GetByValue_cold:
     call CSYM(asm_slow_path_get_by_value)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetByValue.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetByValue.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9749,6 +10265,12 @@ asm_handler_GetByValueWithThis:
     call CSYM(asm_slow_path_get_by_value_with_this)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetByValueWithThis.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetByValueWithThis.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9770,6 +10292,12 @@ asm_handler_PutByValueWithThis:
     call CSYM(asm_slow_path_put_by_value_with_this)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutByValueWithThis.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutByValueWithThis.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9791,6 +10319,12 @@ asm_handler_PutBySpread:
     call CSYM(asm_slow_path_put_by_spread)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutBySpread.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutBySpread.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9821,6 +10355,12 @@ asm_handler_GetLength_cold:
     call CSYM(asm_slow_path_get_length)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetLength.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetLength.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9839,6 +10379,12 @@ asm_handler_GetLengthWithThis:
     call CSYM(asm_slow_path_get_length_with_this)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetLengthWithThis.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetLengthWithThis.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9860,6 +10406,12 @@ asm_handler_GetMethod:
     call CSYM(asm_slow_path_get_method)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetMethod.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetMethod.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9881,6 +10433,12 @@ asm_handler_GetIterator:
     call CSYM(asm_slow_path_get_iterator)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetIterator.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetIterator.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9903,6 +10461,12 @@ asm_handler_GetGlobal_cold:
     call CSYM(asm_slow_path_get_global)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetGlobal.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetGlobal.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9942,6 +10506,12 @@ asm_handler_SetGlobal_cold:
     call CSYM(asm_slow_path_set_global)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetGlobal.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetGlobal.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9975,6 +10545,12 @@ asm_handler_Call_cold:
     call CSYM(asm_slow_path_call)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Call.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Call.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10006,6 +10582,12 @@ asm_handler_CallBuiltinMathAbs_cold:
     call CSYM(asm_slow_path_call_builtin_math_abs)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathAbs.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathAbs.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10025,6 +10607,12 @@ asm_handler_CallBuiltinMathFloor_cold:
     call CSYM(asm_slow_path_call_builtin_math_floor)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathFloor.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathFloor.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10047,6 +10635,12 @@ asm_handler_CallBuiltinMathCeil_cold:
     call CSYM(asm_slow_path_call_builtin_math_ceil)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathCeil.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathCeil.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10069,6 +10663,12 @@ asm_handler_CallBuiltinMathSqrt_cold:
     call CSYM(asm_slow_path_call_builtin_math_sqrt)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathSqrt.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathSqrt.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10091,6 +10691,12 @@ asm_handler_CallBuiltinMathExp_cold:
     call CSYM(asm_slow_path_call_builtin_math_exp)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathExp.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathExp.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10109,6 +10715,12 @@ asm_handler_CallBuiltinMathLog:
     call CSYM(asm_slow_path_call_builtin_math_log)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathLog.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathLog.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10130,6 +10742,12 @@ asm_handler_CallBuiltinMathPow:
     call CSYM(asm_slow_path_call_builtin_math_pow)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathPow.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathPow.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10151,6 +10769,12 @@ asm_handler_CallBuiltinMathImul:
     call CSYM(asm_slow_path_call_builtin_math_imul)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathImul.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathImul.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10172,6 +10796,12 @@ asm_handler_CallBuiltinMathRandom:
     call CSYM(asm_slow_path_call_builtin_math_random)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathRandom.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathRandom.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10193,6 +10823,12 @@ asm_handler_CallBuiltinMathRound:
     call CSYM(asm_slow_path_call_builtin_math_round)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathRound.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathRound.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10214,6 +10850,12 @@ asm_handler_CallBuiltinMathSin:
     call CSYM(asm_slow_path_call_builtin_math_sin)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathSin.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathSin.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10235,6 +10877,12 @@ asm_handler_CallBuiltinMathCos:
     call CSYM(asm_slow_path_call_builtin_math_cos)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathCos.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathCos.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10256,6 +10904,12 @@ asm_handler_CallBuiltinMathTan:
     call CSYM(asm_slow_path_call_builtin_math_tan)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathTan.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathTan.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10277,6 +10931,12 @@ asm_handler_CallBuiltinRegExpPrototypeExec:
     call CSYM(asm_slow_path_call_builtin_regexp_prototype_exec)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10298,6 +10958,12 @@ asm_handler_CallBuiltinRegExpPrototypeReplace:
     call CSYM(asm_slow_path_call_builtin_regexp_prototype_replace)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10319,6 +10985,12 @@ asm_handler_CallBuiltinRegExpPrototypeSplit:
     call CSYM(asm_slow_path_call_builtin_regexp_prototype_split)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10340,6 +11012,12 @@ asm_handler_CallBuiltinOrdinaryHasInstance:
     call CSYM(asm_slow_path_call_builtin_ordinary_has_instance)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10361,6 +11039,12 @@ asm_handler_CallBuiltinArrayIteratorPrototypeNext:
     call CSYM(asm_slow_path_call_builtin_array_iterator_prototype_next)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10382,6 +11066,12 @@ asm_handler_CallBuiltinMapIteratorPrototypeNext:
     call CSYM(asm_slow_path_call_builtin_map_iterator_prototype_next)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10403,6 +11093,12 @@ asm_handler_CallBuiltinSetIteratorPrototypeNext:
     call CSYM(asm_slow_path_call_builtin_set_iterator_prototype_next)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10424,6 +11120,12 @@ asm_handler_CallBuiltinStringIteratorPrototypeNext:
     call CSYM(asm_slow_path_call_builtin_string_iterator_prototype_next)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10446,6 +11148,12 @@ asm_handler_CallBuiltinStringFromCharCode_cold:
     call CSYM(asm_slow_path_call_builtin_string_from_char_code)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10472,6 +11180,12 @@ asm_handler_CallBuiltinStringPrototypeCharCodeAt_cold:
     call CSYM(asm_slow_path_call_builtin_string_prototype_char_code_at)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10500,6 +11214,12 @@ asm_handler_CallBuiltinStringPrototypeCharAt_cold:
     call CSYM(asm_slow_path_call_builtin_string_prototype_char_at)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10518,6 +11238,12 @@ asm_handler_GetObjectPropertyIterator:
     call CSYM(asm_slow_path_get_object_property_iterator)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetObjectPropertyIterator.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetObjectPropertyIterator.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10540,6 +11266,12 @@ asm_handler_ObjectPropertyIteratorNext_cold:
     call CSYM(asm_slow_path_object_property_iterator_next)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ObjectPropertyIteratorNext.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ObjectPropertyIteratorNext.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10558,6 +11290,12 @@ asm_handler_IteratorClose:
     call CSYM(asm_slow_path_iterator_close)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_IteratorClose.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IteratorClose.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10579,6 +11317,12 @@ asm_handler_IteratorNext:
     call CSYM(asm_slow_path_iterator_next)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_IteratorNext.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IteratorNext.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10600,6 +11344,12 @@ asm_handler_IteratorNextUnpack:
     call CSYM(asm_slow_path_iterator_next_unpack)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_IteratorNextUnpack.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IteratorNextUnpack.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10621,6 +11371,12 @@ asm_handler_IteratorToArray:
     call CSYM(asm_slow_path_iterator_to_array)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_IteratorToArray.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IteratorToArray.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10642,6 +11398,12 @@ asm_handler_CallConstruct:
     call CSYM(asm_slow_path_call_construct)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallConstruct.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallConstruct.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10663,6 +11425,12 @@ asm_handler_CallDirectEval:
     call CSYM(asm_slow_path_call_direct_eval)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallDirectEval.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallDirectEval.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10684,6 +11452,12 @@ asm_handler_CallWithArgumentArray:
     call CSYM(asm_slow_path_call_with_argument_array)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallWithArgumentArray.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallWithArgumentArray.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10705,6 +11479,12 @@ asm_handler_CallDirectEvalWithArgumentArray:
     call CSYM(asm_slow_path_call_direct_eval_with_argument_array)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10726,6 +11506,12 @@ asm_handler_CallConstructWithArgumentArray:
     call CSYM(asm_slow_path_call_construct_with_argument_array)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallConstructWithArgumentArray.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallConstructWithArgumentArray.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10747,6 +11533,12 @@ asm_handler_SuperCallWithArgumentArray:
     call CSYM(asm_slow_path_super_call_with_argument_array)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_SuperCallWithArgumentArray.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SuperCallWithArgumentArray.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10768,6 +11560,12 @@ asm_handler_NewObject:
     call CSYM(asm_slow_path_new_object)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewObject.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewObject.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10789,6 +11587,12 @@ asm_handler_NewObjectWithNoPrototype:
     call CSYM(asm_slow_path_new_object_with_no_prototype)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewObjectWithNoPrototype.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewObjectWithNoPrototype.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10810,6 +11614,12 @@ asm_handler_CacheObjectShape:
     call CSYM(asm_slow_path_cache_object_shape)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CacheObjectShape.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CacheObjectShape.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10831,6 +11641,12 @@ asm_handler_InitObjectLiteralProperty:
     call CSYM(asm_slow_path_init_object_literal_property)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_InitObjectLiteralProperty.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_InitObjectLiteralProperty.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10852,6 +11668,12 @@ asm_handler_NewArray:
     call CSYM(asm_slow_path_new_array)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewArray.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewArray.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10873,6 +11695,12 @@ asm_handler_NewPrimitiveArray:
     call CSYM(asm_slow_path_new_primitive_array)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewPrimitiveArray.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewPrimitiveArray.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10894,6 +11722,12 @@ asm_handler_NewRegExp:
     call CSYM(asm_slow_path_new_regexp)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewRegExp.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewRegExp.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10915,6 +11749,12 @@ asm_handler_NewReferenceError:
     call CSYM(asm_slow_path_new_reference_error)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewReferenceError.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewReferenceError.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10936,6 +11776,12 @@ asm_handler_NewTypeError:
     call CSYM(asm_slow_path_new_type_error)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewTypeError.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewTypeError.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10957,6 +11803,12 @@ asm_handler_InstanceOf:
     call CSYM(asm_slow_path_instance_of)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_InstanceOf.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_InstanceOf.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10978,6 +11830,12 @@ asm_handler_In:
     call CSYM(asm_slow_path_in)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_In.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_In.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11001,6 +11859,12 @@ asm_handler_IsConstructor:
     call CSYM(asm_slow_path_is_constructor)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_IsConstructor.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IsConstructor.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11022,6 +11886,12 @@ asm_handler_AddPrivateName:
     call CSYM(asm_slow_path_add_private_name)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_AddPrivateName.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_AddPrivateName.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11043,6 +11913,12 @@ asm_handler_CreateAsyncFromSyncIterator:
     call CSYM(asm_slow_path_create_async_from_sync_iterator)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11064,6 +11940,12 @@ asm_handler_CreateDataPropertyOrThrow:
     call CSYM(asm_slow_path_create_data_property_or_throw)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateDataPropertyOrThrow.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateDataPropertyOrThrow.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11085,6 +11967,12 @@ asm_handler_CreateImmutableBinding:
     call CSYM(asm_slow_path_create_immutable_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateImmutableBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateImmutableBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11106,6 +11994,12 @@ asm_handler_CreateMutableBinding:
     call CSYM(asm_slow_path_create_mutable_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateMutableBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateMutableBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11127,6 +12021,12 @@ asm_handler_CreateRestParams:
     call CSYM(asm_slow_path_create_rest_params)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateRestParams.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateRestParams.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11148,6 +12048,12 @@ asm_handler_CreateArguments:
     call CSYM(asm_slow_path_create_arguments)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateArguments.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateArguments.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11169,6 +12075,12 @@ asm_handler_CreateLexicalEnvironment:
     call CSYM(asm_slow_path_create_lexical_environment)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateLexicalEnvironment.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateLexicalEnvironment.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11190,6 +12102,12 @@ asm_handler_CreatePrivateEnvironment:
     call CSYM(asm_slow_path_create_private_environment)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreatePrivateEnvironment.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreatePrivateEnvironment.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11211,6 +12129,12 @@ asm_handler_CreateVariableEnvironment:
     call CSYM(asm_slow_path_create_variable_environment)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateVariableEnvironment.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateVariableEnvironment.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11232,6 +12156,12 @@ asm_handler_DeleteById:
     call CSYM(asm_slow_path_delete_by_id)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DeleteById.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DeleteById.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11253,6 +12183,12 @@ asm_handler_DeleteByValue:
     call CSYM(asm_slow_path_delete_by_value)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DeleteByValue.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DeleteByValue.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11274,6 +12210,12 @@ asm_handler_DeleteVariable:
     call CSYM(asm_slow_path_delete_variable)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DeleteVariable.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DeleteVariable.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11295,6 +12237,12 @@ asm_handler_GetCompletionFields:
     call CSYM(asm_slow_path_get_completion_fields)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetCompletionFields.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetCompletionFields.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11316,6 +12264,12 @@ asm_handler_SetCompletionType:
     call CSYM(asm_slow_path_set_completion_type)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetCompletionType.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetCompletionType.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11337,6 +12291,12 @@ asm_handler_GetTemplateObject:
     call CSYM(asm_slow_path_get_template_object)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetTemplateObject.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetTemplateObject.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11358,6 +12318,12 @@ asm_handler_NewFunction:
     call CSYM(asm_slow_path_new_function)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewFunction.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewFunction.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11379,6 +12345,12 @@ asm_handler_Typeof:
     call CSYM(asm_slow_path_typeof)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_Typeof.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Typeof.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11403,6 +12375,12 @@ asm_handler_ResolveThisBinding_cold:
     call CSYM(asm_slow_path_resolve_this_binding)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ResolveThisBinding.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ResolveThisBinding.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11421,6 +12399,12 @@ asm_handler_GetPrivateById:
     call CSYM(asm_slow_path_get_private_by_id)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetPrivateById.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetPrivateById.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11442,6 +12426,12 @@ asm_handler_PutPrivateById:
     call CSYM(asm_slow_path_put_private_by_id)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutPrivateById.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutPrivateById.slow_path_transfer_0:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11483,6 +12473,12 @@ asm_handler_AddLhsInt32_cold:
     call CSYM(asm_slow_path_add_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_AddLhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_AddLhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -11519,8 +12515,8 @@ asm_handler_AddLhsInt32_cold:
 .Lasm_AddLhsInt32.ssa_box_number_6_not_integer:
     movq rax, xmm0
     ucomisd xmm0, xmm0
-    jp .Lasm_AddLhsInt32.canon_nan_0
-.Lasm_AddLhsInt32.canon_nan_0_ret:
+    jp .Lasm_AddLhsInt32.canon_nan_1
+.Lasm_AddLhsInt32.canon_nan_1_ret:
 .Lasm_AddLhsInt32.ssa_box_number_6_done:
     mov r11d, DWORD PTR [r14 + r13 + 4]
     mov QWORD PTR [rbx + r11 * 8], rax
@@ -11539,9 +12535,9 @@ asm_handler_AddLhsInt32_cold:
     add r13d, 16
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_AddLhsInt32.canon_nan_0:
+.Lasm_AddLhsInt32.canon_nan_1:
     movabs rax, 9221120237041090560
-    jmp .Lasm_AddLhsInt32.canon_nan_0_ret
+    jmp .Lasm_AddLhsInt32.canon_nan_1_ret
 asm_handler_AddLhsInt32_cold_end:
 asm_handler_AddRhsInt32_cold:
 # Cold paths for AddRhsInt32
@@ -11610,6 +12606,12 @@ asm_handler_AddRhsInt32_cold:
     call CSYM(asm_slow_path_add_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_AddRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_AddRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -11689,6 +12691,12 @@ asm_handler_SubRhsInt32_cold:
     call CSYM(asm_slow_path_sub_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_SubRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SubRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -11719,6 +12727,12 @@ asm_handler_MulRhsInt32_cold:
     call CSYM(asm_slow_path_mul_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_MulRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_MulRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -11755,8 +12769,8 @@ asm_handler_MulRhsInt32_cold:
 .Lasm_MulRhsInt32.ssa_box_number_8_not_integer:
     movq rax, xmm0
     ucomisd xmm0, xmm0
-    jp .Lasm_MulRhsInt32.canon_nan_0
-.Lasm_MulRhsInt32.canon_nan_0_ret:
+    jp .Lasm_MulRhsInt32.canon_nan_1
+.Lasm_MulRhsInt32.canon_nan_1_ret:
 .Lasm_MulRhsInt32.ssa_box_number_8_done:
     mov r11d, DWORD PTR [r14 + r13 + 4]
     mov QWORD PTR [rbx + r11 * 8], rax
@@ -11782,9 +12796,9 @@ asm_handler_MulRhsInt32_cold:
     add r13d, 16
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_MulRhsInt32.canon_nan_0:
+.Lasm_MulRhsInt32.canon_nan_1:
     movabs rax, 9221120237041090560
-    jmp .Lasm_MulRhsInt32.canon_nan_0_ret
+    jmp .Lasm_MulRhsInt32.canon_nan_1_ret
 asm_handler_MulRhsInt32_cold_end:
 asm_handler_ExpRhsInt32_cold:
 asm_handler_ExpRhsInt32_cold_end:
@@ -11803,6 +12817,12 @@ asm_handler_DivRhsInt32_cold:
     call CSYM(asm_slow_path_div_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_DivRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DivRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -11868,6 +12888,12 @@ asm_handler_BitwiseXorRhsInt32_cold:
     call CSYM(asm_slow_path_bitwise_xor_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseXorRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseXorRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -11941,6 +12967,12 @@ asm_handler_BitwiseAndRhsInt32_cold:
     call CSYM(asm_slow_path_bitwise_and_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseAndRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseAndRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12014,6 +13046,12 @@ asm_handler_BitwiseOrRhsInt32_cold:
     call CSYM(asm_slow_path_bitwise_or_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseOrRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseOrRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12050,6 +13088,12 @@ asm_handler_LeftShiftRhsInt32_cold:
     call CSYM(asm_slow_path_left_shift_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LeftShiftRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LeftShiftRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12075,6 +13119,12 @@ asm_handler_RightShiftRhsInt32_cold:
     call CSYM(asm_slow_path_right_shift_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_RightShiftRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_RightShiftRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12108,6 +13158,12 @@ asm_handler_UnsignedRightShiftRhsInt32_cold:
     call CSYM(asm_slow_path_unsigned_right_shift_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12201,6 +13257,12 @@ asm_handler_ModRhsInt32_cold:
     call CSYM(asm_slow_path_mod_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_ModRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ModRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12228,6 +13290,12 @@ asm_handler_LessThanRhsInt32_cold:
     call CSYM(asm_slow_path_less_than_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LessThanRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LessThanRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12263,6 +13331,12 @@ asm_handler_LessThanEqualsRhsInt32_cold:
     call CSYM(asm_slow_path_less_than_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LessThanEqualsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LessThanEqualsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12298,6 +13372,12 @@ asm_handler_GreaterThanRhsInt32_cold:
     call CSYM(asm_slow_path_greater_than_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GreaterThanRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GreaterThanRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12333,6 +13413,12 @@ asm_handler_GreaterThanEqualsRhsInt32_cold:
     call CSYM(asm_slow_path_greater_than_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12372,6 +13458,12 @@ asm_handler_JumpLessThanRhsInt32_cold:
     call CSYM(asm_slow_path_jump_less_than_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpLessThanRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpLessThanRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12411,6 +13503,12 @@ asm_handler_JumpLessThanEqualsRhsInt32_cold:
     call CSYM(asm_slow_path_jump_less_than_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpLessThanEqualsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpLessThanEqualsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12450,6 +13548,12 @@ asm_handler_JumpGreaterThanRhsInt32_cold:
     call CSYM(asm_slow_path_jump_greater_than_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpGreaterThanRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpGreaterThanRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12489,6 +13593,12 @@ asm_handler_JumpGreaterThanEqualsRhsInt32_cold:
     call CSYM(asm_slow_path_jump_greater_than_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpGreaterThanEqualsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpGreaterThanEqualsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12528,6 +13638,12 @@ asm_handler_StrictlyEqualsRhsInt32_cold:
     call CSYM(asm_slow_path_strictly_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12559,6 +13675,12 @@ asm_handler_StrictlyInequalsRhsInt32_cold:
     call CSYM(asm_slow_path_strictly_inequals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12590,6 +13712,12 @@ asm_handler_LooselyEqualsRhsInt32_cold:
     call CSYM(asm_slow_path_loosely_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LooselyEqualsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LooselyEqualsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12621,6 +13749,12 @@ asm_handler_LooselyInequalsRhsInt32_cold:
     call CSYM(asm_slow_path_loosely_inequals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_LooselyInequalsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LooselyInequalsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12656,6 +13790,12 @@ asm_handler_JumpStrictlyEqualsRhsInt32_cold:
     call CSYM(asm_slow_path_jump_strictly_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpStrictlyEqualsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpStrictlyEqualsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12691,6 +13831,12 @@ asm_handler_JumpStrictlyInequalsRhsInt32_cold:
     call CSYM(asm_slow_path_jump_strictly_inequals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpStrictlyInequalsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpStrictlyInequalsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12726,6 +13872,12 @@ asm_handler_JumpLooselyEqualsRhsInt32_cold:
     call CSYM(asm_slow_path_jump_loosely_equals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpLooselyEqualsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpLooselyEqualsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12761,6 +13913,12 @@ asm_handler_JumpLooselyInequalsRhsInt32_cold:
     call CSYM(asm_slow_path_jump_loosely_inequals_values)
     test rax, rax
     js .Lexit
+    bt rax, 32
+    jnc .Lasm_JumpLooselyInequalsRhsInt32.slow_path_transfer_0
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_JumpLooselyInequalsRhsInt32.slow_path_transfer_0:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
@@ -2442,6 +2442,14 @@ asm_handler_Return:
     mov rax, QWORD PTR [rbx - 32]
     test rax, rax
     jz .Lasm_Return.ssa_block_1
+    cmp BYTE PTR [rbx - 50], 0
+    jz .Lasm_Return.ssa_block_7
+    mov r11, rcx
+    shr r11, 48
+    cmp r11w, 65529
+    je .Lasm_Return.ssa_block_7
+    mov rcx, QWORD PTR [rbx - 48]
+.Lasm_Return.ssa_block_7:
     mov edx, DWORD PTR [rbx - 20]
     mov esi, DWORD PTR [rbx - 16]
     mov DWORD PTR [rax + 64], edx
@@ -2470,6 +2478,14 @@ asm_handler_End:
     mov rax, QWORD PTR [rbx - 32]
     test rax, rax
     jz .Lasm_End.ssa_block_1
+    cmp BYTE PTR [rbx - 50], 0
+    jz .Lasm_End.ssa_block_5
+    mov r11, rcx
+    shr r11, 48
+    cmp r11w, 65529
+    je .Lasm_End.ssa_block_5
+    mov rcx, QWORD PTR [rbx - 48]
+.Lasm_End.ssa_block_5:
     mov edx, DWORD PTR [rbx - 20]
     mov esi, DWORD PTR [rbx - 16]
     mov DWORD PTR [rax + 64], edx

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
@@ -12,6 +12,7 @@
 .section .data.rel.ro
 .p2align 3
 asm_dispatch_table:
+    .quad asm_handler_Enter
     .quad asm_handler_Mov
     .quad asm_handler_Add
     .quad asm_handler_Sub
@@ -228,7 +229,6 @@ asm_dispatch_table:
     .quad asm_handler_JumpStrictlyInequalsRhsInt32
     .quad asm_handler_JumpLooselyEqualsRhsInt32
     .quad asm_handler_JumpLooselyInequalsRhsInt32
-    .quad asm_handler_fallback
     .quad asm_handler_fallback
     .quad asm_handler_fallback
     .quad asm_handler_fallback
@@ -530,6 +530,10 @@ asm_debug_dispatch_table:
 .globl CSYM(js_interpreter_handler_ranges)
 .p2align 3
 CSYM(js_interpreter_handler_ranges):
+    .quad asm_handler_Enter
+    .quad asm_handler_Enter_hot_end
+    .quad asm_handler_Enter_cold
+    .quad asm_handler_Enter_cold_end
     .quad asm_handler_Mov
     .quad asm_handler_Mov_hot_end
     .quad asm_handler_Mov_cold
@@ -1550,10 +1554,6 @@ CSYM(js_interpreter_handler_ranges):
     .quad asm_handler_fallback_hot_end
     .quad asm_handler_fallback_cold
     .quad asm_handler_fallback_cold_end
-    .quad asm_handler_fallback
-    .quad asm_handler_fallback_hot_end
-    .quad asm_handler_fallback_cold
-    .quad asm_handler_fallback_cold_end
 
 .text
 
@@ -1628,6 +1628,43 @@ asm_handler_fallback_hot_end:
 asm_handler_fallback_cold:
 asm_handler_fallback_cold_end:
 
+
+.p2align 6
+asm_handler_Enter:
+    mov rcx, QWORD PTR [rbx - 40]
+    mov edx, DWORD PTR [rcx + 364]
+    movabs rsi, 9221964661971222528
+    mov rax, 5
+.Lasm_Enter.ssa_block_3:
+    lea rdi, [rax + 1]
+    cmp rdi, rdx
+    jae .Lasm_Enter.ssa_block_2
+    mov QWORD PTR [rbx + rax * 8], rsi
+    mov QWORD PTR [rbx + rax * 8 + 8], rsi
+    lea rax, [rax + 2]
+    jmp .Lasm_Enter.ssa_block_3
+.Lasm_Enter.ssa_block_2:
+    cmp rax, rdx
+    jae .Lasm_Enter.ssa_block_5
+    mov QWORD PTR [rbx + rax * 8], rsi
+.Lasm_Enter.ssa_block_5:
+    mov rsi, QWORD PTR [rcx + 376]
+    mov rcx, QWORD PTR [rcx + 384]
+    xor rax, rax
+.Lasm_Enter.ssa_block_8:
+    cmp rax, rsi
+    jae .Lasm_Enter.ssa_block_7
+    mov rdi, QWORD PTR [rcx + rax * 8]
+    mov QWORD PTR [rbx + rdx * 8], rdi
+    lea rax, [rax + 1]
+    lea rdx, [rdx + 1]
+    jmp .Lasm_Enter.ssa_block_8
+.Lasm_Enter.ssa_block_7:
+    mov BYTE PTR [rbx - 49], 1
+    add r13d, 8
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+asm_handler_Enter_hot_end:
 
 .p2align 6
 asm_handler_Mov:
@@ -1720,37 +1757,6 @@ asm_handler_Mul:
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
 asm_handler_Mul_hot_end:
-
-.p2align 6
-asm_handler_Exp:
-    mov ecx, DWORD PTR [r14 + r13 + 8]
-    mov eax, DWORD PTR [r14 + r13 + 12]
-    mov rcx, QWORD PTR [rbx + rcx * 8]
-    mov rdx, QWORD PTR [rbx + rax * 8]
-    mov esi, DWORD PTR [r14 + r13 + 4]
-    mov DWORD PTR [rbx + -64], r13d
-    mov r8, rdx
-    mov rdx, rsi
-    mov rdi, QWORD PTR [rbp - 48]
-    mov esi, r13d
-    call CSYM(asm_slow_path_exp_values)
-    test rax, rax
-    js .Lexit
-    bt rax, 32
-    jnc .Lasm_Exp.slow_path_transfer_0
-    mov r13d, eax
-    movzx eax, BYTE PTR [r14 + r13]
-    jmp [r12 + rax * 8]
-.Lasm_Exp.slow_path_transfer_0:
-    mov r11, QWORD PTR [rbp - 48]
-    mov rbx, QWORD PTR [r11 + 15288]
-    add rbx, 128
-    mov r11, QWORD PTR [rbx + -40]
-    mov r14, QWORD PTR [r11 + 80]
-    mov r13d, eax
-    movzx eax, BYTE PTR [r14 + r13]
-    jmp [r12 + rax * 8]
-asm_handler_Exp_hot_end:
 
 .p2align 6
 asm_handler_Jump:
@@ -4238,38 +4244,39 @@ asm_handler_PutByValue_hot_end:
 .p2align 6
 asm_handler_GetById:
     mov eax, DWORD PTR [r14 + r13 + 8]
-    mov rdx, QWORD PTR [rbx + rax * 8]
-    mov r11, rdx
+    mov rcx, QWORD PTR [rbx + rax * 8]
+    mov r11, rcx
     shr r11, 48
     cmp r11w, 65529
     jne .Lasm_GetById.ssa_block_1
+    mov rdx, rcx
     movabs r11, 4398046511103
     and rdx, r11
     add rdx, r15
-    mov rsi, QWORD PTR [rdx + 24]
+    mov rdi, QWORD PTR [rdx + 24]
     mov rax, QWORD PTR [rbx - 40]
     mov rax, QWORD PTR [rax + 112]
-    mov ecx, DWORD PTR [r14 + r13 + 20]
-    mov rcx, QWORD PTR [rax + rcx * 8]
-    test rcx, rcx
+    mov esi, DWORD PTR [r14 + r13 + 20]
+    mov rsi, QWORD PTR [rax + rsi * 8]
+    test rsi, rsi
     jz .Lasm_GetById.ssa_block_1
-    and rcx, -4
-    cmp QWORD PTR [rcx + 24], rsi
+    and rsi, -4
+    cmp QWORD PTR [rsi + 24], rdi
     jne .Lasm_GetById.ssa_block_1
-    mov eax, DWORD PTR [rcx]
+    mov eax, DWORD PTR [rsi]
     cmp eax, 6
     je .Lasm_GetById.ssa_block_1
-    mov rax, QWORD PTR [rcx + 32]
+    mov rax, QWORD PTR [rsi + 32]
     test rax, rax
     jnz .Lasm_GetById.ssa_block_10
     mov rax, rdx
 .Lasm_GetById.ssa_block_8:
-    mov edi, DWORD PTR [rcx + 4]
-    mov r8d, DWORD PTR [rcx + 8]
-    cmp DWORD PTR [rsi + 92], r8d
+    mov r8d, DWORD PTR [rsi + 4]
+    mov r9d, DWORD PTR [rsi + 8]
+    cmp DWORD PTR [rdi + 92], r9d
     jne .Lasm_GetById.ssa_block_1
     mov rax, QWORD PTR [rax + 32]
-    mov rax, QWORD PTR [rax + rdi * 8]
+    mov rax, QWORD PTR [rax + r8 * 8]
     mov r11, rax
     shr r11, 48
     cmp r11w, 65532
@@ -4718,7 +4725,7 @@ asm_handler_Call:
     test eax, 64
     jz .Lasm_Call.ssa_block_3
     mov rax, QWORD PTR [rcx + 80]
-    mov r8, QWORD PTR [rax + 48]
+    mov rdi, QWORD PTR [rax + 48]
     mov rdx, QWORD PTR [rax + 56]
     bt rdx, 32
     jnc .Lasm_Call.ssa_block_1
@@ -4751,129 +4758,102 @@ asm_handler_Call:
     jne .Lasm_Call.ssa_block_2
 .Lasm_Call.ssa_block_9:
     mov eax, DWORD PTR [r14 + r13 + 20]
-    mov esi, edx
-    cmp rsi, rax
-    jae .Lasm_Call.ssa_block_35
-    mov rsi, rax
-.Lasm_Call.ssa_block_35:
-    mov edi, DWORD PTR [r8 + 364]
-    mov r10d, DWORD PTR [r8 + 368]
+    mov edx, edx
+    cmp rdx, rax
+    jae .Lasm_Call.ssa_block_27
+    mov rdx, rax
+.Lasm_Call.ssa_block_27:
+    mov eax, DWORD PTR [rdi + 364]
+    mov esi, DWORD PTR [rdi + 368]
     mov eax, 4294967295
-    sub rax, r10
-    cmp rax, rsi
+    sub rax, rsi
+    cmp rax, rdx
     jb .Lasm_Call.ssa_block_1
     mov rax, QWORD PTR [rbp - 48]
     mov r11, QWORD PTR [rax + 15376]
     mov rax, QWORD PTR [rax + 15368]
-    add r10, rsi
-    mov rdx, r10
-    shl rdx, 3
-    lea rdx, [rdx + 128]
-    add rdx, rax
-    cmp rdx, r11
+    mov r10, rsi
+    add r10, rdx
+    mov r8, r10
+    shl r8, 3
+    lea r8, [r8 + 128]
+    add r8, rax
+    cmp r8, r11
     ja .Lasm_Call.ssa_block_1
     mov r11, QWORD PTR [rbp - 48]
-    mov QWORD PTR [r11 + 15368], rdx
+    mov QWORD PTR [r11 + 15368], r8
     mov DWORD PTR [rax + 116], r10d
-    mov DWORD PTR [rax + 120], esi
-    mov edx, DWORD PTR [r14 + r13 + 20]
-    mov DWORD PTR [rax + 104], edx
-    mov rdx, QWORD PTR [rcx + 24]
-    mov rdx, QWORD PTR [rdx + 16]
+    mov DWORD PTR [rax + 120], edx
+    mov r8d, DWORD PTR [r14 + r13 + 20]
+    mov DWORD PTR [rax + 104], r8d
+    mov r8, QWORD PTR [rcx + 24]
+    mov r8, QWORD PTR [r8 + 16]
     mov QWORD PTR [rax], rcx
-    mov QWORD PTR [rax + 8], rdx
-    mov rdx, QWORD PTR [rcx + 104]
+    mov QWORD PTR [rax + 8], r8
+    mov r8, QWORD PTR [rcx + 104]
     mov r10, QWORD PTR [rcx + 112]
-    mov QWORD PTR [rax + 32], rdx
-    mov QWORD PTR [rax + 40], rdx
+    mov QWORD PTR [rax + 32], r8
+    mov QWORD PTR [rax + 40], r8
     mov QWORD PTR [rax + 48], r10
     mov QWORD PTR [rax + 80], r9
-    mov QWORD PTR [rax + 88], r8
-    movabs rdx, 9221964661971222528
-    mov QWORD PTR [rax + 128], rdx
-    mov QWORD PTR [rax + 136], rdx
+    mov QWORD PTR [rax + 88], rdi
+    movabs rdi, 9221964661971222528
+    mov QWORD PTR [rax + 128], rdi
+    mov QWORD PTR [rax + 136], rdi
     mov QWORD PTR [rax + 144], r9
-    mov QWORD PTR [rax + 152], rdx
-    mov QWORD PTR [rax + 160], rdx
-    lea r8, [rax + 16]
+    mov QWORD PTR [rax + 152], rdi
+    mov QWORD PTR [rax + 160], rdi
+    lea rdi, [rax + 16]
     lea rcx, [rcx + 120]
-    mov r9, QWORD PTR [rcx + 8]
+    mov r8, QWORD PTR [rcx + 8]
     mov rcx, QWORD PTR [rcx]
-    mov QWORD PTR [r8], rcx
-    mov QWORD PTR [r8 + 8], r9
+    mov QWORD PTR [rdi], rcx
+    mov QWORD PTR [rdi + 8], r8
     mov DWORD PTR [rax + 64], 0
-    mov r8, QWORD PTR [rbp - 48]
-    mov rcx, QWORD PTR [r8 + 15384]
+    mov rdi, QWORD PTR [rbp - 48]
+    mov rcx, QWORD PTR [rdi + 15384]
     mov QWORD PTR [rax + 56], rcx
     lea rcx, [rcx + 1]
-    mov QWORD PTR [r8 + 15384], rcx
+    mov QWORD PTR [rdi + 15384], rcx
     mov DWORD PTR [rax + 68], 0
     mov DWORD PTR [rax + 72], 4294967295
     mov BYTE PTR [rax + 76], 0
     mov BYTE PTR [rax + 77], 0
     mov BYTE PTR [rax + 78], 0
+    mov BYTE PTR [rax + 79], 0
     lea r11, [rbx - 128]
     mov QWORD PTR [rax + 96], r11
-    mov r9d, DWORD PTR [r14 + r13 + 4]
-    mov r8d, DWORD PTR [r14 + r13 + 8]
+    mov r8d, DWORD PTR [r14 + r13 + 4]
+    mov edi, DWORD PTR [r14 + r13 + 8]
     mov ecx, r13d
-    add rcx, r9
+    add rcx, r8
     mov DWORD PTR [rax + 108], ecx
-    mov DWORD PTR [rax + 112], r8d
-    mov rcx, 5
+    mov DWORD PTR [rax + 112], edi
+    mov edi, DWORD PTR [r14 + r13 + 20]
+    xor rcx, rcx
     lea r8, [rax + 128]
-.Lasm_Call.ssa_block_17:
-    lea r9, [rcx + 1]
-    cmp r9, rdi
-    jae .Lasm_Call.ssa_block_16
-    mov QWORD PTR [r8 + rcx * 8], rdx
-    mov QWORD PTR [r8 + rcx * 8 + 8], rdx
-    lea rcx, [rcx + 2]
-    jmp .Lasm_Call.ssa_block_17
-.Lasm_Call.ssa_block_16:
-    cmp rcx, rdi
-    jae .Lasm_Call.ssa_block_19
-    mov QWORD PTR [r8 + rcx * 8], rdx
-.Lasm_Call.ssa_block_19:
-    mov rcx, QWORD PTR [rax + 88]
-    mov r9, QWORD PTR [rcx + 376]
-    mov r10, QWORD PTR [rcx + 384]
-    xor rcx, rcx
-    mov rdx, rdi
-.Lasm_Call.ssa_block_22:
-    cmp rcx, r9
-    jae .Lasm_Call.ssa_block_21
-    mov r11, QWORD PTR [r10 + rcx * 8]
-    mov QWORD PTR [r8 + rdx * 8], r11
-    lea rcx, [rcx + 1]
-    lea rdx, [rdx + 1]
-    jmp .Lasm_Call.ssa_block_22
-.Lasm_Call.ssa_block_21:
-    mov edx, DWORD PTR [r14 + r13 + 20]
-    xor rcx, rcx
-    add rdi, r9
     lea r9, [rbx]
     lea r10, [r14 + r13 + 28]
-.Lasm_Call.ssa_block_25:
-    cmp rcx, rdx
-    jae .Lasm_Call.ssa_block_24
+.Lasm_Call.ssa_block_17:
+    cmp rcx, rdi
+    jae .Lasm_Call.ssa_block_16
     mov r11d, DWORD PTR [r10 + rcx * 4]
     mov r11, QWORD PTR [r9 + r11 * 8]
-    mov QWORD PTR [r8 + rdi * 8], r11
+    mov QWORD PTR [r8 + rsi * 8], r11
     lea rcx, [rcx + 1]
-    lea rdi, [rdi + 1]
-    jmp .Lasm_Call.ssa_block_25
-.Lasm_Call.ssa_block_24:
+    lea rsi, [rsi + 1]
+    jmp .Lasm_Call.ssa_block_17
+.Lasm_Call.ssa_block_16:
     movabs rcx, 9222809086901354496
-    add rsi, rdi
-    sub rsi, rdx
-.Lasm_Call.ssa_block_28:
-    cmp rdi, rsi
-    jae .Lasm_Call.ssa_block_27
-    mov QWORD PTR [r8 + rdi * 8], rcx
-    lea rdi, [rdi + 1]
-    jmp .Lasm_Call.ssa_block_28
-.Lasm_Call.ssa_block_27:
+    add rdx, rsi
+    sub rdx, rdi
+.Lasm_Call.ssa_block_20:
+    cmp rsi, rdx
+    jae .Lasm_Call.ssa_block_19
+    mov QWORD PTR [r8 + rsi * 8], rcx
+    lea rsi, [rsi + 1]
+    jmp .Lasm_Call.ssa_block_20
+.Lasm_Call.ssa_block_19:
     mov rcx, QWORD PTR [rax + 88]
     mov r14, QWORD PTR [rcx + 80]
     mov rcx, QWORD PTR [rbp - 48]
@@ -4935,6 +4915,7 @@ asm_handler_Call:
     mov BYTE PTR [rax + 76], 0
     mov BYTE PTR [rax + 77], 0
     mov BYTE PTR [rax + 78], 0
+    mov BYTE PTR [rax + 79], 0
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov r8d, DWORD PTR [r14 + r13 + 8]
     mov edi, r13d
@@ -4948,15 +4929,15 @@ asm_handler_Call:
     lea rdi, [rbx]
     lea r8, [r14 + r13 + 28]
     lea r9, [rax + 128]
-.Lasm_Call.ssa_block_31:
+.Lasm_Call.ssa_block_23:
     cmp rsi, rdx
-    jae .Lasm_Call.ssa_block_30
+    jae .Lasm_Call.ssa_block_22
     mov r10d, DWORD PTR [r8 + rsi * 4]
     mov r10, QWORD PTR [rdi + r10 * 8]
     mov QWORD PTR [r9 + rsi * 8], r10
     lea rsi, [rsi + 1]
-    jmp .Lasm_Call.ssa_block_31
-.Lasm_Call.ssa_block_30:
+    jmp .Lasm_Call.ssa_block_23
+.Lasm_Call.ssa_block_22:
     mov rdx, QWORD PTR [rbp - 48]
     mov QWORD PTR [rdx + 15288], rax
     lea rbx, [rax + 128]
@@ -4987,10 +4968,74 @@ asm_handler_Call:
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
 .Lasm_Call.ssa_block_2:
+    lea rcx, [r14 + r13]
+    mov r11, rsp
+    mov r10d, DWORD PTR [rcx + 20]
+    shl r10, 3
+    add r10, 55
+    and r10, -16
+    mov rax, rsp
+    sub rax, r10
+    mov rdx, QWORD PTR [rbp - 48]
+    mov rdx, QWORD PTR [rdx + 15336]
+    add rdx, 32768
+    cmp rax, rdx
+    jae .Lasm_Call.values_allocate_1
+    mov eax, 1
+    jmp .Lasm_Call.values_call_done_0
+.Lasm_Call.values_allocate_1:
+.Lasm_Call.values_probe_2:
+    lea r10, [rsp - 4096]
+    cmp r10, rax
+    jbe .Lasm_Call.values_allocated_3
+    mov rsp, r10
+    mov QWORD PTR [rsp], 0
+    jmp .Lasm_Call.values_probe_2
+.Lasm_Call.values_allocated_3:
+    mov rsp, rax
+    mov QWORD PTR [rsp], r11
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Call.value_ready_4:
+    mov QWORD PTR [rsp + 24], rax
+    mov r10d, DWORD PTR [rcx + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Call.value_ready_5:
+    mov QWORD PTR [rsp + 32], rax
+    mov r11d, 0
+    mov r10d, DWORD PTR [rcx + 20]
+.Lasm_Call.array_value_next_6:
+    cmp r11, r10
+    jae .Lasm_Call.array_values_end_8
+    mov edx, DWORD PTR [rcx + r11 * 4 + 28]
+    mov rax, QWORD PTR [rbx + rdx * 8]
+.Lasm_Call.array_value_ready_7:
+    mov QWORD PTR [rsp + r11 * 8 + 40], rax
+    add r11, 1
+    jmp .Lasm_Call.array_value_next_6
+.Lasm_Call.array_values_end_8:
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_try_inline_call)
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_Call.values_restore_stack_9
+    test rax, rax
+    jne .Lasm_Call.values_exceptional_outputs_10
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_Call.skip_output_value_11:
+    jmp .Lasm_Call.values_restore_stack_9
+.Lasm_Call.values_exceptional_outputs_10:
+.Lasm_Call.values_restore_stack_9:
+    mov rsp, QWORD PTR [rsp]
+.Lasm_Call.values_call_done_0:
     test eax, eax
     jnz .Lasm_Call.ssa_block_1
     mov rax, QWORD PTR [rbp - 48]
@@ -5759,38 +5804,6 @@ asm_handler_MulRhsInt32:
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
 asm_handler_MulRhsInt32_hot_end:
-
-.p2align 6
-asm_handler_ExpRhsInt32:
-    mov eax, DWORD PTR [r14 + r13 + 8]
-    mov rcx, QWORD PTR [rbx + rax * 8]
-    mov edx, DWORD PTR [r14 + r13 + 12]
-    movabs r11, 9221683186994511872
-    or rdx, r11
-    mov esi, DWORD PTR [r14 + r13 + 4]
-    mov DWORD PTR [rbx + -64], r13d
-    mov r8, rdx
-    mov rdx, rsi
-    mov rdi, QWORD PTR [rbp - 48]
-    mov esi, r13d
-    call CSYM(asm_slow_path_exp_values)
-    test rax, rax
-    js .Lexit
-    bt rax, 32
-    jnc .Lasm_ExpRhsInt32.slow_path_transfer_0
-    mov r13d, eax
-    movzx eax, BYTE PTR [r14 + r13]
-    jmp [r12 + rax * 8]
-.Lasm_ExpRhsInt32.slow_path_transfer_0:
-    mov r11, QWORD PTR [rbp - 48]
-    mov rbx, QWORD PTR [r11 + 15288]
-    add rbx, 128
-    mov r11, QWORD PTR [rbx + -40]
-    mov r14, QWORD PTR [r11 + 80]
-    mov r13d, eax
-    movzx eax, BYTE PTR [r14 + r13]
-    jmp [r12 + rax * 8]
-asm_handler_ExpRhsInt32_hot_end:
 
 .p2align 6
 asm_handler_DivRhsInt32:
@@ -6835,6 +6848,8 @@ asm_handler_JumpLooselyInequalsRhsInt32_hot_end:
 
 # Cold handler paths
 asm_cold_handler_paths:
+asm_handler_Enter_cold:
+asm_handler_Enter_cold_end:
 asm_handler_Mov_cold:
 asm_handler_Mov_cold_end:
 asm_handler_Add_cold:
@@ -6913,20 +6928,35 @@ asm_handler_Add_cold:
 .Lasm_Add.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_add_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_Add.binary_result_restore_1
     bt rax, 32
-    jnc .Lasm_Add.slow_path_transfer_1
+    jnc .Lasm_Add.binary_result_restore_1
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Add.slow_path_transfer_1:
+.Lasm_Add.binary_result_restore_1:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Add.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Add.slow_path_transfer_2:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7015,20 +7045,35 @@ asm_handler_Sub_cold:
 .Lasm_Sub.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_sub_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_Sub.binary_result_restore_1
     bt rax, 32
-    jnc .Lasm_Sub.slow_path_transfer_1
+    jnc .Lasm_Sub.binary_result_restore_1
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Sub.slow_path_transfer_1:
+.Lasm_Sub.binary_result_restore_1:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Sub.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Sub.slow_path_transfer_2:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7116,20 +7161,35 @@ asm_handler_Mul_cold:
 .Lasm_Mul.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_mul_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_Mul.binary_result_restore_1
     bt rax, 32
-    jnc .Lasm_Mul.slow_path_transfer_1
+    jnc .Lasm_Mul.binary_result_restore_1
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Mul.slow_path_transfer_1:
+.Lasm_Mul.binary_result_restore_1:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Mul.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Mul.slow_path_transfer_2:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -7149,23 +7209,107 @@ asm_handler_Mul_cold:
     movabs rax, 9221120237041090560
     jmp .Lasm_Mul.canon_nan_0_ret
 asm_handler_Mul_cold_end:
-asm_handler_Exp_cold:
-asm_handler_Exp_cold_end:
 .p2align 4
-asm_handler_ConcatString:
+asm_handler_Exp:
+    mov ecx, DWORD PTR [r14 + r13 + 8]
+    mov eax, DWORD PTR [r14 + r13 + 12]
+    mov rcx, QWORD PTR [rbx + rcx * 8]
+    mov rdx, QWORD PTR [rbx + rax * 8]
+    mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
+    mov r8, rdx
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
-    lea rdx, [r14 + r13]
-    call CSYM(asm_slow_path_concat_string)
+    call CSYM(asm_slow_path_exp_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_Exp.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_ConcatString.slow_path_transfer_0
+    jnc .Lasm_Exp.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ConcatString.slow_path_transfer_0:
+.Lasm_Exp.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Exp.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Exp.slow_path_transfer_1:
+    mov r11, QWORD PTR [rbp - 48]
+    mov rbx, QWORD PTR [r11 + 15288]
+    add rbx, 128
+    mov r11, QWORD PTR [rbx + -40]
+    mov r14, QWORD PTR [r11 + 80]
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+asm_handler_Exp_hot_end:
+asm_handler_Exp_cold:
+asm_handler_Exp_cold_end:
+
+.p2align 4
+asm_handler_ConcatString:
+    mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 16
+    mov r10d, DWORD PTR [rcx + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ConcatString.value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ConcatString.value_ready_2:
+    mov r9, rax
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    lea rdx, [r14 + r13]
+    lea rcx, [rsp]
+    call CSYM(asm_slow_path_concat_string)
+    test rax, rax
+    js .Lasm_ConcatString.values_exceptional_outputs_4
+    bt rax, 32
+    jnc .Lasm_ConcatString.values_exceptional_outputs_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_ConcatString.skip_output_value_5:
+    add rsp, 16
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ConcatString.values_exceptional_outputs_4:
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_ConcatString.values_restore_stack_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_ConcatString.skip_exceptional_output_6:
+.Lasm_ConcatString.values_restore_stack_3:
+    add rsp, 16
+.Lasm_ConcatString.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ConcatString.slow_path_transfer_7
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ConcatString.slow_path_transfer_7:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7181,18 +7325,81 @@ asm_handler_ConcatString_cold_end:
 .p2align 4
 asm_handler_CopyObjectExcludingProperties:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    mov r11, rsp
+    mov r10d, DWORD PTR [rcx + 16]
+    shl r10, 3
+    add r10, 47
+    and r10, -16
+    mov rax, rsp
+    sub rax, r10
+    mov rdx, QWORD PTR [rbp - 48]
+    mov rdx, QWORD PTR [rdx + 15336]
+    add rdx, 32768
+    cmp rax, rdx
+    jae .Lasm_CopyObjectExcludingProperties.values_allocate_1
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    call CSYM(asm_slow_path_stack_overflow)
+    jmp .Lasm_CopyObjectExcludingProperties.values_call_done_0
+.Lasm_CopyObjectExcludingProperties.values_allocate_1:
+.Lasm_CopyObjectExcludingProperties.values_probe_2:
+    lea r10, [rsp - 4096]
+    cmp r10, rax
+    jbe .Lasm_CopyObjectExcludingProperties.values_allocated_3
+    mov rsp, r10
+    mov QWORD PTR [rsp], 0
+    jmp .Lasm_CopyObjectExcludingProperties.values_probe_2
+.Lasm_CopyObjectExcludingProperties.values_allocated_3:
+    mov rsp, rax
+    mov QWORD PTR [rsp], r11
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CopyObjectExcludingProperties.value_ready_4:
+    mov QWORD PTR [rsp + 24], rax
+    mov r11d, 0
+    mov r10d, DWORD PTR [rcx + 16]
+.Lasm_CopyObjectExcludingProperties.array_value_next_5:
+    cmp r11, r10
+    jae .Lasm_CopyObjectExcludingProperties.array_values_end_7
+    mov edx, DWORD PTR [rcx + r11 * 4 + 20]
+    mov rax, QWORD PTR [rbx + rdx * 8]
+.Lasm_CopyObjectExcludingProperties.array_value_ready_6:
+    mov QWORD PTR [rsp + r11 * 8 + 32], rax
+    add r11, 1
+    jmp .Lasm_CopyObjectExcludingProperties.array_value_next_5
+.Lasm_CopyObjectExcludingProperties.array_values_end_7:
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_copy_object_excluding_properties)
     test rax, rax
-    js .Lexit
+    js .Lasm_CopyObjectExcludingProperties.values_exceptional_outputs_9
     bt rax, 32
-    jnc .Lasm_CopyObjectExcludingProperties.slow_path_transfer_0
+    jnc .Lasm_CopyObjectExcludingProperties.values_exceptional_outputs_9
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_CopyObjectExcludingProperties.skip_output_value_10:
+    mov rsp, QWORD PTR [rsp]
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CopyObjectExcludingProperties.slow_path_transfer_0:
+.Lasm_CopyObjectExcludingProperties.values_exceptional_outputs_9:
+.Lasm_CopyObjectExcludingProperties.values_restore_stack_8:
+    mov rsp, QWORD PTR [rsp]
+.Lasm_CopyObjectExcludingProperties.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CopyObjectExcludingProperties.slow_path_transfer_11
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CopyObjectExcludingProperties.slow_path_transfer_11:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7208,18 +7415,38 @@ asm_handler_CopyObjectExcludingProperties_cold_end:
 .p2align 4
 asm_handler_ImportCall:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ImportCall.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ImportCall.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_import_call)
     test rax, rax
-    js .Lexit
+    js .Lasm_ImportCall.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_ImportCall.slow_path_transfer_0
+    jnc .Lasm_ImportCall.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ImportCall.slow_path_transfer_0:
+.Lasm_ImportCall.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ImportCall.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ImportCall.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7235,18 +7462,91 @@ asm_handler_ImportCall_cold_end:
 .p2align 4
 asm_handler_NewClass:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    mov r11, rsp
+    mov r10d, DWORD PTR [rcx + 28]
+    shl r10, 3
+    add r10, 55
+    and r10, -16
+    mov rax, rsp
+    sub rax, r10
+    mov rdx, QWORD PTR [rbp - 48]
+    mov rdx, QWORD PTR [rdx + 15336]
+    add rdx, 32768
+    cmp rax, rdx
+    jae .Lasm_NewClass.values_allocate_1
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    call CSYM(asm_slow_path_stack_overflow)
+    jmp .Lasm_NewClass.values_call_done_0
+.Lasm_NewClass.values_allocate_1:
+.Lasm_NewClass.values_probe_2:
+    lea r10, [rsp - 4096]
+    cmp r10, rax
+    jbe .Lasm_NewClass.values_allocated_3
+    mov rsp, r10
+    mov QWORD PTR [rsp], 0
+    jmp .Lasm_NewClass.values_probe_2
+.Lasm_NewClass.values_allocated_3:
+    mov rsp, rax
+    mov QWORD PTR [rsp], r11
+    movabs rax, 9221964661971222528
+    mov r10d, DWORD PTR [rcx + 12]
+    cmp r10d, -1
+    je .Lasm_NewClass.value_ready_4
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_NewClass.value_ready_4:
+    mov QWORD PTR [rsp + 24], rax
+    mov r10d, DWORD PTR [rcx + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_NewClass.value_ready_5:
+    mov QWORD PTR [rsp + 32], rax
+    mov r11d, 0
+    mov r10d, DWORD PTR [rcx + 28]
+.Lasm_NewClass.array_value_next_6:
+    cmp r11, r10
+    jae .Lasm_NewClass.array_values_end_8
+    mov edx, DWORD PTR [rcx + r11 * 4 + 32]
+    movabs rax, 9221964661971222528
+    cmp edx, -1
+    je .Lasm_NewClass.array_value_ready_7
+    mov rax, QWORD PTR [rbx + rdx * 8]
+.Lasm_NewClass.array_value_ready_7:
+    mov QWORD PTR [rsp + r11 * 8 + 40], rax
+    add r11, 1
+    jmp .Lasm_NewClass.array_value_next_6
+.Lasm_NewClass.array_values_end_8:
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_new_class)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewClass.values_exceptional_outputs_10
     bt rax, 32
-    jnc .Lasm_NewClass.slow_path_transfer_0
+    jnc .Lasm_NewClass.values_exceptional_outputs_10
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_NewClass.skip_output_value_11:
+    mov rsp, QWORD PTR [rsp]
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewClass.slow_path_transfer_0:
+.Lasm_NewClass.values_exceptional_outputs_10:
+.Lasm_NewClass.values_restore_stack_9:
+    mov rsp, QWORD PTR [rsp]
+.Lasm_NewClass.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewClass.slow_path_transfer_12
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewClass.slow_path_transfer_12:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7680,18 +7980,52 @@ asm_handler_Increment_cold:
     jmp [r12 + rax * 8]
 .Lasm_Increment.ssa_block_2:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 16
+    mov r10d, DWORD PTR [rcx + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Increment.value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_increment)
     test rax, rax
-    js .Lexit
+    js .Lasm_Increment.values_exceptional_outputs_3
     bt rax, 32
-    jnc .Lasm_Increment.slow_path_transfer_0
+    jnc .Lasm_Increment.values_exceptional_outputs_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_Increment.skip_output_value_4:
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Increment.slow_path_transfer_0:
+.Lasm_Increment.values_exceptional_outputs_3:
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_Increment.values_restore_stack_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_Increment.skip_exceptional_output_5:
+.Lasm_Increment.values_restore_stack_2:
+    add rsp, 16
+.Lasm_Increment.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Increment.slow_path_transfer_6
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Increment.slow_path_transfer_6:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7718,18 +8052,52 @@ asm_handler_Decrement_cold:
     jmp [r12 + rax * 8]
 .Lasm_Decrement.ssa_block_2:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 16
+    mov r10d, DWORD PTR [rcx + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Decrement.value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_decrement)
     test rax, rax
-    js .Lexit
+    js .Lasm_Decrement.values_exceptional_outputs_3
     bt rax, 32
-    jnc .Lasm_Decrement.slow_path_transfer_0
+    jnc .Lasm_Decrement.values_exceptional_outputs_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_Decrement.skip_output_value_4:
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Decrement.slow_path_transfer_0:
+.Lasm_Decrement.values_exceptional_outputs_3:
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_Decrement.values_restore_stack_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_Decrement.skip_exceptional_output_5:
+.Lasm_Decrement.values_restore_stack_2:
+    add rsp, 16
+.Lasm_Decrement.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Decrement.slow_path_transfer_6
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Decrement.slow_path_transfer_6:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7754,18 +8122,30 @@ asm_handler_GetLexicalEnvironment_cold_end:
 .p2align 4
 asm_handler_GetImportMeta:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_import_meta)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetImportMeta.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_GetImportMeta.slow_path_transfer_0
+    jnc .Lasm_GetImportMeta.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetImportMeta.slow_path_transfer_0:
+.Lasm_GetImportMeta.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetImportMeta.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetImportMeta.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7781,18 +8161,30 @@ asm_handler_GetImportMeta_cold_end:
 .p2align 4
 asm_handler_GetNewTarget:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_new_target)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetNewTarget.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_GetNewTarget.slow_path_transfer_0
+    jnc .Lasm_GetNewTarget.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetNewTarget.slow_path_transfer_0:
+.Lasm_GetNewTarget.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetNewTarget.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetNewTarget.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7808,18 +8200,30 @@ asm_handler_GetNewTarget_cold_end:
 .p2align 4
 asm_handler_GetSuperConstructor:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_super_constructor)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetSuperConstructor.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_GetSuperConstructor.slow_path_transfer_0
+    jnc .Lasm_GetSuperConstructor.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetSuperConstructor.slow_path_transfer_0:
+.Lasm_GetSuperConstructor.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetSuperConstructor.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetSuperConstructor.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7838,18 +8242,30 @@ asm_handler_GetBinding_cold:
 # Cold paths for GetBinding
 .Lasm_GetBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetBinding.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_GetBinding.slow_path_transfer_0
+    jnc .Lasm_GetBinding.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetBinding.slow_path_transfer_0:
+.Lasm_GetBinding.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetBinding.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetBinding.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7863,18 +8279,30 @@ asm_handler_DynamicGetBinding_cold:
 # Cold paths for DynamicGetBinding
 .Lasm_DynamicGetBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_dynamic_get_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_DynamicGetBinding.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_DynamicGetBinding.slow_path_transfer_0
+    jnc .Lasm_DynamicGetBinding.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DynamicGetBinding.slow_path_transfer_0:
+.Lasm_DynamicGetBinding.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicGetBinding.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicGetBinding.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7890,18 +8318,30 @@ asm_handler_DynamicGetInitializedBinding_cold:
 # Cold paths for DynamicGetInitializedBinding
 .Lasm_DynamicGetInitializedBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_dynamic_get_initialized_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_DynamicGetInitializedBinding.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_DynamicGetInitializedBinding.slow_path_transfer_0
+    jnc .Lasm_DynamicGetInitializedBinding.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DynamicGetInitializedBinding.slow_path_transfer_0:
+.Lasm_DynamicGetInitializedBinding.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicGetInitializedBinding.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicGetInitializedBinding.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7919,18 +8359,31 @@ asm_handler_DynamicInitializeLexicalBinding_cold:
 # Cold paths for DynamicInitializeLexicalBinding
 .Lasm_DynamicInitializeLexicalBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_DynamicInitializeLexicalBinding.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_dynamic_initialize_lexical_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_DynamicInitializeLexicalBinding.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_0
+    jnc .Lasm_DynamicInitializeLexicalBinding.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_0:
+.Lasm_DynamicInitializeLexicalBinding.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicInitializeLexicalBinding.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7944,18 +8397,31 @@ asm_handler_DynamicInitializeVariableBinding_cold:
 # Cold paths for DynamicInitializeVariableBinding
 .Lasm_DynamicInitializeVariableBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_DynamicInitializeVariableBinding.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_dynamic_initialize_variable_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_DynamicInitializeVariableBinding.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_DynamicInitializeVariableBinding.slow_path_transfer_0
+    jnc .Lasm_DynamicInitializeVariableBinding.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DynamicInitializeVariableBinding.slow_path_transfer_0:
+.Lasm_DynamicInitializeVariableBinding.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicInitializeVariableBinding.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicInitializeVariableBinding.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7969,18 +8435,31 @@ asm_handler_SetLexicalBinding_cold:
 # Cold paths for SetLexicalBinding
 .Lasm_SetLexicalBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SetLexicalBinding.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_set_lexical_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_SetLexicalBinding.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_SetLexicalBinding.slow_path_transfer_0
+    jnc .Lasm_SetLexicalBinding.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_SetLexicalBinding.slow_path_transfer_0:
+.Lasm_SetLexicalBinding.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetLexicalBinding.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetLexicalBinding.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -7994,18 +8473,31 @@ asm_handler_SetVariableBinding_cold:
 # Cold paths for SetVariableBinding
 .Lasm_SetVariableBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SetVariableBinding.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_set_variable_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_SetVariableBinding.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_SetVariableBinding.slow_path_transfer_0
+    jnc .Lasm_SetVariableBinding.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_SetVariableBinding.slow_path_transfer_0:
+.Lasm_SetVariableBinding.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetVariableBinding.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetVariableBinding.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8019,18 +8511,31 @@ asm_handler_DynamicSetLexicalBinding_cold:
 # Cold paths for DynamicSetLexicalBinding
 .Lasm_DynamicSetLexicalBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_DynamicSetLexicalBinding.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_dynamic_set_lexical_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_DynamicSetLexicalBinding.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_DynamicSetLexicalBinding.slow_path_transfer_0
+    jnc .Lasm_DynamicSetLexicalBinding.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DynamicSetLexicalBinding.slow_path_transfer_0:
+.Lasm_DynamicSetLexicalBinding.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicSetLexicalBinding.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicSetLexicalBinding.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8044,18 +8549,31 @@ asm_handler_DynamicSetVariableBinding_cold:
 # Cold paths for DynamicSetVariableBinding
 .Lasm_DynamicSetVariableBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_DynamicSetVariableBinding.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_dynamic_set_variable_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_DynamicSetVariableBinding.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_DynamicSetVariableBinding.slow_path_transfer_0
+    jnc .Lasm_DynamicSetVariableBinding.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DynamicSetVariableBinding.slow_path_transfer_0:
+.Lasm_DynamicSetVariableBinding.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicSetVariableBinding.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicSetVariableBinding.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8068,18 +8586,30 @@ asm_handler_DynamicSetVariableBinding_cold_end:
 .p2align 4
 asm_handler_ResolveBinding:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_resolve_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_ResolveBinding.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_ResolveBinding.slow_path_transfer_0
+    jnc .Lasm_ResolveBinding.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ResolveBinding.slow_path_transfer_0:
+.Lasm_ResolveBinding.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ResolveBinding.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ResolveBinding.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8095,18 +8625,30 @@ asm_handler_ResolveBinding_cold_end:
 .p2align 4
 asm_handler_ResolveSuperBase:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_resolve_super_base)
     test rax, rax
-    js .Lexit
+    js .Lasm_ResolveSuperBase.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_ResolveSuperBase.slow_path_transfer_0
+    jnc .Lasm_ResolveSuperBase.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ResolveSuperBase.slow_path_transfer_0:
+.Lasm_ResolveSuperBase.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ResolveSuperBase.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ResolveSuperBase.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8122,18 +8664,35 @@ asm_handler_ResolveSuperBase_cold_end:
 .p2align 4
 asm_handler_SetResolvedBinding:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SetResolvedBinding.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SetResolvedBinding.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_set_resolved_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_SetResolvedBinding.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_SetResolvedBinding.slow_path_transfer_0
+    jnc .Lasm_SetResolvedBinding.scalar_result_done_2
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_SetResolvedBinding.slow_path_transfer_0:
+.Lasm_SetResolvedBinding.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetResolvedBinding.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetResolvedBinding.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8149,18 +8708,30 @@ asm_handler_SetResolvedBinding_cold_end:
 .p2align 4
 asm_handler_TypeofBinding:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_typeof_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_TypeofBinding.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_TypeofBinding.slow_path_transfer_0
+    jnc .Lasm_TypeofBinding.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_TypeofBinding.slow_path_transfer_0:
+.Lasm_TypeofBinding.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_TypeofBinding.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_TypeofBinding.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8176,18 +8747,30 @@ asm_handler_TypeofBinding_cold_end:
 .p2align 4
 asm_handler_DynamicTypeofBinding:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_dynamic_typeof_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_DynamicTypeofBinding.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_DynamicTypeofBinding.slow_path_transfer_0
+    jnc .Lasm_DynamicTypeofBinding.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DynamicTypeofBinding.slow_path_transfer_0:
+.Lasm_DynamicTypeofBinding.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicTypeofBinding.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicTypeofBinding.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8203,18 +8786,34 @@ asm_handler_DynamicTypeofBinding_cold_end:
 .p2align 4
 asm_handler_HasPrivateId:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_HasPrivateId.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_has_private_id)
     test rax, rax
-    js .Lexit
+    js .Lasm_HasPrivateId.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_HasPrivateId.slow_path_transfer_0
+    jnc .Lasm_HasPrivateId.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_HasPrivateId.slow_path_transfer_0:
+.Lasm_HasPrivateId.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_HasPrivateId.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_HasPrivateId.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8230,18 +8829,35 @@ asm_handler_HasPrivateId_cold_end:
 .p2align 4
 asm_handler_SetFunctionName:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SetFunctionName.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SetFunctionName.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_set_function_name)
     test rax, rax
-    js .Lexit
+    js .Lasm_SetFunctionName.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_SetFunctionName.slow_path_transfer_0
+    jnc .Lasm_SetFunctionName.scalar_result_done_2
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_SetFunctionName.slow_path_transfer_0:
+.Lasm_SetFunctionName.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetFunctionName.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetFunctionName.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8257,18 +8873,34 @@ asm_handler_SetFunctionName_cold_end:
 .p2align 4
 asm_handler_NewArrayWithLength:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_NewArrayWithLength.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_new_array_with_length)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewArrayWithLength.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_NewArrayWithLength.slow_path_transfer_0
+    jnc .Lasm_NewArrayWithLength.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewArrayWithLength.slow_path_transfer_0:
+.Lasm_NewArrayWithLength.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewArrayWithLength.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewArrayWithLength.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8284,18 +8916,35 @@ asm_handler_NewArrayWithLength_cold_end:
 .p2align 4
 asm_handler_ArrayAppend:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ArrayAppend.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ArrayAppend.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_array_append)
     test rax, rax
-    js .Lexit
+    js .Lasm_ArrayAppend.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_ArrayAppend.slow_path_transfer_0
+    jnc .Lasm_ArrayAppend.scalar_result_done_2
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ArrayAppend.slow_path_transfer_0:
+.Lasm_ArrayAppend.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ArrayAppend.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ArrayAppend.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8311,18 +8960,27 @@ asm_handler_ArrayAppend_cold_end:
 .p2align 4
 asm_handler_CreateVariable:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_create_variable)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreateVariable.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_CreateVariable.slow_path_transfer_0
+    jnc .Lasm_CreateVariable.scalar_result_done_0
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreateVariable.slow_path_transfer_0:
+.Lasm_CreateVariable.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateVariable.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateVariable.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8338,18 +8996,34 @@ asm_handler_CreateVariable_cold_end:
 .p2align 4
 asm_handler_EnterObjectEnvironment:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_EnterObjectEnvironment.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_enter_object_environment)
     test rax, rax
-    js .Lexit
+    js .Lasm_EnterObjectEnvironment.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_EnterObjectEnvironment.slow_path_transfer_0
+    jnc .Lasm_EnterObjectEnvironment.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_EnterObjectEnvironment.slow_path_transfer_0:
+.Lasm_EnterObjectEnvironment.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_EnterObjectEnvironment.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_EnterObjectEnvironment.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8379,18 +9053,56 @@ asm_handler_PostfixIncrement_cold:
     jmp [r12 + rax * 8]
 .Lasm_PostfixIncrement.ssa_block_2:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 16
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PostfixIncrement.value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_postfix_increment)
     test rax, rax
-    js .Lexit
+    js .Lasm_PostfixIncrement.values_exceptional_outputs_3
     bt rax, 32
-    jnc .Lasm_PostfixIncrement.slow_path_transfer_0
+    jnc .Lasm_PostfixIncrement.values_exceptional_outputs_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_PostfixIncrement.skip_output_value_4:
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 8]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_PostfixIncrement.skip_output_value_5:
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_PostfixIncrement.slow_path_transfer_0:
+.Lasm_PostfixIncrement.values_exceptional_outputs_3:
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_PostfixIncrement.values_restore_stack_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 8]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_PostfixIncrement.skip_exceptional_output_6:
+.Lasm_PostfixIncrement.values_restore_stack_2:
+    add rsp, 16
+.Lasm_PostfixIncrement.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_PostfixIncrement.slow_path_transfer_7
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PostfixIncrement.slow_path_transfer_7:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8405,20 +9117,35 @@ asm_handler_Div_cold:
 .Lasm_Div.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_div_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_Div.binary_result_restore_1
     bt rax, 32
-    jnc .Lasm_Div.slow_path_transfer_1
+    jnc .Lasm_Div.binary_result_restore_1
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Div.slow_path_transfer_1:
+.Lasm_Div.binary_result_restore_1:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Div.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Div.slow_path_transfer_2:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8465,20 +9192,35 @@ asm_handler_LessThan_cold:
 .Lasm_LessThan.ssa_block_3:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_less_than_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LessThan.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LessThan.slow_path_transfer_0
+    jnc .Lasm_LessThan.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LessThan.slow_path_transfer_0:
+.Lasm_LessThan.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LessThan.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LessThan.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8522,20 +9264,35 @@ asm_handler_LessThanEquals_cold:
 .Lasm_LessThanEquals.ssa_block_3:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_less_than_equals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LessThanEquals.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LessThanEquals.slow_path_transfer_0
+    jnc .Lasm_LessThanEquals.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LessThanEquals.slow_path_transfer_0:
+.Lasm_LessThanEquals.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LessThanEquals.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LessThanEquals.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8579,20 +9336,35 @@ asm_handler_GreaterThan_cold:
 .Lasm_GreaterThan.ssa_block_3:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_greater_than_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_GreaterThan.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_GreaterThan.slow_path_transfer_0
+    jnc .Lasm_GreaterThan.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GreaterThan.slow_path_transfer_0:
+.Lasm_GreaterThan.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GreaterThan.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GreaterThan.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8636,20 +9408,35 @@ asm_handler_GreaterThanEquals_cold:
 .Lasm_GreaterThanEquals.ssa_block_3:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_greater_than_equals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_GreaterThanEquals.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_GreaterThanEquals.slow_path_transfer_0
+    jnc .Lasm_GreaterThanEquals.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GreaterThanEquals.slow_path_transfer_0:
+.Lasm_GreaterThanEquals.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GreaterThanEquals.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GreaterThanEquals.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8698,20 +9485,35 @@ asm_handler_BitwiseXor_cold:
 .Lasm_BitwiseXor.ssa_block_1:
     mov ecx, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
-    mov r8, rdx
-    mov rdx, rcx
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], ecx
     mov rcx, rsi
+    mov r8, rdx
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_bitwise_xor_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_BitwiseXor.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_BitwiseXor.slow_path_transfer_0
+    jnc .Lasm_BitwiseXor.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_BitwiseXor.slow_path_transfer_0:
+.Lasm_BitwiseXor.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseXor.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseXor.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -8739,18 +9541,34 @@ asm_handler_UnaryPlus_cold:
     cmp cx, 32760
     jne .Lasm_UnaryPlus.ssa_block_2
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_UnaryPlus.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_unary_plus)
     test rax, rax
-    js .Lexit
+    js .Lasm_UnaryPlus.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_UnaryPlus.slow_path_transfer_0
+    jnc .Lasm_UnaryPlus.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_UnaryPlus.slow_path_transfer_0:
+.Lasm_UnaryPlus.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_UnaryPlus.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_UnaryPlus.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8770,18 +9588,31 @@ asm_handler_ThrowIfTDZ_cold:
 # Cold paths for ThrowIfTDZ
 .Lasm_ThrowIfTDZ.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ThrowIfTDZ.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_throw_if_tdz)
     test rax, rax
-    js .Lexit
+    js .Lasm_ThrowIfTDZ.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_ThrowIfTDZ.slow_path_transfer_0
+    jnc .Lasm_ThrowIfTDZ.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ThrowIfTDZ.slow_path_transfer_0:
+.Lasm_ThrowIfTDZ.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ThrowIfTDZ.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ThrowIfTDZ.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8795,18 +9626,31 @@ asm_handler_ThrowIfNotObject_cold:
 # Cold paths for ThrowIfNotObject
 .Lasm_ThrowIfNotObject.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ThrowIfNotObject.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_throw_if_not_object)
     test rax, rax
-    js .Lexit
+    js .Lasm_ThrowIfNotObject.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_ThrowIfNotObject.slow_path_transfer_0
+    jnc .Lasm_ThrowIfNotObject.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ThrowIfNotObject.slow_path_transfer_0:
+.Lasm_ThrowIfNotObject.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ThrowIfNotObject.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ThrowIfNotObject.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8820,18 +9664,31 @@ asm_handler_ThrowIfNullish_cold:
 # Cold paths for ThrowIfNullish
 .Lasm_ThrowIfNullish.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ThrowIfNullish.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_throw_if_nullish)
     test rax, rax
-    js .Lexit
+    js .Lasm_ThrowIfNullish.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_ThrowIfNullish.slow_path_transfer_0
+    jnc .Lasm_ThrowIfNullish.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ThrowIfNullish.slow_path_transfer_0:
+.Lasm_ThrowIfNullish.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ThrowIfNullish.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ThrowIfNullish.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8844,18 +9701,27 @@ asm_handler_ThrowIfNullish_cold_end:
 .p2align 4
 asm_handler_ThrowConstAssignment:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_throw_const_assignment)
     test rax, rax
-    js .Lexit
+    js .Lasm_ThrowConstAssignment.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_ThrowConstAssignment.slow_path_transfer_0
+    jnc .Lasm_ThrowConstAssignment.scalar_result_done_0
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ThrowConstAssignment.slow_path_transfer_0:
+.Lasm_ThrowConstAssignment.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ThrowConstAssignment.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ThrowConstAssignment.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8871,18 +9737,31 @@ asm_handler_ThrowConstAssignment_cold_end:
 .p2align 4
 asm_handler_Throw:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Throw.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_throw)
     test rax, rax
-    js .Lexit
+    js .Lasm_Throw.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_Throw.slow_path_transfer_0
+    jnc .Lasm_Throw.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Throw.slow_path_transfer_0:
+.Lasm_Throw.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Throw.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Throw.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8898,18 +9777,27 @@ asm_handler_Throw_cold_end:
 .p2align 4
 asm_handler_Debugger:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_debugger)
     test rax, rax
-    js .Lexit
+    js .Lasm_Debugger.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_Debugger.slow_path_transfer_0
+    jnc .Lasm_Debugger.scalar_result_done_0
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Debugger.slow_path_transfer_0:
+.Lasm_Debugger.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Debugger.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Debugger.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8925,18 +9813,31 @@ asm_handler_Debugger_cold_end:
 .p2align 4
 asm_handler_Await:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Await.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_await)
     test rax, rax
-    js .Lexit
+    js .Lasm_Await.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_Await.slow_path_transfer_0
+    jnc .Lasm_Await.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Await.slow_path_transfer_0:
+.Lasm_Await.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Await.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Await.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8952,18 +9853,31 @@ asm_handler_Await_cold_end:
 .p2align 4
 asm_handler_Yield:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Yield.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_yield)
     test rax, rax
-    js .Lexit
+    js .Lasm_Yield.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_Yield.slow_path_transfer_0
+    jnc .Lasm_Yield.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Yield.slow_path_transfer_0:
+.Lasm_Yield.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Yield.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Yield.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -8979,18 +9893,31 @@ asm_handler_Yield_cold_end:
 .p2align 4
 asm_handler_YieldIteratorResult:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_YieldIteratorResult.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_yield_iterator_result)
     test rax, rax
-    js .Lexit
+    js .Lasm_YieldIteratorResult.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_YieldIteratorResult.slow_path_transfer_0
+    jnc .Lasm_YieldIteratorResult.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_YieldIteratorResult.slow_path_transfer_0:
+.Lasm_YieldIteratorResult.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_YieldIteratorResult.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_YieldIteratorResult.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9006,18 +9933,34 @@ asm_handler_YieldIteratorResult_cold_end:
 .p2align 4
 asm_handler_ToString:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ToString.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_to_string)
     test rax, rax
-    js .Lexit
+    js .Lasm_ToString.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_ToString.slow_path_transfer_0
+    jnc .Lasm_ToString.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ToString.slow_path_transfer_0:
+.Lasm_ToString.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToString.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToString.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9033,18 +9976,34 @@ asm_handler_ToString_cold_end:
 .p2align 4
 asm_handler_ToPrimitiveWithStringHint:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ToPrimitiveWithStringHint.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_to_primitive_with_string_hint)
     test rax, rax
-    js .Lexit
+    js .Lasm_ToPrimitiveWithStringHint.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_ToPrimitiveWithStringHint.slow_path_transfer_0
+    jnc .Lasm_ToPrimitiveWithStringHint.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ToPrimitiveWithStringHint.slow_path_transfer_0:
+.Lasm_ToPrimitiveWithStringHint.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToPrimitiveWithStringHint.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToPrimitiveWithStringHint.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9060,18 +10019,34 @@ asm_handler_ToPrimitiveWithStringHint_cold_end:
 .p2align 4
 asm_handler_ToObject:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ToObject.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_to_object)
     test rax, rax
-    js .Lexit
+    js .Lasm_ToObject.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_ToObject.slow_path_transfer_0
+    jnc .Lasm_ToObject.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ToObject.slow_path_transfer_0:
+.Lasm_ToObject.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToObject.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToObject.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9087,18 +10062,34 @@ asm_handler_ToObject_cold_end:
 .p2align 4
 asm_handler_ToLength:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ToLength.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_to_length)
     test rax, rax
-    js .Lexit
+    js .Lasm_ToLength.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_ToLength.slow_path_transfer_0
+    jnc .Lasm_ToLength.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ToLength.slow_path_transfer_0:
+.Lasm_ToLength.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToLength.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToLength.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9115,18 +10106,34 @@ asm_handler_BitwiseNot_cold:
 # Cold paths for BitwiseNot
 .Lasm_BitwiseNot.ssa_block_2:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_BitwiseNot.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_bitwise_not)
     test rax, rax
-    js .Lexit
+    js .Lasm_BitwiseNot.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_BitwiseNot.slow_path_transfer_0
+    jnc .Lasm_BitwiseNot.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_BitwiseNot.slow_path_transfer_0:
+.Lasm_BitwiseNot.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseNot.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseNot.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9175,20 +10182,35 @@ asm_handler_BitwiseAnd_cold:
 .Lasm_BitwiseAnd.ssa_block_1:
     mov ecx, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
-    mov r8, rdx
-    mov rdx, rcx
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], ecx
     mov rcx, rsi
+    mov r8, rdx
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_bitwise_and_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_BitwiseAnd.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_BitwiseAnd.slow_path_transfer_0
+    jnc .Lasm_BitwiseAnd.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_BitwiseAnd.slow_path_transfer_0:
+.Lasm_BitwiseAnd.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseAnd.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseAnd.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9248,20 +10270,35 @@ asm_handler_BitwiseOr_cold:
 .Lasm_BitwiseOr.ssa_block_1:
     mov ecx, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
-    mov r8, rdx
-    mov rdx, rcx
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], ecx
     mov rcx, rsi
+    mov r8, rdx
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_bitwise_or_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_BitwiseOr.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_BitwiseOr.slow_path_transfer_0
+    jnc .Lasm_BitwiseOr.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_BitwiseOr.slow_path_transfer_0:
+.Lasm_BitwiseOr.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseOr.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseOr.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9287,20 +10324,35 @@ asm_handler_LeftShift_cold:
 .Lasm_LeftShift.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_left_shift_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LeftShift.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LeftShift.slow_path_transfer_0
+    jnc .Lasm_LeftShift.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LeftShift.slow_path_transfer_0:
+.Lasm_LeftShift.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LeftShift.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LeftShift.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9315,20 +10367,35 @@ asm_handler_RightShift_cold:
 .Lasm_RightShift.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_right_shift_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_RightShift.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_RightShift.slow_path_transfer_0
+    jnc .Lasm_RightShift.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_RightShift.slow_path_transfer_0:
+.Lasm_RightShift.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_RightShift.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_RightShift.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9351,20 +10418,35 @@ asm_handler_UnsignedRightShift_cold:
 .Lasm_UnsignedRightShift.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_unsigned_right_shift_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_UnsignedRightShift.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_UnsignedRightShift.slow_path_transfer_0
+    jnc .Lasm_UnsignedRightShift.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_UnsignedRightShift.slow_path_transfer_0:
+.Lasm_UnsignedRightShift.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_UnsignedRightShift.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_UnsignedRightShift.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9468,19 +10550,34 @@ asm_handler_Mod_cold:
     mov rdx, QWORD PTR [rbx + rax * 8]
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_mod_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_Mod.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_Mod.slow_path_transfer_0
+    jnc .Lasm_Mod.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Mod.slow_path_transfer_0:
+.Lasm_Mod.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Mod.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Mod.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9505,19 +10602,34 @@ asm_handler_StrictlyEquals_cold:
 .Lasm_StrictlyEquals.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_strictly_equals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_StrictlyEquals.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_StrictlyEquals.slow_path_transfer_0
+    jnc .Lasm_StrictlyEquals.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_StrictlyEquals.slow_path_transfer_0:
+.Lasm_StrictlyEquals.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_StrictlyEquals.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_StrictlyEquals.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9542,19 +10654,34 @@ asm_handler_StrictlyInequals_cold:
 .Lasm_StrictlyInequals.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_strictly_inequals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_StrictlyInequals.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_StrictlyInequals.slow_path_transfer_0
+    jnc .Lasm_StrictlyInequals.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_StrictlyInequals.slow_path_transfer_0:
+.Lasm_StrictlyInequals.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_StrictlyInequals.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_StrictlyInequals.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9568,18 +10695,42 @@ asm_handler_GetCalleeAndThisFromEnvironment_cold:
 # Cold paths for GetCalleeAndThisFromEnvironment
 .Lasm_GetCalleeAndThisFromEnvironment.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 16
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_get_callee_and_this)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetCalleeAndThisFromEnvironment.values_exceptional_outputs_2
     bt rax, 32
-    jnc .Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_0
+    jnc .Lasm_GetCalleeAndThisFromEnvironment.values_exceptional_outputs_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetCalleeAndThisFromEnvironment.skip_output_value_3:
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 8]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetCalleeAndThisFromEnvironment.skip_output_value_4:
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_0:
+.Lasm_GetCalleeAndThisFromEnvironment.values_exceptional_outputs_2:
+.Lasm_GetCalleeAndThisFromEnvironment.values_restore_stack_1:
+    add rsp, 16
+.Lasm_GetCalleeAndThisFromEnvironment.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetCalleeAndThisFromEnvironment.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9593,18 +10744,42 @@ asm_handler_DynamicGetCalleeAndThisFromEnvironment_cold:
 # Cold paths for DynamicGetCalleeAndThisFromEnvironment
 .Lasm_DynamicGetCalleeAndThisFromEnvironment.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 16
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_dynamic_get_callee_and_this)
     test rax, rax
-    js .Lexit
+    js .Lasm_DynamicGetCalleeAndThisFromEnvironment.values_exceptional_outputs_2
     bt rax, 32
-    jnc .Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_0
+    jnc .Lasm_DynamicGetCalleeAndThisFromEnvironment.values_exceptional_outputs_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.skip_output_value_3:
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 8]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.skip_output_value_4:
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_0:
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.values_exceptional_outputs_2:
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.values_restore_stack_1:
+    add rsp, 16
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DynamicGetCalleeAndThisFromEnvironment.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9629,19 +10804,34 @@ asm_handler_LooselyEquals_cold:
 .Lasm_LooselyEquals.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_loosely_equals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LooselyEquals.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LooselyEquals.slow_path_transfer_0
+    jnc .Lasm_LooselyEquals.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LooselyEquals.slow_path_transfer_0:
+.Lasm_LooselyEquals.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LooselyEquals.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LooselyEquals.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9666,19 +10856,34 @@ asm_handler_LooselyInequals_cold:
 .Lasm_LooselyInequals.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_loosely_inequals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LooselyInequals.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LooselyInequals.slow_path_transfer_0
+    jnc .Lasm_LooselyInequals.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LooselyInequals.slow_path_transfer_0:
+.Lasm_LooselyInequals.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LooselyInequals.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LooselyInequals.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -9712,18 +10917,34 @@ asm_handler_UnaryMinus_cold:
     jmp [r12 + rax * 8]
 .Lasm_UnaryMinus.ssa_block_5:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_UnaryMinus.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_unary_minus)
     test rax, rax
-    js .Lexit
+    js .Lasm_UnaryMinus.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_UnaryMinus.slow_path_transfer_0
+    jnc .Lasm_UnaryMinus.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_UnaryMinus.slow_path_transfer_0:
+.Lasm_UnaryMinus.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_UnaryMinus.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_UnaryMinus.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9757,18 +10978,56 @@ asm_handler_PostfixDecrement_cold:
     jmp [r12 + rax * 8]
 .Lasm_PostfixDecrement.ssa_block_2:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 16
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PostfixDecrement.value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_postfix_decrement)
     test rax, rax
-    js .Lexit
+    js .Lasm_PostfixDecrement.values_exceptional_outputs_3
     bt rax, 32
-    jnc .Lasm_PostfixDecrement.slow_path_transfer_0
+    jnc .Lasm_PostfixDecrement.values_exceptional_outputs_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_PostfixDecrement.skip_output_value_4:
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 8]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_PostfixDecrement.skip_output_value_5:
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_PostfixDecrement.slow_path_transfer_0:
+.Lasm_PostfixDecrement.values_exceptional_outputs_3:
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_PostfixDecrement.values_restore_stack_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 8]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_PostfixDecrement.skip_exceptional_output_6:
+.Lasm_PostfixDecrement.values_restore_stack_2:
+    add rsp, 16
+.Lasm_PostfixDecrement.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_PostfixDecrement.slow_path_transfer_7
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PostfixDecrement.slow_path_transfer_7:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9799,18 +11058,34 @@ asm_handler_ToInt32_cold:
     jmp .Lasm_ToInt32.ssa_block_7
 .Lasm_ToInt32.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ToInt32.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_to_int32)
     test rax, rax
-    js .Lexit
+    js .Lasm_ToInt32.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_ToInt32.slow_path_transfer_0
+    jnc .Lasm_ToInt32.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ToInt32.slow_path_transfer_0:
+.Lasm_ToInt32.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ToInt32.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ToInt32.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9833,10 +11108,28 @@ asm_handler_ToInt32_cold_end:
 asm_handler_PutByValue_cold:
 # Cold paths for PutByValue
 .Lasm_PutByValue.ssa_block_3:
+    lea rcx, [r14 + r13]
+    sub rsp, 32
+    mov r10d, DWORD PTR [rcx + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValue.value_ready_1:
+    mov QWORD PTR [rsp], rax
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValue.value_ready_2:
+    mov QWORD PTR [rsp + 8], rax
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValue.value_ready_3:
+    mov QWORD PTR [rsp + 16], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_try_put_by_value_typed_array)
+.Lasm_PutByValue.values_restore_stack_4:
+    add rsp, 32
+.Lasm_PutByValue.values_call_done_0:
     test eax, eax
     jnz .Lasm_PutByValue.ssa_block_1
     add r13d, 24
@@ -9868,18 +11161,39 @@ asm_handler_PutByValue_cold:
     jmp .Lasm_PutByValue.ssa_block_43
 .Lasm_PutByValue.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValue.scalar_value_ready_5:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValue.scalar_value_ready_6:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValue.scalar_value_ready_7:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_put_by_value)
     test rax, rax
-    js .Lexit
+    js .Lasm_PutByValue.scalar_result_done_8
     bt rax, 32
-    jnc .Lasm_PutByValue.slow_path_transfer_0
+    jnc .Lasm_PutByValue.scalar_result_done_8
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_PutByValue.slow_path_transfer_0:
+.Lasm_PutByValue.scalar_result_done_8:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutByValue.slow_path_transfer_9
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutByValue.slow_path_transfer_9:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -9889,10 +11203,28 @@ asm_handler_PutByValue_cold:
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
 .Lasm_PutByValue.ssa_block_2:
+    lea rcx, [r14 + r13]
+    sub rsp, 32
+    mov r10d, DWORD PTR [rcx + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValue.value_ready_11:
+    mov QWORD PTR [rsp], rax
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValue.value_ready_12:
+    mov QWORD PTR [rsp + 8], rax
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValue.value_ready_13:
+    mov QWORD PTR [rsp + 16], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_try_put_by_value_holey_array)
+.Lasm_PutByValue.values_restore_stack_14:
+    add rsp, 32
+.Lasm_PutByValue.values_call_done_10:
     test eax, eax
     jnz .Lasm_PutByValue.ssa_block_1
     add r13d, 24
@@ -9901,8 +11233,8 @@ asm_handler_PutByValue_cold:
 asm_handler_PutByValue_cold_end:
 asm_handler_GetById_cold:
 # Cold paths for GetById
-.Lasm_GetById.ssa_block_13:
-    cmp BYTE PTR [rcx + 12], 0
+.Lasm_GetById.ssa_block_15:
+    cmp BYTE PTR [rsi + 12], 0
     jz .Lasm_GetById.ssa_block_3
     mov ecx, DWORD PTR [rax + 108]
     mov rcx, QWORD PTR [rdx + rcx * 8]
@@ -9919,10 +11251,10 @@ asm_handler_GetById_cold:
     mov eax, DWORD PTR [rax + 112]
     mov rax, QWORD PTR [rcx + rax * 8]
     test rax, rax
-    jnz .Lasm_GetById.ssa_block_26
+    jnz .Lasm_GetById.ssa_block_31
     movabs rcx, 9223090561878065152
-    jmp .Lasm_GetById.ssa_block_27
-.Lasm_GetById.ssa_block_26:
+    jmp .Lasm_GetById.ssa_block_32
+.Lasm_GetById.ssa_block_31:
     mov rax, QWORD PTR [rax + rsi * 8]
     test rax, rax
     jz .Lasm_GetById.ssa_block_3
@@ -9936,13 +11268,13 @@ asm_handler_GetById_cold:
     and rcx, rax
     movabs rax, -1970324836974592
     or rcx, rax
-.Lasm_GetById.ssa_block_27:
+.Lasm_GetById.ssa_block_32:
     mov r11d, DWORD PTR [r14 + r13 + 4]
     mov QWORD PTR [rbx + r11 * 8], rcx
     add r13d, 24
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetById.ssa_block_14:
+.Lasm_GetById.ssa_block_16:
     mov esi, DWORD PTR [rax + 104]
     mov rcx, QWORD PTR [rbp - 48]
     mov rcx, QWORD PTR [rcx + 16704]
@@ -9992,6 +11324,7 @@ asm_handler_GetById_cold:
     mov BYTE PTR [rcx + 76], 0
     mov BYTE PTR [rcx + 77], 0
     mov BYTE PTR [rcx + 78], 0
+    mov BYTE PTR [rcx + 79], 0
     mov eax, r13d
     mov edx, DWORD PTR [r14 + r13 + 4]
     mov edi, DWORD PTR [r14 + r13 + 8]
@@ -10026,18 +11359,34 @@ asm_handler_GetById_cold:
     jmp [r12 + rax * 8]
 .Lasm_GetById.ssa_block_4:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetById.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_by_id_cached_accessor)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetById.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_GetById.slow_path_transfer_0
+    jnc .Lasm_GetById.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetById.slow_path_transfer_0:
+.Lasm_GetById.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetById.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetById.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10054,10 +11403,10 @@ asm_handler_GetById_cold:
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
 .Lasm_GetById.ssa_block_10:
-    mov rdi, QWORD PTR [rcx + 40]
-    test rdi, rdi
+    mov r8, QWORD PTR [rsi + 40]
+    test r8, r8
     jz .Lasm_GetById.ssa_block_1
-    cmp BYTE PTR [rdi + 10], 0
+    cmp BYTE PTR [r8 + 10], 0
     jz .Lasm_GetById.ssa_block_1
     jmp .Lasm_GetById.ssa_block_8
 .Lasm_GetById.ssa_block_9:
@@ -10067,17 +11416,41 @@ asm_handler_GetById_cold:
     mov rax, QWORD PTR [rax + 16]
     test rax, rax
     jz .Lasm_GetById.ssa_block_5
-    movzx esi, WORD PTR [rax + 10]
-    test esi, 2
+    movzx ecx, WORD PTR [rax + 10]
+    test ecx, 2
     jz .Lasm_GetById.ssa_block_3
-    test esi, 1024
-    jz .Lasm_GetById.ssa_block_14
-    jmp .Lasm_GetById.ssa_block_13
+    test ecx, 1024
+    jz .Lasm_GetById.ssa_block_16
+    jmp .Lasm_GetById.ssa_block_15
 .Lasm_GetById.ssa_block_3:
+    lea rcx, [r14 + r13]
+    sub rsp, 16
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetById.value_ready_4:
+    mov QWORD PTR [rsp + 8], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_try_inline_get_by_id_accessor)
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_GetById.values_restore_stack_5
+    test rax, rax
+    jne .Lasm_GetById.values_exceptional_outputs_6
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetById.skip_output_value_7:
+    jmp .Lasm_GetById.values_restore_stack_5
+.Lasm_GetById.values_exceptional_outputs_6:
+.Lasm_GetById.values_restore_stack_5:
+    add rsp, 16
+.Lasm_GetById.values_call_done_3:
     test eax, eax
     jnz .Lasm_GetById.ssa_block_4
     mov rax, QWORD PTR [rbp - 48]
@@ -10103,29 +11476,53 @@ asm_handler_GetById_cold:
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
 .Lasm_GetById.ssa_block_1:
-    mov rdi, QWORD PTR [rbp - 48]
-    mov esi, r13d
-    lea rdx, [r14 + r13]
+    mov rax, QWORD PTR [rbx - 40]
+    mov rdx, QWORD PTR [rax + 112]
+    mov eax, DWORD PTR [r14 + r13 + 20]
+    shl rax, 3
+    add rdx, rax
+    mov rdi, rcx
+    mov rsi, rdx
     call CSYM(asm_try_get_by_id_cache)
-    test eax, eax
-    jnz .Lasm_GetById.ssa_block_2
+    mov r11, rax
+    shr r11, 48
+    cmp r11w, 32763
+    je .Lasm_GetById.ssa_block_2
+    mov r11d, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + r11 * 8], rax
     add r13d, 24
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
 .Lasm_GetById.ssa_block_2:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetById.scalar_value_ready_8:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_by_id)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetById.scalar_result_done_9
     bt rax, 32
-    jnc .Lasm_GetById.slow_path_transfer_1
+    jnc .Lasm_GetById.scalar_result_done_9
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetById.slow_path_transfer_1:
+.Lasm_GetById.scalar_result_done_9:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetById.slow_path_transfer_10
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetById.slow_path_transfer_10:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10140,18 +11537,38 @@ asm_handler_GetById_cold_end:
 .p2align 4
 asm_handler_GetByIdWithThis:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetByIdWithThis.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetByIdWithThis.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_by_id_with_this)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetByIdWithThis.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_GetByIdWithThis.slow_path_transfer_0
+    jnc .Lasm_GetByIdWithThis.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetByIdWithThis.slow_path_transfer_0:
+.Lasm_GetByIdWithThis.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetByIdWithThis.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetByIdWithThis.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10167,10 +11584,24 @@ asm_handler_GetByIdWithThis_cold_end:
 asm_handler_PutById_cold:
 # Cold paths for PutById
 .Lasm_PutById.ssa_block_2:
+    lea rcx, [r14 + r13]
+    sub rsp, 16
+    mov r10d, DWORD PTR [rcx + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutById.value_ready_1:
+    mov QWORD PTR [rsp], rax
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutById.value_ready_2:
+    mov QWORD PTR [rsp + 8], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_try_put_by_id_cache)
+.Lasm_PutById.values_restore_stack_3:
+    add rsp, 16
+.Lasm_PutById.values_call_done_0:
     test eax, eax
     jnz .Lasm_PutById.ssa_block_1
     add r13d, 32
@@ -10178,18 +11609,35 @@ asm_handler_PutById_cold:
     jmp [r12 + rax * 8]
 .Lasm_PutById.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutById.scalar_value_ready_4:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutById.scalar_value_ready_5:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_put_by_id)
     test rax, rax
-    js .Lexit
+    js .Lasm_PutById.scalar_result_done_6
     bt rax, 32
-    jnc .Lasm_PutById.slow_path_transfer_0
+    jnc .Lasm_PutById.scalar_result_done_6
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_PutById.slow_path_transfer_0:
+.Lasm_PutById.scalar_result_done_6:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutById.slow_path_transfer_7
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutById.slow_path_transfer_7:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10202,18 +11650,39 @@ asm_handler_PutById_cold_end:
 .p2align 4
 asm_handler_PutByIdWithThis:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByIdWithThis.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByIdWithThis.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByIdWithThis.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_put_by_id_with_this)
     test rax, rax
-    js .Lexit
+    js .Lasm_PutByIdWithThis.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_PutByIdWithThis.slow_path_transfer_0
+    jnc .Lasm_PutByIdWithThis.scalar_result_done_3
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_PutByIdWithThis.slow_path_transfer_0:
+.Lasm_PutByIdWithThis.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutByIdWithThis.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutByIdWithThis.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10237,10 +11706,38 @@ asm_handler_GetByValue_cold:
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
 .Lasm_GetByValue.ssa_block_2:
+    lea rcx, [r14 + r13]
+    sub rsp, 32
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetByValue.value_ready_2:
+    mov QWORD PTR [rsp + 8], rax
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetByValue.value_ready_3:
+    mov QWORD PTR [rsp + 16], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_try_get_by_value_typed_array)
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_GetByValue.values_restore_stack_4
+    test rax, rax
+    jne .Lasm_GetByValue.values_exceptional_outputs_5
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetByValue.skip_output_value_6:
+    jmp .Lasm_GetByValue.values_restore_stack_4
+.Lasm_GetByValue.values_exceptional_outputs_5:
+.Lasm_GetByValue.values_restore_stack_4:
+    add rsp, 32
+.Lasm_GetByValue.values_call_done_1:
     test eax, eax
     jnz .Lasm_GetByValue.ssa_block_1
     add r13d, 24
@@ -10248,18 +11745,38 @@ asm_handler_GetByValue_cold:
     jmp [r12 + rax * 8]
 .Lasm_GetByValue.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetByValue.scalar_value_ready_7:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetByValue.scalar_value_ready_8:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_by_value)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetByValue.scalar_result_done_9
     bt rax, 32
-    jnc .Lasm_GetByValue.slow_path_transfer_1
+    jnc .Lasm_GetByValue.scalar_result_done_9
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetByValue.slow_path_transfer_1:
+.Lasm_GetByValue.scalar_result_done_9:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetByValue.slow_path_transfer_10
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetByValue.slow_path_transfer_10:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10275,18 +11792,42 @@ asm_handler_GetByValue_cold_end:
 .p2align 4
 asm_handler_GetByValueWithThis:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetByValueWithThis.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetByValueWithThis.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetByValueWithThis.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_by_value_with_this)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetByValueWithThis.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_GetByValueWithThis.slow_path_transfer_0
+    jnc .Lasm_GetByValueWithThis.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetByValueWithThis.slow_path_transfer_0:
+.Lasm_GetByValueWithThis.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetByValueWithThis.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetByValueWithThis.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10302,18 +11843,45 @@ asm_handler_GetByValueWithThis_cold_end:
 .p2align 4
 asm_handler_PutByValueWithThis:
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValueWithThis.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValueWithThis.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValueWithThis.scalar_value_ready_2:
+    mov r9, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutByValueWithThis.scalar_value_ready_3:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_put_by_value_with_this)
+    add rsp, 16
     test rax, rax
-    js .Lexit
+    js .Lasm_PutByValueWithThis.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_PutByValueWithThis.slow_path_transfer_0
+    jnc .Lasm_PutByValueWithThis.scalar_result_done_4
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_PutByValueWithThis.slow_path_transfer_0:
+.Lasm_PutByValueWithThis.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutByValueWithThis.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutByValueWithThis.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10329,18 +11897,35 @@ asm_handler_PutByValueWithThis_cold_end:
 .p2align 4
 asm_handler_PutBySpread:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutBySpread.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutBySpread.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_put_by_spread)
     test rax, rax
-    js .Lexit
+    js .Lasm_PutBySpread.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_PutBySpread.slow_path_transfer_0
+    jnc .Lasm_PutBySpread.scalar_result_done_2
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_PutBySpread.slow_path_transfer_0:
+.Lasm_PutBySpread.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutBySpread.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutBySpread.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10365,18 +11950,34 @@ asm_handler_GetLength_cold:
     jmp [r12 + rax * 8]
 .Lasm_GetLength.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetLength.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_length)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetLength.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_GetLength.slow_path_transfer_0
+    jnc .Lasm_GetLength.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetLength.slow_path_transfer_0:
+.Lasm_GetLength.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetLength.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetLength.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10389,18 +11990,38 @@ asm_handler_GetLength_cold_end:
 .p2align 4
 asm_handler_GetLengthWithThis:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetLengthWithThis.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetLengthWithThis.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_length_with_this)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetLengthWithThis.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_GetLengthWithThis.slow_path_transfer_0
+    jnc .Lasm_GetLengthWithThis.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetLengthWithThis.slow_path_transfer_0:
+.Lasm_GetLengthWithThis.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetLengthWithThis.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetLengthWithThis.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10416,18 +12037,34 @@ asm_handler_GetLengthWithThis_cold_end:
 .p2align 4
 asm_handler_GetMethod:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetMethod.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_method)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetMethod.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_GetMethod.slow_path_transfer_0
+    jnc .Lasm_GetMethod.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetMethod.slow_path_transfer_0:
+.Lasm_GetMethod.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetMethod.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetMethod.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10443,18 +12080,50 @@ asm_handler_GetMethod_cold_end:
 .p2align 4
 asm_handler_GetIterator:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 32
+    mov r10d, DWORD PTR [rcx + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetIterator.value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_get_iterator)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetIterator.values_exceptional_outputs_3
     bt rax, 32
-    jnc .Lasm_GetIterator.slow_path_transfer_0
+    jnc .Lasm_GetIterator.values_exceptional_outputs_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetIterator.skip_output_value_4:
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 8]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetIterator.skip_output_value_5:
+    mov r10d, DWORD PTR [rcx + 12]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetIterator.skip_output_value_6:
+    add rsp, 32
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetIterator.slow_path_transfer_0:
+.Lasm_GetIterator.values_exceptional_outputs_3:
+.Lasm_GetIterator.values_restore_stack_2:
+    add rsp, 32
+.Lasm_GetIterator.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetIterator.slow_path_transfer_7
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetIterator.slow_path_transfer_7:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10471,18 +12140,30 @@ asm_handler_GetGlobal_cold:
 # Cold paths for GetGlobal
 .Lasm_GetGlobal.ssa_block_2:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_global)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetGlobal.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_GetGlobal.slow_path_transfer_0
+    jnc .Lasm_GetGlobal.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetGlobal.slow_path_transfer_0:
+.Lasm_GetGlobal.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetGlobal.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetGlobal.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10492,10 +12173,30 @@ asm_handler_GetGlobal_cold:
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
 .Lasm_GetGlobal.ssa_block_1:
+    lea rcx, [r14 + r13]
+    sub rsp, 16
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_try_get_global_env_binding)
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_GetGlobal.values_restore_stack_3
+    test rax, rax
+    jne .Lasm_GetGlobal.values_exceptional_outputs_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetGlobal.skip_output_value_5:
+    jmp .Lasm_GetGlobal.values_restore_stack_3
+.Lasm_GetGlobal.values_exceptional_outputs_4:
+.Lasm_GetGlobal.values_restore_stack_3:
+    add rsp, 16
+.Lasm_GetGlobal.values_call_done_2:
     test eax, eax
     jnz .Lasm_GetGlobal.ssa_block_2
     add r13d, 16
@@ -10505,10 +12206,20 @@ asm_handler_GetGlobal_cold_end:
 asm_handler_SetGlobal_cold:
 # Cold paths for SetGlobal
 .Lasm_SetGlobal.ssa_block_1:
+    lea rcx, [r14 + r13]
+    sub rsp, 16
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SetGlobal.value_ready_1:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_try_set_global_env_binding)
+.Lasm_SetGlobal.values_restore_stack_2:
+    add rsp, 16
+.Lasm_SetGlobal.values_call_done_0:
     test eax, eax
     jnz .Lasm_SetGlobal.ssa_block_2
     add r13d, 16
@@ -10516,18 +12227,31 @@ asm_handler_SetGlobal_cold:
     jmp [r12 + rax * 8]
 .Lasm_SetGlobal.ssa_block_2:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SetGlobal.scalar_value_ready_3:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_set_global)
     test rax, rax
-    js .Lexit
+    js .Lasm_SetGlobal.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_SetGlobal.slow_path_transfer_0
+    jnc .Lasm_SetGlobal.scalar_result_done_4
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_SetGlobal.slow_path_transfer_0:
+.Lasm_SetGlobal.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetGlobal.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetGlobal.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10555,18 +12279,85 @@ asm_handler_Call_cold:
     jmp [r12 + rax * 8]
 .Lasm_Call.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    mov r11, rsp
+    mov r10d, DWORD PTR [rcx + 20]
+    shl r10, 3
+    add r10, 55
+    and r10, -16
+    mov rax, rsp
+    sub rax, r10
+    mov rdx, QWORD PTR [rbp - 48]
+    mov rdx, QWORD PTR [rdx + 15336]
+    add rdx, 32768
+    cmp rax, rdx
+    jae .Lasm_Call.values_allocate_13
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    call CSYM(asm_slow_path_stack_overflow)
+    jmp .Lasm_Call.values_call_done_12
+.Lasm_Call.values_allocate_13:
+.Lasm_Call.values_probe_14:
+    lea r10, [rsp - 4096]
+    cmp r10, rax
+    jbe .Lasm_Call.values_allocated_15
+    mov rsp, r10
+    mov QWORD PTR [rsp], 0
+    jmp .Lasm_Call.values_probe_14
+.Lasm_Call.values_allocated_15:
+    mov rsp, rax
+    mov QWORD PTR [rsp], r11
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Call.value_ready_16:
+    mov QWORD PTR [rsp + 24], rax
+    mov r10d, DWORD PTR [rcx + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Call.value_ready_17:
+    mov QWORD PTR [rsp + 32], rax
+    mov r11d, 0
+    mov r10d, DWORD PTR [rcx + 20]
+.Lasm_Call.array_value_next_18:
+    cmp r11, r10
+    jae .Lasm_Call.array_values_end_20
+    mov edx, DWORD PTR [rcx + r11 * 4 + 28]
+    mov rax, QWORD PTR [rbx + rdx * 8]
+.Lasm_Call.array_value_ready_19:
+    mov QWORD PTR [rsp + r11 * 8 + 40], rax
+    add r11, 1
+    jmp .Lasm_Call.array_value_next_18
+.Lasm_Call.array_values_end_20:
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_call)
     test rax, rax
-    js .Lexit
+    js .Lasm_Call.values_exceptional_outputs_22
     bt rax, 32
-    jnc .Lasm_Call.slow_path_transfer_0
+    jnc .Lasm_Call.values_exceptional_outputs_22
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_Call.skip_output_value_23:
+    mov rsp, QWORD PTR [rsp]
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Call.slow_path_transfer_0:
+.Lasm_Call.values_exceptional_outputs_22:
+.Lasm_Call.values_restore_stack_21:
+    mov rsp, QWORD PTR [rsp]
+.Lasm_Call.values_call_done_12:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Call.slow_path_transfer_24
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Call.slow_path_transfer_24:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10592,18 +12383,42 @@ asm_handler_CallBuiltinMathAbs_cold:
     jmp [r12 + rax * 8]
 .Lasm_CallBuiltinMathAbs.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathAbs.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathAbs.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathAbs.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_abs)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathAbs.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathAbs.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathAbs.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathAbs.slow_path_transfer_0:
+.Lasm_CallBuiltinMathAbs.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathAbs.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathAbs.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10617,18 +12432,42 @@ asm_handler_CallBuiltinMathFloor_cold:
 # Cold paths for CallBuiltinMathFloor
 .Lasm_CallBuiltinMathFloor.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathFloor.scalar_value_ready_1:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathFloor.scalar_value_ready_2:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathFloor.scalar_value_ready_3:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_floor)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathFloor.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathFloor.slow_path_transfer_1
+    jnc .Lasm_CallBuiltinMathFloor.scalar_result_done_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathFloor.slow_path_transfer_1:
+.Lasm_CallBuiltinMathFloor.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathFloor.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathFloor.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10645,18 +12484,42 @@ asm_handler_CallBuiltinMathCeil_cold:
 # Cold paths for CallBuiltinMathCeil
 .Lasm_CallBuiltinMathCeil.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathCeil.scalar_value_ready_1:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathCeil.scalar_value_ready_2:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathCeil.scalar_value_ready_3:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_ceil)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathCeil.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathCeil.slow_path_transfer_1
+    jnc .Lasm_CallBuiltinMathCeil.scalar_result_done_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathCeil.slow_path_transfer_1:
+.Lasm_CallBuiltinMathCeil.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathCeil.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathCeil.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10673,18 +12536,42 @@ asm_handler_CallBuiltinMathSqrt_cold:
 # Cold paths for CallBuiltinMathSqrt
 .Lasm_CallBuiltinMathSqrt.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathSqrt.scalar_value_ready_1:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathSqrt.scalar_value_ready_2:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathSqrt.scalar_value_ready_3:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_sqrt)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathSqrt.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathSqrt.slow_path_transfer_1
+    jnc .Lasm_CallBuiltinMathSqrt.scalar_result_done_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathSqrt.slow_path_transfer_1:
+.Lasm_CallBuiltinMathSqrt.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathSqrt.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathSqrt.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10701,18 +12588,42 @@ asm_handler_CallBuiltinMathExp_cold:
 # Cold paths for CallBuiltinMathExp
 .Lasm_CallBuiltinMathExp.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathExp.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathExp.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathExp.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_exp)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathExp.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathExp.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathExp.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathExp.slow_path_transfer_0:
+.Lasm_CallBuiltinMathExp.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathExp.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathExp.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10725,18 +12636,42 @@ asm_handler_CallBuiltinMathExp_cold_end:
 .p2align 4
 asm_handler_CallBuiltinMathLog:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathLog.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathLog.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathLog.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_log)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathLog.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathLog.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathLog.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathLog.slow_path_transfer_0:
+.Lasm_CallBuiltinMathLog.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathLog.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathLog.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10752,18 +12687,48 @@ asm_handler_CallBuiltinMathLog_cold_end:
 .p2align 4
 asm_handler_CallBuiltinMathPow:
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathPow.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathPow.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathPow.scalar_value_ready_2:
+    mov r9, rax
+    mov r10d, DWORD PTR [r11 + 20]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathPow.scalar_value_ready_3:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_pow)
+    add rsp, 16
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathPow.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathPow.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathPow.scalar_result_done_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathPow.slow_path_transfer_0:
+.Lasm_CallBuiltinMathPow.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathPow.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathPow.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10779,18 +12744,48 @@ asm_handler_CallBuiltinMathPow_cold_end:
 .p2align 4
 asm_handler_CallBuiltinMathImul:
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathImul.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathImul.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathImul.scalar_value_ready_2:
+    mov r9, rax
+    mov r10d, DWORD PTR [r11 + 20]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathImul.scalar_value_ready_3:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_imul)
+    add rsp, 16
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathImul.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathImul.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathImul.scalar_result_done_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathImul.slow_path_transfer_0:
+.Lasm_CallBuiltinMathImul.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathImul.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathImul.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10806,18 +12801,38 @@ asm_handler_CallBuiltinMathImul_cold_end:
 .p2align 4
 asm_handler_CallBuiltinMathRandom:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathRandom.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathRandom.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_random)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathRandom.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathRandom.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathRandom.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathRandom.slow_path_transfer_0:
+.Lasm_CallBuiltinMathRandom.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathRandom.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathRandom.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10833,18 +12848,42 @@ asm_handler_CallBuiltinMathRandom_cold_end:
 .p2align 4
 asm_handler_CallBuiltinMathRound:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathRound.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathRound.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathRound.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_round)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathRound.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathRound.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathRound.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathRound.slow_path_transfer_0:
+.Lasm_CallBuiltinMathRound.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathRound.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathRound.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10860,18 +12899,42 @@ asm_handler_CallBuiltinMathRound_cold_end:
 .p2align 4
 asm_handler_CallBuiltinMathSin:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathSin.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathSin.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathSin.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_sin)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathSin.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathSin.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathSin.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathSin.slow_path_transfer_0:
+.Lasm_CallBuiltinMathSin.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathSin.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathSin.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10887,18 +12950,42 @@ asm_handler_CallBuiltinMathSin_cold_end:
 .p2align 4
 asm_handler_CallBuiltinMathCos:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathCos.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathCos.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathCos.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_cos)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathCos.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathCos.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathCos.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathCos.slow_path_transfer_0:
+.Lasm_CallBuiltinMathCos.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathCos.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathCos.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10914,18 +13001,42 @@ asm_handler_CallBuiltinMathCos_cold_end:
 .p2align 4
 asm_handler_CallBuiltinMathTan:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathTan.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathTan.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMathTan.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_math_tan)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMathTan.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinMathTan.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMathTan.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMathTan.slow_path_transfer_0:
+.Lasm_CallBuiltinMathTan.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMathTan.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMathTan.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10941,18 +13052,42 @@ asm_handler_CallBuiltinMathTan_cold_end:
 .p2align 4
 asm_handler_CallBuiltinRegExpPrototypeExec:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeExec.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeExec.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeExec.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_regexp_prototype_exec)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinRegExpPrototypeExec.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinRegExpPrototypeExec.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_0:
+.Lasm_CallBuiltinRegExpPrototypeExec.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinRegExpPrototypeExec.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10968,18 +13103,48 @@ asm_handler_CallBuiltinRegExpPrototypeExec_cold_end:
 .p2align 4
 asm_handler_CallBuiltinRegExpPrototypeReplace:
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_value_ready_2:
+    mov r9, rax
+    mov r10d, DWORD PTR [r11 + 20]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_value_ready_3:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_regexp_prototype_replace)
+    add rsp, 16
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinRegExpPrototypeReplace.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinRegExpPrototypeReplace.scalar_result_done_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_0:
+.Lasm_CallBuiltinRegExpPrototypeReplace.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinRegExpPrototypeReplace.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -10995,18 +13160,48 @@ asm_handler_CallBuiltinRegExpPrototypeReplace_cold_end:
 .p2align 4
 asm_handler_CallBuiltinRegExpPrototypeSplit:
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_value_ready_2:
+    mov r9, rax
+    mov r10d, DWORD PTR [r11 + 20]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_value_ready_3:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_regexp_prototype_split)
+    add rsp, 16
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinRegExpPrototypeSplit.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinRegExpPrototypeSplit.scalar_result_done_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_0:
+.Lasm_CallBuiltinRegExpPrototypeSplit.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinRegExpPrototypeSplit.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11022,18 +13217,42 @@ asm_handler_CallBuiltinRegExpPrototypeSplit_cold_end:
 .p2align 4
 asm_handler_CallBuiltinOrdinaryHasInstance:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinOrdinaryHasInstance.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinOrdinaryHasInstance.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinOrdinaryHasInstance.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_ordinary_has_instance)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinOrdinaryHasInstance.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinOrdinaryHasInstance.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_0:
+.Lasm_CallBuiltinOrdinaryHasInstance.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinOrdinaryHasInstance.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11049,18 +13268,38 @@ asm_handler_CallBuiltinOrdinaryHasInstance_cold_end:
 .p2align 4
 asm_handler_CallBuiltinArrayIteratorPrototypeNext:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_array_iterator_prototype_next)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_0:
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinArrayIteratorPrototypeNext.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11076,18 +13315,38 @@ asm_handler_CallBuiltinArrayIteratorPrototypeNext_cold_end:
 .p2align 4
 asm_handler_CallBuiltinMapIteratorPrototypeNext:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_map_iterator_prototype_next)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_0:
+.Lasm_CallBuiltinMapIteratorPrototypeNext.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinMapIteratorPrototypeNext.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11103,18 +13362,38 @@ asm_handler_CallBuiltinMapIteratorPrototypeNext_cold_end:
 .p2align 4
 asm_handler_CallBuiltinSetIteratorPrototypeNext:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_set_iterator_prototype_next)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_0:
+.Lasm_CallBuiltinSetIteratorPrototypeNext.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinSetIteratorPrototypeNext.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11130,18 +13409,38 @@ asm_handler_CallBuiltinSetIteratorPrototypeNext_cold_end:
 .p2align 4
 asm_handler_CallBuiltinStringIteratorPrototypeNext:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_string_iterator_prototype_next)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_0:
+.Lasm_CallBuiltinStringIteratorPrototypeNext.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinStringIteratorPrototypeNext.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11158,18 +13457,42 @@ asm_handler_CallBuiltinStringFromCharCode_cold:
 # Cold paths for CallBuiltinStringFromCharCode
 .Lasm_CallBuiltinStringFromCharCode.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringFromCharCode.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringFromCharCode.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringFromCharCode.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_string_from_char_code)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinStringFromCharCode.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinStringFromCharCode.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_0:
+.Lasm_CallBuiltinStringFromCharCode.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinStringFromCharCode.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11190,18 +13513,42 @@ asm_handler_CallBuiltinStringPrototypeCharCodeAt_cold:
     jmp [r12 + rax * 8]
 .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_2:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_string_prototype_char_code_at)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_0:
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11224,18 +13571,42 @@ asm_handler_CallBuiltinStringPrototypeCharAt_cold:
     jmp [r12 + rax * 8]
 .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringPrototypeCharAt.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringPrototypeCharAt.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallBuiltinStringPrototypeCharAt.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_builtin_string_prototype_char_at)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallBuiltinStringPrototypeCharAt.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_0
+    jnc .Lasm_CallBuiltinStringPrototypeCharAt.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_0:
+.Lasm_CallBuiltinStringPrototypeCharAt.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallBuiltinStringPrototypeCharAt.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11248,18 +13619,34 @@ asm_handler_CallBuiltinStringPrototypeCharAt_cold_end:
 .p2align 4
 asm_handler_GetObjectPropertyIterator:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetObjectPropertyIterator.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_object_property_iterator)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetObjectPropertyIterator.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_GetObjectPropertyIterator.slow_path_transfer_0
+    jnc .Lasm_GetObjectPropertyIterator.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetObjectPropertyIterator.slow_path_transfer_0:
+.Lasm_GetObjectPropertyIterator.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetObjectPropertyIterator.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetObjectPropertyIterator.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11276,18 +13663,46 @@ asm_handler_ObjectPropertyIteratorNext_cold:
 # Cold paths for ObjectPropertyIteratorNext
 .Lasm_ObjectPropertyIteratorNext.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 32
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_ObjectPropertyIteratorNext.value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_object_property_iterator_next)
     test rax, rax
-    js .Lexit
+    js .Lasm_ObjectPropertyIteratorNext.values_exceptional_outputs_3
     bt rax, 32
-    jnc .Lasm_ObjectPropertyIteratorNext.slow_path_transfer_0
+    jnc .Lasm_ObjectPropertyIteratorNext.values_exceptional_outputs_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_ObjectPropertyIteratorNext.skip_output_value_4:
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 8]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_ObjectPropertyIteratorNext.skip_output_value_5:
+    add rsp, 32
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ObjectPropertyIteratorNext.slow_path_transfer_0:
+.Lasm_ObjectPropertyIteratorNext.values_exceptional_outputs_3:
+.Lasm_ObjectPropertyIteratorNext.values_restore_stack_2:
+    add rsp, 32
+.Lasm_ObjectPropertyIteratorNext.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ObjectPropertyIteratorNext.slow_path_transfer_6
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ObjectPropertyIteratorNext.slow_path_transfer_6:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11300,18 +13715,45 @@ asm_handler_ObjectPropertyIteratorNext_cold_end:
 .p2align 4
 asm_handler_IteratorClose:
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorClose.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorClose.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorClose.scalar_value_ready_2:
+    mov r9, rax
+    mov r10d, DWORD PTR [r11 + 20]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorClose.scalar_value_ready_3:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_iterator_close)
+    add rsp, 16
     test rax, rax
-    js .Lexit
+    js .Lasm_IteratorClose.scalar_result_done_4
     bt rax, 32
-    jnc .Lasm_IteratorClose.slow_path_transfer_0
+    jnc .Lasm_IteratorClose.scalar_result_done_4
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_IteratorClose.slow_path_transfer_0:
+.Lasm_IteratorClose.scalar_result_done_4:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_IteratorClose.slow_path_transfer_5
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IteratorClose.slow_path_transfer_5:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11327,18 +13769,64 @@ asm_handler_IteratorClose_cold_end:
 .p2align 4
 asm_handler_IteratorNext:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 48
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorNext.value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorNext.value_ready_2:
+    mov r9, rax
+    mov r10d, DWORD PTR [rcx + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorNext.value_ready_3:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_iterator_next)
     test rax, rax
-    js .Lexit
+    js .Lasm_IteratorNext.values_exceptional_outputs_5
     bt rax, 32
-    jnc .Lasm_IteratorNext.slow_path_transfer_0
+    jnc .Lasm_IteratorNext.values_exceptional_outputs_5
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorNext.skip_output_value_6:
+    mov r10d, DWORD PTR [rcx + 16]
+    mov r11, QWORD PTR [rsp + 40]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorNext.skip_output_value_7:
+    add rsp, 48
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_IteratorNext.slow_path_transfer_0:
+.Lasm_IteratorNext.values_exceptional_outputs_5:
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_IteratorNext.values_restore_stack_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 16]
+    mov r11, QWORD PTR [rsp + 40]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorNext.skip_exceptional_output_8:
+.Lasm_IteratorNext.values_restore_stack_4:
+    add rsp, 48
+.Lasm_IteratorNext.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_IteratorNext.slow_path_transfer_9
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IteratorNext.slow_path_transfer_9:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11354,18 +13842,68 @@ asm_handler_IteratorNext_cold_end:
 .p2align 4
 asm_handler_IteratorNextUnpack:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 64
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorNextUnpack.value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [rcx + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorNextUnpack.value_ready_2:
+    mov r9, rax
+    mov r10d, DWORD PTR [rcx + 20]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorNextUnpack.value_ready_3:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_iterator_next_unpack)
     test rax, rax
-    js .Lexit
+    js .Lasm_IteratorNextUnpack.values_exceptional_outputs_5
     bt rax, 32
-    jnc .Lasm_IteratorNextUnpack.slow_path_transfer_0
+    jnc .Lasm_IteratorNextUnpack.values_exceptional_outputs_5
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorNextUnpack.skip_output_value_6:
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 24]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorNextUnpack.skip_output_value_7:
+    mov r10d, DWORD PTR [rcx + 20]
+    mov r11, QWORD PTR [rsp + 48]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorNextUnpack.skip_output_value_8:
+    add rsp, 64
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_IteratorNextUnpack.slow_path_transfer_0:
+.Lasm_IteratorNextUnpack.values_exceptional_outputs_5:
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_IteratorNextUnpack.values_restore_stack_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 20]
+    mov r11, QWORD PTR [rsp + 48]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorNextUnpack.skip_exceptional_output_9:
+.Lasm_IteratorNextUnpack.values_restore_stack_4:
+    add rsp, 64
+.Lasm_IteratorNextUnpack.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_IteratorNextUnpack.slow_path_transfer_10
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IteratorNextUnpack.slow_path_transfer_10:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11381,18 +13919,64 @@ asm_handler_IteratorNextUnpack_cold_end:
 .p2align 4
 asm_handler_IteratorToArray:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 48
+    mov r10d, DWORD PTR [rcx + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorToArray.value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorToArray.value_ready_2:
+    mov r9, rax
+    mov r10d, DWORD PTR [rcx + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IteratorToArray.value_ready_3:
+    mov QWORD PTR [rsp], rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_iterator_to_array)
     test rax, rax
-    js .Lexit
+    js .Lasm_IteratorToArray.values_exceptional_outputs_5
     bt rax, 32
-    jnc .Lasm_IteratorToArray.slow_path_transfer_0
+    jnc .Lasm_IteratorToArray.values_exceptional_outputs_5
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorToArray.skip_output_value_6:
+    mov r10d, DWORD PTR [rcx + 16]
+    mov r11, QWORD PTR [rsp + 40]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorToArray.skip_output_value_7:
+    add rsp, 48
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_IteratorToArray.slow_path_transfer_0:
+.Lasm_IteratorToArray.values_exceptional_outputs_5:
+    mov r10, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r10 + 15288]
+    add r10, 128
+    cmp r10, rbx
+    jne .Lasm_IteratorToArray.values_restore_stack_4
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 16]
+    mov r11, QWORD PTR [rsp + 40]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_IteratorToArray.skip_exceptional_output_8:
+.Lasm_IteratorToArray.values_restore_stack_4:
+    add rsp, 48
+.Lasm_IteratorToArray.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_IteratorToArray.slow_path_transfer_9
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IteratorToArray.slow_path_transfer_9:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11408,18 +13992,81 @@ asm_handler_IteratorToArray_cold_end:
 .p2align 4
 asm_handler_CallConstruct:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    mov r11, rsp
+    mov r10d, DWORD PTR [rcx + 16]
+    shl r10, 3
+    add r10, 47
+    and r10, -16
+    mov rax, rsp
+    sub rax, r10
+    mov rdx, QWORD PTR [rbp - 48]
+    mov rdx, QWORD PTR [rdx + 15336]
+    add rdx, 32768
+    cmp rax, rdx
+    jae .Lasm_CallConstruct.values_allocate_1
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    call CSYM(asm_slow_path_stack_overflow)
+    jmp .Lasm_CallConstruct.values_call_done_0
+.Lasm_CallConstruct.values_allocate_1:
+.Lasm_CallConstruct.values_probe_2:
+    lea r10, [rsp - 4096]
+    cmp r10, rax
+    jbe .Lasm_CallConstruct.values_allocated_3
+    mov rsp, r10
+    mov QWORD PTR [rsp], 0
+    jmp .Lasm_CallConstruct.values_probe_2
+.Lasm_CallConstruct.values_allocated_3:
+    mov rsp, rax
+    mov QWORD PTR [rsp], r11
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallConstruct.value_ready_4:
+    mov QWORD PTR [rsp + 24], rax
+    mov r11d, 0
+    mov r10d, DWORD PTR [rcx + 16]
+.Lasm_CallConstruct.array_value_next_5:
+    cmp r11, r10
+    jae .Lasm_CallConstruct.array_values_end_7
+    mov edx, DWORD PTR [rcx + r11 * 4 + 24]
+    mov rax, QWORD PTR [rbx + rdx * 8]
+.Lasm_CallConstruct.array_value_ready_6:
+    mov QWORD PTR [rsp + r11 * 8 + 32], rax
+    add r11, 1
+    jmp .Lasm_CallConstruct.array_value_next_5
+.Lasm_CallConstruct.array_values_end_7:
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_call_construct)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallConstruct.values_exceptional_outputs_9
     bt rax, 32
-    jnc .Lasm_CallConstruct.slow_path_transfer_0
+    jnc .Lasm_CallConstruct.values_exceptional_outputs_9
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_CallConstruct.skip_output_value_10:
+    mov rsp, QWORD PTR [rsp]
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallConstruct.slow_path_transfer_0:
+.Lasm_CallConstruct.values_exceptional_outputs_9:
+.Lasm_CallConstruct.values_restore_stack_8:
+    mov rsp, QWORD PTR [rsp]
+.Lasm_CallConstruct.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallConstruct.slow_path_transfer_11
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallConstruct.slow_path_transfer_11:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11435,18 +14082,85 @@ asm_handler_CallConstruct_cold_end:
 .p2align 4
 asm_handler_CallDirectEval:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    mov r11, rsp
+    mov r10d, DWORD PTR [rcx + 20]
+    shl r10, 3
+    add r10, 55
+    and r10, -16
+    mov rax, rsp
+    sub rax, r10
+    mov rdx, QWORD PTR [rbp - 48]
+    mov rdx, QWORD PTR [rdx + 15336]
+    add rdx, 32768
+    cmp rax, rdx
+    jae .Lasm_CallDirectEval.values_allocate_1
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    call CSYM(asm_slow_path_stack_overflow)
+    jmp .Lasm_CallDirectEval.values_call_done_0
+.Lasm_CallDirectEval.values_allocate_1:
+.Lasm_CallDirectEval.values_probe_2:
+    lea r10, [rsp - 4096]
+    cmp r10, rax
+    jbe .Lasm_CallDirectEval.values_allocated_3
+    mov rsp, r10
+    mov QWORD PTR [rsp], 0
+    jmp .Lasm_CallDirectEval.values_probe_2
+.Lasm_CallDirectEval.values_allocated_3:
+    mov rsp, rax
+    mov QWORD PTR [rsp], r11
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallDirectEval.value_ready_4:
+    mov QWORD PTR [rsp + 24], rax
+    mov r10d, DWORD PTR [rcx + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallDirectEval.value_ready_5:
+    mov QWORD PTR [rsp + 32], rax
+    mov r11d, 0
+    mov r10d, DWORD PTR [rcx + 20]
+.Lasm_CallDirectEval.array_value_next_6:
+    cmp r11, r10
+    jae .Lasm_CallDirectEval.array_values_end_8
+    mov edx, DWORD PTR [rcx + r11 * 4 + 28]
+    mov rax, QWORD PTR [rbx + rdx * 8]
+.Lasm_CallDirectEval.array_value_ready_7:
+    mov QWORD PTR [rsp + r11 * 8 + 40], rax
+    add r11, 1
+    jmp .Lasm_CallDirectEval.array_value_next_6
+.Lasm_CallDirectEval.array_values_end_8:
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_call_direct_eval)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallDirectEval.values_exceptional_outputs_10
     bt rax, 32
-    jnc .Lasm_CallDirectEval.slow_path_transfer_0
+    jnc .Lasm_CallDirectEval.values_exceptional_outputs_10
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_CallDirectEval.skip_output_value_11:
+    mov rsp, QWORD PTR [rsp]
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallDirectEval.slow_path_transfer_0:
+.Lasm_CallDirectEval.values_exceptional_outputs_10:
+.Lasm_CallDirectEval.values_restore_stack_9:
+    mov rsp, QWORD PTR [rsp]
+.Lasm_CallDirectEval.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallDirectEval.slow_path_transfer_12
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallDirectEval.slow_path_transfer_12:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11462,18 +14176,42 @@ asm_handler_CallDirectEval_cold_end:
 .p2align 4
 asm_handler_CallWithArgumentArray:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallWithArgumentArray.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallWithArgumentArray.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallWithArgumentArray.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_with_argument_array)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallWithArgumentArray.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallWithArgumentArray.slow_path_transfer_0
+    jnc .Lasm_CallWithArgumentArray.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallWithArgumentArray.slow_path_transfer_0:
+.Lasm_CallWithArgumentArray.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallWithArgumentArray.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallWithArgumentArray.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11489,18 +14227,42 @@ asm_handler_CallWithArgumentArray_cold_end:
 .p2align 4
 asm_handler_CallDirectEvalWithArgumentArray:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallDirectEvalWithArgumentArray.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallDirectEvalWithArgumentArray.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallDirectEvalWithArgumentArray.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_direct_eval_with_argument_array)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallDirectEvalWithArgumentArray.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_0
+    jnc .Lasm_CallDirectEvalWithArgumentArray.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_0:
+.Lasm_CallDirectEvalWithArgumentArray.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallDirectEvalWithArgumentArray.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11516,18 +14278,42 @@ asm_handler_CallDirectEvalWithArgumentArray_cold_end:
 .p2align 4
 asm_handler_CallConstructWithArgumentArray:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallConstructWithArgumentArray.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallConstructWithArgumentArray.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CallConstructWithArgumentArray.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_call_construct_with_argument_array)
     test rax, rax
-    js .Lexit
+    js .Lasm_CallConstructWithArgumentArray.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CallConstructWithArgumentArray.slow_path_transfer_0
+    jnc .Lasm_CallConstructWithArgumentArray.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CallConstructWithArgumentArray.slow_path_transfer_0:
+.Lasm_CallConstructWithArgumentArray.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CallConstructWithArgumentArray.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CallConstructWithArgumentArray.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11543,18 +14329,38 @@ asm_handler_CallConstructWithArgumentArray_cold_end:
 .p2align 4
 asm_handler_SuperCallWithArgumentArray:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SuperCallWithArgumentArray.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SuperCallWithArgumentArray.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_super_call_with_argument_array)
     test rax, rax
-    js .Lexit
+    js .Lasm_SuperCallWithArgumentArray.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_SuperCallWithArgumentArray.slow_path_transfer_0
+    jnc .Lasm_SuperCallWithArgumentArray.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_SuperCallWithArgumentArray.slow_path_transfer_0:
+.Lasm_SuperCallWithArgumentArray.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_SuperCallWithArgumentArray.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SuperCallWithArgumentArray.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11570,18 +14376,30 @@ asm_handler_SuperCallWithArgumentArray_cold_end:
 .p2align 4
 asm_handler_NewObject:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_new_object)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewObject.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_NewObject.slow_path_transfer_0
+    jnc .Lasm_NewObject.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewObject.slow_path_transfer_0:
+.Lasm_NewObject.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewObject.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewObject.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11597,18 +14415,30 @@ asm_handler_NewObject_cold_end:
 .p2align 4
 asm_handler_NewObjectWithNoPrototype:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_new_object_with_no_prototype)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewObjectWithNoPrototype.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_NewObjectWithNoPrototype.slow_path_transfer_0
+    jnc .Lasm_NewObjectWithNoPrototype.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewObjectWithNoPrototype.slow_path_transfer_0:
+.Lasm_NewObjectWithNoPrototype.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewObjectWithNoPrototype.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewObjectWithNoPrototype.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11624,18 +14454,31 @@ asm_handler_NewObjectWithNoPrototype_cold_end:
 .p2align 4
 asm_handler_CacheObjectShape:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CacheObjectShape.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_cache_object_shape)
     test rax, rax
-    js .Lexit
+    js .Lasm_CacheObjectShape.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_CacheObjectShape.slow_path_transfer_0
+    jnc .Lasm_CacheObjectShape.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CacheObjectShape.slow_path_transfer_0:
+.Lasm_CacheObjectShape.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CacheObjectShape.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CacheObjectShape.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11651,18 +14494,35 @@ asm_handler_CacheObjectShape_cold_end:
 .p2align 4
 asm_handler_InitObjectLiteralProperty:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_InitObjectLiteralProperty.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_InitObjectLiteralProperty.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_init_object_literal_property)
     test rax, rax
-    js .Lexit
+    js .Lasm_InitObjectLiteralProperty.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_InitObjectLiteralProperty.slow_path_transfer_0
+    jnc .Lasm_InitObjectLiteralProperty.scalar_result_done_2
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_InitObjectLiteralProperty.slow_path_transfer_0:
+.Lasm_InitObjectLiteralProperty.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_InitObjectLiteralProperty.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_InitObjectLiteralProperty.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11678,18 +14538,77 @@ asm_handler_InitObjectLiteralProperty_cold_end:
 .p2align 4
 asm_handler_NewArray:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    mov r11, rsp
+    mov r10d, DWORD PTR [rcx + 12]
+    shl r10, 3
+    add r10, 39
+    and r10, -16
+    mov rax, rsp
+    sub rax, r10
+    mov rdx, QWORD PTR [rbp - 48]
+    mov rdx, QWORD PTR [rdx + 15336]
+    add rdx, 32768
+    cmp rax, rdx
+    jae .Lasm_NewArray.values_allocate_1
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    call CSYM(asm_slow_path_stack_overflow)
+    jmp .Lasm_NewArray.values_call_done_0
+.Lasm_NewArray.values_allocate_1:
+.Lasm_NewArray.values_probe_2:
+    lea r10, [rsp - 4096]
+    cmp r10, rax
+    jbe .Lasm_NewArray.values_allocated_3
+    mov rsp, r10
+    mov QWORD PTR [rsp], 0
+    jmp .Lasm_NewArray.values_probe_2
+.Lasm_NewArray.values_allocated_3:
+    mov rsp, rax
+    mov QWORD PTR [rsp], r11
+    mov r11d, 0
+    mov r10d, DWORD PTR [rcx + 12]
+.Lasm_NewArray.array_value_next_4:
+    cmp r11, r10
+    jae .Lasm_NewArray.array_values_end_6
+    mov edx, DWORD PTR [rcx + r11 * 4 + 16]
+    mov rax, QWORD PTR [rbx + rdx * 8]
+.Lasm_NewArray.array_value_ready_5:
+    mov QWORD PTR [rsp + r11 * 8 + 24], rax
+    add r11, 1
+    jmp .Lasm_NewArray.array_value_next_4
+.Lasm_NewArray.array_values_end_6:
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_new_array)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewArray.values_exceptional_outputs_8
     bt rax, 32
-    jnc .Lasm_NewArray.slow_path_transfer_0
+    jnc .Lasm_NewArray.values_exceptional_outputs_8
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_NewArray.skip_output_value_9:
+    mov rsp, QWORD PTR [rsp]
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewArray.slow_path_transfer_0:
+.Lasm_NewArray.values_exceptional_outputs_8:
+.Lasm_NewArray.values_restore_stack_7:
+    mov rsp, QWORD PTR [rsp]
+.Lasm_NewArray.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewArray.slow_path_transfer_10
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewArray.slow_path_transfer_10:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11705,18 +14624,30 @@ asm_handler_NewArray_cold_end:
 .p2align 4
 asm_handler_NewPrimitiveArray:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_new_primitive_array)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewPrimitiveArray.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_NewPrimitiveArray.slow_path_transfer_0
+    jnc .Lasm_NewPrimitiveArray.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewPrimitiveArray.slow_path_transfer_0:
+.Lasm_NewPrimitiveArray.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewPrimitiveArray.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewPrimitiveArray.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11732,18 +14663,30 @@ asm_handler_NewPrimitiveArray_cold_end:
 .p2align 4
 asm_handler_NewRegExp:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_new_regexp)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewRegExp.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_NewRegExp.slow_path_transfer_0
+    jnc .Lasm_NewRegExp.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewRegExp.slow_path_transfer_0:
+.Lasm_NewRegExp.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewRegExp.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewRegExp.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11759,18 +14702,30 @@ asm_handler_NewRegExp_cold_end:
 .p2align 4
 asm_handler_NewReferenceError:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_new_reference_error)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewReferenceError.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_NewReferenceError.slow_path_transfer_0
+    jnc .Lasm_NewReferenceError.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewReferenceError.slow_path_transfer_0:
+.Lasm_NewReferenceError.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewReferenceError.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewReferenceError.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11786,18 +14741,30 @@ asm_handler_NewReferenceError_cold_end:
 .p2align 4
 asm_handler_NewTypeError:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_new_type_error)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewTypeError.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_NewTypeError.slow_path_transfer_0
+    jnc .Lasm_NewTypeError.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewTypeError.slow_path_transfer_0:
+.Lasm_NewTypeError.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewTypeError.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewTypeError.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11813,18 +14780,38 @@ asm_handler_NewTypeError_cold_end:
 .p2align 4
 asm_handler_InstanceOf:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_InstanceOf.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_InstanceOf.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_instance_of)
     test rax, rax
-    js .Lexit
+    js .Lasm_InstanceOf.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_InstanceOf.slow_path_transfer_0
+    jnc .Lasm_InstanceOf.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_InstanceOf.slow_path_transfer_0:
+.Lasm_InstanceOf.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_InstanceOf.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_InstanceOf.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11840,18 +14827,38 @@ asm_handler_InstanceOf_cold_end:
 .p2align 4
 asm_handler_In:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_In.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_In.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_in)
     test rax, rax
-    js .Lexit
+    js .Lasm_In.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_In.slow_path_transfer_0
+    jnc .Lasm_In.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_In.slow_path_transfer_0:
+.Lasm_In.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_In.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_In.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11869,18 +14876,34 @@ asm_handler_IsCallable_cold_end:
 .p2align 4
 asm_handler_IsConstructor:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_IsConstructor.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_is_constructor)
     test rax, rax
-    js .Lexit
+    js .Lasm_IsConstructor.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_IsConstructor.slow_path_transfer_0
+    jnc .Lasm_IsConstructor.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_IsConstructor.slow_path_transfer_0:
+.Lasm_IsConstructor.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_IsConstructor.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_IsConstructor.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11896,18 +14919,27 @@ asm_handler_IsConstructor_cold_end:
 .p2align 4
 asm_handler_AddPrivateName:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_add_private_name)
     test rax, rax
-    js .Lexit
+    js .Lasm_AddPrivateName.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_AddPrivateName.slow_path_transfer_0
+    jnc .Lasm_AddPrivateName.scalar_result_done_0
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_AddPrivateName.slow_path_transfer_0:
+.Lasm_AddPrivateName.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_AddPrivateName.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_AddPrivateName.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11923,18 +14955,42 @@ asm_handler_AddPrivateName_cold_end:
 .p2align 4
 asm_handler_CreateAsyncFromSyncIterator:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CreateAsyncFromSyncIterator.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CreateAsyncFromSyncIterator.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 16]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CreateAsyncFromSyncIterator.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_create_async_from_sync_iterator)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreateAsyncFromSyncIterator.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_0
+    jnc .Lasm_CreateAsyncFromSyncIterator.scalar_result_done_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_0:
+.Lasm_CreateAsyncFromSyncIterator.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateAsyncFromSyncIterator.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11950,18 +15006,39 @@ asm_handler_CreateAsyncFromSyncIterator_cold_end:
 .p2align 4
 asm_handler_CreateDataPropertyOrThrow:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CreateDataPropertyOrThrow.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CreateDataPropertyOrThrow.scalar_value_ready_1:
+    mov r8, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CreateDataPropertyOrThrow.scalar_value_ready_2:
+    mov r9, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_create_data_property_or_throw)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreateDataPropertyOrThrow.scalar_result_done_3
     bt rax, 32
-    jnc .Lasm_CreateDataPropertyOrThrow.slow_path_transfer_0
+    jnc .Lasm_CreateDataPropertyOrThrow.scalar_result_done_3
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreateDataPropertyOrThrow.slow_path_transfer_0:
+.Lasm_CreateDataPropertyOrThrow.scalar_result_done_3:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateDataPropertyOrThrow.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateDataPropertyOrThrow.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -11977,18 +15054,31 @@ asm_handler_CreateDataPropertyOrThrow_cold_end:
 .p2align 4
 asm_handler_CreateImmutableBinding:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CreateImmutableBinding.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_create_immutable_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreateImmutableBinding.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_CreateImmutableBinding.slow_path_transfer_0
+    jnc .Lasm_CreateImmutableBinding.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreateImmutableBinding.slow_path_transfer_0:
+.Lasm_CreateImmutableBinding.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateImmutableBinding.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateImmutableBinding.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12004,18 +15094,31 @@ asm_handler_CreateImmutableBinding_cold_end:
 .p2align 4
 asm_handler_CreateMutableBinding:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CreateMutableBinding.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_create_mutable_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreateMutableBinding.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_CreateMutableBinding.slow_path_transfer_0
+    jnc .Lasm_CreateMutableBinding.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreateMutableBinding.slow_path_transfer_0:
+.Lasm_CreateMutableBinding.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateMutableBinding.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateMutableBinding.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12031,18 +15134,30 @@ asm_handler_CreateMutableBinding_cold_end:
 .p2align 4
 asm_handler_CreateRestParams:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_create_rest_params)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreateRestParams.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_CreateRestParams.slow_path_transfer_0
+    jnc .Lasm_CreateRestParams.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreateRestParams.slow_path_transfer_0:
+.Lasm_CreateRestParams.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateRestParams.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateRestParams.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12058,18 +15173,40 @@ asm_handler_CreateRestParams_cold_end:
 .p2align 4
 asm_handler_CreateArguments:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 16
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_create_arguments)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreateArguments.values_exceptional_outputs_2
     bt rax, 32
-    jnc .Lasm_CreateArguments.slow_path_transfer_0
+    jnc .Lasm_CreateArguments.values_exceptional_outputs_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    cmp r10d, -1
+    je .Lasm_CreateArguments.skip_output_value_3
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_CreateArguments.skip_output_value_3:
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreateArguments.slow_path_transfer_0:
+.Lasm_CreateArguments.values_exceptional_outputs_2:
+.Lasm_CreateArguments.values_restore_stack_1:
+    add rsp, 16
+.Lasm_CreateArguments.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateArguments.slow_path_transfer_4
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateArguments.slow_path_transfer_4:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12085,18 +15222,34 @@ asm_handler_CreateArguments_cold_end:
 .p2align 4
 asm_handler_CreateLexicalEnvironment:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_CreateLexicalEnvironment.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_create_lexical_environment)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreateLexicalEnvironment.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_CreateLexicalEnvironment.slow_path_transfer_0
+    jnc .Lasm_CreateLexicalEnvironment.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreateLexicalEnvironment.slow_path_transfer_0:
+.Lasm_CreateLexicalEnvironment.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateLexicalEnvironment.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateLexicalEnvironment.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12112,18 +15265,27 @@ asm_handler_CreateLexicalEnvironment_cold_end:
 .p2align 4
 asm_handler_CreatePrivateEnvironment:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_create_private_environment)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreatePrivateEnvironment.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_CreatePrivateEnvironment.slow_path_transfer_0
+    jnc .Lasm_CreatePrivateEnvironment.scalar_result_done_0
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreatePrivateEnvironment.slow_path_transfer_0:
+.Lasm_CreatePrivateEnvironment.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreatePrivateEnvironment.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreatePrivateEnvironment.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12139,18 +15301,27 @@ asm_handler_CreatePrivateEnvironment_cold_end:
 .p2align 4
 asm_handler_CreateVariableEnvironment:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_create_variable_environment)
     test rax, rax
-    js .Lexit
+    js .Lasm_CreateVariableEnvironment.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_CreateVariableEnvironment.slow_path_transfer_0
+    jnc .Lasm_CreateVariableEnvironment.scalar_result_done_0
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_CreateVariableEnvironment.slow_path_transfer_0:
+.Lasm_CreateVariableEnvironment.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_CreateVariableEnvironment.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_CreateVariableEnvironment.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12166,18 +15337,34 @@ asm_handler_CreateVariableEnvironment_cold_end:
 .p2align 4
 asm_handler_DeleteById:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_DeleteById.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_delete_by_id)
     test rax, rax
-    js .Lexit
+    js .Lasm_DeleteById.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_DeleteById.slow_path_transfer_0
+    jnc .Lasm_DeleteById.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DeleteById.slow_path_transfer_0:
+.Lasm_DeleteById.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DeleteById.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DeleteById.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12193,18 +15380,38 @@ asm_handler_DeleteById_cold_end:
 .p2align 4
 asm_handler_DeleteByValue:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_DeleteByValue.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_DeleteByValue.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_delete_by_value)
     test rax, rax
-    js .Lexit
+    js .Lasm_DeleteByValue.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_DeleteByValue.slow_path_transfer_0
+    jnc .Lasm_DeleteByValue.scalar_result_done_2
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DeleteByValue.slow_path_transfer_0:
+.Lasm_DeleteByValue.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DeleteByValue.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DeleteByValue.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12220,18 +15427,30 @@ asm_handler_DeleteByValue_cold_end:
 .p2align 4
 asm_handler_DeleteVariable:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_delete_variable)
     test rax, rax
-    js .Lexit
+    js .Lasm_DeleteVariable.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_DeleteVariable.slow_path_transfer_0
+    jnc .Lasm_DeleteVariable.scalar_result_done_0
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DeleteVariable.slow_path_transfer_0:
+.Lasm_DeleteVariable.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DeleteVariable.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DeleteVariable.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12247,18 +15466,46 @@ asm_handler_DeleteVariable_cold_end:
 .p2align 4
 asm_handler_GetCompletionFields:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    sub rsp, 32
+    mov r10d, DWORD PTR [rcx + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetCompletionFields.value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    lea rcx, [rsp]
     call CSYM(asm_slow_path_get_completion_fields)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetCompletionFields.values_exceptional_outputs_3
     bt rax, 32
-    jnc .Lasm_GetCompletionFields.slow_path_transfer_0
+    jnc .Lasm_GetCompletionFields.values_exceptional_outputs_3
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetCompletionFields.skip_output_value_4:
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 8]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetCompletionFields.skip_output_value_5:
+    add rsp, 32
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetCompletionFields.slow_path_transfer_0:
+.Lasm_GetCompletionFields.values_exceptional_outputs_3:
+.Lasm_GetCompletionFields.values_restore_stack_2:
+    add rsp, 32
+.Lasm_GetCompletionFields.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetCompletionFields.slow_path_transfer_6
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetCompletionFields.slow_path_transfer_6:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12274,18 +15521,31 @@ asm_handler_GetCompletionFields_cold_end:
 .p2align 4
 asm_handler_SetCompletionType:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_SetCompletionType.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_set_completion_type)
     test rax, rax
-    js .Lexit
+    js .Lasm_SetCompletionType.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_SetCompletionType.slow_path_transfer_0
+    jnc .Lasm_SetCompletionType.scalar_result_done_1
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_SetCompletionType.slow_path_transfer_0:
+.Lasm_SetCompletionType.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_SetCompletionType.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SetCompletionType.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12301,18 +15561,77 @@ asm_handler_SetCompletionType_cold_end:
 .p2align 4
 asm_handler_GetTemplateObject:
     mov DWORD PTR [rbx + -64], r13d
+    lea rcx, [r14 + r13]
+    mov r11, rsp
+    mov r10d, DWORD PTR [rcx + 12]
+    shl r10, 3
+    add r10, 39
+    and r10, -16
+    mov rax, rsp
+    sub rax, r10
+    mov rdx, QWORD PTR [rbp - 48]
+    mov rdx, QWORD PTR [rdx + 15336]
+    add rdx, 32768
+    cmp rax, rdx
+    jae .Lasm_GetTemplateObject.values_allocate_1
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
+    call CSYM(asm_slow_path_stack_overflow)
+    jmp .Lasm_GetTemplateObject.values_call_done_0
+.Lasm_GetTemplateObject.values_allocate_1:
+.Lasm_GetTemplateObject.values_probe_2:
+    lea r10, [rsp - 4096]
+    cmp r10, rax
+    jbe .Lasm_GetTemplateObject.values_allocated_3
+    mov rsp, r10
+    mov QWORD PTR [rsp], 0
+    jmp .Lasm_GetTemplateObject.values_probe_2
+.Lasm_GetTemplateObject.values_allocated_3:
+    mov rsp, rax
+    mov QWORD PTR [rsp], r11
+    mov r11d, 0
+    mov r10d, DWORD PTR [rcx + 12]
+.Lasm_GetTemplateObject.array_value_next_4:
+    cmp r11, r10
+    jae .Lasm_GetTemplateObject.array_values_end_6
+    mov edx, DWORD PTR [rcx + r11 * 4 + 20]
+    mov rax, QWORD PTR [rbx + rdx * 8]
+.Lasm_GetTemplateObject.array_value_ready_5:
+    mov QWORD PTR [rsp + r11 * 8 + 24], rax
+    add r11, 1
+    jmp .Lasm_GetTemplateObject.array_value_next_4
+.Lasm_GetTemplateObject.array_values_end_6:
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    lea rdx, [r14 + r13]
+    lea rcx, [rsp + 16]
     call CSYM(asm_slow_path_get_template_object)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetTemplateObject.values_exceptional_outputs_8
     bt rax, 32
-    jnc .Lasm_GetTemplateObject.slow_path_transfer_0
+    jnc .Lasm_GetTemplateObject.values_exceptional_outputs_8
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 8]
+    mov r11, QWORD PTR [rsp + 16]
+    mov QWORD PTR [rbx + r10 * 8], r11
+.Lasm_GetTemplateObject.skip_output_value_9:
+    mov rsp, QWORD PTR [rsp]
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetTemplateObject.slow_path_transfer_0:
+.Lasm_GetTemplateObject.values_exceptional_outputs_8:
+.Lasm_GetTemplateObject.values_restore_stack_7:
+    mov rsp, QWORD PTR [rsp]
+.Lasm_GetTemplateObject.values_call_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetTemplateObject.slow_path_transfer_10
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetTemplateObject.slow_path_transfer_10:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12328,18 +15647,37 @@ asm_handler_GetTemplateObject_cold_end:
 .p2align 4
 asm_handler_NewFunction:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 16]
+    movabs rax, 9221964661971222528
+    cmp r10d, -1
+    je .Lasm_NewFunction.scalar_value_ready_0
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_NewFunction.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_new_function)
     test rax, rax
-    js .Lexit
+    js .Lasm_NewFunction.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_NewFunction.slow_path_transfer_0
+    jnc .Lasm_NewFunction.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_NewFunction.slow_path_transfer_0:
+.Lasm_NewFunction.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_NewFunction.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_NewFunction.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12355,18 +15693,34 @@ asm_handler_NewFunction_cold_end:
 .p2align 4
 asm_handler_Typeof:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_Typeof.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_typeof)
     test rax, rax
-    js .Lexit
+    js .Lasm_Typeof.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_Typeof.slow_path_transfer_0
+    jnc .Lasm_Typeof.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_Typeof.slow_path_transfer_0:
+.Lasm_Typeof.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_Typeof.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_Typeof.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12385,18 +15739,27 @@ asm_handler_ResolveThisBinding_cold:
 # Cold paths for ResolveThisBinding
 .Lasm_ResolveThisBinding.ssa_block_1:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_resolve_this_binding)
     test rax, rax
-    js .Lexit
+    js .Lasm_ResolveThisBinding.scalar_result_done_0
     bt rax, 32
-    jnc .Lasm_ResolveThisBinding.slow_path_transfer_0
+    jnc .Lasm_ResolveThisBinding.scalar_result_done_0
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ResolveThisBinding.slow_path_transfer_0:
+.Lasm_ResolveThisBinding.scalar_result_done_0:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ResolveThisBinding.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ResolveThisBinding.slow_path_transfer_1:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12409,18 +15772,34 @@ asm_handler_ResolveThisBinding_cold_end:
 .p2align 4
 asm_handler_GetPrivateById:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 8]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_GetPrivateById.scalar_value_ready_0:
+    mov rcx, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_get_private_by_id)
     test rax, rax
-    js .Lexit
+    js .Lasm_GetPrivateById.scalar_result_done_1
     bt rax, 32
-    jnc .Lasm_GetPrivateById.slow_path_transfer_0
+    jnc .Lasm_GetPrivateById.scalar_result_done_1
+    lea rcx, [r14 + r13]
+    mov r10d, DWORD PTR [rcx + 4]
+    mov QWORD PTR [rbx + r10 * 8], rdx
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetPrivateById.slow_path_transfer_0:
+.Lasm_GetPrivateById.scalar_result_done_1:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GetPrivateById.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetPrivateById.slow_path_transfer_2:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12436,18 +15815,35 @@ asm_handler_GetPrivateById_cold_end:
 .p2align 4
 asm_handler_PutPrivateById:
     mov DWORD PTR [rbx + -64], r13d
+    lea r11, [r14 + r13]
+    mov r10d, DWORD PTR [r11 + 4]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutPrivateById.scalar_value_ready_0:
+    mov rcx, rax
+    mov r10d, DWORD PTR [r11 + 12]
+    mov rax, QWORD PTR [rbx + r10 * 8]
+.Lasm_PutPrivateById.scalar_value_ready_1:
+    mov r8, rax
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     lea rdx, [r14 + r13]
     call CSYM(asm_slow_path_put_private_by_id)
     test rax, rax
-    js .Lexit
+    js .Lasm_PutPrivateById.scalar_result_done_2
     bt rax, 32
-    jnc .Lasm_PutPrivateById.slow_path_transfer_0
+    jnc .Lasm_PutPrivateById.scalar_result_done_2
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_PutPrivateById.slow_path_transfer_0:
+.Lasm_PutPrivateById.scalar_result_done_2:
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_PutPrivateById.slow_path_transfer_3
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_PutPrivateById.slow_path_transfer_3:
     mov rcx, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [rcx + 15288]
     add rbx, 128
@@ -12481,20 +15877,35 @@ asm_handler_AddLhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_add_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_AddLhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_AddLhsInt32.slow_path_transfer_0
+    jnc .Lasm_AddLhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_AddLhsInt32.slow_path_transfer_0:
+.Lasm_AddLhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_AddLhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_AddLhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12531,8 +15942,8 @@ asm_handler_AddLhsInt32_cold:
 .Lasm_AddLhsInt32.ssa_box_number_6_not_integer:
     movq rax, xmm0
     ucomisd xmm0, xmm0
-    jp .Lasm_AddLhsInt32.canon_nan_1
-.Lasm_AddLhsInt32.canon_nan_1_ret:
+    jp .Lasm_AddLhsInt32.canon_nan_2
+.Lasm_AddLhsInt32.canon_nan_2_ret:
 .Lasm_AddLhsInt32.ssa_box_number_6_done:
     mov r11d, DWORD PTR [r14 + r13 + 4]
     mov QWORD PTR [rbx + r11 * 8], rax
@@ -12551,9 +15962,9 @@ asm_handler_AddLhsInt32_cold:
     add r13d, 16
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_AddLhsInt32.canon_nan_1:
+.Lasm_AddLhsInt32.canon_nan_2:
     movabs rax, 9221120237041090560
-    jmp .Lasm_AddLhsInt32.canon_nan_1_ret
+    jmp .Lasm_AddLhsInt32.canon_nan_2_ret
 asm_handler_AddLhsInt32_cold_end:
 asm_handler_AddRhsInt32_cold:
 # Cold paths for AddRhsInt32
@@ -12615,19 +16026,34 @@ asm_handler_AddRhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_add_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_AddRhsInt32.binary_result_restore_1
     bt rax, 32
-    jnc .Lasm_AddRhsInt32.slow_path_transfer_1
+    jnc .Lasm_AddRhsInt32.binary_result_restore_1
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_AddRhsInt32.slow_path_transfer_1:
+.Lasm_AddRhsInt32.binary_result_restore_1:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_AddRhsInt32.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_AddRhsInt32.slow_path_transfer_2:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12700,19 +16126,34 @@ asm_handler_SubRhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_sub_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_SubRhsInt32.binary_result_restore_1
     bt rax, 32
-    jnc .Lasm_SubRhsInt32.slow_path_transfer_1
+    jnc .Lasm_SubRhsInt32.binary_result_restore_1
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_SubRhsInt32.slow_path_transfer_1:
+.Lasm_SubRhsInt32.binary_result_restore_1:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_SubRhsInt32.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_SubRhsInt32.slow_path_transfer_2:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12736,19 +16177,34 @@ asm_handler_MulRhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_mul_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_MulRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_MulRhsInt32.slow_path_transfer_0
+    jnc .Lasm_MulRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_MulRhsInt32.slow_path_transfer_0:
+.Lasm_MulRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_MulRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_MulRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12785,8 +16241,8 @@ asm_handler_MulRhsInt32_cold:
 .Lasm_MulRhsInt32.ssa_box_number_8_not_integer:
     movq rax, xmm0
     ucomisd xmm0, xmm0
-    jp .Lasm_MulRhsInt32.canon_nan_1
-.Lasm_MulRhsInt32.canon_nan_1_ret:
+    jp .Lasm_MulRhsInt32.canon_nan_2
+.Lasm_MulRhsInt32.canon_nan_2_ret:
 .Lasm_MulRhsInt32.ssa_box_number_8_done:
     mov r11d, DWORD PTR [r14 + r13 + 4]
     mov QWORD PTR [rbx + r11 * 8], rax
@@ -12812,12 +16268,59 @@ asm_handler_MulRhsInt32_cold:
     add r13d, 16
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_MulRhsInt32.canon_nan_1:
+.Lasm_MulRhsInt32.canon_nan_2:
     movabs rax, 9221120237041090560
-    jmp .Lasm_MulRhsInt32.canon_nan_1_ret
+    jmp .Lasm_MulRhsInt32.canon_nan_2_ret
 asm_handler_MulRhsInt32_cold_end:
+.p2align 4
+asm_handler_ExpRhsInt32:
+    mov eax, DWORD PTR [r14 + r13 + 8]
+    mov rcx, QWORD PTR [rbx + rax * 8]
+    mov edx, DWORD PTR [r14 + r13 + 12]
+    movabs r11, 9221683186994511872
+    or rdx, r11
+    mov esi, DWORD PTR [r14 + r13 + 4]
+    mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
+    mov r8, rdx
+    lea rdx, [rsp]
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    call CSYM(asm_slow_path_exp_values)
+    test rax, rax
+    js .Lasm_ExpRhsInt32.binary_result_restore_0
+    bt rax, 32
+    jnc .Lasm_ExpRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ExpRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ExpRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ExpRhsInt32.slow_path_transfer_1:
+    mov r11, QWORD PTR [rbp - 48]
+    mov rbx, QWORD PTR [r11 + 15288]
+    add rbx, 128
+    mov r11, QWORD PTR [rbx + -40]
+    mov r14, QWORD PTR [r11 + 80]
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+asm_handler_ExpRhsInt32_hot_end:
 asm_handler_ExpRhsInt32_cold:
 asm_handler_ExpRhsInt32_cold_end:
+
 asm_handler_DivRhsInt32_cold:
 # Cold paths for DivRhsInt32
 .Lasm_DivRhsInt32.ssa_block_1:
@@ -12826,19 +16329,34 @@ asm_handler_DivRhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_div_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_DivRhsInt32.binary_result_restore_1
     bt rax, 32
-    jnc .Lasm_DivRhsInt32.slow_path_transfer_1
+    jnc .Lasm_DivRhsInt32.binary_result_restore_1
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_DivRhsInt32.slow_path_transfer_1:
+.Lasm_DivRhsInt32.binary_result_restore_1:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_DivRhsInt32.slow_path_transfer_2
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_DivRhsInt32.slow_path_transfer_2:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12895,21 +16413,35 @@ asm_handler_BitwiseXorRhsInt32_cold:
 .Lasm_BitwiseXorRhsInt32.ssa_block_1:
     mov ecx, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], ecx
+    mov rcx, rdx
     mov r8, rsi
-    mov r11, rdx
-    mov rdx, rcx
-    mov rcx, r11
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_bitwise_xor_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_BitwiseXorRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_BitwiseXorRhsInt32.slow_path_transfer_0
+    jnc .Lasm_BitwiseXorRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_BitwiseXorRhsInt32.slow_path_transfer_0:
+.Lasm_BitwiseXorRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseXorRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseXorRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -12974,21 +16506,35 @@ asm_handler_BitwiseAndRhsInt32_cold:
 .Lasm_BitwiseAndRhsInt32.ssa_block_1:
     mov ecx, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], ecx
+    mov rcx, rdx
     mov r8, rsi
-    mov r11, rdx
-    mov rdx, rcx
-    mov rcx, r11
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_bitwise_and_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_BitwiseAndRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_BitwiseAndRhsInt32.slow_path_transfer_0
+    jnc .Lasm_BitwiseAndRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_BitwiseAndRhsInt32.slow_path_transfer_0:
+.Lasm_BitwiseAndRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseAndRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseAndRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13053,21 +16599,35 @@ asm_handler_BitwiseOrRhsInt32_cold:
 .Lasm_BitwiseOrRhsInt32.ssa_block_1:
     mov ecx, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], ecx
+    mov rcx, rdx
     mov r8, rsi
-    mov r11, rdx
-    mov rdx, rcx
-    mov rcx, r11
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_bitwise_or_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_BitwiseOrRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_BitwiseOrRhsInt32.slow_path_transfer_0
+    jnc .Lasm_BitwiseOrRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_BitwiseOrRhsInt32.slow_path_transfer_0:
+.Lasm_BitwiseOrRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_BitwiseOrRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_BitwiseOrRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13096,20 +16656,35 @@ asm_handler_LeftShiftRhsInt32_cold:
     or rcx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_left_shift_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LeftShiftRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LeftShiftRhsInt32.slow_path_transfer_0
+    jnc .Lasm_LeftShiftRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LeftShiftRhsInt32.slow_path_transfer_0:
+.Lasm_LeftShiftRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LeftShiftRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LeftShiftRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13127,20 +16702,35 @@ asm_handler_RightShiftRhsInt32_cold:
     or rcx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_right_shift_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_RightShiftRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_RightShiftRhsInt32.slow_path_transfer_0
+    jnc .Lasm_RightShiftRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_RightShiftRhsInt32.slow_path_transfer_0:
+.Lasm_RightShiftRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_RightShiftRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_RightShiftRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13166,20 +16756,35 @@ asm_handler_UnsignedRightShiftRhsInt32_cold:
     or rcx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rcx
     mov rcx, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_unsigned_right_shift_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_UnsignedRightShiftRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_0
+    jnc .Lasm_UnsignedRightShiftRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_0:
+.Lasm_UnsignedRightShiftRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_UnsignedRightShiftRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13266,19 +16871,34 @@ asm_handler_ModRhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_mod_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_ModRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_ModRhsInt32.slow_path_transfer_0
+    jnc .Lasm_ModRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_ModRhsInt32.slow_path_transfer_0:
+.Lasm_ModRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_ModRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_ModRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13299,19 +16919,34 @@ asm_handler_LessThanRhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_less_than_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LessThanRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LessThanRhsInt32.slow_path_transfer_0
+    jnc .Lasm_LessThanRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LessThanRhsInt32.slow_path_transfer_0:
+.Lasm_LessThanRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LessThanRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LessThanRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13340,19 +16975,34 @@ asm_handler_LessThanEqualsRhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_less_than_equals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LessThanEqualsRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LessThanEqualsRhsInt32.slow_path_transfer_0
+    jnc .Lasm_LessThanEqualsRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LessThanEqualsRhsInt32.slow_path_transfer_0:
+.Lasm_LessThanEqualsRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LessThanEqualsRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LessThanEqualsRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13381,19 +17031,34 @@ asm_handler_GreaterThanRhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_greater_than_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_GreaterThanRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_GreaterThanRhsInt32.slow_path_transfer_0
+    jnc .Lasm_GreaterThanRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GreaterThanRhsInt32.slow_path_transfer_0:
+.Lasm_GreaterThanRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GreaterThanRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GreaterThanRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13422,19 +17087,34 @@ asm_handler_GreaterThanEqualsRhsInt32_cold:
     or rdx, r11
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_greater_than_equals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_GreaterThanEqualsRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_0
+    jnc .Lasm_GreaterThanEqualsRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_0:
+.Lasm_GreaterThanEqualsRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GreaterThanEqualsRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13647,19 +17327,34 @@ asm_handler_StrictlyEqualsRhsInt32_cold:
 .Lasm_StrictlyEqualsRhsInt32.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_strictly_equals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_StrictlyEqualsRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_0
+    jnc .Lasm_StrictlyEqualsRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_0:
+.Lasm_StrictlyEqualsRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_StrictlyEqualsRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13684,19 +17379,34 @@ asm_handler_StrictlyInequalsRhsInt32_cold:
 .Lasm_StrictlyInequalsRhsInt32.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_strictly_inequals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_StrictlyInequalsRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_0
+    jnc .Lasm_StrictlyInequalsRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_0:
+.Lasm_StrictlyInequalsRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_StrictlyInequalsRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13721,19 +17431,34 @@ asm_handler_LooselyEqualsRhsInt32_cold:
 .Lasm_LooselyEqualsRhsInt32.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_loosely_equals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LooselyEqualsRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LooselyEqualsRhsInt32.slow_path_transfer_0
+    jnc .Lasm_LooselyEqualsRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LooselyEqualsRhsInt32.slow_path_transfer_0:
+.Lasm_LooselyEqualsRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LooselyEqualsRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LooselyEqualsRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128
@@ -13758,19 +17483,34 @@ asm_handler_LooselyInequalsRhsInt32_cold:
 .Lasm_LooselyInequalsRhsInt32.ssa_block_1:
     mov esi, DWORD PTR [r14 + r13 + 4]
     mov DWORD PTR [rbx + -64], r13d
+    sub rsp, 16
+    mov DWORD PTR [rsp + 8], esi
     mov r8, rdx
-    mov rdx, rsi
+    lea rdx, [rsp]
     mov rdi, QWORD PTR [rbp - 48]
     mov esi, r13d
     call CSYM(asm_slow_path_loosely_inequals_values)
     test rax, rax
-    js .Lexit
+    js .Lasm_LooselyInequalsRhsInt32.binary_result_restore_0
     bt rax, 32
-    jnc .Lasm_LooselyInequalsRhsInt32.slow_path_transfer_0
+    jnc .Lasm_LooselyInequalsRhsInt32.binary_result_restore_0
+    mov r10d, DWORD PTR [rsp + 8]
+    mov r11, QWORD PTR [rsp]
+    mov QWORD PTR [rbx + r10 * 8], r11
+    add rsp, 16
     mov r13d, eax
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_LooselyInequalsRhsInt32.slow_path_transfer_0:
+.Lasm_LooselyInequalsRhsInt32.binary_result_restore_0:
+    add rsp, 16
+    test rax, rax
+    js .Lexit
+    bt rax, 32
+    jnc .Lasm_LooselyInequalsRhsInt32.slow_path_transfer_1
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_LooselyInequalsRhsInt32.slow_path_transfer_1:
     mov r11, QWORD PTR [rbp - 48]
     mov rbx, QWORD PTR [r11 + 15288]
     add rbx, 128

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
@@ -4265,152 +4265,6 @@ asm_handler_GetById:
     add r13d, 24
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetById.ssa_block_13:
-    cmp BYTE PTR [rcx + 12], 0
-    jz .Lasm_GetById.ssa_block_3
-    mov ecx, DWORD PTR [rax + 108]
-    mov rcx, QWORD PTR [rdx + rcx * 8]
-    test rcx, rcx
-    jz .Lasm_GetById.ssa_block_3
-    mov esi, DWORD PTR [rax + 116]
-    mov r8, QWORD PTR [rcx + rsi * 8]
-    test r8, r8
-    jz .Lasm_GetById.ssa_block_3
-    mov edi, DWORD PTR [rax + 120]
-    mov r8, QWORD PTR [r8 + rdi * 8]
-    cmp r8, rdx
-    jne .Lasm_GetById.ssa_block_3
-    mov eax, DWORD PTR [rax + 112]
-    mov rax, QWORD PTR [rcx + rax * 8]
-    test rax, rax
-    jnz .Lasm_GetById.ssa_block_25
-    movabs rcx, 9223090561878065152
-    jmp .Lasm_GetById.ssa_block_26
-.Lasm_GetById.ssa_block_25:
-    mov rax, QWORD PTR [rax + rsi * 8]
-    test rax, rax
-    jz .Lasm_GetById.ssa_block_3
-    mov rcx, QWORD PTR [rax + rdi * 8]
-    test rcx, rcx
-    jz .Lasm_GetById.ssa_block_3
-    movzx eax, WORD PTR [rcx + 10]
-    test eax, 2048
-    jnz .Lasm_GetById.ssa_block_3
-    movabs rax, 4398046511103
-    and rcx, rax
-    movabs rax, -1970324836974592
-    or rcx, rax
-.Lasm_GetById.ssa_block_26:
-    mov r11d, DWORD PTR [r14 + r13 + 4]
-    mov QWORD PTR [rbx + r11 * 8], rcx
-    add r13d, 24
-    movzx eax, BYTE PTR [r14 + r13]
-    jmp [r12 + rax * 8]
-.Lasm_GetById.ssa_block_14:
-    mov esi, DWORD PTR [rax + 104]
-    mov rcx, QWORD PTR [rbp - 48]
-    mov rcx, QWORD PTR [rcx + 16704]
-    shl rsi, 4
-    add rsi, rcx
-    mov edi, DWORD PTR [rsi + 8]
-    mov rcx, QWORD PTR [rbp - 48]
-    mov r9, QWORD PTR [rcx + 15376]
-    mov rcx, QWORD PTR [rcx + 15368]
-    lea r8, [rcx + 128]
-    cmp r8, r9
-    ja .Lasm_GetById.ssa_block_3
-    mov r9, QWORD PTR [rbp - 48]
-    mov r10, QWORD PTR [r9 + 15336]
-    mov r9, r10
-    add r9, 32768
-    cmp r9, rbp
-    ja .Lasm_GetById.ssa_block_3
-    mov r9, QWORD PTR [rbp - 48]
-    mov QWORD PTR [r9 + 15368], r8
-    mov DWORD PTR [rcx + 116], edi
-    mov DWORD PTR [rcx + 120], edi
-    mov DWORD PTR [rcx + 104], 0
-    mov rdi, QWORD PTR [rax + 24]
-    mov rdi, QWORD PTR [rdi + 16]
-    mov QWORD PTR [rcx], rax
-    mov QWORD PTR [rcx + 8], rdi
-    mov rax, QWORD PTR [rbx - 96]
-    mov rdi, QWORD PTR [rbx - 88]
-    mov QWORD PTR [rcx + 32], rax
-    mov QWORD PTR [rcx + 40], rdi
-    mov rax, QWORD PTR [rbx - 80]
-    mov QWORD PTR [rcx + 48], rax
-    movabs rax, 4398046511103
-    and rdx, rax
-    movabs rax, -1970324836974592
-    or rdx, rax
-    mov QWORD PTR [rcx + 80], rdx
-    xor rax, rax
-    lea rdx, [rcx + 16]
-    mov QWORD PTR [rdx], rax
-    mov QWORD PTR [rdx + 8], rax
-    mov QWORD PTR [rcx + 88], 0
-    mov DWORD PTR [rcx + 64], 0
-    mov DWORD PTR [rcx + 68], 0
-    mov DWORD PTR [rcx + 72], 4294967295
-    mov BYTE PTR [rcx + 76], 0
-    mov BYTE PTR [rcx + 77], 0
-    mov BYTE PTR [rcx + 78], 0
-    mov eax, r13d
-    mov edx, DWORD PTR [r14 + r13 + 4]
-    mov edi, DWORD PTR [r14 + r13 + 8]
-    mov DWORD PTR [rbx - 64], eax
-    lea r11, [rbx - 128]
-    mov QWORD PTR [rcx + 96], r11
-    lea rax, [rax + 1]
-    mov DWORD PTR [rcx + 108], eax
-    mov DWORD PTR [rcx + 112], edx
-    mov rax, QWORD PTR [rbp - 48]
-    mov QWORD PTR [rax + 15288], rcx
-    lea rbx, [rcx + 128]
-    mov rdx, QWORD PTR [rsi]
-    mov r11, rdx
-    mov rdi, QWORD PTR [rbp - 48]
-    call r11
-    mov rcx, rdx
-    mov rdx, rax
-    and rcx, 255
-    test rcx, rcx
-    jnz .Lasm_GetById.ssa_block_6
-    mov rax, QWORD PTR [rbx - 32]
-    mov rcx, QWORD PTR [rbp - 48]
-    mov QWORD PTR [rcx + 15288], rax
-    lea r11, [rbx - 128]
-    mov QWORD PTR [rcx + 15368], r11
-    lea rbx, [rax + 128]
-    mov r11d, DWORD PTR [r14 + r13 + 4]
-    mov QWORD PTR [rbx + r11 * 8], rdx
-    add r13d, 24
-    movzx eax, BYTE PTR [r14 + r13]
-    jmp [r12 + rax * 8]
-.Lasm_GetById.ssa_block_4:
-    mov DWORD PTR [rbx + -64], r13d
-    mov rdi, QWORD PTR [rbp - 48]
-    mov esi, r13d
-    lea rdx, [r14 + r13]
-    call CSYM(asm_slow_path_get_by_id_cached_accessor)
-    test rax, rax
-    js .Lexit
-    mov rcx, QWORD PTR [rbp - 48]
-    mov rbx, QWORD PTR [rcx + 15288]
-    add rbx, 128
-    mov rcx, QWORD PTR [rbx + -40]
-    mov r14, QWORD PTR [rcx + 80]
-    mov r13d, eax
-    movzx eax, BYTE PTR [r14 + r13]
-    jmp [r12 + rax * 8]
-.Lasm_GetById.ssa_block_5:
-    movabs r11, 9222809086901354496
-    mov eax, DWORD PTR [r14 + r13 + 4]
-    mov QWORD PTR [rbx + rax * 8], r11
-    add r13d, 24
-    movzx eax, BYTE PTR [r14 + r13]
-    jmp [r12 + rax * 8]
 asm_handler_GetById_hot_end:
 
 .p2align 6
@@ -9559,6 +9413,152 @@ asm_handler_PutByValue_cold:
 asm_handler_PutByValue_cold_end:
 asm_handler_GetById_cold:
 # Cold paths for GetById
+.Lasm_GetById.ssa_block_13:
+    cmp BYTE PTR [rcx + 12], 0
+    jz .Lasm_GetById.ssa_block_3
+    mov ecx, DWORD PTR [rax + 108]
+    mov rcx, QWORD PTR [rdx + rcx * 8]
+    test rcx, rcx
+    jz .Lasm_GetById.ssa_block_3
+    mov esi, DWORD PTR [rax + 116]
+    mov r8, QWORD PTR [rcx + rsi * 8]
+    test r8, r8
+    jz .Lasm_GetById.ssa_block_3
+    mov edi, DWORD PTR [rax + 120]
+    mov r8, QWORD PTR [r8 + rdi * 8]
+    cmp r8, rdx
+    jne .Lasm_GetById.ssa_block_3
+    mov eax, DWORD PTR [rax + 112]
+    mov rax, QWORD PTR [rcx + rax * 8]
+    test rax, rax
+    jnz .Lasm_GetById.ssa_block_25
+    movabs rcx, 9223090561878065152
+    jmp .Lasm_GetById.ssa_block_26
+.Lasm_GetById.ssa_block_25:
+    mov rax, QWORD PTR [rax + rsi * 8]
+    test rax, rax
+    jz .Lasm_GetById.ssa_block_3
+    mov rcx, QWORD PTR [rax + rdi * 8]
+    test rcx, rcx
+    jz .Lasm_GetById.ssa_block_3
+    movzx eax, WORD PTR [rcx + 10]
+    test eax, 2048
+    jnz .Lasm_GetById.ssa_block_3
+    movabs rax, 4398046511103
+    and rcx, rax
+    movabs rax, -1970324836974592
+    or rcx, rax
+.Lasm_GetById.ssa_block_26:
+    mov r11d, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + r11 * 8], rcx
+    add r13d, 24
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetById.ssa_block_14:
+    mov esi, DWORD PTR [rax + 104]
+    mov rcx, QWORD PTR [rbp - 48]
+    mov rcx, QWORD PTR [rcx + 16704]
+    shl rsi, 4
+    add rsi, rcx
+    mov edi, DWORD PTR [rsi + 8]
+    mov rcx, QWORD PTR [rbp - 48]
+    mov r9, QWORD PTR [rcx + 15376]
+    mov rcx, QWORD PTR [rcx + 15368]
+    lea r8, [rcx + 128]
+    cmp r8, r9
+    ja .Lasm_GetById.ssa_block_3
+    mov r9, QWORD PTR [rbp - 48]
+    mov r10, QWORD PTR [r9 + 15336]
+    mov r9, r10
+    add r9, 32768
+    cmp r9, rbp
+    ja .Lasm_GetById.ssa_block_3
+    mov r9, QWORD PTR [rbp - 48]
+    mov QWORD PTR [r9 + 15368], r8
+    mov DWORD PTR [rcx + 116], edi
+    mov DWORD PTR [rcx + 120], edi
+    mov DWORD PTR [rcx + 104], 0
+    mov rdi, QWORD PTR [rax + 24]
+    mov rdi, QWORD PTR [rdi + 16]
+    mov QWORD PTR [rcx], rax
+    mov QWORD PTR [rcx + 8], rdi
+    mov rax, QWORD PTR [rbx - 96]
+    mov rdi, QWORD PTR [rbx - 88]
+    mov QWORD PTR [rcx + 32], rax
+    mov QWORD PTR [rcx + 40], rdi
+    mov rax, QWORD PTR [rbx - 80]
+    mov QWORD PTR [rcx + 48], rax
+    movabs rax, 4398046511103
+    and rdx, rax
+    movabs rax, -1970324836974592
+    or rdx, rax
+    mov QWORD PTR [rcx + 80], rdx
+    xor rax, rax
+    lea rdx, [rcx + 16]
+    mov QWORD PTR [rdx], rax
+    mov QWORD PTR [rdx + 8], rax
+    mov QWORD PTR [rcx + 88], 0
+    mov DWORD PTR [rcx + 64], 0
+    mov DWORD PTR [rcx + 68], 0
+    mov DWORD PTR [rcx + 72], 4294967295
+    mov BYTE PTR [rcx + 76], 0
+    mov BYTE PTR [rcx + 77], 0
+    mov BYTE PTR [rcx + 78], 0
+    mov eax, r13d
+    mov edx, DWORD PTR [r14 + r13 + 4]
+    mov edi, DWORD PTR [r14 + r13 + 8]
+    mov DWORD PTR [rbx - 64], eax
+    lea r11, [rbx - 128]
+    mov QWORD PTR [rcx + 96], r11
+    lea rax, [rax + 1]
+    mov DWORD PTR [rcx + 108], eax
+    mov DWORD PTR [rcx + 112], edx
+    mov rax, QWORD PTR [rbp - 48]
+    mov QWORD PTR [rax + 15288], rcx
+    lea rbx, [rcx + 128]
+    mov rdx, QWORD PTR [rsi]
+    mov r11, rdx
+    mov rdi, QWORD PTR [rbp - 48]
+    call r11
+    mov rcx, rdx
+    mov rdx, rax
+    and rcx, 255
+    test rcx, rcx
+    jnz .Lasm_GetById.ssa_block_6
+    mov rax, QWORD PTR [rbx - 32]
+    mov rcx, QWORD PTR [rbp - 48]
+    mov QWORD PTR [rcx + 15288], rax
+    lea r11, [rbx - 128]
+    mov QWORD PTR [rcx + 15368], r11
+    lea rbx, [rax + 128]
+    mov r11d, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + r11 * 8], rdx
+    add r13d, 24
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetById.ssa_block_4:
+    mov DWORD PTR [rbx + -64], r13d
+    mov rdi, QWORD PTR [rbp - 48]
+    mov esi, r13d
+    lea rdx, [r14 + r13]
+    call CSYM(asm_slow_path_get_by_id_cached_accessor)
+    test rax, rax
+    js .Lexit
+    mov rcx, QWORD PTR [rbp - 48]
+    mov rbx, QWORD PTR [rcx + 15288]
+    add rbx, 128
+    mov rcx, QWORD PTR [rbx + -40]
+    mov r14, QWORD PTR [rcx + 80]
+    mov r13d, eax
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
+.Lasm_GetById.ssa_block_5:
+    movabs r11, 9222809086901354496
+    mov eax, DWORD PTR [r14 + r13 + 4]
+    mov QWORD PTR [rbx + rax * 8], r11
+    add r13d, 24
+    movzx eax, BYTE PTR [r14 + r13]
+    jmp [r12 + rax * 8]
 .Lasm_GetById.ssa_block_8:
     movabs r11, 4398046511103
     and rax, r11

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
@@ -4232,24 +4232,16 @@ asm_handler_GetById:
     test rcx, rcx
     jz .Lasm_GetById.ssa_block_1
     and rcx, -4
-    mov rdi, QWORD PTR [rcx + 24]
-    mov rax, QWORD PTR [rcx + 32]
-    cmp rdi, rsi
+    cmp QWORD PTR [rcx + 24], rsi
     jne .Lasm_GetById.ssa_block_1
-    mov edi, DWORD PTR [rcx]
-    cmp edi, 6
+    mov eax, DWORD PTR [rcx]
+    cmp eax, 6
     je .Lasm_GetById.ssa_block_1
+    mov rax, QWORD PTR [rcx + 32]
     test rax, rax
     jnz .Lasm_GetById.ssa_block_10
     mov rax, rdx
-    jmp .Lasm_GetById.ssa_block_11
-.Lasm_GetById.ssa_block_10:
-    mov rdi, QWORD PTR [rcx + 40]
-    test rdi, rdi
-    jz .Lasm_GetById.ssa_block_1
-    cmp BYTE PTR [rdi + 10], 0
-    jz .Lasm_GetById.ssa_block_1
-.Lasm_GetById.ssa_block_11:
+.Lasm_GetById.ssa_block_8:
     mov edi, DWORD PTR [rcx + 4]
     mov r8d, DWORD PTR [rcx + 8]
     cmp DWORD PTR [rsi + 92], r8d
@@ -4259,7 +4251,7 @@ asm_handler_GetById:
     mov r11, rax
     shr r11, 48
     cmp r11w, 65532
-    je .Lasm_GetById.ssa_block_8
+    je .Lasm_GetById.ssa_block_9
     mov r11d, DWORD PTR [r14 + r13 + 4]
     mov QWORD PTR [rbx + r11 * 8], rax
     add r13d, 24
@@ -9431,10 +9423,10 @@ asm_handler_GetById_cold:
     mov eax, DWORD PTR [rax + 112]
     mov rax, QWORD PTR [rcx + rax * 8]
     test rax, rax
-    jnz .Lasm_GetById.ssa_block_25
+    jnz .Lasm_GetById.ssa_block_26
     movabs rcx, 9223090561878065152
-    jmp .Lasm_GetById.ssa_block_26
-.Lasm_GetById.ssa_block_25:
+    jmp .Lasm_GetById.ssa_block_27
+.Lasm_GetById.ssa_block_26:
     mov rax, QWORD PTR [rax + rsi * 8]
     test rax, rax
     jz .Lasm_GetById.ssa_block_3
@@ -9448,7 +9440,7 @@ asm_handler_GetById_cold:
     and rcx, rax
     movabs rax, -1970324836974592
     or rcx, rax
-.Lasm_GetById.ssa_block_26:
+.Lasm_GetById.ssa_block_27:
     mov r11d, DWORD PTR [r14 + r13 + 4]
     mov QWORD PTR [rbx + r11 * 8], rcx
     add r13d, 24
@@ -9559,7 +9551,14 @@ asm_handler_GetById_cold:
     add r13d, 24
     movzx eax, BYTE PTR [r14 + r13]
     jmp [r12 + rax * 8]
-.Lasm_GetById.ssa_block_8:
+.Lasm_GetById.ssa_block_10:
+    mov rdi, QWORD PTR [rcx + 40]
+    test rdi, rdi
+    jz .Lasm_GetById.ssa_block_1
+    cmp BYTE PTR [rdi + 10], 0
+    jz .Lasm_GetById.ssa_block_1
+    jmp .Lasm_GetById.ssa_block_8
+.Lasm_GetById.ssa_block_9:
     movabs r11, 4398046511103
     and rax, r11
     add rax, r15

--- a/Libraries/LibJS/Flap/tests/interpreter-layout.conf
+++ b/Libraries/LibJS/Flap/tests/interpreter-layout.conf
@@ -116,6 +116,7 @@ const EXECUTABLE_REGISTERS_AND_LOCALS_AND_CONSTANTS_COUNT = 368
 field Executable.registers_and_locals_and_constants_count u32 EXECUTABLE_REGISTERS_AND_LOCALS_AND_CONSTANTS_COUNT nullable scalar slot_counts
 const EXECUTABLE_ASM_CONSTANTS_SIZE = 376
 field Executable.asm_constants_size u64 EXECUTABLE_ASM_CONSTANTS_SIZE nullable scalar constants
+const SLOW_PATH_CONTINUATION_BIT = 32
 const EXECUTABLE_ASM_CONSTANTS_DATA = 384
 field Executable.asm_constants_data Sequence<Value> EXECUTABLE_ASM_CONSTANTS_DATA nullable scalar constants
 

--- a/Libraries/LibJS/Flap/tests/interpreter-layout.conf
+++ b/Libraries/LibJS/Flap/tests/interpreter-layout.conf
@@ -143,6 +143,8 @@ const EXECUTION_CONTEXT_YIELD_VALUE_IS_ITERATOR_RESULT = 77
 field ExecutionContext.yield_value_is_iterator_result bool EXECUTION_CONTEXT_YIELD_VALUE_IS_ITERATOR_RESULT nullable scalar
 const EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT = 78
 field ExecutionContext.caller_is_construct bool EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT nullable scalar
+const EXECUTION_CONTEXT_FRAME_INITIALIZED = 79
+field ExecutionContext.frame_initialized bool EXECUTION_CONTEXT_FRAME_INITIALIZED nullable scalar
 const EXECUTION_CONTEXT_THIS_VALUE = 80
 field ExecutionContext.this_value Value EXECUTION_CONTEXT_THIS_VALUE nullable scalar this_and_executable
 const EXECUTION_CONTEXT_EXECUTABLE = 88

--- a/Libraries/LibJS/Flap/tests/interpreter_assembly.rs
+++ b/Libraries/LibJS/Flap/tests/interpreter_assembly.rs
@@ -64,3 +64,14 @@ fn interpreter_assembly_matches_snapshots() {
     compare_or_rebaseline("x86_64.S", &compile_interpreter(Architecture::X86_64));
     compare_or_rebaseline("aarch64.S", &compile_interpreter(Architecture::Aarch64));
 }
+
+#[test]
+fn keeps_helper_setup_out_of_the_hot_handler_region() {
+    for architecture in [Architecture::X86_64, Architecture::Aarch64] {
+        let assembly = compile_interpreter(architecture);
+        let cold_start = assembly.find("asm_cold_handler_paths:").unwrap();
+        for handler in ["Exp", "ExpRhsInt32"] {
+            assert!(assembly.find(&format!("asm_handler_{handler}:")).unwrap() > cold_start);
+        }
+    }
+}

--- a/Libraries/LibJS/Interpreter/GenerateLayout.cpp
+++ b/Libraries/LibJS/Interpreter/GenerateLayout.cpp
@@ -191,6 +191,7 @@ int main()
     EMIT_FIELD(EXECUTION_CONTEXT_YIELD_IS_AWAIT, ExecutionContext, yield_is_await, bool, ExecutionContext, yield_is_await, 1, nullable, scalar);
     EMIT_FIELD(EXECUTION_CONTEXT_YIELD_VALUE_IS_ITERATOR_RESULT, ExecutionContext, yield_value_is_iterator_result, bool, ExecutionContext, yield_value_is_iterator_result, 1, nullable, scalar);
     EMIT_FIELD(EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT, ExecutionContext, caller_is_construct, bool, ExecutionContext, caller_is_construct, 1, nullable, scalar);
+    EMIT_FIELD(EXECUTION_CONTEXT_FRAME_INITIALIZED, ExecutionContext, frame_initialized, bool, ExecutionContext, frame_initialized, 1, nullable, scalar);
     EMIT_PAIRED_FIELD(EXECUTION_CONTEXT_THIS_VALUE, ExecutionContext, this_value, Value, ExecutionContext, this_value, 8, scalar, this_and_executable);
     EMIT_PAIRED_FIELD(EXECUTION_CONTEXT_EXECUTABLE, ExecutionContext, executable, Executable, ExecutionContext, executable, 8, cell, this_and_executable);
     EMIT_FIELD(EXECUTION_CONTEXT_CALLER_FRAME, ExecutionContext, caller_frame, ExecutionContext, ExecutionContext, caller_frame, 8, nullable, scalar);

--- a/Libraries/LibJS/Interpreter/GenerateLayout.cpp
+++ b/Libraries/LibJS/Interpreter/GenerateLayout.cpp
@@ -16,6 +16,7 @@
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/PropertyNameIterator.h>
 #include <LibJS/Bytecode/PutKind.h>
+#include <LibJS/Interpreter/SlowPathResult.h>
 #include <LibJS/Runtime/Accessor.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/DeclarativeEnvironment.h>
@@ -162,6 +163,8 @@ int main()
     EMIT_FIELD(PROPERTY_NAME_ITERATOR_SHAPE_IS_DICTIONARY, PropertyNameIterator, shape_is_dictionary, bool, PropertyNameIterator, m_shape_is_dictionary, 1, nullable, scalar);
     EMIT_FIELD(PROPERTY_NAME_ITERATOR_SHAPE_DICTIONARY_GENERATION, PropertyNameIterator, shape_dictionary_generation, u32, PropertyNameIterator, m_shape_dictionary_generation, 4, nullable, scalar);
     EMIT_FIELD(PROPERTY_NAME_ITERATOR_FAST_PATH, PropertyNameIterator, fast_path, u8, PropertyNameIterator, m_fast_path, 1, nullable, scalar);
+
+    outln("const SLOW_PATH_CONTINUATION_BIT = {}", slow_path_continuation_bit);
 
     // Executable layout
     outln("\n# Executable layout");

--- a/Libraries/LibJS/Interpreter/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter/Interpreter.cpp
@@ -230,7 +230,7 @@ VM::HandleExceptionResponse VM::handle_exception(u32 program_counter, Value exce
 ExecutionContext* VM::push_inline_frame(
     ECMAScriptFunctionObject& callee_function,
     Executable& callee_executable,
-    ReadonlySpan<Operand> arguments,
+    ReadonlySpan<Value> arguments,
     u32 return_pc,
     u32 dst_raw,
     Value this_value,
@@ -247,10 +247,10 @@ ExecutionContext* VM::push_inline_frame(
     if (!callee_context) [[unlikely]]
         return nullptr;
 
-    // Copy arguments from caller's registers into callee's argument slots.
+    // Copy the supplied arguments into the callee's argument slots.
     auto* callee_argument_values = callee_context->arguments_data();
     for (u32 i = 0; i < insn_argument_count; ++i)
-        callee_argument_values[i] = get(arguments[i]);
+        callee_argument_values[i] = arguments[i];
     for (size_t i = insn_argument_count; i < argument_count; ++i)
         callee_argument_values[i] = js_undefined();
     callee_context->passed_argument_count = insn_argument_count;

--- a/Libraries/LibJS/Interpreter/SlowPathResult.h
+++ b/Libraries/LibJS/Interpreter/SlowPathResult.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace JS {
+
+// Successful helpers preserve the current frame and continue at the next
+// instruction. Keep its PC in the low word for interpreter continuations.
+inline constexpr u8 slow_path_continuation_bit = 32;
+
+constexpr i64 continue_after_slow_path(u32 next_pc)
+{
+    return (i64 { 1 } << slow_path_continuation_bit) | next_pc;
+}
+
+}

--- a/Libraries/LibJS/Interpreter/SlowPaths.cpp
+++ b/Libraries/LibJS/Interpreter/SlowPaths.cpp
@@ -1799,6 +1799,22 @@ JS_DEFINE_UNARY_GENERIC_BUILTIN_CALL_SLOW_PATH(StringPrototypeCharAt, string_pro
 
 i64 asm_slow_path_call_construct(VM* vm, u32 pc, Op::CallConstruct const* instruction)
 {
+    auto callee = vm->get(instruction->callee());
+    if (callee.is_object() && is<ECMAScriptFunctionObject>(callee.as_object())) {
+        auto& function = static_cast<ECMAScriptFunctionObject&>(callee.as_object());
+        if (function.can_inline_call() && callee.is_constructor() && function.constructor_kind() == ConstructorKind::Base && !function.has_class_data()) {
+            auto* prototype = ASM_TRY(*vm, pc, get_prototype_from_constructor(*vm, function, &Intrinsics::object_prototype));
+            auto this_object = Object::create(*function.realm(), prototype);
+            auto* context = vm->push_inline_frame(function, function.inline_call_executable(), instruction->arguments(), pc + instruction->length(), instruction->dst().raw(), this_object, &function, true);
+            if (!context) [[unlikely]] {
+                ASM_TRY(*vm, pc, vm->throw_completion<InternalError>(ErrorType::CallStackSizeExceeded));
+                VERIFY_NOT_REACHED();
+            }
+            // Constructors retain their receiver even when the body never reads this.
+            context->this_value = this_object;
+            return 0;
+        }
+    }
     ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Construct, *vm, vm->get(instruction->callee()), js_undefined(), instruction->arguments(), instruction->dst(), instruction->expression_string(), instruction->strict()));
     return continue_after_slow_path(pc + instruction->length());
 }

--- a/Libraries/LibJS/Interpreter/SlowPaths.cpp
+++ b/Libraries/LibJS/Interpreter/SlowPaths.cpp
@@ -43,13 +43,39 @@
 #include <math.h>
 
 // ===== Slow path functions callable from assembly =====
-// All slow path functions follow the same convention:
-//   i64 func(VM* vm, u32 pc, Op::Foo const* instruction)
-//   Returns >= 0: new PC in the low word; bit 32 marks normal same-frame continuation
-//   Returns < 0: should exit the interpreter
+// The caller supplies scalar operands directly, or uses an Op::Values record for
+// variable-length and multiple-output operations. Windows always uses a record.
+// The first required output is returned in a register where the ABI supports it.
+// Input/output operands are also copied back on exceptions if the frame remains active.
+// Output-only fields in caller-provided records are uninitialized on entry.
+// Control result >= 0: new PC in the low word; bit 32 marks same-frame continuation.
+// Control result < 0: exit the interpreter.
 
 using namespace JS;
 using namespace JS::Bytecode;
+
+#define DEFINE_SLOW_PATH(name, op) JS_DEFINE_SLOW_PATH_##op(name)
+#define DECLARE_SLOW_PATH(name, op) JS_DECLARE_SLOW_PATH_##op(name)
+
+#ifndef AK_OS_WINDOWS
+// The System V and AArch64 ABIs return these two words in integer registers.
+struct AsmSlowPathResult {
+    i64 control;
+    u64 value;
+};
+
+template<typename Values>
+static ALWAYS_INLINE AsmSlowPathResult make_asm_slow_path_result(i64 control, Values const& values)
+{
+    if constexpr (requires { values.primary_output(); }) {
+        return { control, values.primary_output().encoded() };
+    }
+    return { control, 0 };
+}
+#endif
+
+#define DEFINE_RECORD_SLOW_PATH(name, OpType) \
+    i64 name([[maybe_unused]] VM* vm, [[maybe_unused]] u32 pc, [[maybe_unused]] OpType const* instruction, [[maybe_unused]] OpType::Values& values)
 
 static i64 handle_asm_exception(VM& vm, u32 pc, Value exception)
 {
@@ -124,7 +150,7 @@ enum class AsmBindingIsKnownToBeInitialized {
 };
 
 template<AsmBindingIsKnownToBeInitialized binding_is_known_to_be_initialized>
-static i64 asm_get_binding(VM& vm, u32 pc, Operand dst, EnvironmentCoordinate const& cache)
+static i64 asm_get_binding(VM& vm, u32 pc, Value& dst, EnvironmentCoordinate const& cache)
 {
     VERIFY(cache.is_valid());
 
@@ -138,12 +164,12 @@ static i64 asm_get_binding(VM& vm, u32 pc, Operand dst, EnvironmentCoordinate co
     } else {
         value = static_cast<DeclarativeEnvironment const&>(*environment).get_initialized_binding_value_direct(cache.index);
     }
-    vm.set(dst, value);
+    dst = value;
     return static_cast<i64>(pc);
 }
 
 template<AsmBindingIsKnownToBeInitialized binding_is_known_to_be_initialized>
-static i64 asm_dynamic_get_binding(VM& vm, u32 pc, Operand dst, IdentifierTableIndex identifier_index, Strict strict, EnvironmentCoordinate& cache)
+static i64 asm_dynamic_get_binding(VM& vm, u32 pc, Value& dst, IdentifierTableIndex identifier_index, Strict strict, EnvironmentCoordinate& cache)
 {
     auto const* current_environment = vm.running_execution_context().lexical_environment.ptr();
     if (auto const* cached_environment = asm_get_cached_environment(current_environment, cache)) [[likely]] {
@@ -153,7 +179,7 @@ static i64 asm_dynamic_get_binding(VM& vm, u32 pc, Operand dst, IdentifierTableI
         } else {
             value = static_cast<DeclarativeEnvironment const&>(*cached_environment).get_initialized_binding_value_direct(cache.index);
         }
-        vm.set(dst, value);
+        dst = value;
         return static_cast<i64>(pc);
     }
 
@@ -161,17 +187,17 @@ static i64 asm_dynamic_get_binding(VM& vm, u32 pc, Operand dst, IdentifierTableI
     auto reference = ASM_TRY(vm, pc, vm.resolve_binding(executable.get_identifier(identifier_index), strict));
     asm_update_environment_coordinate_cache(current_environment, reference, cache);
 
-    vm.set(dst, ASM_TRY(vm, pc, reference.get_value(vm)));
+    dst = ASM_TRY(vm, pc, reference.get_value(vm));
     return static_cast<i64>(pc);
 }
 
-static i64 asm_dynamic_get_callee_and_this_from_environment(VM& vm, u32 pc, Operand callee_dst, Operand this_value_dst, IdentifierTableIndex identifier_index, Strict strict, EnvironmentCoordinate& cache)
+static i64 asm_dynamic_get_callee_and_this_from_environment(VM& vm, u32 pc, Value& callee_dst, Value& this_value_dst, IdentifierTableIndex identifier_index, Strict strict, EnvironmentCoordinate& cache)
 {
     auto const* current_environment = vm.running_execution_context().lexical_environment.ptr();
     if (auto const* cached_environment = asm_get_cached_environment(current_environment, cache)) [[likely]] {
         auto callee = ASM_TRY(vm, pc, static_cast<DeclarativeEnvironment const&>(*cached_environment).get_binding_value_direct(vm, cache.index));
-        vm.set(callee_dst, callee);
-        vm.set(this_value_dst, js_undefined());
+        callee_dst = callee;
+        this_value_dst = js_undefined();
         return static_cast<i64>(pc);
     }
 
@@ -190,8 +216,8 @@ static i64 asm_dynamic_get_callee_and_this_from_environment(VM& vm, u32 pc, Oper
         }
     }
 
-    vm.set(callee_dst, callee);
-    vm.set(this_value_dst, this_value);
+    callee_dst = callee;
+    this_value_dst = this_value;
     return static_cast<i64>(pc);
 }
 
@@ -548,20 +574,27 @@ static ThrowCompletionOr<GC::Ref<PropertyNameIterator>> asm_get_object_property_
     return PropertyNameIterator::create(vm.realm(), object, move(properties));
 }
 
-static i64 finish_binary_slow_path_value(VM& vm, u32 pc, Operand destination, Value result)
+static i64 finish_binary_slow_path_value(VM& vm, u32 pc, Value& destination, Value result)
 {
-    vm.set(destination, result);
+    destination = result;
     auto const* instruction = bit_cast<Instruction const*>(vm.current_executable().bytecode.data() + pc);
     return continue_after_slow_path(pc + instruction->length());
 }
 
 template<typename Result>
-static i64 finish_binary_slow_path(VM& vm, u32 pc, Operand destination, ThrowCompletionOr<Result> result)
+static i64 finish_binary_slow_path(VM& vm, u32 pc, Value& destination, ThrowCompletionOr<Result> result)
 {
     return finish_binary_slow_path_value(vm, pc, destination, Value { ASM_TRY(vm, pc, move(result)) });
 }
 
 extern "C" {
+
+i64 asm_slow_path_stack_overflow(VM*, u32);
+
+i64 asm_slow_path_stack_overflow(VM* vm, u32 pc)
+{
+    return handle_asm_exception(*vm, pc, vm->throw_completion<InternalError>(ErrorType::CallStackSizeExceeded).value());
+}
 
 // Forward declarations for all functions called from assembly.
 void asm_debugger_check_breakpoint(VM*, u32 pc);
@@ -571,174 +604,174 @@ i64 asm_slow_path_jump_greater_than_values(VM*, u32 pc, Value, Value, u32, u32);
 i64 asm_slow_path_jump_less_than_equals_values(VM*, u32 pc, Value, Value, u32, u32);
 i64 asm_slow_path_jump_greater_than_equals_values(VM*, u32 pc, Value, Value, u32, u32);
 i64 asm_slow_path_jump_loosely_equals_values(VM*, u32 pc, Value, Value, u32, u32);
-i64 asm_slow_path_create_private_environment(VM*, u32 pc, Op::CreatePrivateEnvironment const*);
-i64 asm_slow_path_throw_const_assignment(VM*, u32 pc, Op::ThrowConstAssignment const*);
-i64 asm_slow_path_resolve_this_binding(VM*, u32 pc, Op::ResolveThisBinding const*);
+DECLARE_SLOW_PATH(asm_slow_path_create_private_environment, CreatePrivateEnvironment);
+DECLARE_SLOW_PATH(asm_slow_path_throw_const_assignment, ThrowConstAssignment);
+DECLARE_SLOW_PATH(asm_slow_path_resolve_this_binding, ResolveThisBinding);
 #define DECLARE_CALL_BUILTIN_SLOW_PATH(name, snake_case_name, ...) \
-    i64 asm_slow_path_call_builtin_##snake_case_name(VM*, u32 pc, Op::CallBuiltin##name const*);
+    DECLARE_SLOW_PATH(asm_slow_path_call_builtin_##snake_case_name, CallBuiltin##name);
 JS_ENUMERATE_BUILTINS(DECLARE_CALL_BUILTIN_SLOW_PATH)
 #undef DECLARE_CALL_BUILTIN_SLOW_PATH
-i64 asm_slow_path_add(VM*, u32 pc, Op::Add const*);
-i64 asm_slow_path_sub(VM*, u32 pc, Op::Sub const*);
-i64 asm_slow_path_add_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_sub_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_mul_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_div_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_less_than(VM*, u32 pc, Op::LessThan const*);
-i64 asm_slow_path_less_than_equals(VM*, u32 pc, Op::LessThanEquals const*);
-i64 asm_slow_path_greater_than(VM*, u32 pc, Op::GreaterThan const*);
-i64 asm_slow_path_greater_than_equals(VM*, u32 pc, Op::GreaterThanEquals const*);
-i64 asm_slow_path_less_than_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_less_than_equals_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_greater_than_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_greater_than_equals_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_increment(VM*, u32 pc, Op::Increment const*);
-i64 asm_slow_path_decrement(VM*, u32 pc, Op::Decrement const*);
+DECLARE_SLOW_PATH(asm_slow_path_add, Add);
+DECLARE_SLOW_PATH(asm_slow_path_sub, Sub);
+i64 asm_slow_path_add_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_sub_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_mul_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_div_values(VM*, u32 pc, Value&, Value, Value);
+DECLARE_SLOW_PATH(asm_slow_path_less_than, LessThan);
+DECLARE_SLOW_PATH(asm_slow_path_less_than_equals, LessThanEquals);
+DECLARE_SLOW_PATH(asm_slow_path_greater_than, GreaterThan);
+DECLARE_SLOW_PATH(asm_slow_path_greater_than_equals, GreaterThanEquals);
+i64 asm_slow_path_less_than_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_less_than_equals_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_greater_than_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_greater_than_equals_values(VM*, u32 pc, Value&, Value, Value);
+DECLARE_SLOW_PATH(asm_slow_path_increment, Increment);
+DECLARE_SLOW_PATH(asm_slow_path_decrement, Decrement);
 i64 asm_slow_path_jump_loosely_inequals_values(VM*, u32 pc, Value, Value, u32, u32);
 i64 asm_slow_path_jump_strictly_equals_values(VM*, u32 pc, Value, Value, u32, u32);
 i64 asm_slow_path_jump_strictly_inequals_values(VM*, u32 pc, Value, Value, u32, u32);
-i64 asm_slow_path_get_initialized_binding(VM*, u32 pc, Op::GetInitializedBinding const*);
-i64 asm_slow_path_dynamic_get_initialized_binding(VM*, u32 pc, Op::DynamicGetInitializedBinding const*);
-i64 asm_slow_path_get_callee_and_this(VM*, u32 pc, Op::GetCalleeAndThisFromEnvironment const*);
-i64 asm_slow_path_dynamic_get_callee_and_this(VM*, u32 pc, Op::DynamicGetCalleeAndThisFromEnvironment const*);
-i64 asm_slow_path_postfix_increment(VM*, u32 pc, Op::PostfixIncrement const*);
-i64 asm_slow_path_get_by_id(VM*, u32 pc, Op::GetById const*);
-i64 asm_slow_path_get_by_id_cached_accessor(VM*, u32 pc, Op::GetById const*);
-i64 asm_slow_path_get_by_id_with_this(VM*, u32 pc, Op::GetByIdWithThis const*);
-i64 asm_slow_path_put_by_id(VM*, u32 pc, Op::PutById const*);
-i64 asm_slow_path_put_by_id_with_this(VM*, u32 pc, Op::PutByIdWithThis const*);
-i64 asm_slow_path_get_by_value(VM*, u32 pc, Op::GetByValue const*);
-i64 asm_slow_path_get_by_value_with_this(VM*, u32 pc, Op::GetByValueWithThis const*);
-i64 asm_slow_path_get_length(VM*, u32 pc, Op::GetLength const*);
-i64 asm_slow_path_get_length_with_this(VM*, u32 pc, Op::GetLengthWithThis const*);
-i64 asm_slow_path_get_method(VM*, u32 pc, Op::GetMethod const*);
-i64 asm_slow_path_get_iterator(VM*, u32 pc, Op::GetIterator const*);
-i64 asm_slow_path_get_import_meta(VM*, u32 pc, Op::GetImportMeta const*);
-i64 asm_slow_path_get_new_target(VM*, u32 pc, Op::GetNewTarget const*);
-i64 asm_slow_path_get_super_constructor(VM*, u32 pc, Op::GetSuperConstructor const*);
-i64 asm_slow_path_get_global(VM*, u32 pc, Op::GetGlobal const*);
-i64 asm_slow_path_set_global(VM*, u32 pc, Op::SetGlobal const*);
-i64 asm_slow_path_concat_string(VM*, u32 pc, Op::ConcatString const*);
-i64 asm_slow_path_copy_object_excluding_properties(VM*, u32 pc, Op::CopyObjectExcludingProperties const*);
-i64 asm_slow_path_exp_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_import_call(VM*, u32 pc, Op::ImportCall const*);
-i64 asm_slow_path_new_class(VM*, u32 pc, Op::NewClass const*);
-i64 asm_slow_path_call(VM*, u32 pc, Op::Call const*);
-i64 asm_slow_path_call_direct_eval(VM*, u32 pc, Op::CallDirectEval const*);
-i64 asm_slow_path_call_with_argument_array(VM*, u32 pc, Op::CallWithArgumentArray const*);
-i64 asm_slow_path_call_direct_eval_with_argument_array(VM*, u32 pc, Op::CallDirectEvalWithArgumentArray const*);
-i64 asm_slow_path_get_object_property_iterator(VM*, u32 pc, Op::GetObjectPropertyIterator const*);
-i64 asm_slow_path_object_property_iterator_next(VM*, u32 pc, Op::ObjectPropertyIteratorNext const*);
-i64 asm_slow_path_iterator_close(VM*, u32 pc, Op::IteratorClose const*);
-i64 asm_slow_path_iterator_next(VM*, u32 pc, Op::IteratorNext const*);
-i64 asm_slow_path_iterator_next_unpack(VM*, u32 pc, Op::IteratorNextUnpack const*);
-i64 asm_slow_path_iterator_to_array(VM*, u32 pc, Op::IteratorToArray const*);
-i64 asm_slow_path_call_construct(VM*, u32 pc, Op::CallConstruct const*);
-i64 asm_slow_path_call_construct_with_argument_array(VM*, u32 pc, Op::CallConstructWithArgumentArray const*);
-i64 asm_slow_path_super_call_with_argument_array(VM*, u32 pc, Op::SuperCallWithArgumentArray const*);
-i64 asm_slow_path_new_object(VM*, u32 pc, Op::NewObject const*);
-i64 asm_slow_path_new_object_with_no_prototype(VM*, u32 pc, Op::NewObjectWithNoPrototype const*);
-i64 asm_slow_path_cache_object_shape(VM*, u32 pc, Op::CacheObjectShape const*);
-i64 asm_slow_path_init_object_literal_property(VM*, u32 pc, Op::InitObjectLiteralProperty const*);
-i64 asm_slow_path_new_array(VM*, u32 pc, Op::NewArray const*);
-i64 asm_slow_path_new_primitive_array(VM*, u32 pc, Op::NewPrimitiveArray const*);
-i64 asm_slow_path_new_regexp(VM*, u32 pc, Op::NewRegExp const*);
-i64 asm_slow_path_new_reference_error(VM*, u32 pc, Op::NewReferenceError const*);
-i64 asm_slow_path_new_type_error(VM*, u32 pc, Op::NewTypeError const*);
-i64 asm_slow_path_bitwise_xor(VM*, u32 pc, Op::BitwiseXor const*);
-i64 asm_slow_path_bitwise_and(VM*, u32 pc, Op::BitwiseAnd const*);
-i64 asm_slow_path_bitwise_or(VM*, u32 pc, Op::BitwiseOr const*);
-i64 asm_slow_path_bitwise_xor_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_bitwise_and_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_bitwise_or_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_left_shift_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_right_shift_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_unsigned_right_shift_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_mod_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_strictly_equals_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_strictly_inequals_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_loosely_equals_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_loosely_inequals_values(VM*, u32 pc, Operand, Value, Value);
-i64 asm_slow_path_unary_minus(VM*, u32 pc, Op::UnaryMinus const*);
-i64 asm_slow_path_to_string(VM*, u32 pc, Op::ToString const*);
-i64 asm_slow_path_to_primitive_with_string_hint(VM*, u32 pc, Op::ToPrimitiveWithStringHint const*);
-i64 asm_slow_path_to_object(VM*, u32 pc, Op::ToObject const*);
-i64 asm_slow_path_to_length(VM*, u32 pc, Op::ToLength const*);
-i64 asm_slow_path_typeof(VM*, u32 pc, Op::Typeof const*);
-i64 asm_slow_path_postfix_decrement(VM*, u32 pc, Op::PostfixDecrement const*);
-i64 asm_slow_path_to_int32(VM*, u32 pc, Op::ToInt32 const*);
-i64 asm_slow_path_put_by_value(VM*, u32 pc, Op::PutByValue const*);
-i64 asm_slow_path_put_by_value_with_this(VM*, u32 pc, Op::PutByValueWithThis const*);
-i64 asm_slow_path_put_by_spread(VM*, u32 pc, Op::PutBySpread const*);
-i64 asm_slow_path_get_binding(VM*, u32 pc, Op::GetBinding const*);
-i64 asm_slow_path_dynamic_get_binding(VM*, u32 pc, Op::DynamicGetBinding const*);
-i64 asm_slow_path_initialize_lexical_binding(VM*, u32 pc, Op::InitializeLexicalBinding const*);
-i64 asm_slow_path_dynamic_initialize_lexical_binding(VM*, u32 pc, Op::DynamicInitializeLexicalBinding const*);
-i64 asm_slow_path_initialize_variable_binding(VM*, u32 pc, Op::InitializeVariableBinding const*);
-i64 asm_slow_path_dynamic_initialize_variable_binding(VM*, u32 pc, Op::DynamicInitializeVariableBinding const*);
-i64 asm_slow_path_set_lexical_binding(VM*, u32 pc, Op::SetLexicalBinding const*);
-i64 asm_slow_path_dynamic_set_lexical_binding(VM*, u32 pc, Op::DynamicSetLexicalBinding const*);
-i64 asm_slow_path_set_variable_binding(VM*, u32 pc, Op::SetVariableBinding const*);
-i64 asm_slow_path_dynamic_set_variable_binding(VM*, u32 pc, Op::DynamicSetVariableBinding const*);
-i64 asm_slow_path_resolve_binding(VM*, u32 pc, Op::ResolveBinding const*);
-i64 asm_slow_path_resolve_super_base(VM*, u32 pc, Op::ResolveSuperBase const*);
-i64 asm_slow_path_set_resolved_binding(VM*, u32 pc, Op::SetResolvedBinding const*);
-i64 asm_slow_path_typeof_binding(VM*, u32 pc, Op::TypeofBinding const*);
-i64 asm_slow_path_dynamic_typeof_binding(VM*, u32 pc, Op::DynamicTypeofBinding const*);
-i64 asm_slow_path_has_private_id(VM*, u32 pc, Op::HasPrivateId const*);
-i64 asm_slow_path_set_function_name(VM*, u32 pc, Op::SetFunctionName const*);
-i64 asm_slow_path_new_array_with_length(VM*, u32 pc, Op::NewArrayWithLength const*);
-i64 asm_slow_path_array_append(VM*, u32 pc, Op::ArrayAppend const*);
-i64 asm_slow_path_create_variable(VM*, u32 pc, Op::CreateVariable const*);
-i64 asm_slow_path_enter_object_environment(VM*, u32 pc, Op::EnterObjectEnvironment const*);
-i64 asm_slow_path_bitwise_not(VM*, u32 pc, Op::BitwiseNot const*);
-i64 asm_slow_path_unary_plus(VM*, u32 pc, Op::UnaryPlus const*);
-i64 asm_slow_path_is_constructor(VM*, u32 pc, Op::IsConstructor const*);
-i64 asm_slow_path_add_private_name(VM*, u32 pc, Op::AddPrivateName const*);
-i64 asm_slow_path_create_async_from_sync_iterator(VM*, u32 pc, Op::CreateAsyncFromSyncIterator const*);
-i64 asm_slow_path_create_data_property_or_throw(VM*, u32 pc, Op::CreateDataPropertyOrThrow const*);
-i64 asm_slow_path_create_immutable_binding(VM*, u32 pc, Op::CreateImmutableBinding const*);
-i64 asm_slow_path_create_mutable_binding(VM*, u32 pc, Op::CreateMutableBinding const*);
-i64 asm_slow_path_create_rest_params(VM*, u32 pc, Op::CreateRestParams const*);
-i64 asm_slow_path_create_arguments(VM*, u32 pc, Op::CreateArguments const*);
-i64 asm_slow_path_await(VM*, u32 pc, Op::Await const*);
-i64 asm_slow_path_create_lexical_environment(VM*, u32 pc, Op::CreateLexicalEnvironment const*);
-i64 asm_slow_path_create_variable_environment(VM*, u32 pc, Op::CreateVariableEnvironment const*);
-i64 asm_slow_path_delete_by_id(VM*, u32 pc, Op::DeleteById const*);
-i64 asm_slow_path_delete_by_value(VM*, u32 pc, Op::DeleteByValue const*);
-i64 asm_slow_path_delete_variable(VM*, u32 pc, Op::DeleteVariable const*);
-i64 asm_slow_path_get_completion_fields(VM*, u32 pc, Op::GetCompletionFields const*);
-i64 asm_slow_path_set_completion_type(VM*, u32 pc, Op::SetCompletionType const*);
-i64 asm_slow_path_get_template_object(VM*, u32 pc, Op::GetTemplateObject const*);
-i64 asm_slow_path_new_function(VM*, u32 pc, Op::NewFunction const*);
-i64 asm_slow_path_throw(VM*, u32 pc, Op::Throw const*);
-i64 asm_slow_path_throw_if_tdz(VM*, u32 pc, Op::ThrowIfTDZ const*);
-i64 asm_slow_path_throw_if_not_object(VM*, u32 pc, Op::ThrowIfNotObject const*);
-i64 asm_slow_path_throw_if_nullish(VM*, u32 pc, Op::ThrowIfNullish const*);
-i64 asm_slow_path_debugger(VM*, u32 pc, Op::Debugger const*);
-i64 asm_slow_path_yield(VM*, u32 pc, Op::Yield const*);
-i64 asm_slow_path_yield_iterator_result(VM*, u32 pc, Op::YieldIteratorResult const*);
-i64 asm_slow_path_instance_of(VM*, u32 pc, Op::InstanceOf const*);
-i64 asm_slow_path_in(VM*, u32 pc, Op::In const*);
-i64 asm_slow_path_get_private_by_id(VM*, u32 pc, Op::GetPrivateById const*);
-i64 asm_slow_path_put_private_by_id(VM*, u32 pc, Op::PutPrivateById const*);
+DECLARE_SLOW_PATH(asm_slow_path_get_initialized_binding, GetInitializedBinding);
+DECLARE_SLOW_PATH(asm_slow_path_dynamic_get_initialized_binding, DynamicGetInitializedBinding);
+DECLARE_SLOW_PATH(asm_slow_path_get_callee_and_this, GetCalleeAndThisFromEnvironment);
+DECLARE_SLOW_PATH(asm_slow_path_dynamic_get_callee_and_this, DynamicGetCalleeAndThisFromEnvironment);
+DECLARE_SLOW_PATH(asm_slow_path_postfix_increment, PostfixIncrement);
+DECLARE_SLOW_PATH(asm_slow_path_get_by_id, GetById);
+DECLARE_SLOW_PATH(asm_slow_path_get_by_id_cached_accessor, GetById);
+DECLARE_SLOW_PATH(asm_slow_path_get_by_id_with_this, GetByIdWithThis);
+DECLARE_SLOW_PATH(asm_slow_path_put_by_id, PutById);
+DECLARE_SLOW_PATH(asm_slow_path_put_by_id_with_this, PutByIdWithThis);
+DECLARE_SLOW_PATH(asm_slow_path_get_by_value, GetByValue);
+DECLARE_SLOW_PATH(asm_slow_path_get_by_value_with_this, GetByValueWithThis);
+DECLARE_SLOW_PATH(asm_slow_path_get_length, GetLength);
+DECLARE_SLOW_PATH(asm_slow_path_get_length_with_this, GetLengthWithThis);
+DECLARE_SLOW_PATH(asm_slow_path_get_method, GetMethod);
+DECLARE_SLOW_PATH(asm_slow_path_get_iterator, GetIterator);
+DECLARE_SLOW_PATH(asm_slow_path_get_import_meta, GetImportMeta);
+DECLARE_SLOW_PATH(asm_slow_path_get_new_target, GetNewTarget);
+DECLARE_SLOW_PATH(asm_slow_path_get_super_constructor, GetSuperConstructor);
+DECLARE_SLOW_PATH(asm_slow_path_get_global, GetGlobal);
+DECLARE_SLOW_PATH(asm_slow_path_set_global, SetGlobal);
+DECLARE_SLOW_PATH(asm_slow_path_concat_string, ConcatString);
+DECLARE_SLOW_PATH(asm_slow_path_copy_object_excluding_properties, CopyObjectExcludingProperties);
+i64 asm_slow_path_exp_values(VM*, u32 pc, Value&, Value, Value);
+DECLARE_SLOW_PATH(asm_slow_path_import_call, ImportCall);
+DECLARE_SLOW_PATH(asm_slow_path_new_class, NewClass);
+DECLARE_SLOW_PATH(asm_slow_path_call, Call);
+DECLARE_SLOW_PATH(asm_slow_path_call_direct_eval, CallDirectEval);
+DECLARE_SLOW_PATH(asm_slow_path_call_with_argument_array, CallWithArgumentArray);
+DECLARE_SLOW_PATH(asm_slow_path_call_direct_eval_with_argument_array, CallDirectEvalWithArgumentArray);
+DECLARE_SLOW_PATH(asm_slow_path_get_object_property_iterator, GetObjectPropertyIterator);
+DECLARE_SLOW_PATH(asm_slow_path_object_property_iterator_next, ObjectPropertyIteratorNext);
+DECLARE_SLOW_PATH(asm_slow_path_iterator_close, IteratorClose);
+DECLARE_SLOW_PATH(asm_slow_path_iterator_next, IteratorNext);
+DECLARE_SLOW_PATH(asm_slow_path_iterator_next_unpack, IteratorNextUnpack);
+DECLARE_SLOW_PATH(asm_slow_path_iterator_to_array, IteratorToArray);
+DECLARE_SLOW_PATH(asm_slow_path_call_construct, CallConstruct);
+DECLARE_SLOW_PATH(asm_slow_path_call_construct_with_argument_array, CallConstructWithArgumentArray);
+DECLARE_SLOW_PATH(asm_slow_path_super_call_with_argument_array, SuperCallWithArgumentArray);
+DECLARE_SLOW_PATH(asm_slow_path_new_object, NewObject);
+DECLARE_SLOW_PATH(asm_slow_path_new_object_with_no_prototype, NewObjectWithNoPrototype);
+DECLARE_SLOW_PATH(asm_slow_path_cache_object_shape, CacheObjectShape);
+DECLARE_SLOW_PATH(asm_slow_path_init_object_literal_property, InitObjectLiteralProperty);
+DECLARE_SLOW_PATH(asm_slow_path_new_array, NewArray);
+DECLARE_SLOW_PATH(asm_slow_path_new_primitive_array, NewPrimitiveArray);
+DECLARE_SLOW_PATH(asm_slow_path_new_regexp, NewRegExp);
+DECLARE_SLOW_PATH(asm_slow_path_new_reference_error, NewReferenceError);
+DECLARE_SLOW_PATH(asm_slow_path_new_type_error, NewTypeError);
+DECLARE_SLOW_PATH(asm_slow_path_bitwise_xor, BitwiseXor);
+DECLARE_SLOW_PATH(asm_slow_path_bitwise_and, BitwiseAnd);
+DECLARE_SLOW_PATH(asm_slow_path_bitwise_or, BitwiseOr);
+i64 asm_slow_path_bitwise_xor_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_bitwise_and_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_bitwise_or_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_left_shift_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_right_shift_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_unsigned_right_shift_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_mod_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_strictly_equals_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_strictly_inequals_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_loosely_equals_values(VM*, u32 pc, Value&, Value, Value);
+i64 asm_slow_path_loosely_inequals_values(VM*, u32 pc, Value&, Value, Value);
+DECLARE_SLOW_PATH(asm_slow_path_unary_minus, UnaryMinus);
+DECLARE_SLOW_PATH(asm_slow_path_to_string, ToString);
+DECLARE_SLOW_PATH(asm_slow_path_to_primitive_with_string_hint, ToPrimitiveWithStringHint);
+DECLARE_SLOW_PATH(asm_slow_path_to_object, ToObject);
+DECLARE_SLOW_PATH(asm_slow_path_to_length, ToLength);
+DECLARE_SLOW_PATH(asm_slow_path_typeof, Typeof);
+DECLARE_SLOW_PATH(asm_slow_path_postfix_decrement, PostfixDecrement);
+DECLARE_SLOW_PATH(asm_slow_path_to_int32, ToInt32);
+DECLARE_SLOW_PATH(asm_slow_path_put_by_value, PutByValue);
+DECLARE_SLOW_PATH(asm_slow_path_put_by_value_with_this, PutByValueWithThis);
+DECLARE_SLOW_PATH(asm_slow_path_put_by_spread, PutBySpread);
+DECLARE_SLOW_PATH(asm_slow_path_get_binding, GetBinding);
+DECLARE_SLOW_PATH(asm_slow_path_dynamic_get_binding, DynamicGetBinding);
+DECLARE_SLOW_PATH(asm_slow_path_initialize_lexical_binding, InitializeLexicalBinding);
+DECLARE_SLOW_PATH(asm_slow_path_dynamic_initialize_lexical_binding, DynamicInitializeLexicalBinding);
+DECLARE_SLOW_PATH(asm_slow_path_initialize_variable_binding, InitializeVariableBinding);
+DECLARE_SLOW_PATH(asm_slow_path_dynamic_initialize_variable_binding, DynamicInitializeVariableBinding);
+DECLARE_SLOW_PATH(asm_slow_path_set_lexical_binding, SetLexicalBinding);
+DECLARE_SLOW_PATH(asm_slow_path_dynamic_set_lexical_binding, DynamicSetLexicalBinding);
+DECLARE_SLOW_PATH(asm_slow_path_set_variable_binding, SetVariableBinding);
+DECLARE_SLOW_PATH(asm_slow_path_dynamic_set_variable_binding, DynamicSetVariableBinding);
+DECLARE_SLOW_PATH(asm_slow_path_resolve_binding, ResolveBinding);
+DECLARE_SLOW_PATH(asm_slow_path_resolve_super_base, ResolveSuperBase);
+DECLARE_SLOW_PATH(asm_slow_path_set_resolved_binding, SetResolvedBinding);
+DECLARE_SLOW_PATH(asm_slow_path_typeof_binding, TypeofBinding);
+DECLARE_SLOW_PATH(asm_slow_path_dynamic_typeof_binding, DynamicTypeofBinding);
+DECLARE_SLOW_PATH(asm_slow_path_has_private_id, HasPrivateId);
+DECLARE_SLOW_PATH(asm_slow_path_set_function_name, SetFunctionName);
+DECLARE_SLOW_PATH(asm_slow_path_new_array_with_length, NewArrayWithLength);
+DECLARE_SLOW_PATH(asm_slow_path_array_append, ArrayAppend);
+DECLARE_SLOW_PATH(asm_slow_path_create_variable, CreateVariable);
+DECLARE_SLOW_PATH(asm_slow_path_enter_object_environment, EnterObjectEnvironment);
+DECLARE_SLOW_PATH(asm_slow_path_bitwise_not, BitwiseNot);
+DECLARE_SLOW_PATH(asm_slow_path_unary_plus, UnaryPlus);
+DECLARE_SLOW_PATH(asm_slow_path_is_constructor, IsConstructor);
+DECLARE_SLOW_PATH(asm_slow_path_add_private_name, AddPrivateName);
+DECLARE_SLOW_PATH(asm_slow_path_create_async_from_sync_iterator, CreateAsyncFromSyncIterator);
+DECLARE_SLOW_PATH(asm_slow_path_create_data_property_or_throw, CreateDataPropertyOrThrow);
+DECLARE_SLOW_PATH(asm_slow_path_create_immutable_binding, CreateImmutableBinding);
+DECLARE_SLOW_PATH(asm_slow_path_create_mutable_binding, CreateMutableBinding);
+DECLARE_SLOW_PATH(asm_slow_path_create_rest_params, CreateRestParams);
+DECLARE_SLOW_PATH(asm_slow_path_create_arguments, CreateArguments);
+DECLARE_SLOW_PATH(asm_slow_path_await, Await);
+DECLARE_SLOW_PATH(asm_slow_path_create_lexical_environment, CreateLexicalEnvironment);
+DECLARE_SLOW_PATH(asm_slow_path_create_variable_environment, CreateVariableEnvironment);
+DECLARE_SLOW_PATH(asm_slow_path_delete_by_id, DeleteById);
+DECLARE_SLOW_PATH(asm_slow_path_delete_by_value, DeleteByValue);
+DECLARE_SLOW_PATH(asm_slow_path_delete_variable, DeleteVariable);
+DECLARE_SLOW_PATH(asm_slow_path_get_completion_fields, GetCompletionFields);
+DECLARE_SLOW_PATH(asm_slow_path_set_completion_type, SetCompletionType);
+DECLARE_SLOW_PATH(asm_slow_path_get_template_object, GetTemplateObject);
+DECLARE_SLOW_PATH(asm_slow_path_new_function, NewFunction);
+DECLARE_SLOW_PATH(asm_slow_path_throw, Throw);
+DECLARE_SLOW_PATH(asm_slow_path_throw_if_tdz, ThrowIfTDZ);
+DECLARE_SLOW_PATH(asm_slow_path_throw_if_not_object, ThrowIfNotObject);
+DECLARE_SLOW_PATH(asm_slow_path_throw_if_nullish, ThrowIfNullish);
+DECLARE_SLOW_PATH(asm_slow_path_debugger, Debugger);
+DECLARE_SLOW_PATH(asm_slow_path_yield, Yield);
+DECLARE_SLOW_PATH(asm_slow_path_yield_iterator_result, YieldIteratorResult);
+DECLARE_SLOW_PATH(asm_slow_path_instance_of, InstanceOf);
+DECLARE_SLOW_PATH(asm_slow_path_in, In);
+DECLARE_SLOW_PATH(asm_slow_path_get_private_by_id, GetPrivateById);
+DECLARE_SLOW_PATH(asm_slow_path_put_private_by_id, PutPrivateById);
 
-i64 asm_try_get_global_env_binding(VM*, u32 pc, Op::GetGlobal const*);
-i64 asm_try_set_global_env_binding(VM*, u32 pc, Op::SetGlobal const*);
-i64 asm_try_put_by_value_holey_array(VM*, u32 pc, Op::PutByValue const*);
+i64 asm_try_get_global_env_binding(VM*, u32 pc, Op::GetGlobal const*, Op::GetGlobal::Values& values);
+i64 asm_try_set_global_env_binding(VM*, u32 pc, Op::SetGlobal const*, Op::SetGlobal::Values& values);
+i64 asm_try_put_by_value_holey_array(VM*, u32 pc, Op::PutByValue const*, Op::PutByValue::Values& values);
 u64 asm_helper_to_boolean(u64 encoded_value);
 u64 asm_helper_math_exp(u64 encoded_value);
 u64 asm_helper_empty_string(u64);
 u64 asm_helper_single_ascii_character_string(u64 encoded_value);
 u64 asm_helper_single_utf16_code_unit_string(u64 encoded_value);
 i64 asm_helper_handle_raw_native_exception(u64 encoded_exception);
-i64 asm_try_inline_call(VM*, u32 pc, Op::Call const*);
-i64 asm_try_inline_get_by_id_accessor(VM*, u32 pc, Op::GetById const*);
-i64 asm_try_put_by_id_cache(VM*, u32 pc, Op::PutById const*);
-i64 asm_try_get_by_id_cache(VM*, u32 pc, Op::GetById const*);
+i64 asm_try_inline_call(VM*, u32 pc, Op::Call const*, Op::Call::Values& values);
+i64 asm_try_inline_get_by_id_accessor(VM*, u32 pc, Op::GetById const*, Op::GetById::Values& values);
+i64 asm_try_put_by_id_cache(VM*, u32 pc, Op::PutById const*, Op::PutById::Values& values);
+u64 asm_try_get_by_id_cache(u64, PropertyLookupCache*);
 
-i64 asm_try_get_by_value_typed_array(VM*, u32 pc, Op::GetByValue const*);
-i64 asm_try_put_by_value_typed_array(VM*, u32 pc, Op::PutByValue const*);
+i64 asm_try_get_by_value_typed_array(VM*, u32 pc, Op::GetByValue const*, Op::GetByValue::Values& values);
+i64 asm_try_put_by_value_typed_array(VM*, u32 pc, Op::PutByValue const*, Op::PutByValue::Values& values);
 
 // ===== Fallback handler for invalid dispatch table entries =====
 // NB: Every bytecode opcode has a DSL handler, so this should never run.
@@ -779,97 +812,96 @@ i64 asm_fallback_handler(VM*, u32, u8 const*)
 
 // ===== Specific slow paths for asm-optimized instructions =====
 // These are called from asm handlers when the fast path fails.
-// Convention: i64 func(VM*, u32 pc, Op::Foo const* instruction)
-//   Returns >= 0: new PC, optionally marked by continue_after_slow_path()
-//   Returns < 0: exit
+// The implementation bodies use named values; the generated wrappers adapt these
+// to each helper's native calling convention.
 
-i64 asm_slow_path_add_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_add_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, add(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_add(VM* vm, u32 pc, Op::Add const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_add, Add)
 {
-    return asm_slow_path_add_values(vm, pc, instruction->dst(), vm->get(instruction->lhs()), vm->get(instruction->rhs()));
+    return asm_slow_path_add_values(vm, pc, values.dst, values.lhs, values.rhs);
 }
 
-i64 asm_slow_path_sub_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_sub_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, sub(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_sub(VM* vm, u32 pc, Op::Sub const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_sub, Sub)
 {
-    return asm_slow_path_sub_values(vm, pc, instruction->dst(), vm->get(instruction->lhs()), vm->get(instruction->rhs()));
+    return asm_slow_path_sub_values(vm, pc, values.dst, values.lhs, values.rhs);
 }
 
-i64 asm_slow_path_mul_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_mul_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, mul(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_div_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_div_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, div(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_less_than(VM* vm, u32 pc, Op::LessThan const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_less_than, LessThan)
 {
-    return asm_slow_path_less_than_values(vm, pc, instruction->dst(), vm->get(instruction->lhs()), vm->get(instruction->rhs()));
+    return asm_slow_path_less_than_values(vm, pc, values.dst, values.lhs, values.rhs);
 }
 
-i64 asm_slow_path_less_than_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_less_than_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, less_than(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_less_than_equals(VM* vm, u32 pc, Op::LessThanEquals const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_less_than_equals, LessThanEquals)
 {
-    return asm_slow_path_less_than_equals_values(vm, pc, instruction->dst(), vm->get(instruction->lhs()), vm->get(instruction->rhs()));
+    return asm_slow_path_less_than_equals_values(vm, pc, values.dst, values.lhs, values.rhs);
 }
 
-i64 asm_slow_path_less_than_equals_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_less_than_equals_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, less_than_equals(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_greater_than(VM* vm, u32 pc, Op::GreaterThan const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_greater_than, GreaterThan)
 {
-    return asm_slow_path_greater_than_values(vm, pc, instruction->dst(), vm->get(instruction->lhs()), vm->get(instruction->rhs()));
+    return asm_slow_path_greater_than_values(vm, pc, values.dst, values.lhs, values.rhs);
 }
 
-i64 asm_slow_path_greater_than_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_greater_than_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, greater_than(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_greater_than_equals(VM* vm, u32 pc, Op::GreaterThanEquals const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_greater_than_equals, GreaterThanEquals)
 {
-    return asm_slow_path_greater_than_equals_values(vm, pc, instruction->dst(), vm->get(instruction->lhs()), vm->get(instruction->rhs()));
+    return asm_slow_path_greater_than_equals_values(vm, pc, values.dst, values.lhs, values.rhs);
 }
 
-i64 asm_slow_path_greater_than_equals_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_greater_than_equals_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, greater_than_equals(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_increment(VM* vm, u32 pc, Op::Increment const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_increment, Increment)
 {
-    auto old_value = ASM_TRY(*vm, pc, vm->get(instruction->dst()).to_numeric(*vm));
+    auto old_value = ASM_TRY(*vm, pc, values.dst.to_numeric(*vm));
     if (old_value.is_number())
-        vm->set(instruction->dst(), Value(old_value.as_double() + 1));
+        values.dst = Value(old_value.as_double() + 1);
     else
-        vm->set(instruction->dst(), BigInt::create(*vm, old_value.as_bigint().big_integer().plus(Crypto::SignedBigInteger { 1 })));
+        values.dst = BigInt::create(*vm, old_value.as_bigint().big_integer().plus(Crypto::SignedBigInteger { 1 }));
     return continue_after_slow_path(pc + sizeof(Op::Increment));
 }
 
-i64 asm_slow_path_decrement(VM* vm, u32 pc, Op::Decrement const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_decrement, Decrement)
 {
-    auto old_value = ASM_TRY(*vm, pc, vm->get(instruction->dst()).to_numeric(*vm));
+    auto old_value = ASM_TRY(*vm, pc, values.dst.to_numeric(*vm));
     if (old_value.is_number())
-        vm->set(instruction->dst(), Value(old_value.as_double() - 1));
+        values.dst = Value(old_value.as_double() - 1);
     else
-        vm->set(instruction->dst(), BigInt::create(*vm, old_value.as_bigint().big_integer().minus(Crypto::SignedBigInteger { 1 })));
+        values.dst = BigInt::create(*vm, old_value.as_bigint().big_integer().minus(Crypto::SignedBigInteger { 1 }));
     return continue_after_slow_path(pc + sizeof(Op::Decrement));
 }
 
@@ -921,20 +953,20 @@ i64 asm_slow_path_jump_strictly_inequals_values(
 
 // ===== Dedicated slow paths for hot instructions =====
 
-i64 asm_slow_path_get_initialized_binding(VM* vm, u32 pc, Op::GetInitializedBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_initialized_binding, GetInitializedBinding)
 {
-    auto next_pc = asm_get_binding<AsmBindingIsKnownToBeInitialized::Yes>(*vm, pc, instruction->dst(), instruction->cache());
+    auto next_pc = asm_get_binding<AsmBindingIsKnownToBeInitialized::Yes>(*vm, pc, values.dst, instruction->cache());
     return advance_or_continue<Op::GetInitializedBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_dynamic_get_initialized_binding(VM* vm, u32 pc, Op::DynamicGetInitializedBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_dynamic_get_initialized_binding, DynamicGetInitializedBinding)
 {
     auto& cache = vm->current_executable().environment_coordinate_caches[instruction->cache()];
-    auto next_pc = asm_dynamic_get_binding<AsmBindingIsKnownToBeInitialized::Yes>(*vm, pc, instruction->dst(), instruction->identifier(), instruction->strict(), cache);
+    auto next_pc = asm_dynamic_get_binding<AsmBindingIsKnownToBeInitialized::Yes>(*vm, pc, values.dst, instruction->identifier(), instruction->strict(), cache);
     return advance_or_continue<Op::DynamicGetInitializedBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_get_callee_and_this(VM* vm, u32 pc, Op::GetCalleeAndThisFromEnvironment const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_callee_and_this, GetCalleeAndThisFromEnvironment)
 {
     auto const& cache = instruction->cache();
     VERIFY(cache.is_valid());
@@ -944,44 +976,44 @@ i64 asm_slow_path_get_callee_and_this(VM* vm, u32 pc, Op::GetCalleeAndThisFromEn
         environment = environment->outer_environment();
 
     auto callee = ASM_TRY(*vm, pc, static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(*vm, cache.index));
-    vm->set(instruction->callee(), callee);
+    values.callee = callee;
     auto this_value = js_undefined();
     if (auto base_object = environment->with_base_object()) [[unlikely]]
         this_value = base_object;
-    vm->set(instruction->this_value(), this_value);
+    values.this_value = this_value;
     return continue_after_slow_path(pc + sizeof(Op::GetCalleeAndThisFromEnvironment));
 }
 
-i64 asm_slow_path_dynamic_get_callee_and_this(VM* vm, u32 pc, Op::DynamicGetCalleeAndThisFromEnvironment const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_dynamic_get_callee_and_this, DynamicGetCalleeAndThisFromEnvironment)
 {
     auto& cache = vm->current_executable().environment_coordinate_caches[instruction->cache()];
-    auto next_pc = asm_dynamic_get_callee_and_this_from_environment(*vm, pc, instruction->callee(), instruction->this_value(), instruction->identifier(), instruction->strict(), cache);
+    auto next_pc = asm_dynamic_get_callee_and_this_from_environment(*vm, pc, values.callee, values.this_value, instruction->identifier(), instruction->strict(), cache);
     return advance_or_continue<Op::DynamicGetCalleeAndThisFromEnvironment>(pc, next_pc);
 }
 
-i64 asm_slow_path_postfix_increment(VM* vm, u32 pc, Op::PostfixIncrement const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_postfix_increment, PostfixIncrement)
 {
-    auto old_value = ASM_TRY(*vm, pc, vm->get(instruction->src()).to_numeric(*vm));
-    vm->set(instruction->dst(), old_value);
+    auto old_value = ASM_TRY(*vm, pc, values.src.to_numeric(*vm));
+    values.dst = old_value;
     if (old_value.is_number())
-        vm->set(instruction->src(), Value(old_value.as_double() + 1));
+        values.src = Value(old_value.as_double() + 1);
     else
-        vm->set(instruction->src(), BigInt::create(*vm, old_value.as_bigint().big_integer().plus(Crypto::SignedBigInteger { 1 })));
+        values.src = BigInt::create(*vm, old_value.as_bigint().big_integer().plus(Crypto::SignedBigInteger { 1 }));
     return continue_after_slow_path(pc + sizeof(Op::PostfixIncrement));
 }
 
-i64 asm_slow_path_get_by_id(VM* vm, u32 pc, Op::GetById const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_by_id, GetById)
 {
-    auto base_value = vm->get(instruction->base());
+    auto base_value = values.base;
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
     auto value = ASM_TRY(*vm, pc, get_by_id<GetByIdMode::Normal>(*vm, [&] { return vm->get_identifier(instruction->base_identifier()); }, [&] -> PropertyKey const& { return vm->get_property_key(instruction->property()); }, base_value, base_value, cache, CachePropertyAbsence::Yes));
-    vm->set(instruction->dst(), value);
+    values.dst = value;
     return continue_after_slow_path(pc + sizeof(Op::GetById));
 }
 
-i64 asm_slow_path_get_by_id_cached_accessor(VM* vm, u32 pc, Op::GetById const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_by_id_cached_accessor, GetById)
 {
-    auto& object = vm->get(instruction->base()).as_object();
+    auto& object = values.base.as_object();
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
     auto* entry = cache.first_entry();
     VERIFY(entry);
@@ -999,24 +1031,24 @@ i64 asm_slow_path_get_by_id_cached_accessor(VM* vm, u32 pc, Op::GetById const* i
                 completed_entry->direct_getter_validated = true;
         }
     }
-    vm->set(instruction->dst(), result);
+    values.dst = result;
     return continue_after_slow_path(pc + sizeof(Op::GetById));
 }
 
-i64 asm_slow_path_get_by_id_with_this(VM* vm, u32 pc, Op::GetByIdWithThis const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_by_id_with_this, GetByIdWithThis)
 {
-    auto base_value = vm->get(instruction->base());
-    auto this_value = vm->get(instruction->this_value());
+    auto base_value = values.base;
+    auto this_value = values.this_value;
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
     auto value = ASM_TRY(*vm, pc, get_by_id<GetByIdMode::Normal>(*vm, [] { return Optional<Utf16FlyString const&> {}; }, [&] -> PropertyKey const& { return vm->get_property_key(instruction->property()); }, base_value, this_value, cache));
-    vm->set(instruction->dst(), value);
+    values.dst = value;
     return continue_after_slow_path(pc + sizeof(Op::GetByIdWithThis));
 }
 
-i64 asm_slow_path_put_by_id(VM* vm, u32 pc, Op::PutById const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_put_by_id, PutById)
 {
-    auto value = vm->get(instruction->src());
-    auto base = vm->get(instruction->base());
+    auto value = values.src;
+    auto base = values.base;
     Optional<Utf16FlyString const&> base_identifier;
     if (instruction->base_identifier().has_value())
         base_identifier = vm->get_identifier(instruction->base_identifier().value());
@@ -1026,20 +1058,20 @@ i64 asm_slow_path_put_by_id(VM* vm, u32 pc, Op::PutById const* instruction)
     return continue_after_slow_path(pc + sizeof(Op::PutById));
 }
 
-i64 asm_slow_path_put_by_id_with_this(VM* vm, u32 pc, Op::PutByIdWithThis const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_put_by_id_with_this, PutByIdWithThis)
 {
-    auto value = vm->get(instruction->src());
-    auto base = vm->get(instruction->base());
+    auto value = values.src;
+    auto base = values.base;
     auto const& name = vm->get_property_key(instruction->property());
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
-    ASM_TRY(*vm, pc, put_by_property_key(*vm, base, vm->get(instruction->this_value()), value, {}, name, instruction->kind(), instruction->strict(), &cache));
+    ASM_TRY(*vm, pc, put_by_property_key(*vm, base, values.this_value, value, {}, name, instruction->kind(), instruction->strict(), &cache));
     return continue_after_slow_path(pc + sizeof(Op::PutByIdWithThis));
 }
 
-i64 asm_slow_path_get_by_value(VM* vm, u32 pc, Op::GetByValue const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_by_value, GetByValue)
 {
-    auto base_value = vm->get(instruction->base());
-    auto property_key_value = vm->get(instruction->property());
+    auto base_value = values.base;
+    auto property_key_value = values.property;
     auto object = ASM_TRY(*vm, pc, base_object_for_get(*vm, base_value, [&]() -> Optional<Utf16FlyString const&> {
         if (instruction->base_identifier().has_value())
             return vm->get_identifier(instruction->base_identifier().value());
@@ -1048,82 +1080,82 @@ i64 asm_slow_path_get_by_value(VM* vm, u32 pc, Op::GetByValue const* instruction
     if (base_value.is_string()) {
         auto string_value = ASM_TRY(*vm, pc, base_value.as_string().get(*vm, property_key));
         if (string_value.has_value()) {
-            vm->set(instruction->dst(), *string_value);
+            values.dst = *string_value;
             return continue_after_slow_path(pc + sizeof(Op::GetByValue));
         }
     }
-    vm->set(instruction->dst(), ASM_TRY(*vm, pc, get_by_value_with_keyed_cache(*vm, *object, base_value, property_key)));
+    values.dst = ASM_TRY(*vm, pc, get_by_value_with_keyed_cache(*vm, *object, base_value, property_key));
     return continue_after_slow_path(pc + sizeof(Op::GetByValue));
 }
 
-i64 asm_slow_path_get_by_value_with_this(VM* vm, u32 pc, Op::GetByValueWithThis const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_by_value_with_this, GetByValueWithThis)
 {
-    auto property_key_value = vm->get(instruction->property());
-    auto object = ASM_TRY(*vm, pc, vm->get(instruction->base()).to_object(*vm));
+    auto property_key_value = values.property;
+    auto object = ASM_TRY(*vm, pc, values.base.to_object(*vm));
     auto property_key = ASM_TRY(*vm, pc, property_key_value.to_property_key(*vm));
-    auto value = ASM_TRY(*vm, pc, get_by_value_with_keyed_cache(*vm, *object, vm->get(instruction->this_value()), property_key));
-    vm->set(instruction->dst(), value);
+    auto value = ASM_TRY(*vm, pc, get_by_value_with_keyed_cache(*vm, *object, values.this_value, property_key));
+    values.dst = value;
     return continue_after_slow_path(pc + sizeof(Op::GetByValueWithThis));
 }
 
-i64 asm_slow_path_get_length(VM* vm, u32 pc, Op::GetLength const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_length, GetLength)
 {
-    auto base_value = vm->get(instruction->base());
+    auto base_value = values.base;
     auto& executable = vm->current_executable();
     auto& cache = executable.property_lookup_caches[instruction->cache()];
     auto value = ASM_TRY(*vm, pc, get_by_id<GetByIdMode::Length>(*vm, [&] { return vm->get_identifier(instruction->base_identifier()); }, [&] -> PropertyKey const& { return executable.get_property_key(*executable.length_identifier); }, base_value, base_value, cache));
-    vm->set(instruction->dst(), value);
+    values.dst = value;
     return continue_after_slow_path(pc + sizeof(Op::GetLength));
 }
 
-i64 asm_slow_path_get_length_with_this(VM* vm, u32 pc, Op::GetLengthWithThis const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_length_with_this, GetLengthWithThis)
 {
-    auto base_value = vm->get(instruction->base());
-    auto this_value = vm->get(instruction->this_value());
+    auto base_value = values.base;
+    auto this_value = values.this_value;
     auto& executable = vm->current_executable();
     auto& cache = executable.property_lookup_caches[instruction->cache()];
     auto value = ASM_TRY(*vm, pc, get_by_id<GetByIdMode::Length>(*vm, [] { return Optional<Utf16FlyString const&> {}; }, [&] -> PropertyKey const& { return executable.get_property_key(*executable.length_identifier); }, base_value, this_value, cache));
-    vm->set(instruction->dst(), value);
+    values.dst = value;
     return continue_after_slow_path(pc + sizeof(Op::GetLengthWithThis));
 }
 
-i64 asm_slow_path_get_method(VM* vm, u32 pc, Op::GetMethod const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_method, GetMethod)
 {
     auto const& property_key = vm->get_property_key(instruction->property());
-    auto method = ASM_TRY(*vm, pc, vm->get(instruction->object()).get_method(*vm, property_key));
-    vm->set(instruction->dst(), method ?: js_undefined());
+    auto method = ASM_TRY(*vm, pc, values.object.get_method(*vm, property_key));
+    values.dst = method ?: js_undefined();
     return continue_after_slow_path(pc + sizeof(Op::GetMethod));
 }
 
-i64 asm_slow_path_get_iterator(VM* vm, u32 pc, Op::GetIterator const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_iterator, GetIterator)
 {
-    auto iterator_record = ASM_TRY(*vm, pc, get_iterator_impl(*vm, vm->get(instruction->iterable()), instruction->hint()));
-    vm->set(instruction->dst_iterator_object(), iterator_record.iterator);
-    vm->set(instruction->dst_iterator_next(), iterator_record.next_method);
-    vm->set(instruction->dst_iterator_done(), Value(iterator_record.done));
+    auto iterator_record = ASM_TRY(*vm, pc, get_iterator_impl(*vm, values.iterable, instruction->hint()));
+    values.dst_iterator_object = iterator_record.iterator;
+    values.dst_iterator_next = iterator_record.next_method;
+    values.dst_iterator_done = Value(iterator_record.done);
     return continue_after_slow_path(pc + sizeof(Op::GetIterator));
 }
 
-i64 asm_slow_path_get_import_meta(VM* vm, u32 pc, Op::GetImportMeta const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_import_meta, GetImportMeta)
 {
-    vm->set(instruction->dst(), vm->get_import_meta());
+    values.dst = vm->get_import_meta();
     return continue_after_slow_path(pc + sizeof(Op::GetImportMeta));
 }
 
-i64 asm_slow_path_get_new_target(VM* vm, u32 pc, Op::GetNewTarget const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_new_target, GetNewTarget)
 {
-    vm->set(instruction->dst(), vm->get_new_target());
+    values.dst = vm->get_new_target();
     return continue_after_slow_path(pc + sizeof(Op::GetNewTarget));
 }
 
-i64 asm_slow_path_get_super_constructor(VM* vm, u32 pc, Op::GetSuperConstructor const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_super_constructor, GetSuperConstructor)
 {
     auto* super_constructor = get_super_constructor(*vm);
-    vm->set(instruction->dst(), super_constructor ? Value(super_constructor) : js_null());
+    values.dst = super_constructor ? Value(super_constructor) : js_null();
     return continue_after_slow_path(pc + sizeof(Op::GetSuperConstructor));
 }
 
-i64 asm_try_get_global_env_binding(VM* vm, u32, Op::GetGlobal const* instruction)
+i64 asm_try_get_global_env_binding(VM* vm, u32, Op::GetGlobal const* instruction, Op::GetGlobal::Values& values)
 {
     auto& cache = vm->current_executable().global_variable_caches[instruction->cache()];
 
@@ -1142,13 +1174,12 @@ i64 asm_try_get_global_env_binding(VM* vm, u32, Op::GetGlobal const* instruction
     }
     if (result.is_error()) [[unlikely]]
         return 1;
-    vm->set(instruction->dst(), result.value());
+    values.dst = result.value();
     return 0;
 }
 
-i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_global, GetGlobal)
 {
-
     auto& binding_object = vm->global_object();
     auto& declarative_record = vm->global_declarative_environment();
     auto& cache = vm->current_executable().global_variable_caches[instruction->cache()];
@@ -1158,7 +1189,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
         auto* entry = cache.first_entry();
         if (entry && &shape == entry->shape.ptr() && (!shape.is_dictionary() || shape.dictionary_generation() == entry->shape_dictionary_generation)) {
             auto value = binding_object.get_direct(entry->property_offset);
-            vm->set(instruction->dst(), ASM_TRY(*vm, pc, get_cached_property_value(*vm, value, &binding_object)));
+            values.dst = ASM_TRY(*vm, pc, get_cached_property_value(*vm, value, &binding_object));
             return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
         }
 
@@ -1170,7 +1201,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
             } else {
                 value = ASM_TRY(*vm, pc, declarative_record.get_binding_value_direct(*vm, cache.environment_binding_index));
             }
-            vm->set(instruction->dst(), value);
+            values.dst = value;
             return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
         }
     }
@@ -1188,10 +1219,10 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
                 cache.environment_binding_index = static_cast<u32>(index.value());
                 cache.has_environment_binding_index = true;
                 cache.in_module_environment = true;
-                vm->set(instruction->dst(), ASM_TRY(*vm, pc, module_environment.get_binding_value_direct(*vm, index.value())));
+                values.dst = ASM_TRY(*vm, pc, module_environment.get_binding_value_direct(*vm, index.value()));
                 return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
             }
-            vm->set(instruction->dst(), ASM_TRY(*vm, pc, module_environment.get_binding_value(*vm, identifier, true)));
+            values.dst = ASM_TRY(*vm, pc, module_environment.get_binding_value(*vm, identifier, true));
             return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
         }
     }
@@ -1201,7 +1232,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
         cache.environment_binding_index = static_cast<u32>(offset.value());
         cache.has_environment_binding_index = true;
         cache.in_module_environment = false;
-        vm->set(instruction->dst(), ASM_TRY(*vm, pc, declarative_record.get_binding_value(*vm, identifier, instruction->strict() == Strict::Yes)));
+        values.dst = ASM_TRY(*vm, pc, declarative_record.get_binding_value(*vm, identifier, instruction->strict() == Strict::Yes));
         return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
     }
 
@@ -1219,7 +1250,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
                     entry.shape_dictionary_generation = shape.dictionary_generation();
             });
         }
-        vm->set(instruction->dst(), value);
+        values.dst = value;
         return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
     }
 
@@ -1227,7 +1258,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
     return handle_asm_exception(*vm, pc, completion.value());
 }
 
-i64 asm_try_set_global_env_binding(VM* vm, u32, Op::SetGlobal const* instruction)
+i64 asm_try_set_global_env_binding(VM* vm, u32, Op::SetGlobal const* instruction, Op::SetGlobal::Values& values)
 {
     auto& cache = vm->current_executable().global_variable_caches[instruction->cache()];
 
@@ -1235,7 +1266,7 @@ i64 asm_try_set_global_env_binding(VM* vm, u32, Op::SetGlobal const* instruction
         return 1;
 
     auto& current_vm = *vm;
-    auto src = vm->get(instruction->src());
+    auto src = values.src;
     ThrowCompletionOr<void> result;
     if (cache.in_module_environment) {
         auto module = current_vm.running_execution_context().script_or_module.get_pointer<GC::Ref<Module>>();
@@ -1250,14 +1281,13 @@ i64 asm_try_set_global_env_binding(VM* vm, u32, Op::SetGlobal const* instruction
     return 0;
 }
 
-i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_set_global, SetGlobal)
 {
-
     auto& binding_object = vm->global_object();
     auto& declarative_record = vm->global_declarative_environment();
     auto& cache = vm->current_executable().global_variable_caches[instruction->cache()];
     auto& shape = binding_object.shape();
-    auto src = vm->get(instruction->src());
+    auto src = values.src;
 
     if (cache.environment_serial_number == declarative_record.environment_serial_number()) {
         auto* entry = cache.first_entry();
@@ -1345,59 +1375,57 @@ i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
     return continue_after_slow_path(pc + sizeof(Op::SetGlobal));
 }
 
-i64 asm_slow_path_concat_string(VM* vm, u32 pc, Op::ConcatString const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_concat_string, ConcatString)
 {
-    auto string = ASM_TRY(*vm, pc, vm->get(instruction->src()).to_primitive_string(*vm));
-    vm->set(instruction->dst(), PrimitiveString::create(*vm, vm->get(instruction->dst()).as_string(), string));
+    auto string = ASM_TRY(*vm, pc, values.src.to_primitive_string(*vm));
+    values.dst = PrimitiveString::create(*vm, values.dst.as_string(), string);
     return continue_after_slow_path(pc + sizeof(Op::ConcatString));
 }
 
-i64 asm_slow_path_copy_object_excluding_properties(VM* vm, u32 pc, Op::CopyObjectExcludingProperties const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_copy_object_excluding_properties, CopyObjectExcludingProperties)
 {
     auto& realm = *vm->current_realm();
-    auto from_object = vm->get(instruction->from_object());
+    auto from_object = values.from_object;
     auto to_object = Object::create(realm, realm.intrinsics().object_prototype().ptr());
 
     GC::ConservativeHashTable<PropertyKey> excluded_names;
-    auto excluded_names_operands = instruction->excluded_names();
     for (size_t i = 0; i < instruction->excluded_names_count(); ++i)
-        excluded_names.set(ASM_TRY(*vm, pc, vm->get(excluded_names_operands[i]).to_property_key(*vm)));
+        excluded_names.set(ASM_TRY(*vm, pc, values.excluded_names[i].to_property_key(*vm)));
 
     ASM_TRY(*vm, pc, to_object->copy_data_properties(*vm, from_object, excluded_names));
-    vm->set(instruction->dst(), to_object);
+    values.dst = to_object;
     return continue_after_slow_path(pc + instruction->length());
 }
 
-i64 asm_slow_path_exp_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_exp_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, exp(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_import_call(VM* vm, u32 pc, Op::ImportCall const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_import_call, ImportCall)
 {
-    auto specifier = vm->get(instruction->specifier());
-    auto options_value = vm->get(instruction->options());
-    vm->set(instruction->dst(), ASM_TRY(*vm, pc, perform_import_call(*vm, specifier, options_value)));
+    auto specifier = values.specifier;
+    auto options_value = values.options;
+    values.dst = ASM_TRY(*vm, pc, perform_import_call(*vm, specifier, options_value));
     return continue_after_slow_path(pc + sizeof(Op::ImportCall));
 }
 
-i64 asm_slow_path_new_class(VM* vm, u32 pc, Op::NewClass const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_class, NewClass)
 {
-
     Value super_class;
     if (instruction->super_class().has_value())
-        super_class = vm->get(instruction->super_class().value());
+        super_class = values.super_class;
     GC::RootVector<Value> element_keys;
     element_keys.ensure_capacity(instruction->element_keys_count());
     for (size_t i = 0; i < instruction->element_keys_count(); ++i) {
         Value element_key;
         if (instruction->element_keys()[i].has_value())
-            element_key = vm->get(instruction->element_keys()[i].value());
+            element_key = values.element_keys[i];
         element_keys.unchecked_append(element_key);
     }
 
     auto& running_execution_context = vm->running_execution_context();
-    auto* class_environment = &as<Environment>(vm->get(instruction->class_environment()).as_cell());
+    auto* class_environment = &as<Environment>(values.class_environment.as_cell());
     auto& outer_environment = running_execution_context.lexical_environment;
 
     auto const& blueprint = vm->current_executable().class_blueprints[instruction->class_blueprint_index()];
@@ -1412,7 +1440,7 @@ i64 asm_slow_path_new_class(VM* vm, u32 pc, Op::NewClass const* instruction)
     }
 
     auto retval = ASM_TRY(*vm, pc, construct_class(*vm, blueprint, vm->current_executable(), class_environment, outer_environment, super_class, element_keys, binding_name, class_name));
-    vm->set(instruction->dst(), retval);
+    values.dst = retval;
     return continue_after_slow_path(pc + instruction->length());
 }
 
@@ -1439,8 +1467,8 @@ NEVER_INLINE static ThrowCompletionOr<void> execute_asm_call(
     VM& vm,
     Value callee,
     Value this_value,
-    ReadonlySpan<Operand> arguments,
-    Operand dst,
+    ReadonlySpan<Value> arguments,
+    Value& dst,
     Optional<StringTableIndex> const expression_string,
     Strict strict)
 {
@@ -1468,7 +1496,7 @@ NEVER_INLINE static ThrowCompletionOr<void> execute_asm_call(
     auto const insn_argument_count = arguments.size();
 
     for (size_t i = 0; i < insn_argument_count; ++i)
-        callee_context_argument_values[i] = vm.get(arguments.data()[i]);
+        callee_context_argument_values[i] = arguments[i];
     for (size_t i = insn_argument_count; i < callee_context_argument_count; ++i)
         callee_context_argument_values[i] = js_undefined();
     callee_context->passed_argument_count = insn_argument_count;
@@ -1485,13 +1513,13 @@ NEVER_INLINE static ThrowCompletionOr<void> execute_asm_call(
     } else {
         retval = TRY(function.internal_call(*callee_context, this_value));
     }
-    vm.set(dst, retval);
+    dst = retval;
     return {};
 }
 
-i64 asm_slow_path_call(VM* vm, u32 pc, Op::Call const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_call, Call)
 {
-    ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), instruction->arguments(), instruction->dst(), instruction->expression_string(), instruction->strict()));
+    ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, values.callee, values.this_value, ReadonlySpan<Value> { values.arguments, instruction->argument_count() }, values.dst, instruction->expression_string(), instruction->strict()));
     return continue_after_slow_path(pc + instruction->length());
 }
 
@@ -1499,8 +1527,8 @@ static ThrowCompletionOr<void> call_direct_eval(
     VM& vm,
     Value callee,
     Value this_value,
-    ReadonlySpan<Operand> arguments,
-    Operand dst,
+    ReadonlySpan<Value> arguments,
+    Value& dst,
     Optional<StringTableIndex> const expression_string,
     Strict strict)
 {
@@ -1525,7 +1553,7 @@ static ThrowCompletionOr<void> call_direct_eval(
     auto const insn_argument_count = arguments.size();
 
     for (size_t i = 0; i < insn_argument_count; ++i)
-        callee_context_argument_values[i] = vm.get(arguments.data()[i]);
+        callee_context_argument_values[i] = arguments[i];
     for (size_t i = insn_argument_count; i < callee_context_argument_count; ++i)
         callee_context_argument_values[i] = js_undefined();
     callee_context->passed_argument_count = insn_argument_count;
@@ -1536,13 +1564,13 @@ static ThrowCompletionOr<void> call_direct_eval(
     } else {
         retval = TRY(function.internal_call(*callee_context, this_value));
     }
-    vm.set(dst, retval);
+    dst = retval;
     return {};
 }
 
-i64 asm_slow_path_call_direct_eval(VM* vm, u32 pc, Op::CallDirectEval const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_call_direct_eval, CallDirectEval)
 {
-    ASM_TRY(*vm, pc, call_direct_eval(*vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), instruction->arguments(), instruction->dst(), instruction->expression_string(), instruction->strict()));
+    ASM_TRY(*vm, pc, call_direct_eval(*vm, values.callee, values.this_value, ReadonlySpan<Value> { values.arguments, instruction->argument_count() }, values.dst, instruction->expression_string(), instruction->strict()));
     return continue_after_slow_path(pc + instruction->length());
 }
 
@@ -1552,7 +1580,7 @@ static ThrowCompletionOr<void> call_with_argument_array(
     Value callee,
     Value this_value,
     Value arguments,
-    Operand dst,
+    Value& dst,
     Optional<StringTableIndex> const expression_string,
     Strict strict)
 {
@@ -1601,94 +1629,94 @@ static ThrowCompletionOr<void> call_with_argument_array(
         retval = TRY(function.internal_call(*callee_context, this_value));
     }
 
-    vm.set(dst, retval);
+    dst = retval;
     return {};
 }
 
-i64 asm_slow_path_call_with_argument_array(VM* vm, u32 pc, Op::CallWithArgumentArray const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_call_with_argument_array, CallWithArgumentArray)
 {
-    ASM_TRY(*vm, pc, call_with_argument_array(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), vm->get(instruction->arguments()), instruction->dst(), instruction->expression_string(), instruction->strict()));
+    ASM_TRY(*vm, pc, call_with_argument_array(Op::CallType::Call, *vm, values.callee, values.this_value, values.arguments, values.dst, instruction->expression_string(), instruction->strict()));
     return continue_after_slow_path(pc + sizeof(Op::CallWithArgumentArray));
 }
 
-i64 asm_slow_path_call_direct_eval_with_argument_array(VM* vm, u32 pc, Op::CallDirectEvalWithArgumentArray const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_call_direct_eval_with_argument_array, CallDirectEvalWithArgumentArray)
 {
-    ASM_TRY(*vm, pc, call_with_argument_array(Op::CallType::DirectEval, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), vm->get(instruction->arguments()), instruction->dst(), instruction->expression_string(), instruction->strict()));
+    ASM_TRY(*vm, pc, call_with_argument_array(Op::CallType::DirectEval, *vm, values.callee, values.this_value, values.arguments, values.dst, instruction->expression_string(), instruction->strict()));
     return continue_after_slow_path(pc + sizeof(Op::CallDirectEvalWithArgumentArray));
 }
 
-i64 asm_slow_path_get_object_property_iterator(VM* vm, u32 pc, Op::GetObjectPropertyIterator const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_object_property_iterator, GetObjectPropertyIterator)
 {
     auto* cache = &vm->current_executable().object_property_iterator_caches[instruction->cache()];
-    vm->set(instruction->dst_iterator(), ASM_TRY(*vm, pc, asm_get_object_property_iterator(*vm, vm->get(instruction->object()), cache)));
+    values.dst_iterator = ASM_TRY(*vm, pc, asm_get_object_property_iterator(*vm, values.object, cache));
     return continue_after_slow_path(pc + sizeof(Op::GetObjectPropertyIterator));
 }
 
-i64 asm_slow_path_object_property_iterator_next(VM* vm, u32 pc, Op::ObjectPropertyIteratorNext const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_object_property_iterator_next, ObjectPropertyIteratorNext)
 {
-    auto& iterator = static_cast<PropertyNameIterator&>(vm->get(instruction->iterator_object()).as_object());
+    auto& iterator = static_cast<PropertyNameIterator&>(values.iterator_object.as_object());
     Value value;
     bool done = false;
     ASM_TRY(*vm, pc, iterator.next(*vm, done, value));
-    vm->set(instruction->dst_done(), Value(done));
-    if (!done)
-        vm->set(instruction->dst_value(), value);
+    values.dst_done = Value(done);
+    values.dst_value = value;
     return continue_after_slow_path(pc + sizeof(Op::ObjectPropertyIteratorNext));
 }
 
-i64 asm_slow_path_iterator_close(VM* vm, u32 pc, Op::IteratorClose const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_iterator_close, IteratorClose)
 {
-    auto& iterator_object = vm->get(instruction->iterator_object()).as_object();
-    auto iterator_next_method = vm->get(instruction->iterator_next());
-    auto iterator_done_property = vm->get(instruction->iterator_done()).as_bool();
+    auto& iterator_object = values.iterator_object.as_object();
+    auto iterator_next_method = values.iterator_next;
+    auto iterator_done_property = values.iterator_done.as_bool();
     IteratorRecordImpl iterator_record { .done = iterator_done_property, .iterator = iterator_object, .next_method = iterator_next_method };
 
-    ASM_TRY(*vm, pc, iterator_close(*vm, iterator_record, Completion { instruction->completion_type(), vm->get(instruction->completion_value()) }));
+    ASM_TRY(*vm, pc, iterator_close(*vm, iterator_record, Completion { instruction->completion_type(), values.completion_value }));
     return continue_after_slow_path(pc + sizeof(Op::IteratorClose));
 }
 
-i64 asm_slow_path_iterator_next(VM* vm, u32 pc, Op::IteratorNext const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_iterator_next, IteratorNext)
 {
-    auto& iterator_object = vm->get(instruction->iterator_object()).as_object();
-    auto iterator_next_method = vm->get(instruction->iterator_next());
-    auto iterator_done_property = vm->get(instruction->iterator_done()).as_bool();
+    auto& iterator_object = values.iterator_object.as_object();
+    auto iterator_next_method = values.iterator_next;
+    auto iterator_done_property = values.iterator_done.as_bool();
     IteratorRecordImpl iterator_record { .done = iterator_done_property, .iterator = iterator_object, .next_method = iterator_next_method };
     auto result = iterator_next(*vm, iterator_record);
     if (iterator_record.done)
-        vm->set(instruction->iterator_done(), Value(true));
-    vm->set(instruction->dst(), ASM_TRY(*vm, pc, result));
+        values.iterator_done = Value(true);
+    values.dst = ASM_TRY(*vm, pc, result);
     return continue_after_slow_path(pc + sizeof(Op::IteratorNext));
 }
 
-i64 asm_slow_path_iterator_next_unpack(VM* vm, u32 pc, Op::IteratorNextUnpack const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_iterator_next_unpack, IteratorNextUnpack)
 {
-    auto& iterator_object = vm->get(instruction->iterator_object()).as_object();
-    auto iterator_next_method = vm->get(instruction->iterator_next());
-    auto iterator_done_property = vm->get(instruction->iterator_done()).as_bool();
+    auto& iterator_object = values.iterator_object.as_object();
+    auto iterator_next_method = values.iterator_next;
+    auto iterator_done_property = values.iterator_done.as_bool();
     IteratorRecordImpl iterator_record { .done = iterator_done_property, .iterator = iterator_object, .next_method = iterator_next_method };
     auto iteration_result_or_done_or_error = iterator_step(*vm, iterator_record);
     if (iterator_record.done)
-        vm->set(instruction->iterator_done(), Value(true));
+        values.iterator_done = Value(true);
     auto iteration_result_or_done = ASM_TRY(*vm, pc, iteration_result_or_done_or_error);
     if (iteration_result_or_done.has<IterationDone>()) {
-        vm->set(instruction->dst_done(), Value(true));
+        values.dst_value = js_undefined();
+        values.dst_done = Value(true);
         return continue_after_slow_path(pc + sizeof(Op::IteratorNextUnpack));
     }
     auto& iteration_result = iteration_result_or_done.get<IterationResult>();
-    vm->set(instruction->dst_done(), ASM_TRY(*vm, pc, iteration_result.done));
+    values.dst_done = ASM_TRY(*vm, pc, iteration_result.done);
     auto value = move(iteration_result.value);
     if (value.is_throw_completion())
-        vm->set(instruction->iterator_done(), Value(true));
-    vm->set(instruction->dst_value(), ASM_TRY(*vm, pc, value));
+        values.iterator_done = Value(true);
+    values.dst_value = ASM_TRY(*vm, pc, value);
     return continue_after_slow_path(pc + sizeof(Op::IteratorNextUnpack));
 }
 
-i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_iterator_to_array, IteratorToArray)
 {
     IteratorRecordImpl iterator_record {
-        .done = vm->get(instruction->iterator_done_property()).as_bool(),
-        .iterator = vm->get(instruction->iterator_object()).as_object(),
-        .next_method = vm->get(instruction->iterator_next_method())
+        .done = values.iterator_done_property.as_bool(),
+        .iterator = values.iterator_object.as_object(),
+        .next_method = values.iterator_next_method
     };
 
     auto array = MUST(JS::Array::create(*vm->current_realm(), 0));
@@ -1696,10 +1724,10 @@ i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* i
     while (true) {
         auto value_or_error = iterator_step_value(*vm, iterator_record);
         if (iterator_record.done)
-            vm->set(instruction->iterator_done_property(), Value(true));
+            values.iterator_done_property = Value(true);
         auto value = ASM_TRY(*vm, pc, value_or_error);
         if (!value.has_value()) {
-            vm->set(instruction->dst(), array);
+            values.dst = array;
             return continue_after_slow_path(pc + sizeof(Op::IteratorToArray));
         }
 
@@ -1708,65 +1736,65 @@ i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* i
     }
 }
 
-#define JS_DEFINE_UNARY_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, implementation)                                                                                                                    \
-    i64 asm_slow_path_call_builtin_##snake_case_name(VM* vm, u32 pc, Op::CallBuiltin##name const* instruction)                                                                                           \
-    {                                                                                                                                                                                                    \
-        Operand arguments[] { instruction->argument() };                                                                                                                                                 \
-        auto callee = vm->get(instruction->callee());                                                                                                                                                    \
-        if (callee.is_function() && callee.as_function().builtin() == Builtin::name) {                                                                                                                   \
-            vm->set(instruction->dst(), ASM_TRY(*vm, pc, implementation(*vm, vm->get(instruction->argument()))));                                                                                        \
-            return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                         \
-        }                                                                                                                                                                                                \
-        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, callee, vm->get(instruction->this_value()), arguments, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                             \
+#define JS_DEFINE_UNARY_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, implementation)                                                                                           \
+    DEFINE_SLOW_PATH(asm_slow_path_call_builtin_##snake_case_name, CallBuiltin##name)                                                                                           \
+    {                                                                                                                                                                           \
+        Value arguments[] { values.argument };                                                                                                                                  \
+        auto callee = values.callee;                                                                                                                                            \
+        if (callee.is_function() && callee.as_function().builtin() == Builtin::name) {                                                                                          \
+            values.dst = ASM_TRY(*vm, pc, implementation(*vm, values.argument));                                                                                                \
+            return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                \
+        }                                                                                                                                                                       \
+        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, callee, values.this_value, arguments, values.dst, instruction->expression_string(), instruction->strict())); \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                    \
     }
 
-#define JS_DEFINE_BINARY_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, implementation)                                                                                                                   \
-    i64 asm_slow_path_call_builtin_##snake_case_name(VM* vm, u32 pc, Op::CallBuiltin##name const* instruction)                                                                                           \
-    {                                                                                                                                                                                                    \
-        Operand arguments[] { instruction->argument0(), instruction->argument1() };                                                                                                                      \
-        auto callee = vm->get(instruction->callee());                                                                                                                                                    \
-        if (callee.is_function() && callee.as_function().builtin() == Builtin::name) {                                                                                                                   \
-            vm->set(instruction->dst(), ASM_TRY(*vm, pc, implementation(*vm, vm->get(instruction->argument0()), vm->get(instruction->argument1()))));                                                    \
-            return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                         \
-        }                                                                                                                                                                                                \
-        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, callee, vm->get(instruction->this_value()), arguments, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                             \
+#define JS_DEFINE_BINARY_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, implementation)                                                                                          \
+    DEFINE_SLOW_PATH(asm_slow_path_call_builtin_##snake_case_name, CallBuiltin##name)                                                                                           \
+    {                                                                                                                                                                           \
+        Value arguments[] { values.argument0, values.argument1 };                                                                                                               \
+        auto callee = values.callee;                                                                                                                                            \
+        if (callee.is_function() && callee.as_function().builtin() == Builtin::name) {                                                                                          \
+            values.dst = ASM_TRY(*vm, pc, implementation(*vm, values.argument0, values.argument1));                                                                             \
+            return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                \
+        }                                                                                                                                                                       \
+        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, callee, values.this_value, arguments, values.dst, instruction->expression_string(), instruction->strict())); \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                    \
     }
 
-#define JS_DEFINE_NULLARY_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, implementation)                                                                                                           \
-    i64 asm_slow_path_call_builtin_##snake_case_name(VM* vm, u32 pc, Op::CallBuiltin##name const* instruction)                                                                                    \
-    {                                                                                                                                                                                             \
-        auto callee = vm->get(instruction->callee());                                                                                                                                             \
-        if (callee.is_function() && callee.as_function().builtin() == Builtin::name) {                                                                                                            \
-            vm->set(instruction->dst(), implementation());                                                                                                                                        \
-            return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                  \
-        }                                                                                                                                                                                         \
-        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, callee, vm->get(instruction->this_value()), {}, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                      \
+#define JS_DEFINE_NULLARY_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, implementation)                                                                                  \
+    DEFINE_SLOW_PATH(asm_slow_path_call_builtin_##snake_case_name, CallBuiltin##name)                                                                                    \
+    {                                                                                                                                                                    \
+        auto callee = values.callee;                                                                                                                                     \
+        if (callee.is_function() && callee.as_function().builtin() == Builtin::name) {                                                                                   \
+            values.dst = implementation();                                                                                                                               \
+            return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                         \
+        }                                                                                                                                                                \
+        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, callee, values.this_value, {}, values.dst, instruction->expression_string(), instruction->strict())); \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                             \
     }
 
-#define JS_DEFINE_GENERIC_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, ...)                                                                                                                                              \
-    i64 asm_slow_path_call_builtin_##snake_case_name(VM* vm, u32 pc, Op::CallBuiltin##name const* instruction)                                                                                                            \
-    {                                                                                                                                                                                                                     \
-        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), {}, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                              \
+#define JS_DEFINE_GENERIC_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, ...)                                                                                                    \
+    DEFINE_SLOW_PATH(asm_slow_path_call_builtin_##snake_case_name, CallBuiltin##name)                                                                                           \
+    {                                                                                                                                                                           \
+        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, values.callee, values.this_value, {}, values.dst, instruction->expression_string(), instruction->strict())); \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                    \
     }
 
-#define JS_DEFINE_UNARY_GENERIC_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, ...)                                                                                                                                               \
-    i64 asm_slow_path_call_builtin_##snake_case_name(VM* vm, u32 pc, Op::CallBuiltin##name const* instruction)                                                                                                                   \
-    {                                                                                                                                                                                                                            \
-        Operand arguments[] { instruction->argument() };                                                                                                                                                                         \
-        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), arguments, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                                     \
+#define JS_DEFINE_UNARY_GENERIC_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, ...)                                                                                                     \
+    DEFINE_SLOW_PATH(asm_slow_path_call_builtin_##snake_case_name, CallBuiltin##name)                                                                                                  \
+    {                                                                                                                                                                                  \
+        Value arguments[] { values.argument };                                                                                                                                         \
+        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, values.callee, values.this_value, arguments, values.dst, instruction->expression_string(), instruction->strict())); \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                           \
     }
 
-#define JS_DEFINE_BINARY_GENERIC_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, ...)                                                                                                                                              \
-    i64 asm_slow_path_call_builtin_##snake_case_name(VM* vm, u32 pc, Op::CallBuiltin##name const* instruction)                                                                                                                   \
-    {                                                                                                                                                                                                                            \
-        Operand arguments[] { instruction->argument0(), instruction->argument1() };                                                                                                                                              \
-        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), arguments, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                                     \
+#define JS_DEFINE_BINARY_GENERIC_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, ...)                                                                                                    \
+    DEFINE_SLOW_PATH(asm_slow_path_call_builtin_##snake_case_name, CallBuiltin##name)                                                                                                  \
+    {                                                                                                                                                                                  \
+        Value arguments[] { values.argument0, values.argument1 };                                                                                                                      \
+        ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, values.callee, values.this_value, arguments, values.dst, instruction->expression_string(), instruction->strict())); \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                           \
     }
 
 JS_DEFINE_UNARY_BUILTIN_CALL_SLOW_PATH(MathAbs, math_abs, MathObject::abs_impl)
@@ -1801,15 +1829,15 @@ JS_DEFINE_UNARY_GENERIC_BUILTIN_CALL_SLOW_PATH(StringPrototypeCharAt, string_pro
 #undef JS_DEFINE_BINARY_BUILTIN_CALL_SLOW_PATH
 #undef JS_DEFINE_UNARY_BUILTIN_CALL_SLOW_PATH
 
-i64 asm_slow_path_call_construct(VM* vm, u32 pc, Op::CallConstruct const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_call_construct, CallConstruct)
 {
-    auto callee = vm->get(instruction->callee());
+    auto callee = values.callee;
     if (callee.is_object() && is<ECMAScriptFunctionObject>(callee.as_object())) {
         auto& function = static_cast<ECMAScriptFunctionObject&>(callee.as_object());
         if (function.can_inline_call() && callee.is_constructor() && function.constructor_kind() == ConstructorKind::Base && !function.has_class_data()) {
             auto* prototype = ASM_TRY(*vm, pc, get_prototype_from_constructor(*vm, function, &Intrinsics::object_prototype));
             auto this_object = Object::create(*function.realm(), prototype);
-            auto* context = vm->push_inline_frame(function, function.inline_call_executable(), instruction->arguments(), pc + instruction->length(), instruction->dst().raw(), this_object, &function, true);
+            auto* context = vm->push_inline_frame(function, function.inline_call_executable(), ReadonlySpan<Value> { values.arguments, instruction->argument_count() }, pc + instruction->length(), instruction->dst().raw(), this_object, &function, true);
             if (!context) [[unlikely]] {
                 ASM_TRY(*vm, pc, vm->throw_completion<InternalError>(ErrorType::CallStackSizeExceeded));
                 VERIFY_NOT_REACHED();
@@ -1819,23 +1847,22 @@ i64 asm_slow_path_call_construct(VM* vm, u32 pc, Op::CallConstruct const* instru
             return 0;
         }
     }
-    ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Construct, *vm, vm->get(instruction->callee()), js_undefined(), instruction->arguments(), instruction->dst(), instruction->expression_string(), instruction->strict()));
+    ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Construct, *vm, values.callee, js_undefined(), ReadonlySpan<Value> { values.arguments, instruction->argument_count() }, values.dst, instruction->expression_string(), instruction->strict()));
     return continue_after_slow_path(pc + instruction->length());
 }
 
-i64 asm_slow_path_call_construct_with_argument_array(VM* vm, u32 pc, Op::CallConstructWithArgumentArray const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_call_construct_with_argument_array, CallConstructWithArgumentArray)
 {
-    ASM_TRY(*vm, pc, call_with_argument_array(Op::CallType::Construct, *vm, vm->get(instruction->callee()), js_undefined(), vm->get(instruction->arguments()), instruction->dst(), instruction->expression_string(), instruction->strict()));
+    ASM_TRY(*vm, pc, call_with_argument_array(Op::CallType::Construct, *vm, values.callee, js_undefined(), values.arguments, values.dst, instruction->expression_string(), instruction->strict()));
     return continue_after_slow_path(pc + sizeof(Op::CallConstructWithArgumentArray));
 }
 
-i64 asm_slow_path_super_call_with_argument_array(VM* vm, u32 pc, Op::SuperCallWithArgumentArray const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_super_call_with_argument_array, SuperCallWithArgumentArray)
 {
-
     auto new_target = vm->get_new_target();
     VERIFY(new_target.is_object());
 
-    auto super_constructor = vm->get(instruction->super_constructor());
+    auto super_constructor = values.super_constructor;
     if (!super_constructor.is_constructor()) [[unlikely]] {
         vm->running_execution_context().program_counter = pc;
         auto completion = vm->throw_completion<TypeError>(ErrorType::NotAConstructor, "Super constructor");
@@ -1844,7 +1871,7 @@ i64 asm_slow_path_super_call_with_argument_array(VM* vm, u32 pc, Op::SuperCallWi
 
     auto& function = super_constructor.as_function();
 
-    auto& argument_array = vm->get(instruction->arguments()).as_array_exotic_object();
+    auto& argument_array = values.arguments.as_array_exotic_object();
     size_t argument_array_length = 0;
 
     if (instruction->is_synthetic()) {
@@ -1898,11 +1925,11 @@ i64 asm_slow_path_super_call_with_argument_array(VM* vm, u32 pc, Op::SuperCallWi
     auto& f = as<ECMAScriptFunctionObject>(this_environment.function_object());
     ASM_TRY(*vm, pc, result->initialize_instance_elements(f));
 
-    vm->set(instruction->dst(), result);
+    values.dst = result;
     return continue_after_slow_path(pc + sizeof(Op::SuperCallWithArgumentArray));
 }
 
-i64 asm_slow_path_new_object(VM* vm, u32 pc, Op::NewObject const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_object, NewObject)
 {
     auto& realm = *vm->current_realm();
 
@@ -1910,37 +1937,37 @@ i64 asm_slow_path_new_object(VM* vm, u32 pc, Op::NewObject const* instruction)
         auto& cache = vm->current_executable().object_shape_caches[instruction->cache()];
         auto cached_shape = cache.shape.ptr();
         if (cached_shape) {
-            vm->set(instruction->dst(), Object::create_with_premade_shape(*cached_shape));
+            values.dst = Object::create_with_premade_shape(*cached_shape);
             return continue_after_slow_path(pc + sizeof(Op::NewObject));
         }
     }
 
-    vm->set(instruction->dst(), Object::create(realm, realm.intrinsics().object_prototype().ptr()));
+    values.dst = Object::create(realm, realm.intrinsics().object_prototype().ptr());
     return continue_after_slow_path(pc + sizeof(Op::NewObject));
 }
 
-i64 asm_slow_path_new_object_with_no_prototype(VM* vm, u32 pc, Op::NewObjectWithNoPrototype const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_object_with_no_prototype, NewObjectWithNoPrototype)
 {
     auto& realm = *vm->current_realm();
-    vm->set(instruction->dst(), Object::create(realm, nullptr));
+    values.dst = Object::create(realm, nullptr);
     return continue_after_slow_path(pc + sizeof(Op::NewObjectWithNoPrototype));
 }
 
-i64 asm_slow_path_cache_object_shape(VM* vm, u32 pc, Op::CacheObjectShape const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_cache_object_shape, CacheObjectShape)
 {
     auto& cache = vm->current_executable().object_shape_caches[instruction->cache()];
     if (!cache.shape) {
-        auto& object = vm->get(instruction->object()).as_object();
+        auto& object = values.object.as_object();
         if (!object.shape().is_dictionary())
             cache.shape = &object.shape();
     }
     return continue_after_slow_path(pc + sizeof(Op::CacheObjectShape));
 }
 
-i64 asm_slow_path_init_object_literal_property(VM* vm, u32 pc, Op::InitObjectLiteralProperty const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_init_object_literal_property, InitObjectLiteralProperty)
 {
-    auto& object = vm->get(instruction->object()).as_object();
-    auto value = vm->get(instruction->src());
+    auto& object = values.object.as_object();
+    auto value = values.src;
     auto& cache = vm->current_executable().object_shape_caches[instruction->shape_cache_index()];
 
     auto cached_shape = cache.shape.ptr();
@@ -1964,25 +1991,25 @@ i64 asm_slow_path_init_object_literal_property(VM* vm, u32 pc, Op::InitObjectLit
     return continue_after_slow_path(pc + sizeof(Op::InitObjectLiteralProperty));
 }
 
-i64 asm_slow_path_new_array(VM* vm, u32 pc, Op::NewArray const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_array, NewArray)
 {
     auto array = MUST(JS::Array::create(vm->realm(), instruction->element_count()));
     for (size_t i = 0; i < instruction->element_count(); ++i)
-        array->indexed_put(i, vm->get(instruction->elements()[i]));
-    vm->set(instruction->dst(), array);
+        array->indexed_put(i, values.elements[i]);
+    values.dst = array;
     return continue_after_slow_path(pc + instruction->length());
 }
 
-i64 asm_slow_path_new_primitive_array(VM* vm, u32 pc, Op::NewPrimitiveArray const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_primitive_array, NewPrimitiveArray)
 {
     auto array = MUST(JS::Array::create(vm->realm(), instruction->element_count()));
     for (size_t i = 0; i < instruction->element_count(); ++i)
         array->indexed_put(i, instruction->elements()[i]);
-    vm->set(instruction->dst(), array);
+    values.dst = array;
     return continue_after_slow_path(pc + instruction->length());
 }
 
-i64 asm_slow_path_new_regexp(VM* vm, u32 pc, Op::NewRegExp const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_regexp, NewRegExp)
 {
     auto& realm = *vm->current_realm();
     auto regexp_object = RegExpObject::create(
@@ -1991,70 +2018,70 @@ i64 asm_slow_path_new_regexp(VM* vm, u32 pc, Op::NewRegExp const* instruction)
         vm->current_executable().get_string(instruction->flags_index()));
     regexp_object->set_realm(realm);
     regexp_object->set_legacy_features_enabled(true);
-    vm->set(instruction->dst(), regexp_object);
+    values.dst = regexp_object;
     return continue_after_slow_path(pc + sizeof(Op::NewRegExp));
 }
 
-i64 asm_slow_path_new_reference_error(VM* vm, u32 pc, Op::NewReferenceError const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_reference_error, NewReferenceError)
 {
     auto& realm = *vm->current_realm();
-    vm->set(instruction->dst(), ReferenceError::create(realm, vm->current_executable().get_string(instruction->error_string())));
+    values.dst = ReferenceError::create(realm, vm->current_executable().get_string(instruction->error_string()));
     return continue_after_slow_path(pc + sizeof(Op::NewReferenceError));
 }
 
-i64 asm_slow_path_new_type_error(VM* vm, u32 pc, Op::NewTypeError const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_type_error, NewTypeError)
 {
     auto& realm = *vm->current_realm();
-    vm->set(instruction->dst(), TypeError::create(realm, vm->current_executable().get_string(instruction->error_string())));
+    values.dst = TypeError::create(realm, vm->current_executable().get_string(instruction->error_string()));
     return continue_after_slow_path(pc + sizeof(Op::NewTypeError));
 }
 
-i64 asm_slow_path_bitwise_xor(VM* vm, u32 pc, Op::BitwiseXor const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_bitwise_xor, BitwiseXor)
 {
-    return asm_slow_path_bitwise_xor_values(vm, pc, instruction->dst(), vm->get(instruction->lhs()), vm->get(instruction->rhs()));
+    return asm_slow_path_bitwise_xor_values(vm, pc, values.dst, values.lhs, values.rhs);
 }
 
-i64 asm_slow_path_bitwise_xor_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_bitwise_xor_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, bitwise_xor(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_bitwise_and(VM* vm, u32 pc, Op::BitwiseAnd const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_bitwise_and, BitwiseAnd)
 {
-    return asm_slow_path_bitwise_and_values(vm, pc, instruction->dst(), vm->get(instruction->lhs()), vm->get(instruction->rhs()));
+    return asm_slow_path_bitwise_and_values(vm, pc, values.dst, values.lhs, values.rhs);
 }
 
-i64 asm_slow_path_bitwise_and_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_bitwise_and_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, bitwise_and(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_bitwise_or(VM* vm, u32 pc, Op::BitwiseOr const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_bitwise_or, BitwiseOr)
 {
-    return asm_slow_path_bitwise_or_values(vm, pc, instruction->dst(), vm->get(instruction->lhs()), vm->get(instruction->rhs()));
+    return asm_slow_path_bitwise_or_values(vm, pc, values.dst, values.lhs, values.rhs);
 }
 
-i64 asm_slow_path_bitwise_or_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_bitwise_or_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, bitwise_or(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_left_shift_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_left_shift_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, left_shift(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_right_shift_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_right_shift_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, right_shift(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_unsigned_right_shift_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_unsigned_right_shift_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, unsigned_right_shift(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_mod_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_mod_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, mod(*vm, lhs, rhs));
 }
@@ -2082,110 +2109,110 @@ static bool strictly_equals(Value lhs, Value rhs)
     return is_strictly_equal(lhs, rhs);
 }
 
-i64 asm_slow_path_strictly_equals_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_strictly_equals_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path_value(*vm, pc, destination, Value { strictly_equals(lhs, rhs) });
 }
 
-i64 asm_slow_path_strictly_inequals_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_strictly_inequals_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path_value(*vm, pc, destination, Value { !strictly_equals(lhs, rhs) });
 }
 
-i64 asm_slow_path_loosely_equals_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_loosely_equals_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, loosely_equals(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_loosely_inequals_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
+i64 asm_slow_path_loosely_inequals_values(VM* vm, u32 pc, Value& destination, Value lhs, Value rhs)
 {
     return finish_binary_slow_path(*vm, pc, destination, loosely_inequals(*vm, lhs, rhs));
 }
 
-i64 asm_slow_path_unary_minus(VM* vm, u32 pc, Op::UnaryMinus const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_unary_minus, UnaryMinus)
 {
-    vm->set(instruction->dst(), ASM_TRY(*vm, pc, unary_minus(*vm, vm->get(instruction->src()))));
+    values.dst = ASM_TRY(*vm, pc, unary_minus(*vm, values.src));
     return continue_after_slow_path(pc + sizeof(Op::UnaryMinus));
 }
 
-i64 asm_slow_path_to_string(VM* vm, u32 pc, Op::ToString const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_to_string, ToString)
 {
-    auto result = ASM_TRY(*vm, pc, vm->get(instruction->value()).to_primitive_string(*vm));
-    vm->set(instruction->dst(), Value { result });
+    auto result = ASM_TRY(*vm, pc, values.value.to_primitive_string(*vm));
+    values.dst = Value { result };
     return continue_after_slow_path(pc + sizeof(Op::ToString));
 }
 
-i64 asm_slow_path_to_primitive_with_string_hint(VM* vm, u32 pc, Op::ToPrimitiveWithStringHint const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_to_primitive_with_string_hint, ToPrimitiveWithStringHint)
 {
-    auto result = ASM_TRY(*vm, pc, vm->get(instruction->value()).to_primitive(*vm, Value::PreferredType::String));
-    vm->set(instruction->dst(), result);
+    auto result = ASM_TRY(*vm, pc, values.value.to_primitive(*vm, Value::PreferredType::String));
+    values.dst = result;
     return continue_after_slow_path(pc + sizeof(Op::ToPrimitiveWithStringHint));
 }
 
-i64 asm_slow_path_to_object(VM* vm, u32 pc, Op::ToObject const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_to_object, ToObject)
 {
-    auto result = ASM_TRY(*vm, pc, vm->get(instruction->value()).to_object(*vm));
-    vm->set(instruction->dst(), result);
+    auto result = ASM_TRY(*vm, pc, values.value.to_object(*vm));
+    values.dst = result;
     return continue_after_slow_path(pc + sizeof(Op::ToObject));
 }
 
-i64 asm_slow_path_to_length(VM* vm, u32 pc, Op::ToLength const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_to_length, ToLength)
 {
-    auto result = ASM_TRY(*vm, pc, vm->get(instruction->value()).to_length(*vm));
-    vm->set(instruction->dst(), Value { result });
+    auto result = ASM_TRY(*vm, pc, values.value.to_length(*vm));
+    values.dst = Value { result };
     return continue_after_slow_path(pc + sizeof(Op::ToLength));
 }
 
-i64 asm_slow_path_typeof(VM* vm, u32 pc, Op::Typeof const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_typeof, Typeof)
 {
-    vm->set(instruction->dst(), vm->get(instruction->src()).typeof_(*vm));
+    values.dst = values.src.typeof_(*vm);
     return continue_after_slow_path(pc + sizeof(Op::Typeof));
 }
 
-i64 asm_slow_path_postfix_decrement(VM* vm, u32 pc, Op::PostfixDecrement const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_postfix_decrement, PostfixDecrement)
 {
-    auto old_value = ASM_TRY(*vm, pc, vm->get(instruction->src()).to_numeric(*vm));
-    vm->set(instruction->dst(), old_value);
+    auto old_value = ASM_TRY(*vm, pc, values.src.to_numeric(*vm));
+    values.dst = old_value;
     if (old_value.is_number())
-        vm->set(instruction->src(), Value(old_value.as_double() - 1));
+        values.src = Value(old_value.as_double() - 1);
     else
-        vm->set(instruction->src(), BigInt::create(*vm, old_value.as_bigint().big_integer().minus(Crypto::SignedBigInteger { 1 })));
+        values.src = BigInt::create(*vm, old_value.as_bigint().big_integer().minus(Crypto::SignedBigInteger { 1 }));
     return continue_after_slow_path(pc + sizeof(Op::PostfixDecrement));
 }
 
-i64 asm_slow_path_to_int32(VM* vm, u32 pc, Op::ToInt32 const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_to_int32, ToInt32)
 {
-    vm->set(instruction->dst(), Value(ASM_TRY(*vm, pc, vm->get(instruction->value()).to_i32(*vm))));
+    values.dst = Value(ASM_TRY(*vm, pc, values.value.to_i32(*vm)));
     return continue_after_slow_path(pc + sizeof(Op::ToInt32));
 }
 
-i64 asm_slow_path_put_by_value(VM* vm, u32 pc, Op::PutByValue const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_put_by_value, PutByValue)
 {
-    auto value = vm->get(instruction->src());
-    auto base = vm->get(instruction->base());
+    auto value = values.src;
+    auto base = values.base;
     Optional<Utf16FlyString const&> base_identifier;
     if (instruction->base_identifier().has_value())
         base_identifier = vm->get_identifier(instruction->base_identifier().value());
-    auto property = vm->get(instruction->property());
+    auto property = values.property;
     auto property_key = ASM_TRY(*vm, pc, property.to_property_key(*vm));
     ASM_TRY(*vm, pc, put_by_property_key(*vm, base, base, value, base_identifier, property_key, instruction->kind(), instruction->strict()));
     return continue_after_slow_path(pc + sizeof(Op::PutByValue));
 }
 
-i64 asm_slow_path_put_by_value_with_this(VM* vm, u32 pc, Op::PutByValueWithThis const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_put_by_value_with_this, PutByValueWithThis)
 {
-    auto value = vm->get(instruction->src());
-    auto base = vm->get(instruction->base());
-    auto this_value = vm->get(instruction->this_value());
-    auto property_key = ASM_TRY(*vm, pc, vm->get(instruction->property()).to_property_key(*vm));
+    auto value = values.src;
+    auto base = values.base;
+    auto this_value = values.this_value;
+    auto property_key = ASM_TRY(*vm, pc, values.property.to_property_key(*vm));
     ASM_TRY(*vm, pc, put_by_property_key(*vm, base, this_value, value, {}, property_key, instruction->kind(), instruction->strict()));
     return continue_after_slow_path(pc + sizeof(Op::PutByValueWithThis));
 }
 
-i64 asm_slow_path_put_by_spread(VM* vm, u32 pc, Op::PutBySpread const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_put_by_spread, PutBySpread)
 {
-    auto value = vm->get(instruction->src());
-    auto base = vm->get(instruction->base());
+    auto value = values.src;
+    auto base = values.base;
 
     // a. Let baseObj be ? ToObject(V.[[Base]]).
     auto object = ASM_TRY(*vm, pc, base.to_object(*vm));
@@ -2194,14 +2221,13 @@ i64 asm_slow_path_put_by_spread(VM* vm, u32 pc, Op::PutBySpread const* instructi
     return continue_after_slow_path(pc + sizeof(Op::PutBySpread));
 }
 
-i64 asm_try_put_by_value_holey_array(VM* vm, u32, Op::PutByValue const* instruction)
+i64 asm_try_put_by_value_holey_array(VM*, u32, Op::PutByValue const*, Op::PutByValue::Values& values)
 {
-
-    auto base = vm->get(instruction->base());
+    auto base = values.base;
     if (!base.is_object()) [[unlikely]]
         return 1;
 
-    auto property = vm->get(instruction->property());
+    auto property = values.property;
     if (!property.is_non_negative_int32()) [[unlikely]]
         return 1;
 
@@ -2221,17 +2247,16 @@ i64 asm_try_put_by_value_holey_array(VM* vm, u32, Op::PutByValue const* instruct
     if (index >= array.indexed_array_like_size()) [[unlikely]]
         return 1;
 
-    array.indexed_put(index, vm->get(instruction->src()));
+    array.indexed_put(index, values.src);
     return 0;
 }
 
 // Try to inline a JS-to-JS call by building the callee frame through the
 // shared VM::push_inline_frame() helper. Returns 0 on success (callee frame
 // pushed) and 1 on failure (caller should keep handling the Call itself).
-i64 asm_try_inline_call(VM* vm, u32 pc, Op::Call const* instruction)
+i64 asm_try_inline_call(VM* vm, u32 pc, Op::Call const* instruction, Op::Call::Values& values)
 {
-
-    auto callee = vm->get(instruction->callee());
+    auto callee = values.callee;
     if (!callee.is_object()) [[unlikely]]
         return 1;
 
@@ -2246,19 +2271,19 @@ i64 asm_try_inline_call(VM* vm, u32 pc, Op::Call const* instruction)
     auto* callee_context = vm->push_inline_frame(
         callee_function,
         callee_function.inline_call_executable(),
-        instruction->arguments(),
+        ReadonlySpan<Value> { values.arguments, instruction->argument_count() },
         pc + instruction->length(),
         instruction->dst().raw(),
-        vm->get(instruction->this_value()),
+        values.this_value,
         nullptr,
         false);
 
     return callee_context ? 0 : 1;
 }
 
-i64 asm_try_inline_get_by_id_accessor(VM* vm, u32 pc, Op::GetById const* instruction)
+i64 asm_try_inline_get_by_id_accessor(VM* vm, u32 pc, Op::GetById const* instruction, Op::GetById::Values& values)
 {
-    auto& object = vm->get(instruction->base()).as_object();
+    auto& object = values.base.as_object();
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
     auto* entry = cache.first_entry();
     VERIFY(entry);
@@ -2290,13 +2315,13 @@ i64 asm_try_inline_get_by_id_accessor(VM* vm, u32 pc, Op::GetById const* instruc
 
 // Fast cache-only PutById. Tries all cache entries for ChangeOwnProperty and
 // AddOwnProperty. Returns 0 on cache hit, 1 on miss (caller should use full slow path).
-i64 asm_try_put_by_id_cache(VM* vm, u32, Op::PutById const* instruction)
+i64 asm_try_put_by_id_cache(VM* vm, u32, Op::PutById const* instruction, Op::PutById::Values& values)
 {
-    auto base = vm->get(instruction->base());
+    auto base = values.base;
     if (!base.is_object()) [[unlikely]]
         return 1;
     auto& object = base.as_object();
-    auto value = vm->get(instruction->src());
+    auto value = values.src;
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
 
     for (auto& entry : cache.entries_for_shape(object.shape())) {
@@ -2342,18 +2367,16 @@ i64 asm_try_put_by_id_cache(VM* vm, u32, Op::PutById const* instruction)
 }
 
 // Fast cache-only GetById. Tries all cache entries for own-property and prototype
-// chain lookups. On cache hit, writes the result to the dst operand and returns 0.
-// On miss, returns 1 (caller should use full slow path).
-i64 asm_try_get_by_id_cache(VM* vm, u32, Op::GetById const* instruction)
+// chain lookups. Returns the cached value on hit, or Empty on miss.
+u64 asm_try_get_by_id_cache(u64 encoded_base, PropertyLookupCache* cache)
 {
-    auto base = vm->get(instruction->base());
+    auto base = bit_cast<Value>(encoded_base);
     if (!base.is_object()) [[unlikely]]
-        return 1;
+        return js_special_empty_value().encoded();
     auto& object = base.as_object();
     auto& shape = object.shape();
-    auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
 
-    for (auto& entry : cache.entries_for_shape(shape)) {
+    for (auto& entry : cache->entries_for_shape(shape)) {
         if (entry.type == PropertyLookupCache::Entry::Type::GetMissingProperty) {
             if (!object.is_cacheable_for_property_absence()) [[unlikely]]
                 continue;
@@ -2367,8 +2390,7 @@ i64 asm_try_get_by_id_cache(VM* vm, u32, Op::GetById const* instruction)
                 if (!prototype_chain_validity || !prototype_chain_validity->is_valid()) [[unlikely]]
                     continue;
             }
-            vm->set(instruction->dst(), js_undefined());
-            return 0;
+            return js_undefined().encoded();
         }
 
         if (entry.type != PropertyLookupCache::Entry::Type::GetOwnProperty
@@ -2388,120 +2410,117 @@ i64 asm_try_get_by_id_cache(VM* vm, u32, Op::GetById const* instruction)
                 continue;
             auto value = cached_prototype->get_direct(entry.property_offset);
             if (value.is_accessor()) [[unlikely]]
-                return 1;
-            vm->set(instruction->dst(), value);
-            return 0;
+                return js_special_empty_value().encoded();
+            return value.encoded();
         } else if (&shape == entry.shape.ptr()) {
             if (shape.is_dictionary()
                 && shape.dictionary_generation() != entry.shape_dictionary_generation)
                 continue;
             auto value = object.get_direct(entry.property_offset);
             if (value.is_accessor()) [[unlikely]]
-                return 1;
-            vm->set(instruction->dst(), value);
-            return 0;
+                return js_special_empty_value().encoded();
+            return value.encoded();
         }
     }
-    return 1;
+    return js_special_empty_value().encoded();
 }
 
-i64 asm_slow_path_get_binding(VM* vm, u32 pc, Op::GetBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_binding, GetBinding)
 {
-    auto next_pc = asm_get_binding<AsmBindingIsKnownToBeInitialized::No>(*vm, pc, instruction->dst(), instruction->cache());
+    auto next_pc = asm_get_binding<AsmBindingIsKnownToBeInitialized::No>(*vm, pc, values.dst, instruction->cache());
     return advance_or_continue<Op::GetBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_dynamic_get_binding(VM* vm, u32 pc, Op::DynamicGetBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_dynamic_get_binding, DynamicGetBinding)
 {
     auto& cache = vm->current_executable().environment_coordinate_caches[instruction->cache()];
-    auto next_pc = asm_dynamic_get_binding<AsmBindingIsKnownToBeInitialized::No>(*vm, pc, instruction->dst(), instruction->identifier(), instruction->strict(), cache);
+    auto next_pc = asm_dynamic_get_binding<AsmBindingIsKnownToBeInitialized::No>(*vm, pc, values.dst, instruction->identifier(), instruction->strict(), cache);
     return advance_or_continue<Op::DynamicGetBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_initialize_lexical_binding(VM* vm, u32 pc, Op::InitializeLexicalBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_initialize_lexical_binding, InitializeLexicalBinding)
 {
-    auto next_pc = asm_initialize_or_set_binding<Op::EnvironmentMode::Lexical, Op::BindingInitializationMode::Initialize>(*vm, pc, instruction->strict(), vm->get(instruction->src()), instruction->cache());
+    auto next_pc = asm_initialize_or_set_binding<Op::EnvironmentMode::Lexical, Op::BindingInitializationMode::Initialize>(*vm, pc, instruction->strict(), values.src, instruction->cache());
     return advance_or_continue<Op::InitializeLexicalBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_dynamic_initialize_lexical_binding(VM* vm, u32 pc, Op::DynamicInitializeLexicalBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_dynamic_initialize_lexical_binding, DynamicInitializeLexicalBinding)
 {
-    auto next_pc = asm_dynamic_initialize_or_set_binding<Op::EnvironmentMode::Lexical, Op::BindingInitializationMode::Initialize>(*vm, pc, instruction->identifier(), instruction->strict(), vm->get(instruction->src()), vm->current_executable().environment_coordinate_caches[instruction->cache()]);
+    auto next_pc = asm_dynamic_initialize_or_set_binding<Op::EnvironmentMode::Lexical, Op::BindingInitializationMode::Initialize>(*vm, pc, instruction->identifier(), instruction->strict(), values.src, vm->current_executable().environment_coordinate_caches[instruction->cache()]);
     return advance_or_continue<Op::DynamicInitializeLexicalBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_initialize_variable_binding(VM* vm, u32 pc, Op::InitializeVariableBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_initialize_variable_binding, InitializeVariableBinding)
 {
-    auto next_pc = asm_initialize_or_set_binding<Op::EnvironmentMode::Var, Op::BindingInitializationMode::Initialize>(*vm, pc, instruction->strict(), vm->get(instruction->src()), instruction->cache());
+    auto next_pc = asm_initialize_or_set_binding<Op::EnvironmentMode::Var, Op::BindingInitializationMode::Initialize>(*vm, pc, instruction->strict(), values.src, instruction->cache());
     return advance_or_continue<Op::InitializeVariableBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_dynamic_initialize_variable_binding(VM* vm, u32 pc, Op::DynamicInitializeVariableBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_dynamic_initialize_variable_binding, DynamicInitializeVariableBinding)
 {
-    auto next_pc = asm_dynamic_initialize_or_set_binding<Op::EnvironmentMode::Var, Op::BindingInitializationMode::Initialize>(*vm, pc, instruction->identifier(), instruction->strict(), vm->get(instruction->src()), vm->current_executable().environment_coordinate_caches[instruction->cache()]);
+    auto next_pc = asm_dynamic_initialize_or_set_binding<Op::EnvironmentMode::Var, Op::BindingInitializationMode::Initialize>(*vm, pc, instruction->identifier(), instruction->strict(), values.src, vm->current_executable().environment_coordinate_caches[instruction->cache()]);
     return advance_or_continue<Op::DynamicInitializeVariableBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_set_lexical_binding(VM* vm, u32 pc, Op::SetLexicalBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_set_lexical_binding, SetLexicalBinding)
 {
-    auto next_pc = asm_initialize_or_set_binding<Op::EnvironmentMode::Lexical, Op::BindingInitializationMode::Set>(*vm, pc, instruction->strict(), vm->get(instruction->src()), instruction->cache());
+    auto next_pc = asm_initialize_or_set_binding<Op::EnvironmentMode::Lexical, Op::BindingInitializationMode::Set>(*vm, pc, instruction->strict(), values.src, instruction->cache());
     return advance_or_continue<Op::SetLexicalBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_dynamic_set_lexical_binding(VM* vm, u32 pc, Op::DynamicSetLexicalBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_dynamic_set_lexical_binding, DynamicSetLexicalBinding)
 {
-    auto next_pc = asm_dynamic_initialize_or_set_binding<Op::EnvironmentMode::Lexical, Op::BindingInitializationMode::Set>(*vm, pc, instruction->identifier(), instruction->strict(), vm->get(instruction->src()), vm->current_executable().environment_coordinate_caches[instruction->cache()]);
+    auto next_pc = asm_dynamic_initialize_or_set_binding<Op::EnvironmentMode::Lexical, Op::BindingInitializationMode::Set>(*vm, pc, instruction->identifier(), instruction->strict(), values.src, vm->current_executable().environment_coordinate_caches[instruction->cache()]);
     return advance_or_continue<Op::DynamicSetLexicalBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_set_variable_binding(VM* vm, u32 pc, Op::SetVariableBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_set_variable_binding, SetVariableBinding)
 {
-    auto next_pc = asm_initialize_or_set_binding<Op::EnvironmentMode::Var, Op::BindingInitializationMode::Set>(*vm, pc, instruction->strict(), vm->get(instruction->src()), instruction->cache());
+    auto next_pc = asm_initialize_or_set_binding<Op::EnvironmentMode::Var, Op::BindingInitializationMode::Set>(*vm, pc, instruction->strict(), values.src, instruction->cache());
     return advance_or_continue<Op::SetVariableBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_dynamic_set_variable_binding(VM* vm, u32 pc, Op::DynamicSetVariableBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_dynamic_set_variable_binding, DynamicSetVariableBinding)
 {
-    auto next_pc = asm_dynamic_initialize_or_set_binding<Op::EnvironmentMode::Var, Op::BindingInitializationMode::Set>(*vm, pc, instruction->identifier(), instruction->strict(), vm->get(instruction->src()), vm->current_executable().environment_coordinate_caches[instruction->cache()]);
+    auto next_pc = asm_dynamic_initialize_or_set_binding<Op::EnvironmentMode::Var, Op::BindingInitializationMode::Set>(*vm, pc, instruction->identifier(), instruction->strict(), values.src, vm->current_executable().environment_coordinate_caches[instruction->cache()]);
     return advance_or_continue<Op::DynamicSetVariableBinding>(pc, next_pc);
 }
 
-i64 asm_slow_path_resolve_binding(VM* vm, u32 pc, Op::ResolveBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_resolve_binding, ResolveBinding)
 {
     auto const& identifier = vm->get_identifier(instruction->identifier());
     auto reference = ASM_TRY(*vm, pc, vm->resolve_binding(identifier, instruction->strict()));
     if (reference.is_unresolvable()) {
-        vm->set(instruction->dst(), js_null());
+        values.dst = js_null();
         return continue_after_slow_path(pc + sizeof(Op::ResolveBinding));
     }
 
     VERIFY(reference.is_environment_reference());
-    vm->set(instruction->dst(), &reference.base_environment());
+    values.dst = &reference.base_environment();
     return continue_after_slow_path(pc + sizeof(Op::ResolveBinding));
 }
 
-i64 asm_slow_path_resolve_super_base(VM* vm, u32 pc, Op::ResolveSuperBase const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_resolve_super_base, ResolveSuperBase)
 {
-
     auto& environment = as<FunctionEnvironment>(*get_this_environment(*vm));
     VERIFY(environment.has_super_binding());
     auto base_value = ASM_TRY(*vm, pc, environment.get_super_base());
-    vm->set(instruction->dst(), base_value);
+    values.dst = base_value;
     return continue_after_slow_path(pc + sizeof(Op::ResolveSuperBase));
 }
 
-i64 asm_slow_path_set_resolved_binding(VM* vm, u32 pc, Op::SetResolvedBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_set_resolved_binding, SetResolvedBinding)
 {
     auto const& identifier = vm->get_identifier(instruction->identifier());
-    auto environment = vm->get(instruction->environment());
+    auto environment = values.environment;
     auto reference = environment.is_null()
         ? Reference { Reference::BaseType::Unresolvable, PropertyKey { identifier }, instruction->strict() }
         : Reference { as<Environment>(environment.as_cell()), identifier, instruction->strict() };
-    ASM_TRY(*vm, pc, reference.put_value(*vm, vm->get(instruction->src())));
+    ASM_TRY(*vm, pc, reference.put_value(*vm, values.src));
     return continue_after_slow_path(pc + sizeof(Op::SetResolvedBinding));
 }
 
-i64 asm_slow_path_typeof_binding(VM* vm, u32 pc, Op::TypeofBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_typeof_binding, TypeofBinding)
 {
     VERIFY(instruction->cache().is_valid());
 
@@ -2510,29 +2529,29 @@ i64 asm_slow_path_typeof_binding(VM* vm, u32 pc, Op::TypeofBinding const* instru
         environment = environment->outer_environment();
 
     auto value = ASM_TRY(*vm, pc, static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(*vm, instruction->cache().index));
-    vm->set(instruction->dst(), value.typeof_(*vm));
+    values.dst = value.typeof_(*vm);
     return continue_after_slow_path(pc + sizeof(Op::TypeofBinding));
 }
 
-i64 asm_slow_path_dynamic_typeof_binding(VM* vm, u32 pc, Op::DynamicTypeofBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_dynamic_typeof_binding, DynamicTypeofBinding)
 {
     auto& cache = vm->current_executable().environment_coordinate_caches[instruction->cache()];
     auto const* current_environment = vm->running_execution_context().lexical_environment.ptr();
     if (auto const* environment = asm_get_cached_environment(current_environment, cache)) [[likely]] {
         auto value = ASM_TRY(*vm, pc, static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(*vm, cache.index));
-        vm->set(instruction->dst(), value.typeof_(*vm));
+        values.dst = value.typeof_(*vm);
         return continue_after_slow_path(pc + sizeof(Op::DynamicTypeofBinding));
     }
 
     auto reference = ASM_TRY(*vm, pc, vm->resolve_binding(vm->get_identifier(instruction->identifier()), instruction->strict()));
     if (reference.is_unresolvable()) {
-        vm->set(instruction->dst(), PrimitiveString::create(*vm, "undefined"_utf16_fly_string));
+        values.dst = PrimitiveString::create(*vm, "undefined"_utf16_fly_string);
         return continue_after_slow_path(pc + sizeof(Op::DynamicTypeofBinding));
     }
 
     asm_update_environment_coordinate_cache(current_environment, reference, cache);
     auto value = ASM_TRY(*vm, pc, reference.get_value(*vm));
-    vm->set(instruction->dst(), value.typeof_(*vm));
+    values.dst = value.typeof_(*vm);
     return continue_after_slow_path(pc + sizeof(Op::DynamicTypeofBinding));
 }
 
@@ -2549,9 +2568,9 @@ static Optional<StringView> asm_function_name_prefix_to_string(Op::FunctionNameP
     VERIFY_NOT_REACHED();
 }
 
-i64 asm_slow_path_has_private_id(VM* vm, u32 pc, Op::HasPrivateId const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_has_private_id, HasPrivateId)
 {
-    auto base = vm->get(instruction->base());
+    auto base = values.base;
     if (!base.is_object()) [[unlikely]] {
         auto completion = vm->throw_completion<TypeError>(ErrorType::InOperatorWithObject);
         return handle_asm_exception(*vm, pc, completion.value());
@@ -2560,33 +2579,33 @@ i64 asm_slow_path_has_private_id(VM* vm, u32 pc, Op::HasPrivateId const* instruc
     auto private_environment = vm->running_execution_context().private_environment;
     VERIFY(private_environment);
     auto private_name = private_environment->resolve_private_identifier(vm->get_identifier(instruction->property()));
-    vm->set(instruction->dst(), Value(base.as_object().private_element_find(private_name) != nullptr));
+    values.dst = Value(base.as_object().private_element_find(private_name) != nullptr);
     return continue_after_slow_path(pc + sizeof(Op::HasPrivateId));
 }
 
-i64 asm_slow_path_set_function_name(VM* vm, u32 pc, Op::SetFunctionName const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_set_function_name, SetFunctionName)
 {
-    auto function = vm->get(instruction->function()).as_if<ECMAScriptFunctionObject>();
+    auto function = values.function.as_if<ECMAScriptFunctionObject>();
     if (!function || !function->name().is_empty())
         return continue_after_slow_path(pc + sizeof(Op::SetFunctionName));
 
-    auto property_key = ASM_TRY(*vm, pc, vm->get(instruction->name()).to_property_key(*vm));
+    auto property_key = ASM_TRY(*vm, pc, values.name.to_property_key(*vm));
     function->set_inferred_name(Variant<PropertyKey, PrivateName> { move(property_key) }, asm_function_name_prefix_to_string(instruction->prefix()));
     return continue_after_slow_path(pc + sizeof(Op::SetFunctionName));
 }
 
-i64 asm_slow_path_new_array_with_length(VM* vm, u32 pc, Op::NewArrayWithLength const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_array_with_length, NewArrayWithLength)
 {
-    auto length = static_cast<u64>(vm->get(instruction->array_length()).as_double());
+    auto length = static_cast<u64>(values.array_length.as_double());
     auto array = ASM_TRY(*vm, pc, JS::Array::create(vm->realm(), length));
-    vm->set(instruction->dst(), array);
+    values.dst = array;
     return continue_after_slow_path(pc + sizeof(Op::NewArrayWithLength));
 }
 
-i64 asm_slow_path_array_append(VM* vm, u32 pc, Op::ArrayAppend const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_array_append, ArrayAppend)
 {
-    auto rhs = vm->get(instruction->src());
-    auto& lhs_array = vm->get(instruction->dst()).as_array_exotic_object();
+    auto rhs = values.src;
+    auto& lhs_array = values.dst.as_array_exotic_object();
     auto lhs_size = lhs_array.indexed_array_like_size();
 
     if (instruction->is_spread()) {
@@ -2651,55 +2670,55 @@ i64 asm_slow_path_array_append(VM* vm, u32 pc, Op::ArrayAppend const* instructio
     return continue_after_slow_path(pc + sizeof(Op::ArrayAppend));
 }
 
-i64 asm_slow_path_create_variable(VM* vm, u32 pc, Op::CreateVariable const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_create_variable, CreateVariable)
 {
     auto const& name = vm->get_identifier(instruction->identifier());
     ASM_TRY(*vm, pc, asm_create_variable(*vm, name, instruction->mode(), instruction->is_global(), instruction->is_immutable(), instruction->is_strict()));
     return continue_after_slow_path(pc + sizeof(Op::CreateVariable));
 }
 
-i64 asm_slow_path_enter_object_environment(VM* vm, u32 pc, Op::EnterObjectEnvironment const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_enter_object_environment, EnterObjectEnvironment)
 {
-    auto object = ASM_TRY(*vm, pc, vm->get(instruction->object()).to_object(*vm));
+    auto object = ASM_TRY(*vm, pc, values.object.to_object(*vm));
     auto& old_environment = vm->running_execution_context().lexical_environment;
     auto new_environment = new_object_environment(*object, true, old_environment.ptr());
-    vm->set(instruction->dst(), new_environment);
+    values.dst = new_environment;
     vm->running_execution_context().lexical_environment = new_environment;
     return continue_after_slow_path(pc + sizeof(Op::EnterObjectEnvironment));
 }
 
-i64 asm_slow_path_bitwise_not(VM* vm, u32 pc, Op::BitwiseNot const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_bitwise_not, BitwiseNot)
 {
-    vm->set(instruction->dst(), ASM_TRY(*vm, pc, bitwise_not(*vm, vm->get(instruction->src()))));
+    values.dst = ASM_TRY(*vm, pc, bitwise_not(*vm, values.src));
     return continue_after_slow_path(pc + sizeof(Op::BitwiseNot));
 }
 
-i64 asm_slow_path_unary_plus(VM* vm, u32 pc, Op::UnaryPlus const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_unary_plus, UnaryPlus)
 {
-    vm->set(instruction->dst(), ASM_TRY(*vm, pc, unary_plus(*vm, vm->get(instruction->src()))));
+    values.dst = ASM_TRY(*vm, pc, unary_plus(*vm, values.src));
     return continue_after_slow_path(pc + sizeof(Op::UnaryPlus));
 }
 
-i64 asm_slow_path_is_constructor(VM* vm, u32 pc, Op::IsConstructor const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_is_constructor, IsConstructor)
 {
-    vm->set(instruction->dst(), Value(vm->get(instruction->value()).is_constructor()));
+    values.dst = Value(values.value.is_constructor());
     return continue_after_slow_path(pc + sizeof(Op::IsConstructor));
 }
 
-i64 asm_slow_path_add_private_name(VM* vm, u32 pc, Op::AddPrivateName const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_add_private_name, AddPrivateName)
 {
     auto const& name = vm->get_identifier(instruction->name());
     vm->running_execution_context().private_environment->add_private_name(name);
     return continue_after_slow_path(pc + sizeof(Op::AddPrivateName));
 }
 
-i64 asm_slow_path_create_async_from_sync_iterator(VM* vm, u32 pc, Op::CreateAsyncFromSyncIterator const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_create_async_from_sync_iterator, CreateAsyncFromSyncIterator)
 {
     auto& realm = vm->realm();
 
-    auto& iterator = vm->get(instruction->iterator()).as_object();
-    auto next_method = vm->get(instruction->next_method());
-    auto done = vm->get(instruction->done()).as_bool();
+    auto& iterator = values.iterator.as_object();
+    auto next_method = values.next_method;
+    auto done = values.done.as_bool();
 
     auto iterator_record = realm.create<IteratorRecord>(iterator, next_method, done);
     auto async_from_sync_iterator = create_async_from_sync_iterator(*vm, iterator_record);
@@ -2709,45 +2728,45 @@ i64 asm_slow_path_create_async_from_sync_iterator(VM* vm, u32 pc, Op::CreateAsyn
     iterator_object->define_direct_property(vm->names.nextMethod, async_from_sync_iterator.next_method, default_attributes);
     iterator_object->define_direct_property(vm->names.done, Value { async_from_sync_iterator.done }, default_attributes);
 
-    vm->set(instruction->dst(), iterator_object);
+    values.dst = iterator_object;
     return continue_after_slow_path(pc + sizeof(Op::CreateAsyncFromSyncIterator));
 }
 
-i64 asm_slow_path_create_data_property_or_throw(VM* vm, u32 pc, Op::CreateDataPropertyOrThrow const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_create_data_property_or_throw, CreateDataPropertyOrThrow)
 {
-    auto& object = vm->get(instruction->object()).as_object();
-    auto property = ASM_TRY(*vm, pc, vm->get(instruction->property()).to_property_key(*vm));
-    auto value = vm->get(instruction->value());
+    auto& object = values.object.as_object();
+    auto property = ASM_TRY(*vm, pc, values.property.to_property_key(*vm));
+    auto value = values.value;
     ASM_TRY(*vm, pc, object.create_data_property_or_throw(property, value));
     return continue_after_slow_path(pc + sizeof(Op::CreateDataPropertyOrThrow));
 }
 
-i64 asm_slow_path_create_immutable_binding(VM* vm, u32 pc, Op::CreateImmutableBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_create_immutable_binding, CreateImmutableBinding)
 {
-    auto& environment = as<Environment>(vm->get(instruction->environment()).as_cell());
+    auto& environment = as<Environment>(values.environment.as_cell());
     ASM_TRY(*vm, pc, environment.create_immutable_binding(*vm, vm->get_identifier(instruction->identifier()), instruction->strict_binding()));
     return continue_after_slow_path(pc + sizeof(Op::CreateImmutableBinding));
 }
 
-i64 asm_slow_path_create_mutable_binding(VM* vm, u32 pc, Op::CreateMutableBinding const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_create_mutable_binding, CreateMutableBinding)
 {
-    auto& environment = as<Environment>(vm->get(instruction->environment()).as_cell());
+    auto& environment = as<Environment>(values.environment.as_cell());
     ASM_TRY(*vm, pc, environment.create_mutable_binding(*vm, vm->get_identifier(instruction->identifier()), instruction->can_be_deleted()));
     return continue_after_slow_path(pc + sizeof(Op::CreateMutableBinding));
 }
 
-i64 asm_slow_path_create_rest_params(VM* vm, u32 pc, Op::CreateRestParams const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_create_rest_params, CreateRestParams)
 {
     auto const arguments = vm->running_execution_context().arguments_span();
     auto arguments_count = vm->running_execution_context().passed_argument_count;
     auto array = MUST(JS::Array::create(vm->realm(), 0));
     for (size_t rest_index = instruction->rest_index(); rest_index < arguments_count; ++rest_index)
         array->indexed_append(arguments[rest_index]);
-    vm->set(instruction->dst(), array);
+    values.dst = array;
     return continue_after_slow_path(pc + sizeof(Op::CreateRestParams));
 }
 
-i64 asm_slow_path_create_arguments(VM* vm, u32 pc, Op::CreateArguments const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_create_arguments, CreateArguments)
 {
     auto const& function = vm->running_execution_context().function;
     auto const arguments = vm->running_execution_context().arguments_span();
@@ -2763,7 +2782,7 @@ i64 asm_slow_path_create_arguments(VM* vm, u32 pc, Op::CreateArguments const* in
     }
 
     if (instruction->dst().has_value()) {
-        vm->set(*instruction->dst(), arguments_object);
+        values.dst = arguments_object;
         return continue_after_slow_path(pc + sizeof(Op::CreateArguments));
     }
 
@@ -2776,9 +2795,9 @@ i64 asm_slow_path_create_arguments(VM* vm, u32 pc, Op::CreateArguments const* in
     return continue_after_slow_path(pc + sizeof(Op::CreateArguments));
 }
 
-i64 asm_slow_path_await(VM* vm, [[maybe_unused]] u32 pc, Op::Await const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_await, Await)
 {
-    auto yielded_value = vm->get(instruction->argument()).is_special_empty_value() ? js_undefined() : vm->get(instruction->argument());
+    auto yielded_value = values.argument.is_special_empty_value() ? js_undefined() : values.argument;
     auto& context = vm->running_execution_context();
     context.yield_continuation = instruction->continuation_label().address();
     context.yield_is_await = true;
@@ -2787,18 +2806,18 @@ i64 asm_slow_path_await(VM* vm, [[maybe_unused]] u32 pc, Op::Await const* instru
     return -1;
 }
 
-i64 asm_slow_path_create_lexical_environment(VM* vm, u32 pc, Op::CreateLexicalEnvironment const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_create_lexical_environment, CreateLexicalEnvironment)
 {
-    auto& parent = as<Environment>(vm->get(instruction->parent()).as_cell());
+    auto& parent = as<Environment>(values.parent.as_cell());
     auto environment = new_declarative_environment(parent);
     environment->ensure_capacity(instruction->capacity());
     environment->set_is_catch_environment(instruction->is_catch_environment());
-    vm->set(instruction->dst(), environment);
+    values.dst = environment;
     vm->running_execution_context().lexical_environment = environment;
     return continue_after_slow_path(pc + sizeof(Op::CreateLexicalEnvironment));
 }
 
-i64 asm_slow_path_create_private_environment(VM* vm, u32 pc, Op::CreatePrivateEnvironment const*)
+DEFINE_SLOW_PATH(asm_slow_path_create_private_environment, CreatePrivateEnvironment)
 {
     auto& running_execution_context = vm->running_execution_context();
     auto outer_private_environment = running_execution_context.private_environment;
@@ -2806,7 +2825,7 @@ i64 asm_slow_path_create_private_environment(VM* vm, u32 pc, Op::CreatePrivateEn
     return continue_after_slow_path(pc + sizeof(Op::CreatePrivateEnvironment));
 }
 
-i64 asm_slow_path_create_variable_environment(VM* vm, u32 pc, Op::CreateVariableEnvironment const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_create_variable_environment, CreateVariableEnvironment)
 {
     auto& running_execution_context = vm->running_execution_context();
     auto var_environment = new_declarative_environment(*running_execution_context.lexical_environment);
@@ -2818,52 +2837,52 @@ i64 asm_slow_path_create_variable_environment(VM* vm, u32 pc, Op::CreateVariable
     return continue_after_slow_path(pc + sizeof(Op::CreateVariableEnvironment));
 }
 
-i64 asm_slow_path_delete_by_id(VM* vm, u32 pc, Op::DeleteById const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_delete_by_id, DeleteById)
 {
     auto const& property_key = vm->get_property_key(instruction->property());
-    auto reference = Reference { vm->get(instruction->base()), property_key, {}, instruction->strict() };
+    auto reference = Reference { values.base, property_key, {}, instruction->strict() };
     auto result = ASM_TRY(*vm, pc, reference.delete_(*vm));
-    vm->set(instruction->dst(), Value(result));
+    values.dst = Value(result);
     return continue_after_slow_path(pc + sizeof(Op::DeleteById));
 }
 
-i64 asm_slow_path_delete_by_value(VM* vm, u32 pc, Op::DeleteByValue const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_delete_by_value, DeleteByValue)
 {
-    auto property_key = ASM_TRY(*vm, pc, vm->get(instruction->property()).to_property_key(*vm));
-    auto reference = Reference { vm->get(instruction->base()), property_key, {}, instruction->strict() };
+    auto property_key = ASM_TRY(*vm, pc, values.property.to_property_key(*vm));
+    auto reference = Reference { values.base, property_key, {}, instruction->strict() };
     auto result = ASM_TRY(*vm, pc, reference.delete_(*vm));
-    vm->set(instruction->dst(), Value(result));
+    values.dst = Value(result);
     return continue_after_slow_path(pc + sizeof(Op::DeleteByValue));
 }
 
-i64 asm_slow_path_delete_variable(VM* vm, u32 pc, Op::DeleteVariable const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_delete_variable, DeleteVariable)
 {
     auto const& string = vm->get_identifier(instruction->identifier());
     auto reference = ASM_TRY(*vm, pc, vm->resolve_binding(string, instruction->strict()));
     auto result = ASM_TRY(*vm, pc, reference.delete_(*vm));
-    vm->set(instruction->dst(), Value(result));
+    values.dst = Value(result);
     return continue_after_slow_path(pc + sizeof(Op::DeleteVariable));
 }
 
-i64 asm_slow_path_get_completion_fields(VM* vm, u32 pc, Op::GetCompletionFields const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_completion_fields, GetCompletionFields)
 {
-    auto& completion_source = vm->get(instruction->completion()).as_object();
+    auto& completion_source = values.completion.as_object();
     if (is<GeneratorObject>(completion_source)) {
         auto const& generator = as<GeneratorObject>(completion_source);
-        vm->set(instruction->value_dst(), generator.pending_completion_value());
-        vm->set(instruction->type_dst(), Value(to_underlying(generator.pending_completion_type())));
+        values.value_dst = generator.pending_completion_value();
+        values.type_dst = Value(to_underlying(generator.pending_completion_type()));
         return continue_after_slow_path(pc + sizeof(Op::GetCompletionFields));
     }
 
     auto const& async_generator = as<AsyncGenerator>(completion_source);
-    vm->set(instruction->value_dst(), async_generator.pending_completion_value());
-    vm->set(instruction->type_dst(), Value(to_underlying(async_generator.pending_completion_type())));
+    values.value_dst = async_generator.pending_completion_value();
+    values.type_dst = Value(to_underlying(async_generator.pending_completion_type()));
     return continue_after_slow_path(pc + sizeof(Op::GetCompletionFields));
 }
 
-i64 asm_slow_path_set_completion_type(VM* vm, u32 pc, Op::SetCompletionType const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_set_completion_type, SetCompletionType)
 {
-    auto& completion_source = vm->get(instruction->completion()).as_object();
+    auto& completion_source = values.completion.as_object();
     if (is<GeneratorObject>(completion_source)) {
         as<GeneratorObject>(completion_source).set_pending_completion_type(instruction->completion_type());
         return continue_after_slow_path(pc + sizeof(Op::SetCompletionType));
@@ -2873,24 +2892,23 @@ i64 asm_slow_path_set_completion_type(VM* vm, u32 pc, Op::SetCompletionType cons
     return continue_after_slow_path(pc + sizeof(Op::SetCompletionType));
 }
 
-i64 asm_slow_path_get_template_object(VM* vm, u32 pc, Op::GetTemplateObject const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_template_object, GetTemplateObject)
 {
     auto& cache = *vm->current_executable().template_object_caches[instruction->cache()];
 
     if (cache.cached_template_object) {
-        vm->set(instruction->dst(), cache.cached_template_object);
+        values.dst = cache.cached_template_object;
         return continue_after_slow_path(pc + instruction->length());
     }
 
     auto& realm = *vm->current_realm();
-    auto strings = instruction->strings();
     u32 count = instruction->strings_count() / 2;
     auto template_object = MUST(JS::Array::create(realm, count));
     auto raw_object = MUST(JS::Array::create(realm, count));
 
     for (size_t index = 0; index < count; ++index) {
-        template_object->indexed_put(index, vm->get(strings[index]), Attribute::Enumerable);
-        raw_object->indexed_put(index, vm->get(strings[count + index]), Attribute::Enumerable);
+        template_object->indexed_put(index, values.strings[index], Attribute::Enumerable);
+        raw_object->indexed_put(index, values.strings[count + index], Attribute::Enumerable);
     }
 
     MUST(raw_object->set_integrity_level(Object::IntegrityLevel::Frozen));
@@ -2898,11 +2916,11 @@ i64 asm_slow_path_get_template_object(VM* vm, u32 pc, Op::GetTemplateObject cons
     MUST(template_object->set_integrity_level(Object::IntegrityLevel::Frozen));
 
     cache.cached_template_object = template_object;
-    vm->set(instruction->dst(), template_object);
+    values.dst = template_object;
     return continue_after_slow_path(pc + instruction->length());
 }
 
-i64 asm_slow_path_new_function(VM* vm, u32 pc, Op::NewFunction const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_new_function, NewFunction)
 {
     auto& shared_data = *vm->current_executable().shared_function_data[instruction->shared_function_data_index()];
     auto& realm = *vm->current_realm();
@@ -2929,22 +2947,22 @@ i64 asm_slow_path_new_function(VM* vm, u32 pc, Op::NewFunction const* instructio
         *prototype);
 
     if (instruction->home_object().has_value()) {
-        auto home_object_value = vm->get(instruction->home_object().value());
+        auto home_object_value = values.home_object;
         function->make_method(home_object_value.as_object());
     }
 
-    vm->set(instruction->dst(), function);
+    values.dst = function;
     return continue_after_slow_path(pc + sizeof(Op::NewFunction));
 }
 
-i64 asm_slow_path_throw(VM* vm, u32 pc, Op::Throw const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_throw, Throw)
 {
-    return handle_asm_exception(*vm, pc, vm->get(instruction->src()));
+    return handle_asm_exception(*vm, pc, values.src);
 }
 
-i64 asm_slow_path_throw_if_tdz(VM* vm, u32 pc, Op::ThrowIfTDZ const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_throw_if_tdz, ThrowIfTDZ)
 {
-    auto value = vm->get(instruction->src());
+    auto value = values.src;
     if (value.is_special_empty_value()) [[unlikely]] {
         auto completion = vm->throw_completion<ReferenceError>(ErrorType::BindingNotInitialized, value);
         return handle_asm_exception(*vm, pc, completion.value());
@@ -2952,9 +2970,9 @@ i64 asm_slow_path_throw_if_tdz(VM* vm, u32 pc, Op::ThrowIfTDZ const* instruction
     return continue_after_slow_path(pc + sizeof(Op::ThrowIfTDZ));
 }
 
-i64 asm_slow_path_throw_if_not_object(VM* vm, u32 pc, Op::ThrowIfNotObject const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_throw_if_not_object, ThrowIfNotObject)
 {
-    auto src = vm->get(instruction->src());
+    auto src = values.src;
     if (!src.is_object()) [[unlikely]] {
         auto completion = vm->throw_completion<TypeError>(ErrorType::NotAnObject, src);
         return handle_asm_exception(*vm, pc, completion.value());
@@ -2962,9 +2980,9 @@ i64 asm_slow_path_throw_if_not_object(VM* vm, u32 pc, Op::ThrowIfNotObject const
     return continue_after_slow_path(pc + sizeof(Op::ThrowIfNotObject));
 }
 
-i64 asm_slow_path_throw_if_nullish(VM* vm, u32 pc, Op::ThrowIfNullish const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_throw_if_nullish, ThrowIfNullish)
 {
-    auto value = vm->get(instruction->src());
+    auto value = values.src;
     if (value.is_nullish()) [[unlikely]] {
         auto completion = vm->throw_completion<TypeError>(ErrorType::NotObjectCoercible, value);
         return handle_asm_exception(*vm, pc, completion.value());
@@ -2972,13 +2990,13 @@ i64 asm_slow_path_throw_if_nullish(VM* vm, u32 pc, Op::ThrowIfNullish const* ins
     return continue_after_slow_path(pc + sizeof(Op::ThrowIfNullish));
 }
 
-i64 asm_slow_path_throw_const_assignment(VM* vm, u32 pc, Op::ThrowConstAssignment const*)
+DEFINE_SLOW_PATH(asm_slow_path_throw_const_assignment, ThrowConstAssignment)
 {
     auto completion = vm->throw_completion<TypeError>(ErrorType::InvalidAssignToConst);
     return handle_asm_exception(*vm, pc, completion.value());
 }
 
-i64 asm_slow_path_debugger(VM* vm, u32 pc, Op::Debugger const*)
+DEFINE_SLOW_PATH(asm_slow_path_debugger, Debugger)
 {
     // NB: Don't pause twice if the debugger trampoline already paused before this instruction.
     if (auto* debugger = vm->debugger(); debugger && !debugger->did_pause_before_current_instruction())
@@ -2986,9 +3004,9 @@ i64 asm_slow_path_debugger(VM* vm, u32 pc, Op::Debugger const*)
     return continue_after_slow_path(pc + sizeof(Op::Debugger));
 }
 
-i64 asm_slow_path_yield(VM* vm, [[maybe_unused]] u32 pc, Op::Yield const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_yield, Yield)
 {
-    auto yielded_value = vm->get(instruction->value()).is_special_empty_value() ? js_undefined() : vm->get(instruction->value());
+    auto yielded_value = values.value.is_special_empty_value() ? js_undefined() : values.value;
     auto& context = vm->running_execution_context();
     if (instruction->continuation_label().has_value())
         context.yield_continuation = instruction->continuation_label()->address();
@@ -3000,9 +3018,9 @@ i64 asm_slow_path_yield(VM* vm, [[maybe_unused]] u32 pc, Op::Yield const* instru
     return -1;
 }
 
-i64 asm_slow_path_yield_iterator_result(VM* vm, [[maybe_unused]] u32 pc, Op::YieldIteratorResult const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_yield_iterator_result, YieldIteratorResult)
 {
-    auto yielded_value = vm->get(instruction->value()).is_special_empty_value() ? js_undefined() : vm->get(instruction->value());
+    auto yielded_value = values.value.is_special_empty_value() ? js_undefined() : values.value;
     auto& context = vm->running_execution_context();
     context.yield_continuation = instruction->continuation_label().address();
     context.yield_is_await = false;
@@ -3013,14 +3031,13 @@ i64 asm_slow_path_yield_iterator_result(VM* vm, [[maybe_unused]] u32 pc, Op::Yie
 
 // Fast path for GetByValue on typed arrays.
 // Returns 0 on success (result stored in dst), 1 on miss (fall to slow path).
-i64 asm_try_get_by_value_typed_array(VM* vm, u32, Op::GetByValue const* instruction)
+i64 asm_try_get_by_value_typed_array(VM*, u32, Op::GetByValue const*, Op::GetByValue::Values& values)
 {
-
-    auto base = vm->get(instruction->base());
+    auto base = values.base;
     if (!base.is_object()) [[unlikely]]
         return 1;
 
-    auto property = vm->get(instruction->property());
+    auto property = values.property;
     if (!property.is_non_negative_int32()) [[unlikely]]
         return 1;
 
@@ -3038,12 +3055,12 @@ i64 asm_try_get_by_value_typed_array(VM* vm, u32, Op::GetByValue const* instruct
 
     auto length = array_length.length();
     if (index >= length) [[unlikely]] {
-        vm->set(instruction->dst(), js_undefined());
+        values.dst = js_undefined();
         return 0;
     }
 
     if (!is_valid_integer_index(typed_array, CanonicalIndex { CanonicalIndex::Type::Index, index })) [[unlikely]] {
-        vm->set(instruction->dst(), js_undefined());
+        values.dst = js_undefined();
         return 0;
     }
 
@@ -3085,20 +3102,19 @@ i64 asm_try_get_by_value_typed_array(VM* vm, u32, Op::GetByValue const* instruct
         return 1;
     }
 
-    vm->set(instruction->dst(), result);
+    values.dst = result;
     return 0;
 }
 
 // Fast path for PutByValue on typed arrays.
 // Returns 0 on success, 1 on miss (fall to slow path).
-i64 asm_try_put_by_value_typed_array(VM* vm, u32, Op::PutByValue const* instruction)
+i64 asm_try_put_by_value_typed_array(VM*, u32, Op::PutByValue const*, Op::PutByValue::Values& values)
 {
-
-    auto base = vm->get(instruction->base());
+    auto base = values.base;
     if (!base.is_object()) [[unlikely]]
         return 1;
 
-    auto property = vm->get(instruction->property());
+    auto property = values.property;
     if (!property.is_non_negative_int32()) [[unlikely]]
         return 1;
 
@@ -3128,7 +3144,7 @@ i64 asm_try_put_by_value_typed_array(VM* vm, u32, Op::PutByValue const* instruct
     byte_index += typed_array.byte_offset();
     if (byte_index.has_overflow()) [[unlikely]]
         return 1;
-    auto value = vm->get(instruction->src());
+    auto value = values.src;
 
     if (value.is_int32()) {
         auto int_val = value.as_i32();
@@ -3174,21 +3190,21 @@ i64 asm_try_put_by_value_typed_array(VM* vm, u32, Op::PutByValue const* instruct
     return 1;
 }
 
-i64 asm_slow_path_instance_of(VM* vm, u32 pc, Op::InstanceOf const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_instance_of, InstanceOf)
 {
-    auto result = ASM_TRY(*vm, pc, instance_of(*vm, vm->get(instruction->lhs()), vm->get(instruction->rhs())));
-    vm->set(instruction->dst(), result);
+    auto result = ASM_TRY(*vm, pc, instance_of(*vm, values.lhs, values.rhs));
+    values.dst = result;
     return continue_after_slow_path(pc + sizeof(Op::InstanceOf));
 }
 
-i64 asm_slow_path_in(VM* vm, u32 pc, Op::In const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_in, In)
 {
-    auto result = ASM_TRY(*vm, pc, in(*vm, vm->get(instruction->lhs()), vm->get(instruction->rhs())));
-    vm->set(instruction->dst(), result);
+    auto result = ASM_TRY(*vm, pc, in(*vm, values.lhs, values.rhs));
+    values.dst = result;
     return continue_after_slow_path(pc + sizeof(Op::In));
 }
 
-i64 asm_slow_path_resolve_this_binding(VM* vm, u32 pc, Op::ResolveThisBinding const*)
+DEFINE_SLOW_PATH(asm_slow_path_resolve_this_binding, ResolveThisBinding)
 {
     auto& cached_this_value = vm->reg(Register::this_value());
     if (!cached_this_value.is_special_empty_value())
@@ -3207,9 +3223,9 @@ i64 asm_slow_path_resolve_this_binding(VM* vm, u32 pc, Op::ResolveThisBinding co
 }
 
 // Direct handler for GetPrivateById: bypasses Reference indirection.
-i64 asm_slow_path_get_private_by_id(VM* vm, u32 pc, Op::GetPrivateById const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_get_private_by_id, GetPrivateById)
 {
-    auto base_value = vm->get(instruction->base());
+    auto base_value = values.base;
     auto& current_vm = *vm;
 
     if (!base_value.is_object()) [[unlikely]] {
@@ -3217,7 +3233,7 @@ i64 asm_slow_path_get_private_by_id(VM* vm, u32 pc, Op::GetPrivateById const* in
         auto const& name = current_vm.get_identifier(instruction->property());
         auto private_name = make_private_reference(current_vm, base_value, name);
         auto result = ASM_TRY(*vm, pc, private_name.get_value(current_vm));
-        vm->set(instruction->dst(), result);
+        values.dst = result;
         return continue_after_slow_path(pc + sizeof(Op::GetPrivateById));
     }
 
@@ -3226,16 +3242,16 @@ i64 asm_slow_path_get_private_by_id(VM* vm, u32 pc, Op::GetPrivateById const* in
     VERIFY(private_environment);
     auto private_name = private_environment->resolve_private_identifier(name);
     auto result = ASM_TRY(*vm, pc, base_value.as_object().private_get(private_name));
-    vm->set(instruction->dst(), result);
+    values.dst = result;
     return continue_after_slow_path(pc + sizeof(Op::GetPrivateById));
 }
 
 // Direct handler for PutPrivateById: bypasses Reference indirection.
-i64 asm_slow_path_put_private_by_id(VM* vm, u32 pc, Op::PutPrivateById const* instruction)
+DEFINE_SLOW_PATH(asm_slow_path_put_private_by_id, PutPrivateById)
 {
-    auto base_value = vm->get(instruction->base());
+    auto base_value = values.base;
     auto& current_vm = *vm;
-    auto value = vm->get(instruction->src());
+    auto value = values.src;
 
     if (!base_value.is_object()) [[unlikely]] {
         auto object = ASM_TRY(*vm, pc, base_value.to_object(current_vm));

--- a/Libraries/LibJS/Interpreter/SlowPaths.cpp
+++ b/Libraries/LibJS/Interpreter/SlowPaths.cpp
@@ -13,6 +13,7 @@
 #include <LibJS/Bytecode/PropertyAccess.h>
 #include <LibJS/Bytecode/PropertyNameIterator.h>
 #include <LibJS/Debugger.h>
+#include <LibJS/Interpreter/SlowPathResult.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/AsyncFromSyncIteratorPrototype.h>
@@ -44,7 +45,7 @@
 // ===== Slow path functions callable from assembly =====
 // All slow path functions follow the same convention:
 //   i64 func(VM* vm, u32 pc, Op::Foo const* instruction)
-//   Returns >= 0: new program counter to dispatch to
+//   Returns >= 0: new PC in the low word; bit 32 marks normal same-frame continuation
 //   Returns < 0: should exit the interpreter
 
 using namespace JS;
@@ -74,7 +75,7 @@ static i64 advance_or_continue(u32 pc, i64 next_pc)
 {
     if (next_pc != static_cast<i64>(pc))
         return next_pc;
-    return static_cast<i64>(pc + sizeof(Op));
+    return continue_after_slow_path(pc + sizeof(Op));
 }
 
 template<typename EnvironmentPointer>
@@ -551,7 +552,7 @@ static i64 finish_binary_slow_path_value(VM& vm, u32 pc, Operand destination, Va
 {
     vm.set(destination, result);
     auto const* instruction = bit_cast<Instruction const*>(vm.current_executable().bytecode.data() + pc);
-    return static_cast<i64>(pc + instruction->length());
+    return continue_after_slow_path(pc + instruction->length());
 }
 
 template<typename Result>
@@ -775,7 +776,7 @@ i64 asm_fallback_handler(VM*, u32, u8 const*)
 // ===== Specific slow paths for asm-optimized instructions =====
 // These are called from asm handlers when the fast path fails.
 // Convention: i64 func(VM*, u32 pc, Op::Foo const* instruction)
-//   Returns >= 0: new pc
+//   Returns >= 0: new PC, optionally marked by continue_after_slow_path()
 //   Returns < 0: exit
 
 i64 asm_slow_path_add_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
@@ -855,7 +856,7 @@ i64 asm_slow_path_increment(VM* vm, u32 pc, Op::Increment const* instruction)
         vm->set(instruction->dst(), Value(old_value.as_double() + 1));
     else
         vm->set(instruction->dst(), BigInt::create(*vm, old_value.as_bigint().big_integer().plus(Crypto::SignedBigInteger { 1 })));
-    return static_cast<i64>(pc + sizeof(Op::Increment));
+    return continue_after_slow_path(pc + sizeof(Op::Increment));
 }
 
 i64 asm_slow_path_decrement(VM* vm, u32 pc, Op::Decrement const* instruction)
@@ -865,7 +866,7 @@ i64 asm_slow_path_decrement(VM* vm, u32 pc, Op::Decrement const* instruction)
         vm->set(instruction->dst(), Value(old_value.as_double() - 1));
     else
         vm->set(instruction->dst(), BigInt::create(*vm, old_value.as_bigint().big_integer().minus(Crypto::SignedBigInteger { 1 })));
-    return static_cast<i64>(pc + sizeof(Op::Decrement));
+    return continue_after_slow_path(pc + sizeof(Op::Decrement));
 }
 
 // Comparison jump slow paths return one of two target PCs.
@@ -944,7 +945,7 @@ i64 asm_slow_path_get_callee_and_this(VM* vm, u32 pc, Op::GetCalleeAndThisFromEn
     if (auto base_object = environment->with_base_object()) [[unlikely]]
         this_value = base_object;
     vm->set(instruction->this_value(), this_value);
-    return static_cast<i64>(pc + sizeof(Op::GetCalleeAndThisFromEnvironment));
+    return continue_after_slow_path(pc + sizeof(Op::GetCalleeAndThisFromEnvironment));
 }
 
 i64 asm_slow_path_dynamic_get_callee_and_this(VM* vm, u32 pc, Op::DynamicGetCalleeAndThisFromEnvironment const* instruction)
@@ -962,7 +963,7 @@ i64 asm_slow_path_postfix_increment(VM* vm, u32 pc, Op::PostfixIncrement const* 
         vm->set(instruction->src(), Value(old_value.as_double() + 1));
     else
         vm->set(instruction->src(), BigInt::create(*vm, old_value.as_bigint().big_integer().plus(Crypto::SignedBigInteger { 1 })));
-    return static_cast<i64>(pc + sizeof(Op::PostfixIncrement));
+    return continue_after_slow_path(pc + sizeof(Op::PostfixIncrement));
 }
 
 i64 asm_slow_path_get_by_id(VM* vm, u32 pc, Op::GetById const* instruction)
@@ -971,7 +972,7 @@ i64 asm_slow_path_get_by_id(VM* vm, u32 pc, Op::GetById const* instruction)
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
     auto value = ASM_TRY(*vm, pc, get_by_id<GetByIdMode::Normal>(*vm, [&] { return vm->get_identifier(instruction->base_identifier()); }, [&] -> PropertyKey const& { return vm->get_property_key(instruction->property()); }, base_value, base_value, cache, CachePropertyAbsence::Yes));
     vm->set(instruction->dst(), value);
-    return static_cast<i64>(pc + sizeof(Op::GetById));
+    return continue_after_slow_path(pc + sizeof(Op::GetById));
 }
 
 i64 asm_slow_path_get_by_id_cached_accessor(VM* vm, u32 pc, Op::GetById const* instruction)
@@ -995,7 +996,7 @@ i64 asm_slow_path_get_by_id_cached_accessor(VM* vm, u32 pc, Op::GetById const* i
         }
     }
     vm->set(instruction->dst(), result);
-    return static_cast<i64>(pc + sizeof(Op::GetById));
+    return continue_after_slow_path(pc + sizeof(Op::GetById));
 }
 
 i64 asm_slow_path_get_by_id_with_this(VM* vm, u32 pc, Op::GetByIdWithThis const* instruction)
@@ -1005,7 +1006,7 @@ i64 asm_slow_path_get_by_id_with_this(VM* vm, u32 pc, Op::GetByIdWithThis const*
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
     auto value = ASM_TRY(*vm, pc, get_by_id<GetByIdMode::Normal>(*vm, [] { return Optional<Utf16FlyString const&> {}; }, [&] -> PropertyKey const& { return vm->get_property_key(instruction->property()); }, base_value, this_value, cache));
     vm->set(instruction->dst(), value);
-    return static_cast<i64>(pc + sizeof(Op::GetByIdWithThis));
+    return continue_after_slow_path(pc + sizeof(Op::GetByIdWithThis));
 }
 
 i64 asm_slow_path_put_by_id(VM* vm, u32 pc, Op::PutById const* instruction)
@@ -1018,7 +1019,7 @@ i64 asm_slow_path_put_by_id(VM* vm, u32 pc, Op::PutById const* instruction)
     auto const& property_key = vm->get_property_key(instruction->property());
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
     ASM_TRY(*vm, pc, put_by_property_key(*vm, base, base, value, base_identifier, property_key, instruction->kind(), instruction->strict(), &cache));
-    return static_cast<i64>(pc + sizeof(Op::PutById));
+    return continue_after_slow_path(pc + sizeof(Op::PutById));
 }
 
 i64 asm_slow_path_put_by_id_with_this(VM* vm, u32 pc, Op::PutByIdWithThis const* instruction)
@@ -1028,7 +1029,7 @@ i64 asm_slow_path_put_by_id_with_this(VM* vm, u32 pc, Op::PutByIdWithThis const*
     auto const& name = vm->get_property_key(instruction->property());
     auto& cache = vm->current_executable().property_lookup_caches[instruction->cache()];
     ASM_TRY(*vm, pc, put_by_property_key(*vm, base, vm->get(instruction->this_value()), value, {}, name, instruction->kind(), instruction->strict(), &cache));
-    return static_cast<i64>(pc + sizeof(Op::PutByIdWithThis));
+    return continue_after_slow_path(pc + sizeof(Op::PutByIdWithThis));
 }
 
 i64 asm_slow_path_get_by_value(VM* vm, u32 pc, Op::GetByValue const* instruction)
@@ -1044,11 +1045,11 @@ i64 asm_slow_path_get_by_value(VM* vm, u32 pc, Op::GetByValue const* instruction
         auto string_value = ASM_TRY(*vm, pc, base_value.as_string().get(*vm, property_key));
         if (string_value.has_value()) {
             vm->set(instruction->dst(), *string_value);
-            return static_cast<i64>(pc + sizeof(Op::GetByValue));
+            return continue_after_slow_path(pc + sizeof(Op::GetByValue));
         }
     }
     vm->set(instruction->dst(), ASM_TRY(*vm, pc, get_by_value_with_keyed_cache(*vm, *object, base_value, property_key)));
-    return static_cast<i64>(pc + sizeof(Op::GetByValue));
+    return continue_after_slow_path(pc + sizeof(Op::GetByValue));
 }
 
 i64 asm_slow_path_get_by_value_with_this(VM* vm, u32 pc, Op::GetByValueWithThis const* instruction)
@@ -1058,7 +1059,7 @@ i64 asm_slow_path_get_by_value_with_this(VM* vm, u32 pc, Op::GetByValueWithThis 
     auto property_key = ASM_TRY(*vm, pc, property_key_value.to_property_key(*vm));
     auto value = ASM_TRY(*vm, pc, get_by_value_with_keyed_cache(*vm, *object, vm->get(instruction->this_value()), property_key));
     vm->set(instruction->dst(), value);
-    return static_cast<i64>(pc + sizeof(Op::GetByValueWithThis));
+    return continue_after_slow_path(pc + sizeof(Op::GetByValueWithThis));
 }
 
 i64 asm_slow_path_get_length(VM* vm, u32 pc, Op::GetLength const* instruction)
@@ -1068,7 +1069,7 @@ i64 asm_slow_path_get_length(VM* vm, u32 pc, Op::GetLength const* instruction)
     auto& cache = executable.property_lookup_caches[instruction->cache()];
     auto value = ASM_TRY(*vm, pc, get_by_id<GetByIdMode::Length>(*vm, [&] { return vm->get_identifier(instruction->base_identifier()); }, [&] -> PropertyKey const& { return executable.get_property_key(*executable.length_identifier); }, base_value, base_value, cache));
     vm->set(instruction->dst(), value);
-    return static_cast<i64>(pc + sizeof(Op::GetLength));
+    return continue_after_slow_path(pc + sizeof(Op::GetLength));
 }
 
 i64 asm_slow_path_get_length_with_this(VM* vm, u32 pc, Op::GetLengthWithThis const* instruction)
@@ -1079,7 +1080,7 @@ i64 asm_slow_path_get_length_with_this(VM* vm, u32 pc, Op::GetLengthWithThis con
     auto& cache = executable.property_lookup_caches[instruction->cache()];
     auto value = ASM_TRY(*vm, pc, get_by_id<GetByIdMode::Length>(*vm, [] { return Optional<Utf16FlyString const&> {}; }, [&] -> PropertyKey const& { return executable.get_property_key(*executable.length_identifier); }, base_value, this_value, cache));
     vm->set(instruction->dst(), value);
-    return static_cast<i64>(pc + sizeof(Op::GetLengthWithThis));
+    return continue_after_slow_path(pc + sizeof(Op::GetLengthWithThis));
 }
 
 i64 asm_slow_path_get_method(VM* vm, u32 pc, Op::GetMethod const* instruction)
@@ -1087,7 +1088,7 @@ i64 asm_slow_path_get_method(VM* vm, u32 pc, Op::GetMethod const* instruction)
     auto const& property_key = vm->get_property_key(instruction->property());
     auto method = ASM_TRY(*vm, pc, vm->get(instruction->object()).get_method(*vm, property_key));
     vm->set(instruction->dst(), method ?: js_undefined());
-    return static_cast<i64>(pc + sizeof(Op::GetMethod));
+    return continue_after_slow_path(pc + sizeof(Op::GetMethod));
 }
 
 i64 asm_slow_path_get_iterator(VM* vm, u32 pc, Op::GetIterator const* instruction)
@@ -1096,26 +1097,26 @@ i64 asm_slow_path_get_iterator(VM* vm, u32 pc, Op::GetIterator const* instructio
     vm->set(instruction->dst_iterator_object(), iterator_record.iterator);
     vm->set(instruction->dst_iterator_next(), iterator_record.next_method);
     vm->set(instruction->dst_iterator_done(), Value(iterator_record.done));
-    return static_cast<i64>(pc + sizeof(Op::GetIterator));
+    return continue_after_slow_path(pc + sizeof(Op::GetIterator));
 }
 
 i64 asm_slow_path_get_import_meta(VM* vm, u32 pc, Op::GetImportMeta const* instruction)
 {
     vm->set(instruction->dst(), vm->get_import_meta());
-    return static_cast<i64>(pc + sizeof(Op::GetImportMeta));
+    return continue_after_slow_path(pc + sizeof(Op::GetImportMeta));
 }
 
 i64 asm_slow_path_get_new_target(VM* vm, u32 pc, Op::GetNewTarget const* instruction)
 {
     vm->set(instruction->dst(), vm->get_new_target());
-    return static_cast<i64>(pc + sizeof(Op::GetNewTarget));
+    return continue_after_slow_path(pc + sizeof(Op::GetNewTarget));
 }
 
 i64 asm_slow_path_get_super_constructor(VM* vm, u32 pc, Op::GetSuperConstructor const* instruction)
 {
     auto* super_constructor = get_super_constructor(*vm);
     vm->set(instruction->dst(), super_constructor ? Value(super_constructor) : js_null());
-    return static_cast<i64>(pc + sizeof(Op::GetSuperConstructor));
+    return continue_after_slow_path(pc + sizeof(Op::GetSuperConstructor));
 }
 
 i64 asm_try_get_global_env_binding(VM* vm, u32, Op::GetGlobal const* instruction)
@@ -1154,7 +1155,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
         if (entry && &shape == entry->shape.ptr() && (!shape.is_dictionary() || shape.dictionary_generation() == entry->shape_dictionary_generation)) {
             auto value = binding_object.get_direct(entry->property_offset);
             vm->set(instruction->dst(), ASM_TRY(*vm, pc, get_cached_property_value(*vm, value, &binding_object)));
-            return static_cast<i64>(pc + sizeof(Op::GetGlobal));
+            return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
         }
 
         if (cache.has_environment_binding_index) {
@@ -1166,7 +1167,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
                 value = ASM_TRY(*vm, pc, declarative_record.get_binding_value_direct(*vm, cache.environment_binding_index));
             }
             vm->set(instruction->dst(), value);
-            return static_cast<i64>(pc + sizeof(Op::GetGlobal));
+            return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
         }
     }
 
@@ -1184,10 +1185,10 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
                 cache.has_environment_binding_index = true;
                 cache.in_module_environment = true;
                 vm->set(instruction->dst(), ASM_TRY(*vm, pc, module_environment.get_binding_value_direct(*vm, index.value())));
-                return static_cast<i64>(pc + sizeof(Op::GetGlobal));
+                return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
             }
             vm->set(instruction->dst(), ASM_TRY(*vm, pc, module_environment.get_binding_value(*vm, identifier, true)));
-            return static_cast<i64>(pc + sizeof(Op::GetGlobal));
+            return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
         }
     }
 
@@ -1197,7 +1198,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
         cache.has_environment_binding_index = true;
         cache.in_module_environment = false;
         vm->set(instruction->dst(), ASM_TRY(*vm, pc, declarative_record.get_binding_value(*vm, identifier, instruction->strict() == Strict::Yes)));
-        return static_cast<i64>(pc + sizeof(Op::GetGlobal));
+        return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
     }
 
     if (ASM_TRY(*vm, pc, binding_object.has_property(identifier))) [[likely]] {
@@ -1215,7 +1216,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
             });
         }
         vm->set(instruction->dst(), value);
-        return static_cast<i64>(pc + sizeof(Op::GetGlobal));
+        return continue_after_slow_path(pc + sizeof(Op::GetGlobal));
     }
 
     auto completion = vm->throw_completion<ReferenceError>(ErrorType::UnknownIdentifier, identifier);
@@ -1262,7 +1263,7 @@ i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
                 ASM_TRY(*vm, pc, call(*vm, value.as_accessor().setter(), &binding_object, src));
             else
                 binding_object.put_direct(entry->property_offset, src);
-            return static_cast<i64>(pc + sizeof(Op::SetGlobal));
+            return continue_after_slow_path(pc + sizeof(Op::SetGlobal));
         }
 
         if (cache.has_environment_binding_index) {
@@ -1272,7 +1273,7 @@ i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
             } else {
                 ASM_TRY(*vm, pc, declarative_record.set_mutable_binding_direct(*vm, cache.environment_binding_index, src, instruction->strict() == Strict::Yes));
             }
-            return static_cast<i64>(pc + sizeof(Op::SetGlobal));
+            return continue_after_slow_path(pc + sizeof(Op::SetGlobal));
         }
     }
 
@@ -1290,10 +1291,10 @@ i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
                 cache.has_environment_binding_index = true;
                 cache.in_module_environment = true;
                 ASM_TRY(*vm, pc, module_environment.set_mutable_binding_direct(*vm, index.value(), src, instruction->strict() == Strict::Yes));
-                return static_cast<i64>(pc + sizeof(Op::SetGlobal));
+                return continue_after_slow_path(pc + sizeof(Op::SetGlobal));
             }
             ASM_TRY(*vm, pc, module_environment.set_mutable_binding(*vm, identifier, src, instruction->strict() == Strict::Yes));
-            return static_cast<i64>(pc + sizeof(Op::SetGlobal));
+            return continue_after_slow_path(pc + sizeof(Op::SetGlobal));
         }
     }
 
@@ -1303,7 +1304,7 @@ i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
         cache.has_environment_binding_index = true;
         cache.in_module_environment = false;
         ASM_TRY(*vm, pc, declarative_record.set_mutable_binding(*vm, identifier, src, instruction->strict() == Strict::Yes));
-        return static_cast<i64>(pc + sizeof(Op::SetGlobal));
+        return continue_after_slow_path(pc + sizeof(Op::SetGlobal));
     }
 
     if (ASM_TRY(*vm, pc, binding_object.has_property(identifier))) {
@@ -1332,19 +1333,19 @@ i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
                     entry.shape_dictionary_generation = shape.dictionary_generation();
             });
         }
-        return static_cast<i64>(pc + sizeof(Op::SetGlobal));
+        return continue_after_slow_path(pc + sizeof(Op::SetGlobal));
     }
 
     auto reference = ASM_TRY(*vm, pc, vm->resolve_binding(identifier, instruction->strict(), &declarative_record));
     ASM_TRY(*vm, pc, reference.put_value(*vm, src));
-    return static_cast<i64>(pc + sizeof(Op::SetGlobal));
+    return continue_after_slow_path(pc + sizeof(Op::SetGlobal));
 }
 
 i64 asm_slow_path_concat_string(VM* vm, u32 pc, Op::ConcatString const* instruction)
 {
     auto string = ASM_TRY(*vm, pc, vm->get(instruction->src()).to_primitive_string(*vm));
     vm->set(instruction->dst(), PrimitiveString::create(*vm, vm->get(instruction->dst()).as_string(), string));
-    return static_cast<i64>(pc + sizeof(Op::ConcatString));
+    return continue_after_slow_path(pc + sizeof(Op::ConcatString));
 }
 
 i64 asm_slow_path_copy_object_excluding_properties(VM* vm, u32 pc, Op::CopyObjectExcludingProperties const* instruction)
@@ -1360,7 +1361,7 @@ i64 asm_slow_path_copy_object_excluding_properties(VM* vm, u32 pc, Op::CopyObjec
 
     ASM_TRY(*vm, pc, to_object->copy_data_properties(*vm, from_object, excluded_names));
     vm->set(instruction->dst(), to_object);
-    return static_cast<i64>(pc + instruction->length());
+    return continue_after_slow_path(pc + instruction->length());
 }
 
 i64 asm_slow_path_exp_values(VM* vm, u32 pc, Operand destination, Value lhs, Value rhs)
@@ -1373,7 +1374,7 @@ i64 asm_slow_path_import_call(VM* vm, u32 pc, Op::ImportCall const* instruction)
     auto specifier = vm->get(instruction->specifier());
     auto options_value = vm->get(instruction->options());
     vm->set(instruction->dst(), ASM_TRY(*vm, pc, perform_import_call(*vm, specifier, options_value)));
-    return static_cast<i64>(pc + sizeof(Op::ImportCall));
+    return continue_after_slow_path(pc + sizeof(Op::ImportCall));
 }
 
 i64 asm_slow_path_new_class(VM* vm, u32 pc, Op::NewClass const* instruction)
@@ -1408,7 +1409,7 @@ i64 asm_slow_path_new_class(VM* vm, u32 pc, Op::NewClass const* instruction)
 
     auto retval = ASM_TRY(*vm, pc, construct_class(*vm, blueprint, vm->current_executable(), class_environment, outer_environment, super_class, element_keys, binding_name, class_name));
     vm->set(instruction->dst(), retval);
-    return static_cast<i64>(pc + instruction->length());
+    return continue_after_slow_path(pc + instruction->length());
 }
 
 static COLD Completion throw_type_error_for_asm_callee(VM& vm, Value callee, StringView callee_type, Optional<StringTableIndex> const expression_string)
@@ -1487,7 +1488,7 @@ NEVER_INLINE static ThrowCompletionOr<void> execute_asm_call(
 i64 asm_slow_path_call(VM* vm, u32 pc, Op::Call const* instruction)
 {
     ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), instruction->arguments(), instruction->dst(), instruction->expression_string(), instruction->strict()));
-    return static_cast<i64>(pc + instruction->length());
+    return continue_after_slow_path(pc + instruction->length());
 }
 
 static ThrowCompletionOr<void> call_direct_eval(
@@ -1538,7 +1539,7 @@ static ThrowCompletionOr<void> call_direct_eval(
 i64 asm_slow_path_call_direct_eval(VM* vm, u32 pc, Op::CallDirectEval const* instruction)
 {
     ASM_TRY(*vm, pc, call_direct_eval(*vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), instruction->arguments(), instruction->dst(), instruction->expression_string(), instruction->strict()));
-    return static_cast<i64>(pc + instruction->length());
+    return continue_after_slow_path(pc + instruction->length());
 }
 
 static ThrowCompletionOr<void> call_with_argument_array(
@@ -1603,20 +1604,20 @@ static ThrowCompletionOr<void> call_with_argument_array(
 i64 asm_slow_path_call_with_argument_array(VM* vm, u32 pc, Op::CallWithArgumentArray const* instruction)
 {
     ASM_TRY(*vm, pc, call_with_argument_array(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), vm->get(instruction->arguments()), instruction->dst(), instruction->expression_string(), instruction->strict()));
-    return static_cast<i64>(pc + sizeof(Op::CallWithArgumentArray));
+    return continue_after_slow_path(pc + sizeof(Op::CallWithArgumentArray));
 }
 
 i64 asm_slow_path_call_direct_eval_with_argument_array(VM* vm, u32 pc, Op::CallDirectEvalWithArgumentArray const* instruction)
 {
     ASM_TRY(*vm, pc, call_with_argument_array(Op::CallType::DirectEval, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), vm->get(instruction->arguments()), instruction->dst(), instruction->expression_string(), instruction->strict()));
-    return static_cast<i64>(pc + sizeof(Op::CallDirectEvalWithArgumentArray));
+    return continue_after_slow_path(pc + sizeof(Op::CallDirectEvalWithArgumentArray));
 }
 
 i64 asm_slow_path_get_object_property_iterator(VM* vm, u32 pc, Op::GetObjectPropertyIterator const* instruction)
 {
     auto* cache = &vm->current_executable().object_property_iterator_caches[instruction->cache()];
     vm->set(instruction->dst_iterator(), ASM_TRY(*vm, pc, asm_get_object_property_iterator(*vm, vm->get(instruction->object()), cache)));
-    return static_cast<i64>(pc + sizeof(Op::GetObjectPropertyIterator));
+    return continue_after_slow_path(pc + sizeof(Op::GetObjectPropertyIterator));
 }
 
 i64 asm_slow_path_object_property_iterator_next(VM* vm, u32 pc, Op::ObjectPropertyIteratorNext const* instruction)
@@ -1628,7 +1629,7 @@ i64 asm_slow_path_object_property_iterator_next(VM* vm, u32 pc, Op::ObjectProper
     vm->set(instruction->dst_done(), Value(done));
     if (!done)
         vm->set(instruction->dst_value(), value);
-    return static_cast<i64>(pc + sizeof(Op::ObjectPropertyIteratorNext));
+    return continue_after_slow_path(pc + sizeof(Op::ObjectPropertyIteratorNext));
 }
 
 i64 asm_slow_path_iterator_close(VM* vm, u32 pc, Op::IteratorClose const* instruction)
@@ -1639,7 +1640,7 @@ i64 asm_slow_path_iterator_close(VM* vm, u32 pc, Op::IteratorClose const* instru
     IteratorRecordImpl iterator_record { .done = iterator_done_property, .iterator = iterator_object, .next_method = iterator_next_method };
 
     ASM_TRY(*vm, pc, iterator_close(*vm, iterator_record, Completion { instruction->completion_type(), vm->get(instruction->completion_value()) }));
-    return static_cast<i64>(pc + sizeof(Op::IteratorClose));
+    return continue_after_slow_path(pc + sizeof(Op::IteratorClose));
 }
 
 i64 asm_slow_path_iterator_next(VM* vm, u32 pc, Op::IteratorNext const* instruction)
@@ -1652,7 +1653,7 @@ i64 asm_slow_path_iterator_next(VM* vm, u32 pc, Op::IteratorNext const* instruct
     if (iterator_record.done)
         vm->set(instruction->iterator_done(), Value(true));
     vm->set(instruction->dst(), ASM_TRY(*vm, pc, result));
-    return static_cast<i64>(pc + sizeof(Op::IteratorNext));
+    return continue_after_slow_path(pc + sizeof(Op::IteratorNext));
 }
 
 i64 asm_slow_path_iterator_next_unpack(VM* vm, u32 pc, Op::IteratorNextUnpack const* instruction)
@@ -1667,7 +1668,7 @@ i64 asm_slow_path_iterator_next_unpack(VM* vm, u32 pc, Op::IteratorNextUnpack co
     auto iteration_result_or_done = ASM_TRY(*vm, pc, iteration_result_or_done_or_error);
     if (iteration_result_or_done.has<IterationDone>()) {
         vm->set(instruction->dst_done(), Value(true));
-        return static_cast<i64>(pc + sizeof(Op::IteratorNextUnpack));
+        return continue_after_slow_path(pc + sizeof(Op::IteratorNextUnpack));
     }
     auto& iteration_result = iteration_result_or_done.get<IterationResult>();
     vm->set(instruction->dst_done(), ASM_TRY(*vm, pc, iteration_result.done));
@@ -1675,7 +1676,7 @@ i64 asm_slow_path_iterator_next_unpack(VM* vm, u32 pc, Op::IteratorNextUnpack co
     if (value.is_throw_completion())
         vm->set(instruction->iterator_done(), Value(true));
     vm->set(instruction->dst_value(), ASM_TRY(*vm, pc, value));
-    return static_cast<i64>(pc + sizeof(Op::IteratorNextUnpack));
+    return continue_after_slow_path(pc + sizeof(Op::IteratorNextUnpack));
 }
 
 i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* instruction)
@@ -1695,7 +1696,7 @@ i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* i
         auto value = ASM_TRY(*vm, pc, value_or_error);
         if (!value.has_value()) {
             vm->set(instruction->dst(), array);
-            return static_cast<i64>(pc + sizeof(Op::IteratorToArray));
+            return continue_after_slow_path(pc + sizeof(Op::IteratorToArray));
         }
 
         MUST(array->create_data_property_or_throw(index, value.release_value()));
@@ -1710,10 +1711,10 @@ i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* i
         auto callee = vm->get(instruction->callee());                                                                                                                                                    \
         if (callee.is_function() && callee.as_function().builtin() == Builtin::name) {                                                                                                                   \
             vm->set(instruction->dst(), ASM_TRY(*vm, pc, implementation(*vm, vm->get(instruction->argument()))));                                                                                        \
-            return static_cast<i64>(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                 \
+            return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                         \
         }                                                                                                                                                                                                \
         ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, callee, vm->get(instruction->this_value()), arguments, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return static_cast<i64>(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                     \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                             \
     }
 
 #define JS_DEFINE_BINARY_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, implementation)                                                                                                                   \
@@ -1723,10 +1724,10 @@ i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* i
         auto callee = vm->get(instruction->callee());                                                                                                                                                    \
         if (callee.is_function() && callee.as_function().builtin() == Builtin::name) {                                                                                                                   \
             vm->set(instruction->dst(), ASM_TRY(*vm, pc, implementation(*vm, vm->get(instruction->argument0()), vm->get(instruction->argument1()))));                                                    \
-            return static_cast<i64>(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                 \
+            return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                         \
         }                                                                                                                                                                                                \
         ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, callee, vm->get(instruction->this_value()), arguments, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return static_cast<i64>(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                     \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                             \
     }
 
 #define JS_DEFINE_NULLARY_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, implementation)                                                                                                           \
@@ -1735,17 +1736,17 @@ i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* i
         auto callee = vm->get(instruction->callee());                                                                                                                                             \
         if (callee.is_function() && callee.as_function().builtin() == Builtin::name) {                                                                                                            \
             vm->set(instruction->dst(), implementation());                                                                                                                                        \
-            return static_cast<i64>(pc + sizeof(Op::CallBuiltin##name));                                                                                                                          \
+            return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                  \
         }                                                                                                                                                                                         \
         ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, callee, vm->get(instruction->this_value()), {}, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return static_cast<i64>(pc + sizeof(Op::CallBuiltin##name));                                                                                                                              \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                      \
     }
 
 #define JS_DEFINE_GENERIC_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, ...)                                                                                                                                              \
     i64 asm_slow_path_call_builtin_##snake_case_name(VM* vm, u32 pc, Op::CallBuiltin##name const* instruction)                                                                                                            \
     {                                                                                                                                                                                                                     \
         ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), {}, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return static_cast<i64>(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                                      \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                              \
     }
 
 #define JS_DEFINE_UNARY_GENERIC_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, ...)                                                                                                                                               \
@@ -1753,7 +1754,7 @@ i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* i
     {                                                                                                                                                                                                                            \
         Operand arguments[] { instruction->argument() };                                                                                                                                                                         \
         ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), arguments, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return static_cast<i64>(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                                             \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                                     \
     }
 
 #define JS_DEFINE_BINARY_GENERIC_BUILTIN_CALL_SLOW_PATH(name, snake_case_name, ...)                                                                                                                                              \
@@ -1761,7 +1762,7 @@ i64 asm_slow_path_iterator_to_array(VM* vm, u32 pc, Op::IteratorToArray const* i
     {                                                                                                                                                                                                                            \
         Operand arguments[] { instruction->argument0(), instruction->argument1() };                                                                                                                                              \
         ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Call, *vm, vm->get(instruction->callee()), vm->get(instruction->this_value()), arguments, instruction->dst(), instruction->expression_string(), instruction->strict())); \
-        return static_cast<i64>(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                                             \
+        return continue_after_slow_path(pc + sizeof(Op::CallBuiltin##name));                                                                                                                                                     \
     }
 
 JS_DEFINE_UNARY_BUILTIN_CALL_SLOW_PATH(MathAbs, math_abs, MathObject::abs_impl)
@@ -1799,13 +1800,13 @@ JS_DEFINE_UNARY_GENERIC_BUILTIN_CALL_SLOW_PATH(StringPrototypeCharAt, string_pro
 i64 asm_slow_path_call_construct(VM* vm, u32 pc, Op::CallConstruct const* instruction)
 {
     ASM_TRY(*vm, pc, execute_asm_call(Op::CallType::Construct, *vm, vm->get(instruction->callee()), js_undefined(), instruction->arguments(), instruction->dst(), instruction->expression_string(), instruction->strict()));
-    return static_cast<i64>(pc + instruction->length());
+    return continue_after_slow_path(pc + instruction->length());
 }
 
 i64 asm_slow_path_call_construct_with_argument_array(VM* vm, u32 pc, Op::CallConstructWithArgumentArray const* instruction)
 {
     ASM_TRY(*vm, pc, call_with_argument_array(Op::CallType::Construct, *vm, vm->get(instruction->callee()), js_undefined(), vm->get(instruction->arguments()), instruction->dst(), instruction->expression_string(), instruction->strict()));
-    return static_cast<i64>(pc + sizeof(Op::CallConstructWithArgumentArray));
+    return continue_after_slow_path(pc + sizeof(Op::CallConstructWithArgumentArray));
 }
 
 i64 asm_slow_path_super_call_with_argument_array(VM* vm, u32 pc, Op::SuperCallWithArgumentArray const* instruction)
@@ -1878,7 +1879,7 @@ i64 asm_slow_path_super_call_with_argument_array(VM* vm, u32 pc, Op::SuperCallWi
     ASM_TRY(*vm, pc, result->initialize_instance_elements(f));
 
     vm->set(instruction->dst(), result);
-    return static_cast<i64>(pc + sizeof(Op::SuperCallWithArgumentArray));
+    return continue_after_slow_path(pc + sizeof(Op::SuperCallWithArgumentArray));
 }
 
 i64 asm_slow_path_new_object(VM* vm, u32 pc, Op::NewObject const* instruction)
@@ -1890,19 +1891,19 @@ i64 asm_slow_path_new_object(VM* vm, u32 pc, Op::NewObject const* instruction)
         auto cached_shape = cache.shape.ptr();
         if (cached_shape) {
             vm->set(instruction->dst(), Object::create_with_premade_shape(*cached_shape));
-            return static_cast<i64>(pc + sizeof(Op::NewObject));
+            return continue_after_slow_path(pc + sizeof(Op::NewObject));
         }
     }
 
     vm->set(instruction->dst(), Object::create(realm, realm.intrinsics().object_prototype().ptr()));
-    return static_cast<i64>(pc + sizeof(Op::NewObject));
+    return continue_after_slow_path(pc + sizeof(Op::NewObject));
 }
 
 i64 asm_slow_path_new_object_with_no_prototype(VM* vm, u32 pc, Op::NewObjectWithNoPrototype const* instruction)
 {
     auto& realm = *vm->current_realm();
     vm->set(instruction->dst(), Object::create(realm, nullptr));
-    return static_cast<i64>(pc + sizeof(Op::NewObjectWithNoPrototype));
+    return continue_after_slow_path(pc + sizeof(Op::NewObjectWithNoPrototype));
 }
 
 i64 asm_slow_path_cache_object_shape(VM* vm, u32 pc, Op::CacheObjectShape const* instruction)
@@ -1913,7 +1914,7 @@ i64 asm_slow_path_cache_object_shape(VM* vm, u32 pc, Op::CacheObjectShape const*
         if (!object.shape().is_dictionary())
             cache.shape = &object.shape();
     }
-    return static_cast<i64>(pc + sizeof(Op::CacheObjectShape));
+    return continue_after_slow_path(pc + sizeof(Op::CacheObjectShape));
 }
 
 i64 asm_slow_path_init_object_literal_property(VM* vm, u32 pc, Op::InitObjectLiteralProperty const* instruction)
@@ -1925,7 +1926,7 @@ i64 asm_slow_path_init_object_literal_property(VM* vm, u32 pc, Op::InitObjectLit
     auto cached_shape = cache.shape.ptr();
     if (cached_shape && &object.shape() == cached_shape && instruction->property_slot() < cache.property_offsets.size()) {
         object.put_direct(cache.property_offsets[instruction->property_slot()], value);
-        return static_cast<i64>(pc + sizeof(Op::InitObjectLiteralProperty));
+        return continue_after_slow_path(pc + sizeof(Op::InitObjectLiteralProperty));
     }
 
     auto const& property_key = vm->current_executable().get_property_key(instruction->property());
@@ -1940,7 +1941,7 @@ i64 asm_slow_path_init_object_literal_property(VM* vm, u32 pc, Op::InitObjectLit
         }
     }
 
-    return static_cast<i64>(pc + sizeof(Op::InitObjectLiteralProperty));
+    return continue_after_slow_path(pc + sizeof(Op::InitObjectLiteralProperty));
 }
 
 i64 asm_slow_path_new_array(VM* vm, u32 pc, Op::NewArray const* instruction)
@@ -1949,7 +1950,7 @@ i64 asm_slow_path_new_array(VM* vm, u32 pc, Op::NewArray const* instruction)
     for (size_t i = 0; i < instruction->element_count(); ++i)
         array->indexed_put(i, vm->get(instruction->elements()[i]));
     vm->set(instruction->dst(), array);
-    return static_cast<i64>(pc + instruction->length());
+    return continue_after_slow_path(pc + instruction->length());
 }
 
 i64 asm_slow_path_new_primitive_array(VM* vm, u32 pc, Op::NewPrimitiveArray const* instruction)
@@ -1958,7 +1959,7 @@ i64 asm_slow_path_new_primitive_array(VM* vm, u32 pc, Op::NewPrimitiveArray cons
     for (size_t i = 0; i < instruction->element_count(); ++i)
         array->indexed_put(i, instruction->elements()[i]);
     vm->set(instruction->dst(), array);
-    return static_cast<i64>(pc + instruction->length());
+    return continue_after_slow_path(pc + instruction->length());
 }
 
 i64 asm_slow_path_new_regexp(VM* vm, u32 pc, Op::NewRegExp const* instruction)
@@ -1971,21 +1972,21 @@ i64 asm_slow_path_new_regexp(VM* vm, u32 pc, Op::NewRegExp const* instruction)
     regexp_object->set_realm(realm);
     regexp_object->set_legacy_features_enabled(true);
     vm->set(instruction->dst(), regexp_object);
-    return static_cast<i64>(pc + sizeof(Op::NewRegExp));
+    return continue_after_slow_path(pc + sizeof(Op::NewRegExp));
 }
 
 i64 asm_slow_path_new_reference_error(VM* vm, u32 pc, Op::NewReferenceError const* instruction)
 {
     auto& realm = *vm->current_realm();
     vm->set(instruction->dst(), ReferenceError::create(realm, vm->current_executable().get_string(instruction->error_string())));
-    return static_cast<i64>(pc + sizeof(Op::NewReferenceError));
+    return continue_after_slow_path(pc + sizeof(Op::NewReferenceError));
 }
 
 i64 asm_slow_path_new_type_error(VM* vm, u32 pc, Op::NewTypeError const* instruction)
 {
     auto& realm = *vm->current_realm();
     vm->set(instruction->dst(), TypeError::create(realm, vm->current_executable().get_string(instruction->error_string())));
-    return static_cast<i64>(pc + sizeof(Op::NewTypeError));
+    return continue_after_slow_path(pc + sizeof(Op::NewTypeError));
 }
 
 i64 asm_slow_path_bitwise_xor(VM* vm, u32 pc, Op::BitwiseXor const* instruction)
@@ -2084,41 +2085,41 @@ i64 asm_slow_path_loosely_inequals_values(VM* vm, u32 pc, Operand destination, V
 i64 asm_slow_path_unary_minus(VM* vm, u32 pc, Op::UnaryMinus const* instruction)
 {
     vm->set(instruction->dst(), ASM_TRY(*vm, pc, unary_minus(*vm, vm->get(instruction->src()))));
-    return static_cast<i64>(pc + sizeof(Op::UnaryMinus));
+    return continue_after_slow_path(pc + sizeof(Op::UnaryMinus));
 }
 
 i64 asm_slow_path_to_string(VM* vm, u32 pc, Op::ToString const* instruction)
 {
     auto result = ASM_TRY(*vm, pc, vm->get(instruction->value()).to_primitive_string(*vm));
     vm->set(instruction->dst(), Value { result });
-    return static_cast<i64>(pc + sizeof(Op::ToString));
+    return continue_after_slow_path(pc + sizeof(Op::ToString));
 }
 
 i64 asm_slow_path_to_primitive_with_string_hint(VM* vm, u32 pc, Op::ToPrimitiveWithStringHint const* instruction)
 {
     auto result = ASM_TRY(*vm, pc, vm->get(instruction->value()).to_primitive(*vm, Value::PreferredType::String));
     vm->set(instruction->dst(), result);
-    return static_cast<i64>(pc + sizeof(Op::ToPrimitiveWithStringHint));
+    return continue_after_slow_path(pc + sizeof(Op::ToPrimitiveWithStringHint));
 }
 
 i64 asm_slow_path_to_object(VM* vm, u32 pc, Op::ToObject const* instruction)
 {
     auto result = ASM_TRY(*vm, pc, vm->get(instruction->value()).to_object(*vm));
     vm->set(instruction->dst(), result);
-    return static_cast<i64>(pc + sizeof(Op::ToObject));
+    return continue_after_slow_path(pc + sizeof(Op::ToObject));
 }
 
 i64 asm_slow_path_to_length(VM* vm, u32 pc, Op::ToLength const* instruction)
 {
     auto result = ASM_TRY(*vm, pc, vm->get(instruction->value()).to_length(*vm));
     vm->set(instruction->dst(), Value { result });
-    return static_cast<i64>(pc + sizeof(Op::ToLength));
+    return continue_after_slow_path(pc + sizeof(Op::ToLength));
 }
 
 i64 asm_slow_path_typeof(VM* vm, u32 pc, Op::Typeof const* instruction)
 {
     vm->set(instruction->dst(), vm->get(instruction->src()).typeof_(*vm));
-    return static_cast<i64>(pc + sizeof(Op::Typeof));
+    return continue_after_slow_path(pc + sizeof(Op::Typeof));
 }
 
 i64 asm_slow_path_postfix_decrement(VM* vm, u32 pc, Op::PostfixDecrement const* instruction)
@@ -2129,13 +2130,13 @@ i64 asm_slow_path_postfix_decrement(VM* vm, u32 pc, Op::PostfixDecrement const* 
         vm->set(instruction->src(), Value(old_value.as_double() - 1));
     else
         vm->set(instruction->src(), BigInt::create(*vm, old_value.as_bigint().big_integer().minus(Crypto::SignedBigInteger { 1 })));
-    return static_cast<i64>(pc + sizeof(Op::PostfixDecrement));
+    return continue_after_slow_path(pc + sizeof(Op::PostfixDecrement));
 }
 
 i64 asm_slow_path_to_int32(VM* vm, u32 pc, Op::ToInt32 const* instruction)
 {
     vm->set(instruction->dst(), Value(ASM_TRY(*vm, pc, vm->get(instruction->value()).to_i32(*vm))));
-    return static_cast<i64>(pc + sizeof(Op::ToInt32));
+    return continue_after_slow_path(pc + sizeof(Op::ToInt32));
 }
 
 i64 asm_slow_path_put_by_value(VM* vm, u32 pc, Op::PutByValue const* instruction)
@@ -2148,7 +2149,7 @@ i64 asm_slow_path_put_by_value(VM* vm, u32 pc, Op::PutByValue const* instruction
     auto property = vm->get(instruction->property());
     auto property_key = ASM_TRY(*vm, pc, property.to_property_key(*vm));
     ASM_TRY(*vm, pc, put_by_property_key(*vm, base, base, value, base_identifier, property_key, instruction->kind(), instruction->strict()));
-    return static_cast<i64>(pc + sizeof(Op::PutByValue));
+    return continue_after_slow_path(pc + sizeof(Op::PutByValue));
 }
 
 i64 asm_slow_path_put_by_value_with_this(VM* vm, u32 pc, Op::PutByValueWithThis const* instruction)
@@ -2158,7 +2159,7 @@ i64 asm_slow_path_put_by_value_with_this(VM* vm, u32 pc, Op::PutByValueWithThis 
     auto this_value = vm->get(instruction->this_value());
     auto property_key = ASM_TRY(*vm, pc, vm->get(instruction->property()).to_property_key(*vm));
     ASM_TRY(*vm, pc, put_by_property_key(*vm, base, this_value, value, {}, property_key, instruction->kind(), instruction->strict()));
-    return static_cast<i64>(pc + sizeof(Op::PutByValueWithThis));
+    return continue_after_slow_path(pc + sizeof(Op::PutByValueWithThis));
 }
 
 i64 asm_slow_path_put_by_spread(VM* vm, u32 pc, Op::PutBySpread const* instruction)
@@ -2170,7 +2171,7 @@ i64 asm_slow_path_put_by_spread(VM* vm, u32 pc, Op::PutBySpread const* instructi
     auto object = ASM_TRY(*vm, pc, base.to_object(*vm));
 
     ASM_TRY(*vm, pc, object->copy_data_properties(*vm, value, {}));
-    return static_cast<i64>(pc + sizeof(Op::PutBySpread));
+    return continue_after_slow_path(pc + sizeof(Op::PutBySpread));
 }
 
 i64 asm_try_put_by_value_holey_array(VM* vm, u32, Op::PutByValue const* instruction)
@@ -2451,12 +2452,12 @@ i64 asm_slow_path_resolve_binding(VM* vm, u32 pc, Op::ResolveBinding const* inst
     auto reference = ASM_TRY(*vm, pc, vm->resolve_binding(identifier, instruction->strict()));
     if (reference.is_unresolvable()) {
         vm->set(instruction->dst(), js_null());
-        return static_cast<i64>(pc + sizeof(Op::ResolveBinding));
+        return continue_after_slow_path(pc + sizeof(Op::ResolveBinding));
     }
 
     VERIFY(reference.is_environment_reference());
     vm->set(instruction->dst(), &reference.base_environment());
-    return static_cast<i64>(pc + sizeof(Op::ResolveBinding));
+    return continue_after_slow_path(pc + sizeof(Op::ResolveBinding));
 }
 
 i64 asm_slow_path_resolve_super_base(VM* vm, u32 pc, Op::ResolveSuperBase const* instruction)
@@ -2466,7 +2467,7 @@ i64 asm_slow_path_resolve_super_base(VM* vm, u32 pc, Op::ResolveSuperBase const*
     VERIFY(environment.has_super_binding());
     auto base_value = ASM_TRY(*vm, pc, environment.get_super_base());
     vm->set(instruction->dst(), base_value);
-    return static_cast<i64>(pc + sizeof(Op::ResolveSuperBase));
+    return continue_after_slow_path(pc + sizeof(Op::ResolveSuperBase));
 }
 
 i64 asm_slow_path_set_resolved_binding(VM* vm, u32 pc, Op::SetResolvedBinding const* instruction)
@@ -2477,7 +2478,7 @@ i64 asm_slow_path_set_resolved_binding(VM* vm, u32 pc, Op::SetResolvedBinding co
         ? Reference { Reference::BaseType::Unresolvable, PropertyKey { identifier }, instruction->strict() }
         : Reference { as<Environment>(environment.as_cell()), identifier, instruction->strict() };
     ASM_TRY(*vm, pc, reference.put_value(*vm, vm->get(instruction->src())));
-    return static_cast<i64>(pc + sizeof(Op::SetResolvedBinding));
+    return continue_after_slow_path(pc + sizeof(Op::SetResolvedBinding));
 }
 
 i64 asm_slow_path_typeof_binding(VM* vm, u32 pc, Op::TypeofBinding const* instruction)
@@ -2490,7 +2491,7 @@ i64 asm_slow_path_typeof_binding(VM* vm, u32 pc, Op::TypeofBinding const* instru
 
     auto value = ASM_TRY(*vm, pc, static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(*vm, instruction->cache().index));
     vm->set(instruction->dst(), value.typeof_(*vm));
-    return static_cast<i64>(pc + sizeof(Op::TypeofBinding));
+    return continue_after_slow_path(pc + sizeof(Op::TypeofBinding));
 }
 
 i64 asm_slow_path_dynamic_typeof_binding(VM* vm, u32 pc, Op::DynamicTypeofBinding const* instruction)
@@ -2500,19 +2501,19 @@ i64 asm_slow_path_dynamic_typeof_binding(VM* vm, u32 pc, Op::DynamicTypeofBindin
     if (auto const* environment = asm_get_cached_environment(current_environment, cache)) [[likely]] {
         auto value = ASM_TRY(*vm, pc, static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(*vm, cache.index));
         vm->set(instruction->dst(), value.typeof_(*vm));
-        return static_cast<i64>(pc + sizeof(Op::DynamicTypeofBinding));
+        return continue_after_slow_path(pc + sizeof(Op::DynamicTypeofBinding));
     }
 
     auto reference = ASM_TRY(*vm, pc, vm->resolve_binding(vm->get_identifier(instruction->identifier()), instruction->strict()));
     if (reference.is_unresolvable()) {
         vm->set(instruction->dst(), PrimitiveString::create(*vm, "undefined"_utf16_fly_string));
-        return static_cast<i64>(pc + sizeof(Op::DynamicTypeofBinding));
+        return continue_after_slow_path(pc + sizeof(Op::DynamicTypeofBinding));
     }
 
     asm_update_environment_coordinate_cache(current_environment, reference, cache);
     auto value = ASM_TRY(*vm, pc, reference.get_value(*vm));
     vm->set(instruction->dst(), value.typeof_(*vm));
-    return static_cast<i64>(pc + sizeof(Op::DynamicTypeofBinding));
+    return continue_after_slow_path(pc + sizeof(Op::DynamicTypeofBinding));
 }
 
 static Optional<StringView> asm_function_name_prefix_to_string(Op::FunctionNamePrefix prefix)
@@ -2540,18 +2541,18 @@ i64 asm_slow_path_has_private_id(VM* vm, u32 pc, Op::HasPrivateId const* instruc
     VERIFY(private_environment);
     auto private_name = private_environment->resolve_private_identifier(vm->get_identifier(instruction->property()));
     vm->set(instruction->dst(), Value(base.as_object().private_element_find(private_name) != nullptr));
-    return static_cast<i64>(pc + sizeof(Op::HasPrivateId));
+    return continue_after_slow_path(pc + sizeof(Op::HasPrivateId));
 }
 
 i64 asm_slow_path_set_function_name(VM* vm, u32 pc, Op::SetFunctionName const* instruction)
 {
     auto function = vm->get(instruction->function()).as_if<ECMAScriptFunctionObject>();
     if (!function || !function->name().is_empty())
-        return static_cast<i64>(pc + sizeof(Op::SetFunctionName));
+        return continue_after_slow_path(pc + sizeof(Op::SetFunctionName));
 
     auto property_key = ASM_TRY(*vm, pc, vm->get(instruction->name()).to_property_key(*vm));
     function->set_inferred_name(Variant<PropertyKey, PrivateName> { move(property_key) }, asm_function_name_prefix_to_string(instruction->prefix()));
-    return static_cast<i64>(pc + sizeof(Op::SetFunctionName));
+    return continue_after_slow_path(pc + sizeof(Op::SetFunctionName));
 }
 
 i64 asm_slow_path_new_array_with_length(VM* vm, u32 pc, Op::NewArrayWithLength const* instruction)
@@ -2559,7 +2560,7 @@ i64 asm_slow_path_new_array_with_length(VM* vm, u32 pc, Op::NewArrayWithLength c
     auto length = static_cast<u64>(vm->get(instruction->array_length()).as_double());
     auto array = ASM_TRY(*vm, pc, JS::Array::create(vm->realm(), length));
     vm->set(instruction->dst(), array);
-    return static_cast<i64>(pc + sizeof(Op::NewArrayWithLength));
+    return continue_after_slow_path(pc + sizeof(Op::NewArrayWithLength));
 }
 
 i64 asm_slow_path_array_append(VM* vm, u32 pc, Op::ArrayAppend const* instruction)
@@ -2597,7 +2598,7 @@ i64 asm_slow_path_array_append(VM* vm, u32 pc, Op::ArrayAppend const* instructio
                     auto elements = rhs_array->indexed_packed_elements_span();
                     if (elements.size() <= NumericLimits<u32>::max() - lhs_size) {
                         lhs_array.indexed_append(elements);
-                        return static_cast<i64>(pc + sizeof(Op::ArrayAppend));
+                        return continue_after_slow_path(pc + sizeof(Op::ArrayAppend));
                     }
                 }
             }
@@ -2613,7 +2614,7 @@ i64 asm_slow_path_array_append(VM* vm, u32 pc, Op::ArrayAppend const* instructio
                     break;
                 lhs_array.indexed_put(i++, iterator_value.release_value());
             }
-            return static_cast<i64>(pc + sizeof(Op::ArrayAppend));
+            return continue_after_slow_path(pc + sizeof(Op::ArrayAppend));
         }
 
         auto result = get_iterator_values(*vm, rhs, [&i, &lhs_array](Value iterator_value) -> Optional<Completion> {
@@ -2627,14 +2628,14 @@ i64 asm_slow_path_array_append(VM* vm, u32 pc, Op::ArrayAppend const* instructio
         lhs_array.indexed_put(lhs_size, rhs);
     }
 
-    return static_cast<i64>(pc + sizeof(Op::ArrayAppend));
+    return continue_after_slow_path(pc + sizeof(Op::ArrayAppend));
 }
 
 i64 asm_slow_path_create_variable(VM* vm, u32 pc, Op::CreateVariable const* instruction)
 {
     auto const& name = vm->get_identifier(instruction->identifier());
     ASM_TRY(*vm, pc, asm_create_variable(*vm, name, instruction->mode(), instruction->is_global(), instruction->is_immutable(), instruction->is_strict()));
-    return static_cast<i64>(pc + sizeof(Op::CreateVariable));
+    return continue_after_slow_path(pc + sizeof(Op::CreateVariable));
 }
 
 i64 asm_slow_path_enter_object_environment(VM* vm, u32 pc, Op::EnterObjectEnvironment const* instruction)
@@ -2644,32 +2645,32 @@ i64 asm_slow_path_enter_object_environment(VM* vm, u32 pc, Op::EnterObjectEnviro
     auto new_environment = new_object_environment(*object, true, old_environment.ptr());
     vm->set(instruction->dst(), new_environment);
     vm->running_execution_context().lexical_environment = new_environment;
-    return static_cast<i64>(pc + sizeof(Op::EnterObjectEnvironment));
+    return continue_after_slow_path(pc + sizeof(Op::EnterObjectEnvironment));
 }
 
 i64 asm_slow_path_bitwise_not(VM* vm, u32 pc, Op::BitwiseNot const* instruction)
 {
     vm->set(instruction->dst(), ASM_TRY(*vm, pc, bitwise_not(*vm, vm->get(instruction->src()))));
-    return static_cast<i64>(pc + sizeof(Op::BitwiseNot));
+    return continue_after_slow_path(pc + sizeof(Op::BitwiseNot));
 }
 
 i64 asm_slow_path_unary_plus(VM* vm, u32 pc, Op::UnaryPlus const* instruction)
 {
     vm->set(instruction->dst(), ASM_TRY(*vm, pc, unary_plus(*vm, vm->get(instruction->src()))));
-    return static_cast<i64>(pc + sizeof(Op::UnaryPlus));
+    return continue_after_slow_path(pc + sizeof(Op::UnaryPlus));
 }
 
 i64 asm_slow_path_is_constructor(VM* vm, u32 pc, Op::IsConstructor const* instruction)
 {
     vm->set(instruction->dst(), Value(vm->get(instruction->value()).is_constructor()));
-    return static_cast<i64>(pc + sizeof(Op::IsConstructor));
+    return continue_after_slow_path(pc + sizeof(Op::IsConstructor));
 }
 
 i64 asm_slow_path_add_private_name(VM* vm, u32 pc, Op::AddPrivateName const* instruction)
 {
     auto const& name = vm->get_identifier(instruction->name());
     vm->running_execution_context().private_environment->add_private_name(name);
-    return static_cast<i64>(pc + sizeof(Op::AddPrivateName));
+    return continue_after_slow_path(pc + sizeof(Op::AddPrivateName));
 }
 
 i64 asm_slow_path_create_async_from_sync_iterator(VM* vm, u32 pc, Op::CreateAsyncFromSyncIterator const* instruction)
@@ -2689,7 +2690,7 @@ i64 asm_slow_path_create_async_from_sync_iterator(VM* vm, u32 pc, Op::CreateAsyn
     iterator_object->define_direct_property(vm->names.done, Value { async_from_sync_iterator.done }, default_attributes);
 
     vm->set(instruction->dst(), iterator_object);
-    return static_cast<i64>(pc + sizeof(Op::CreateAsyncFromSyncIterator));
+    return continue_after_slow_path(pc + sizeof(Op::CreateAsyncFromSyncIterator));
 }
 
 i64 asm_slow_path_create_data_property_or_throw(VM* vm, u32 pc, Op::CreateDataPropertyOrThrow const* instruction)
@@ -2698,21 +2699,21 @@ i64 asm_slow_path_create_data_property_or_throw(VM* vm, u32 pc, Op::CreateDataPr
     auto property = ASM_TRY(*vm, pc, vm->get(instruction->property()).to_property_key(*vm));
     auto value = vm->get(instruction->value());
     ASM_TRY(*vm, pc, object.create_data_property_or_throw(property, value));
-    return static_cast<i64>(pc + sizeof(Op::CreateDataPropertyOrThrow));
+    return continue_after_slow_path(pc + sizeof(Op::CreateDataPropertyOrThrow));
 }
 
 i64 asm_slow_path_create_immutable_binding(VM* vm, u32 pc, Op::CreateImmutableBinding const* instruction)
 {
     auto& environment = as<Environment>(vm->get(instruction->environment()).as_cell());
     ASM_TRY(*vm, pc, environment.create_immutable_binding(*vm, vm->get_identifier(instruction->identifier()), instruction->strict_binding()));
-    return static_cast<i64>(pc + sizeof(Op::CreateImmutableBinding));
+    return continue_after_slow_path(pc + sizeof(Op::CreateImmutableBinding));
 }
 
 i64 asm_slow_path_create_mutable_binding(VM* vm, u32 pc, Op::CreateMutableBinding const* instruction)
 {
     auto& environment = as<Environment>(vm->get(instruction->environment()).as_cell());
     ASM_TRY(*vm, pc, environment.create_mutable_binding(*vm, vm->get_identifier(instruction->identifier()), instruction->can_be_deleted()));
-    return static_cast<i64>(pc + sizeof(Op::CreateMutableBinding));
+    return continue_after_slow_path(pc + sizeof(Op::CreateMutableBinding));
 }
 
 i64 asm_slow_path_create_rest_params(VM* vm, u32 pc, Op::CreateRestParams const* instruction)
@@ -2723,7 +2724,7 @@ i64 asm_slow_path_create_rest_params(VM* vm, u32 pc, Op::CreateRestParams const*
     for (size_t rest_index = instruction->rest_index(); rest_index < arguments_count; ++rest_index)
         array->indexed_append(arguments[rest_index]);
     vm->set(instruction->dst(), array);
-    return static_cast<i64>(pc + sizeof(Op::CreateRestParams));
+    return continue_after_slow_path(pc + sizeof(Op::CreateRestParams));
 }
 
 i64 asm_slow_path_create_arguments(VM* vm, u32 pc, Op::CreateArguments const* instruction)
@@ -2743,7 +2744,7 @@ i64 asm_slow_path_create_arguments(VM* vm, u32 pc, Op::CreateArguments const* in
 
     if (instruction->dst().has_value()) {
         vm->set(*instruction->dst(), arguments_object);
-        return static_cast<i64>(pc + sizeof(Op::CreateArguments));
+        return continue_after_slow_path(pc + sizeof(Op::CreateArguments));
     }
 
     if (instruction->is_immutable()) {
@@ -2752,7 +2753,7 @@ i64 asm_slow_path_create_arguments(VM* vm, u32 pc, Op::CreateArguments const* in
         MUST(environment->create_mutable_binding(*vm, vm->names.arguments.as_string(), false));
     }
     MUST(environment->initialize_binding(*vm, vm->names.arguments.as_string(), arguments_object, Environment::InitializeBindingHint::Normal));
-    return static_cast<i64>(pc + sizeof(Op::CreateArguments));
+    return continue_after_slow_path(pc + sizeof(Op::CreateArguments));
 }
 
 i64 asm_slow_path_await(VM* vm, [[maybe_unused]] u32 pc, Op::Await const* instruction)
@@ -2774,7 +2775,7 @@ i64 asm_slow_path_create_lexical_environment(VM* vm, u32 pc, Op::CreateLexicalEn
     environment->set_is_catch_environment(instruction->is_catch_environment());
     vm->set(instruction->dst(), environment);
     vm->running_execution_context().lexical_environment = environment;
-    return static_cast<i64>(pc + sizeof(Op::CreateLexicalEnvironment));
+    return continue_after_slow_path(pc + sizeof(Op::CreateLexicalEnvironment));
 }
 
 i64 asm_slow_path_create_private_environment(VM* vm, u32 pc, Op::CreatePrivateEnvironment const*)
@@ -2782,7 +2783,7 @@ i64 asm_slow_path_create_private_environment(VM* vm, u32 pc, Op::CreatePrivateEn
     auto& running_execution_context = vm->running_execution_context();
     auto outer_private_environment = running_execution_context.private_environment;
     running_execution_context.private_environment = new_private_environment(*vm, outer_private_environment.ptr());
-    return static_cast<i64>(pc + sizeof(Op::CreatePrivateEnvironment));
+    return continue_after_slow_path(pc + sizeof(Op::CreatePrivateEnvironment));
 }
 
 i64 asm_slow_path_create_variable_environment(VM* vm, u32 pc, Op::CreateVariableEnvironment const* instruction)
@@ -2794,7 +2795,7 @@ i64 asm_slow_path_create_variable_environment(VM* vm, u32 pc, Op::CreateVariable
     var_environment->ensure_capacity(instruction->capacity());
     running_execution_context.variable_environment = var_environment;
     running_execution_context.lexical_environment = var_environment;
-    return static_cast<i64>(pc + sizeof(Op::CreateVariableEnvironment));
+    return continue_after_slow_path(pc + sizeof(Op::CreateVariableEnvironment));
 }
 
 i64 asm_slow_path_delete_by_id(VM* vm, u32 pc, Op::DeleteById const* instruction)
@@ -2803,7 +2804,7 @@ i64 asm_slow_path_delete_by_id(VM* vm, u32 pc, Op::DeleteById const* instruction
     auto reference = Reference { vm->get(instruction->base()), property_key, {}, instruction->strict() };
     auto result = ASM_TRY(*vm, pc, reference.delete_(*vm));
     vm->set(instruction->dst(), Value(result));
-    return static_cast<i64>(pc + sizeof(Op::DeleteById));
+    return continue_after_slow_path(pc + sizeof(Op::DeleteById));
 }
 
 i64 asm_slow_path_delete_by_value(VM* vm, u32 pc, Op::DeleteByValue const* instruction)
@@ -2812,7 +2813,7 @@ i64 asm_slow_path_delete_by_value(VM* vm, u32 pc, Op::DeleteByValue const* instr
     auto reference = Reference { vm->get(instruction->base()), property_key, {}, instruction->strict() };
     auto result = ASM_TRY(*vm, pc, reference.delete_(*vm));
     vm->set(instruction->dst(), Value(result));
-    return static_cast<i64>(pc + sizeof(Op::DeleteByValue));
+    return continue_after_slow_path(pc + sizeof(Op::DeleteByValue));
 }
 
 i64 asm_slow_path_delete_variable(VM* vm, u32 pc, Op::DeleteVariable const* instruction)
@@ -2821,7 +2822,7 @@ i64 asm_slow_path_delete_variable(VM* vm, u32 pc, Op::DeleteVariable const* inst
     auto reference = ASM_TRY(*vm, pc, vm->resolve_binding(string, instruction->strict()));
     auto result = ASM_TRY(*vm, pc, reference.delete_(*vm));
     vm->set(instruction->dst(), Value(result));
-    return static_cast<i64>(pc + sizeof(Op::DeleteVariable));
+    return continue_after_slow_path(pc + sizeof(Op::DeleteVariable));
 }
 
 i64 asm_slow_path_get_completion_fields(VM* vm, u32 pc, Op::GetCompletionFields const* instruction)
@@ -2831,13 +2832,13 @@ i64 asm_slow_path_get_completion_fields(VM* vm, u32 pc, Op::GetCompletionFields 
         auto const& generator = as<GeneratorObject>(completion_source);
         vm->set(instruction->value_dst(), generator.pending_completion_value());
         vm->set(instruction->type_dst(), Value(to_underlying(generator.pending_completion_type())));
-        return static_cast<i64>(pc + sizeof(Op::GetCompletionFields));
+        return continue_after_slow_path(pc + sizeof(Op::GetCompletionFields));
     }
 
     auto const& async_generator = as<AsyncGenerator>(completion_source);
     vm->set(instruction->value_dst(), async_generator.pending_completion_value());
     vm->set(instruction->type_dst(), Value(to_underlying(async_generator.pending_completion_type())));
-    return static_cast<i64>(pc + sizeof(Op::GetCompletionFields));
+    return continue_after_slow_path(pc + sizeof(Op::GetCompletionFields));
 }
 
 i64 asm_slow_path_set_completion_type(VM* vm, u32 pc, Op::SetCompletionType const* instruction)
@@ -2845,11 +2846,11 @@ i64 asm_slow_path_set_completion_type(VM* vm, u32 pc, Op::SetCompletionType cons
     auto& completion_source = vm->get(instruction->completion()).as_object();
     if (is<GeneratorObject>(completion_source)) {
         as<GeneratorObject>(completion_source).set_pending_completion_type(instruction->completion_type());
-        return static_cast<i64>(pc + sizeof(Op::SetCompletionType));
+        return continue_after_slow_path(pc + sizeof(Op::SetCompletionType));
     }
 
     as<AsyncGenerator>(completion_source).set_pending_completion_type(instruction->completion_type());
-    return static_cast<i64>(pc + sizeof(Op::SetCompletionType));
+    return continue_after_slow_path(pc + sizeof(Op::SetCompletionType));
 }
 
 i64 asm_slow_path_get_template_object(VM* vm, u32 pc, Op::GetTemplateObject const* instruction)
@@ -2858,7 +2859,7 @@ i64 asm_slow_path_get_template_object(VM* vm, u32 pc, Op::GetTemplateObject cons
 
     if (cache.cached_template_object) {
         vm->set(instruction->dst(), cache.cached_template_object);
-        return static_cast<i64>(pc + instruction->length());
+        return continue_after_slow_path(pc + instruction->length());
     }
 
     auto& realm = *vm->current_realm();
@@ -2878,7 +2879,7 @@ i64 asm_slow_path_get_template_object(VM* vm, u32 pc, Op::GetTemplateObject cons
 
     cache.cached_template_object = template_object;
     vm->set(instruction->dst(), template_object);
-    return static_cast<i64>(pc + instruction->length());
+    return continue_after_slow_path(pc + instruction->length());
 }
 
 i64 asm_slow_path_new_function(VM* vm, u32 pc, Op::NewFunction const* instruction)
@@ -2913,7 +2914,7 @@ i64 asm_slow_path_new_function(VM* vm, u32 pc, Op::NewFunction const* instructio
     }
 
     vm->set(instruction->dst(), function);
-    return static_cast<i64>(pc + sizeof(Op::NewFunction));
+    return continue_after_slow_path(pc + sizeof(Op::NewFunction));
 }
 
 i64 asm_slow_path_throw(VM* vm, u32 pc, Op::Throw const* instruction)
@@ -2928,7 +2929,7 @@ i64 asm_slow_path_throw_if_tdz(VM* vm, u32 pc, Op::ThrowIfTDZ const* instruction
         auto completion = vm->throw_completion<ReferenceError>(ErrorType::BindingNotInitialized, value);
         return handle_asm_exception(*vm, pc, completion.value());
     }
-    return static_cast<i64>(pc + sizeof(Op::ThrowIfTDZ));
+    return continue_after_slow_path(pc + sizeof(Op::ThrowIfTDZ));
 }
 
 i64 asm_slow_path_throw_if_not_object(VM* vm, u32 pc, Op::ThrowIfNotObject const* instruction)
@@ -2938,7 +2939,7 @@ i64 asm_slow_path_throw_if_not_object(VM* vm, u32 pc, Op::ThrowIfNotObject const
         auto completion = vm->throw_completion<TypeError>(ErrorType::NotAnObject, src);
         return handle_asm_exception(*vm, pc, completion.value());
     }
-    return static_cast<i64>(pc + sizeof(Op::ThrowIfNotObject));
+    return continue_after_slow_path(pc + sizeof(Op::ThrowIfNotObject));
 }
 
 i64 asm_slow_path_throw_if_nullish(VM* vm, u32 pc, Op::ThrowIfNullish const* instruction)
@@ -2948,7 +2949,7 @@ i64 asm_slow_path_throw_if_nullish(VM* vm, u32 pc, Op::ThrowIfNullish const* ins
         auto completion = vm->throw_completion<TypeError>(ErrorType::NotObjectCoercible, value);
         return handle_asm_exception(*vm, pc, completion.value());
     }
-    return static_cast<i64>(pc + sizeof(Op::ThrowIfNullish));
+    return continue_after_slow_path(pc + sizeof(Op::ThrowIfNullish));
 }
 
 i64 asm_slow_path_throw_const_assignment(VM* vm, u32 pc, Op::ThrowConstAssignment const*)
@@ -2962,7 +2963,7 @@ i64 asm_slow_path_debugger(VM* vm, u32 pc, Op::Debugger const*)
     // NB: Don't pause twice if the debugger trampoline already paused before this instruction.
     if (auto* debugger = vm->debugger(); debugger && !debugger->did_pause_before_current_instruction())
         debugger->pause_execution(vm->current_executable(), pc, Debugger::PauseReason::DebuggerStatement);
-    return static_cast<i64>(pc + sizeof(Op::Debugger));
+    return continue_after_slow_path(pc + sizeof(Op::Debugger));
 }
 
 i64 asm_slow_path_yield(VM* vm, [[maybe_unused]] u32 pc, Op::Yield const* instruction)
@@ -3157,32 +3158,32 @@ i64 asm_slow_path_instance_of(VM* vm, u32 pc, Op::InstanceOf const* instruction)
 {
     auto result = ASM_TRY(*vm, pc, instance_of(*vm, vm->get(instruction->lhs()), vm->get(instruction->rhs())));
     vm->set(instruction->dst(), result);
-    return static_cast<i64>(pc + sizeof(Op::InstanceOf));
+    return continue_after_slow_path(pc + sizeof(Op::InstanceOf));
 }
 
 i64 asm_slow_path_in(VM* vm, u32 pc, Op::In const* instruction)
 {
     auto result = ASM_TRY(*vm, pc, in(*vm, vm->get(instruction->lhs()), vm->get(instruction->rhs())));
     vm->set(instruction->dst(), result);
-    return static_cast<i64>(pc + sizeof(Op::In));
+    return continue_after_slow_path(pc + sizeof(Op::In));
 }
 
 i64 asm_slow_path_resolve_this_binding(VM* vm, u32 pc, Op::ResolveThisBinding const*)
 {
     auto& cached_this_value = vm->reg(Register::this_value());
     if (!cached_this_value.is_special_empty_value())
-        return static_cast<i64>(pc + sizeof(Op::ResolveThisBinding));
+        return continue_after_slow_path(pc + sizeof(Op::ResolveThisBinding));
 
     auto& running_execution_context = vm->running_execution_context();
     if (auto function = running_execution_context.function; function && is<ECMAScriptFunctionObject>(*function)) {
         auto& ecmascript_function = static_cast<ECMAScriptFunctionObject&>(*function);
         if (!ecmascript_function.allocates_function_environment() && !ecmascript_function.this_value_needs_environment_resolution()) {
             cached_this_value = running_execution_context.this_value.value();
-            return static_cast<i64>(pc + sizeof(Op::ResolveThisBinding));
+            return continue_after_slow_path(pc + sizeof(Op::ResolveThisBinding));
         }
     }
     cached_this_value = ASM_TRY(*vm, pc, vm->resolve_this_binding());
-    return static_cast<i64>(pc + sizeof(Op::ResolveThisBinding));
+    return continue_after_slow_path(pc + sizeof(Op::ResolveThisBinding));
 }
 
 // Direct handler for GetPrivateById: bypasses Reference indirection.
@@ -3197,7 +3198,7 @@ i64 asm_slow_path_get_private_by_id(VM* vm, u32 pc, Op::GetPrivateById const* in
         auto private_name = make_private_reference(current_vm, base_value, name);
         auto result = ASM_TRY(*vm, pc, private_name.get_value(current_vm));
         vm->set(instruction->dst(), result);
-        return static_cast<i64>(pc + sizeof(Op::GetPrivateById));
+        return continue_after_slow_path(pc + sizeof(Op::GetPrivateById));
     }
 
     auto const& name = current_vm.get_identifier(instruction->property());
@@ -3206,7 +3207,7 @@ i64 asm_slow_path_get_private_by_id(VM* vm, u32 pc, Op::GetPrivateById const* in
     auto private_name = private_environment->resolve_private_identifier(name);
     auto result = ASM_TRY(*vm, pc, base_value.as_object().private_get(private_name));
     vm->set(instruction->dst(), result);
-    return static_cast<i64>(pc + sizeof(Op::GetPrivateById));
+    return continue_after_slow_path(pc + sizeof(Op::GetPrivateById));
 }
 
 // Direct handler for PutPrivateById: bypasses Reference indirection.
@@ -3221,7 +3222,7 @@ i64 asm_slow_path_put_private_by_id(VM* vm, u32 pc, Op::PutPrivateById const* in
         auto const& name = current_vm.get_identifier(instruction->property());
         auto private_reference = make_private_reference(current_vm, object, name);
         ASM_TRY(*vm, pc, private_reference.put_value(current_vm, value));
-        return static_cast<i64>(pc + sizeof(Op::PutPrivateById));
+        return continue_after_slow_path(pc + sizeof(Op::PutPrivateById));
     }
 
     auto const& name = current_vm.get_identifier(instruction->property());
@@ -3229,7 +3230,7 @@ i64 asm_slow_path_put_private_by_id(VM* vm, u32 pc, Op::PutPrivateById const* in
     VERIFY(private_environment);
     auto private_name = private_environment->resolve_private_identifier(name);
     ASM_TRY(*vm, pc, base_value.as_object().private_set(private_name, value));
-    return static_cast<i64>(pc + sizeof(Op::PutPrivateById));
+    return continue_after_slow_path(pc + sizeof(Op::PutPrivateById));
 }
 
 // Helper: convert value to boolean (called from asm jump handlers)

--- a/Libraries/LibJS/Interpreter/SlowPaths.cpp
+++ b/Libraries/LibJS/Interpreter/SlowPaths.cpp
@@ -1170,6 +1170,7 @@ i64 asm_slow_path_get_global(VM* vm, u32 pc, Op::GetGlobal const* instruction)
         }
     }
 
+    cache = {};
     cache.environment_serial_number = declarative_record.environment_serial_number();
 
     auto& identifier = vm->get_identifier(instruction->identifier());
@@ -1275,6 +1276,7 @@ i64 asm_slow_path_set_global(VM* vm, u32 pc, Op::SetGlobal const* instruction)
         }
     }
 
+    cache = {};
     cache.environment_serial_number = declarative_record.environment_serial_number();
 
     auto& identifier = vm->get_identifier(instruction->identifier());

--- a/Libraries/LibJS/Interpreter/SlowPaths.cpp
+++ b/Libraries/LibJS/Interpreter/SlowPaths.cpp
@@ -750,6 +750,10 @@ void asm_debugger_check_breakpoint(VM* vm, u32 pc)
     if (!debugger)
         return;
 
+    // NB: Debugger callbacks must not inspect slots before Enter initializes them.
+    if (!vm->running_execution_context().frame_initialized)
+        return;
+
     auto& executable = vm->current_executable();
     debugger->register_executable(executable);
     auto reason = [&]() -> Optional<Debugger::PauseReason> {

--- a/Libraries/LibJS/Interpreter/interpreter.flap
+++ b/Libraries/LibJS/Interpreter/interpreter.flap
@@ -1118,12 +1118,12 @@ handler Exp(
     dst: out Operand,
     lhs: in Operand,
     rhs: in Operand
-) {
+) @cold {
     call_binary_slow_path(exp_values, dst, load(lhs), load(rhs));
 }
 
 handler ConcatString(
-    dst: out Operand,
+    dst: inout Operand,
     src: Operand
 ) @cold = call_slow_path(concat_string);
 
@@ -1698,7 +1698,7 @@ handler NewArrayWithLength(
 ) @cold = call_slow_path(new_array_with_length);
 
 handler ArrayAppend(
-    dst: out Operand,
+    dst: in Operand,
     src: Operand,
     is_spread: bool
 ) @cold = call_slow_path(array_append);
@@ -2360,7 +2360,13 @@ handler GetById(
     cache: PropertyLookupCacheIndex
 ) {
     let try_cache = || @cold {
-        guard call_interp(asm_try_get_by_id_cache) == 0 else slow;
+        let executable = exec_ctx.executable;
+        let caches: u64 = alias(executable.property_lookup_caches);
+        let cache_index: u64 = alias(load(cache));
+        let cache_pointer = caches + cache_index * PROPERTY_LOOKUP_CACHE_SIZE;
+        let result: Value = call_helper_with_two_arguments(asm_try_get_by_id_cache, load(base), cache_pointer);
+        guard result is not Value<Empty> else slow;
+        store(dst, result);
         dispatch_next;
     };
 
@@ -3526,7 +3532,7 @@ handler IteratorNext(
     dst: out Operand,
     iterator_object: Operand,
     iterator_next: Operand,
-    iterator_done: Operand
+    iterator_done: inout Operand
 ) @cold = call_slow_path(asm_slow_path_iterator_next);
 
 handler IteratorNextUnpack(
@@ -3534,14 +3540,14 @@ handler IteratorNextUnpack(
     dst_done: out Operand,
     iterator_object: Operand,
     iterator_next: Operand,
-    iterator_done: Operand
+    iterator_done: inout Operand
 ) @cold = call_slow_path(iterator_next_unpack);
 
 handler IteratorToArray(
     dst: out Operand,
     iterator_object: Operand,
     iterator_next_method: Operand,
-    iterator_done_property: Operand
+    iterator_done_property: inout Operand
 ) @cold = call_slow_path(iterator_to_array);
 
 handler CallConstruct(
@@ -3750,8 +3756,8 @@ handler DeleteVariable(
 ) @cold = call_slow_path(delete_variable);
 
 handler GetCompletionFields(
-    type_dst: Operand,
-    value_dst: Operand,
+    type_dst: out Operand,
+    value_dst: out Operand,
     completion: Operand
 ) @cold = call_slow_path(get_completion_fields);
 

--- a/Libraries/LibJS/Interpreter/interpreter.flap
+++ b/Libraries/LibJS/Interpreter/interpreter.flap
@@ -2467,23 +2467,22 @@ handler GetById(
     guard let property_cache = load_property_lookup_cache(cache) else try_cache;
     guard property_cache.shape == shape else try_cache;
     guard property_cache.entry_type != PROPERTY_LOOKUP_CACHE_ENTRY_TYPE_GET_MISSING_PROPERTY else try_cache;
-    let cached_prototype = property_cache.prototype;
+    let load_cached_value = |holder: Object, object: Object, property_cache: PropertyLookupCache, shape: Shape| {
+        guard property_cache.shape_dictionary_generation == shape.dictionary_generation else try_cache;
+        let value = holder.named_properties[property_cache.property_offset];
+        guard value is not Value<Accessor> else invoke_accessor(value, object, property_cache);
+        store(dst, value);
+        dispatch_next;
+    };
 
-    # FIXME: Restore a value-producing if once SSA destruction can coalesce its
-    #        holder phi with object without adding a hot-path jump.
-    let mut holder = object;
-    if cached_prototype != 0 {
+    let cached_prototype = property_cache.prototype;
+    guard cached_prototype == 0 else @cold {
         let prototype_chain_validity = property_cache.prototype_chain_validity;
         guard prototype_chain_validity != 0 else try_cache;
         guard prototype_chain_validity.valid != 0 else try_cache;
-        holder = cached_prototype;
-    }
-
-    guard property_cache.shape_dictionary_generation == shape.dictionary_generation else try_cache;
-    let value = holder.named_properties[property_cache.property_offset];
-    guard value is not Value<Accessor> else invoke_accessor(value, object, property_cache);
-    store(dst, value);
-    dispatch_next;
+        goto load_cached_value(cached_prototype, object, property_cache, shape);
+    };
+    goto load_cached_value(object, object, property_cache, shape);
 }
 
 handler GetByIdWithThis(

--- a/Libraries/LibJS/Interpreter/interpreter.flap
+++ b/Libraries/LibJS/Interpreter/interpreter.flap
@@ -365,10 +365,16 @@ inline fn return_to_caller(
 ) {
     let caller_frame = exec_ctx.caller_frame;
     guard caller_frame != 0 else top_level;
+    let mut result = return_value;
+    if exec_ctx.caller_is_construct {
+        if result is not Value<Object> {
+            result = exec_ctx.this_value;
+        }
+    }
     let return_pc = exec_ctx.caller_return_pc;
     let destination_index = exec_ctx.caller_dst_raw;
     caller_frame.program_counter = return_pc;
-    caller_frame.slots[destination_index] = return_value;
+    caller_frame.slots[destination_index] = result;
     let vm = current_vm();
     vm.running_execution_context = caller_frame;
     vm.interpreter_stack_top = alias(exec_ctx);

--- a/Libraries/LibJS/Interpreter/interpreter.flap
+++ b/Libraries/LibJS/Interpreter/interpreter.flap
@@ -894,6 +894,35 @@ inline fn load_primitive_string_utf16_code_unit(
 
 # Bytecode handlers are kept in native layout order.
 
+handler Enter() {
+    let executable = exec_ctx.executable;
+    assert_nonzero(executable);
+    let registers_and_locals_count = executable.registers_and_locals_count;
+    let empty_tag: Value = Value<Empty>;
+    let mut slot_index: u64 = RESERVED_REGISTER_COUNT;
+    while slot_index + 1 < alias(registers_and_locals_count) {
+        let next_slot_index = slot_index + 1;
+        values[slot_index] = empty_tag;
+        values[next_slot_index] = empty_tag;
+        slot_index = slot_index + 2;
+    }
+    if slot_index < alias(registers_and_locals_count) {
+        values[slot_index] = empty_tag;
+    }
+    let constant_count = executable.asm_constants_size;
+    let constant_data = executable.asm_constants_data;
+    let mut write_index: u64 = alias(registers_and_locals_count);
+    let mut constant_index: u64 = 0;
+    while constant_index < alias(constant_count) {
+        assert_nonzero(constant_data);
+        values[write_index] = constant_data[constant_index];
+        constant_index = constant_index + 1;
+        write_index = write_index + 1;
+    }
+    exec_ctx.frame_initialized = true;
+    dispatch_next;
+}
+
 handler Mov(
     dst: out Operand,
     src: in Operand
@@ -2419,6 +2448,7 @@ handler GetById(
         native_frame.yield_is_await = false;
         native_frame.yield_value_is_iterator_result = false;
         native_frame.caller_is_construct = false;
+        native_frame.frame_initialized = false;
         let native_pc: u32 = pc;
         let [destination_offset, _] = load_pair32(
             [pb, pc, dst],
@@ -2909,35 +2939,14 @@ handler Call(
     frame.yield_is_await = false;
     frame.yield_value_is_iterator_result = false;
     frame.caller_is_construct = false;
+    frame.frame_initialized = false;
     frame.caller_frame = exec_ctx;
     let [_, return_pc, return_destination] = call_site_info(length, dst);
     frame.caller_return_pc = return_pc;
     frame.caller_dst_raw = return_destination;
-    let mut slot_index: u64 = RESERVED_REGISTER_COUNT;
-    while slot_index + 1 < alias(registers_and_locals_count) {
-        let next_slot_index = slot_index + 1;
-        frame_values[slot_index] = empty_tag;
-        frame_values[next_slot_index] = empty_tag;
-        slot_index = slot_index + 2;
-    }
-    if slot_index < alias(registers_and_locals_count) {
-        frame_values[slot_index] = empty_tag;
-    }
-    let executable = frame.executable;
-    assert_nonzero(executable);
-    let constant_count = executable.asm_constants_size;
-    let constant_data = executable.asm_constants_data;
-    let mut write_index: u64 = alias(registers_and_locals_count);
-    let mut constant_index: u64 = 0;
-    while constant_index < alias(constant_count) {
-        assert_nonzero(constant_data);
-        frame_values[write_index] = constant_data[constant_index];
-        constant_index = constant_index + 1;
-        write_index = write_index + 1;
-    }
     let actual_argument_count = load(argument_count);
     assert_ge_unsigned(formal_count, actual_argument_count);
-    write_index = alias(registers_and_locals_count) + alias(constant_count);
+    let mut write_index: u64 = alias(callee_slot_count);
     let caller_values = exec_ctx.slots;
     let argument_operand_indices = &arguments;
     let mut argument_index: u32 = 0;
@@ -3027,6 +3036,7 @@ handler Call(
         native_frame.yield_is_await = false;
         native_frame.yield_value_is_iterator_result = false;
         native_frame.caller_is_construct = false;
+        native_frame.frame_initialized = false;
         let [native_pc, after_pc, destination_offset] = call_site_info(length, dst);
         exec_ctx.program_counter = native_pc;
         native_frame.caller_frame = exec_ctx;

--- a/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -103,7 +103,6 @@ void ExecutionContext::operator delete(void* ptr)
 NonnullOwnPtr<ExecutionContext> ExecutionContext::copy() const
 {
     // NB: We pass the entire non-argument count as registers_and_locals_count with 0 constants.
-    //     This means all slots get initialized to empty, but we immediately overwrite them below.
     auto copy = create(registers_and_constants_and_locals_and_arguments_count - argument_count, ReadonlySpan<Value> {}, argument_count);
     copy->function = function;
     copy->realm = realm;
@@ -117,12 +116,16 @@ NonnullOwnPtr<ExecutionContext> ExecutionContext::copy() const
     copy->yield_is_await = yield_is_await;
     copy->yield_value_is_iterator_result = yield_value_is_iterator_result;
     copy->caller_is_construct = caller_is_construct;
+    copy->frame_initialized = frame_initialized;
     copy->this_value = this_value;
     copy->executable = executable;
     copy->passed_argument_count = passed_argument_count;
     copy->registers_and_constants_and_locals_and_arguments_count = registers_and_constants_and_locals_and_arguments_count;
-    for (size_t i = 0; i < registers_and_constants_and_locals_and_arguments_count; ++i)
+    for (size_t i = 0; i < registers_and_constants_and_locals_and_arguments_count; ++i) {
+        if (!frame_initialized && i >= Bytecode::Register::reserved_register_count && i < registers_and_constants_and_locals_and_arguments_count - argument_count)
+            continue;
         copy->registers_and_constants_and_locals_and_arguments()[i] = registers_and_constants_and_locals_and_arguments()[i];
+    }
     copy->argument_count = argument_count;
     return copy;
 }
@@ -148,7 +151,16 @@ void ExecutionContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(private_environment);
     visitor.visit(this_value);
     visitor.visit(executable);
-    visitor.visit(registers_and_constants_and_locals_and_arguments_span());
+    auto values = registers_and_constants_and_locals_and_arguments_span();
+    if (frame_initialized) {
+        visitor.visit(values);
+    } else {
+        // NB: Call setup can trigger GC before Enter initializes the frame.
+        //     Only the reserved registers and arguments are live at that point.
+        auto non_argument_count = registers_and_constants_and_locals_and_arguments_count - argument_count;
+        visitor.visit(values.slice(0, min(non_argument_count, Bytecode::Register::reserved_register_count)));
+        visitor.visit(arguments_span());
+    }
     visitor.visit(script_or_module);
 }
 

--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -11,6 +11,7 @@
 
 #include <AK/Checked.h>
 #include <AK/Span.h>
+#include <LibJS/Bytecode/Register.h>
 #include <LibJS/Export.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Module.h>
@@ -43,10 +44,9 @@ public:
         registers_and_constants_and_locals_and_arguments_count = registers_and_locals_count + constants.size() + arguments_count_;
         argument_count = arguments_count_;
         auto* values = registers_and_constants_and_locals_and_arguments();
-        for (size_t i = 0; i < registers_and_locals_count; ++i)
+        // NB: Enter initializes the remaining registers, locals, and constants.
+        for (size_t i = 0; i < min(registers_and_locals_count, Bytecode::Register::reserved_register_count); ++i)
             values[i] = js_special_empty_value();
-        for (size_t i = 0; i < constants.size(); ++i)
-            values[registers_and_locals_count + i] = constants[i];
     }
 
     void operator delete(void* ptr);
@@ -74,6 +74,7 @@ public:
     bool yield_is_await { false };
     bool yield_value_is_iterator_result { false };
     bool caller_is_construct { false };
+    bool frame_initialized { false };
 
     Optional<Value> this_value;
 

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -21,7 +21,6 @@
 #include <LibGC/RootVector.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/Label.h>
-#include <LibJS/Bytecode/Operand.h>
 #include <LibJS/Bytecode/Register.h>
 #include <LibJS/CyclicModule.h>
 #include <LibJS/Export.h>
@@ -114,15 +113,6 @@ public:
         return m_running_execution_context->registers_and_constants_and_locals_and_arguments()[r.index()];
     }
 
-    ALWAYS_INLINE Value get(Bytecode::Operand op) const
-    {
-        return m_running_execution_context->registers_and_constants_and_locals_and_arguments()[op.raw()];
-    }
-    ALWAYS_INLINE void set(Bytecode::Operand op, Value value)
-    {
-        m_running_execution_context->registers_and_constants_and_locals_and_arguments_span().data()[op.raw()] = value;
-    }
-
     void do_return(Value value)
     {
         if (value.is_special_empty_value())
@@ -164,7 +154,7 @@ public:
     ExecutionContext* push_inline_frame(
         ECMAScriptFunctionObject& callee_function,
         Bytecode::Executable& callee_executable,
-        ReadonlySpan<Bytecode::Operand> arguments,
+        ReadonlySpan<Value> arguments,
         u32 return_pc,
         u32 dst_raw,
         Value this_value,

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -1671,27 +1671,27 @@ impl Generator {
     /// 4. Encode to bytes and build source map + exception handlers
     pub fn assemble(&mut self) -> AssembledBytecode {
         let saved_environment = Operand::register(Register::SAVED_LEXICAL_ENVIRONMENT);
-        let synthetic_load_block = self.basic_blocks.iter().position(|block| {
+        let synthetic_load = self.basic_blocks.iter().enumerate().find_map(|(block_index, block)| {
+            let (instruction_index, (instruction, _, _)) = block
+                .instructions
+                .iter()
+                .enumerate()
+                .find(|(_, (instruction, _, _))| !matches!(instruction, Instruction::Enter))?;
             matches!(
-                block.instructions.first(),
-                Some((
-                    Instruction::GetLexicalEnvironment {
-                        dst,
-                    },
-                    _,
-                    _
-                )) if *dst == saved_environment
+                instruction,
+                Instruction::GetLexicalEnvironment { dst } if *dst == saved_environment
             )
+            .then_some((block_index, instruction_index))
         });
 
-        if let Some(load_block_index) = synthetic_load_block {
+        if let Some((load_block_index, load_instruction_index)) = synthetic_load {
             let saved_environment_is_used = self.basic_blocks.iter().enumerate().any(|(block_index, block)| {
                 block
                     .instructions
                     .iter()
                     .enumerate()
                     .any(|(instruction_index, (instruction, _, _))| {
-                        if block_index == load_block_index && instruction_index == 0 {
+                        if block_index == load_block_index && instruction_index == load_instruction_index {
                             return false;
                         }
                         let mut instruction = instruction.clone();
@@ -1706,7 +1706,9 @@ impl Generator {
             });
 
             if !saved_environment_is_used {
-                self.basic_blocks[load_block_index].instructions.remove(0);
+                self.basic_blocks[load_block_index]
+                    .instructions
+                    .remove(load_instruction_index);
             }
         }
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -42,7 +42,7 @@ use crate::bytecode::validator::validate_bytecode;
 use crate::u32_from_usize;
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
-const FORMAT_VERSION: u32 = 15;
+const FORMAT_VERSION: u32 = 16;
 const SOURCE_HASH_SIZE: usize = 32;
 const BYTECODE_ALIGNMENT: usize = 8;
 const COMPLETION_TYPE_VARIANT_COUNT: u32 = 6;

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -332,6 +332,7 @@ fn compile_program_body_to_bytecode(
 
     let entry_block = generator.make_block();
     generator.switch_to_basic_block(entry_block);
+    generator.emit(bytecode::instruction::Instruction::Enter {});
     generator.capture_saved_lexical_environment();
 
     let result = bytecode::codegen::generate_statement(program, generator, None);
@@ -2649,6 +2650,7 @@ fn compile_module_as_async_to_bytecode(
 
     let entry_block = generator.make_block();
     generator.switch_to_basic_block(entry_block);
+    generator.emit(Instruction::Enter {});
 
     // Async function start: emit initial Yield before GetLexicalEnvironment.
     let start_block = generator.make_block();
@@ -3295,6 +3297,7 @@ fn compile_function_payload_to_bytecode(
 
     let entry_block = generator.make_block();
     generator.switch_to_basic_block(entry_block);
+    generator.emit(bytecode::instruction::Instruction::Enter {});
 
     // https://tc39.es/ecma262/#sec-async-functions-abstract-operations-async-function-start
     // For async (non-generator) functions, emit the initial Yield BEFORE

--- a/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
+++ b/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
@@ -1,4 +1,4 @@
-$f7367586 annex-b-function-in-if.js:13:1
+$80e4413e annex-b-function-in-if.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -7,74 +7,78 @@ $f7367586 annex-b-function-in-if.js:13:1
     [2] = Bool(false)
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `annexBFunctionInIf`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(true)]
-  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  88] GetGlobal dst:reg6, `console`
-  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  b0] GetGlobal dst:reg10, `annexBFunctionInIf`
-  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(false)]
-  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 110] End value:reg7
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `annexBFunctionInIf`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(true)]
+  [  68] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  90] GetGlobal dst:reg6, `console`
+  [  a0] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b8] GetGlobal dst:reg10, `annexBFunctionInIf`
+  [  c8] Call dst:reg9, callee:reg10, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(false)]
+  [  f0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 118] End value:reg7
 
 
-annexBFunctionInIf$f1f2b149 annex-b-function-in-if.js:2:5
+annexBFunctionInIf$6dccc7b1 annex-b-function-in-if.js:2:5
   Registers: 8
   Blocks:    4
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
-  [  18] InitializeVariableBinding `inner`, src:Undefined
-  [  30] JumpFalse condition:arg0, target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
+  [  20] InitializeVariableBinding `inner`, src:Undefined
+  [  38] JumpFalse condition:arg0, target:block2
 
 block1:
-  [  40] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  58] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
-  [  68] NewFunction dst:reg6, shared_function_data_index:0
-  [  80] InitializeLexicalBinding `inner`, src:reg6
-  [  98] GetBinding dst:reg6, `inner`
-  [  b0] SetVariableBinding `inner`, src:reg6
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] Jump target:block3
+  [  48] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  60] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
+  [  70] NewFunction dst:reg6, shared_function_data_index:0
+  [  88] InitializeLexicalBinding `inner`, src:reg6
+  [  a0] GetBinding dst:reg6, `inner`
+  [  b8] SetVariableBinding `inner`, src:reg6
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] Jump target:block3
 
 block2:
-  [  d8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  f0] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
-  [ 100] NewFunction dst:reg6, shared_function_data_index:1
-  [ 118] InitializeLexicalBinding `inner`, src:reg6
-  [ 130] GetBinding dst:reg6, `inner`
-  [ 148] SetVariableBinding `inner`, src:reg6
-  [ 160] SetLexicalEnvironment environment:reg4
+  [  e0] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  f8] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
+  [ 108] NewFunction dst:reg6, shared_function_data_index:1
+  [ 120] InitializeLexicalBinding `inner`, src:reg6
+  [ 138] GetBinding dst:reg6, `inner`
+  [ 150] SetVariableBinding `inner`, src:reg6
+  [ 168] SetLexicalEnvironment environment:reg4
 
 block3:
-  [ 168] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
-  [ 180] Call dst:reg5, callee:reg6, this_value:reg7, inner
-  [ 1a0] Return value:reg5
+  [ 170] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
+  [ 188] Call dst:reg5, callee:reg6, this_value:reg7, inner
+  [ 1a8] Return value:reg5
 
 
-inner$b5b8e95a annex-b-function-in-if.js:4:13
+inner$3192ffc2 annex-b-function-in-if.js:4:13
   Registers: 5
   Blocks:    1
   Constants:
     [0] = String("true branch")
 
 block0:
-  [   0] Return value:String("true branch")
+  [   0] Enter
+  [   8] Return value:String("true branch")
 
 
-inner$8980a116 annex-b-function-in-if.js:8:13
+inner$081ea88e annex-b-function-in-if.js:8:13
   Registers: 5
   Blocks:    1
   Constants:
     [0] = String("false branch")
 
 block0:
-  [   0] Return value:String("false branch")
+  [   0] Enter
+  [   8] Return value:String("false branch")
 
 
 "true branch"

--- a/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
+++ b/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
@@ -1,16 +1,17 @@
-$49b95e06 annexb-function-existing-var.js:10:1
+$d36729be annexb-function-existing-var.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `test`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `test`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  38] End value:reg5
 
 
-test$02c02c04 annexb-function-existing-var.js:2:5
+test$aa255e47 annexb-function-existing-var.js:2:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -19,16 +20,17 @@ test$02c02c04 annexb-function-existing-var.js:2:5
     [2] = Bool(true)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateVariable `f`, is_immutable:false, is_global:false, is_strict:false
-  [  18] InitializeVariableBinding `f`, src:Undefined
-  [  30] SetLexicalBinding `f`, src:Int32(123)
-  [  48] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  60] CreateMutableBinding environment:reg5, `f`, can_be_deleted:false
-  [  70] NewFunction dst:reg6, shared_function_data_index:0
-  [  88] InitializeLexicalBinding `f`, src:reg6
-  [  a0] GetBinding dst:reg6, `f`
-  [  b8] SetVariableBinding `f`, src:reg6
-  [  d0] SetLexicalEnvironment environment:reg4
-  [  d8] GetInitializedBinding dst:reg5, `f`
-  [  f0] Return value:reg5
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateVariable `f`, is_immutable:false, is_global:false, is_strict:false
+  [  20] InitializeVariableBinding `f`, src:Undefined
+  [  38] SetLexicalBinding `f`, src:Int32(123)
+  [  50] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  68] CreateMutableBinding environment:reg5, `f`, can_be_deleted:false
+  [  78] NewFunction dst:reg6, shared_function_data_index:0
+  [  90] InitializeLexicalBinding `f`, src:reg6
+  [  a8] GetBinding dst:reg6, `f`
+  [  c0] SetVariableBinding `f`, src:reg6
+  [  d8] SetLexicalEnvironment environment:reg4
+  [  e0] GetInitializedBinding dst:reg5, `f`
+  [  f8] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/annexb-var-coordinate-with-default-param.txt
+++ b/Tests/LibJS/Bytecode/expected/annexb-var-coordinate-with-default-param.txt
@@ -1,16 +1,17 @@
-$546ebce0 annexb-var-coordinate-with-default-param.js:12:1
+$c7fd0018 annexb-var-coordinate-with-default-param.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  38] End value:reg5
 
 
-f$40af7db5 annexb-var-coordinate-with-default-param.js:4:5
+f$bf4d852d annexb-var-coordinate-with-default-param.js:4:5
   Registers: 10
   Blocks:    3
   Constants:
@@ -20,39 +21,41 @@ f$40af7db5 annexb-var-coordinate-with-default-param.js:4:5
     [3] = Bool(true)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  30] JumpUndefined condition:arg0, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  38] JumpUndefined condition:arg0, true_target:block1, false_target:block2
 
 block1:
-  [  40] Mov dst:arg0, src:Int32(1)
+  [  48] Mov dst:arg0, src:Int32(1)
 
 block2:
-  [  50] InitializeLexicalBinding `x`, src:arg0
-  [  68] CreateVariable `g`, is_immutable:false, is_global:false, is_strict:false
-  [  78] InitializeVariableBinding `g`, src:Undefined
-  [  90] CreateLexicalEnvironment dst:reg6, parent:reg5, capacity:1, is_catch_environment:false
-  [  a8] CreateVariable `y`, is_immutable:false, is_global:false, is_strict:false
-  [  b8] InitializeLexicalBinding `y`, src:Int32(2)
-  [  d0] CreateLexicalEnvironment dst:reg7, parent:reg6, capacity:0, is_catch_environment:false
-  [  e8] CreateMutableBinding environment:reg7, `g`, can_be_deleted:false
-  [  f8] NewFunction dst:reg8, shared_function_data_index:0
-  [ 110] InitializeLexicalBinding `g`, src:reg8
-  [ 128] GetBinding dst:reg8, `g`
-  [ 140] SetVariableBinding `g`, src:reg8
-  [ 158] SetLexicalEnvironment environment:reg6
-  [ 160] GetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `g`
-  [ 178] Call dst:reg7, callee:reg8, this_value:reg9, g
-  [ 198] Return value:reg7
+  [  58] InitializeLexicalBinding `x`, src:arg0
+  [  70] CreateVariable `g`, is_immutable:false, is_global:false, is_strict:false
+  [  80] InitializeVariableBinding `g`, src:Undefined
+  [  98] CreateLexicalEnvironment dst:reg6, parent:reg5, capacity:1, is_catch_environment:false
+  [  b0] CreateVariable `y`, is_immutable:false, is_global:false, is_strict:false
+  [  c0] InitializeLexicalBinding `y`, src:Int32(2)
+  [  d8] CreateLexicalEnvironment dst:reg7, parent:reg6, capacity:0, is_catch_environment:false
+  [  f0] CreateMutableBinding environment:reg7, `g`, can_be_deleted:false
+  [ 100] NewFunction dst:reg8, shared_function_data_index:0
+  [ 118] InitializeLexicalBinding `g`, src:reg8
+  [ 130] GetBinding dst:reg8, `g`
+  [ 148] SetVariableBinding `g`, src:reg8
+  [ 160] SetLexicalEnvironment environment:reg6
+  [ 168] GetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `g`
+  [ 180] Call dst:reg7, callee:reg8, this_value:reg9, g
+  [ 1a0] Return value:reg7
 
 
-g$b7262970 annexb-var-coordinate-with-default-param.js:7:13
+g$252c8a88 annexb-var-coordinate-with-default-param.js:7:13
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `x`
-  [  10] DynamicGetBinding dst:reg6, `y`
-  [  20] Add dst:reg7, lhs:reg5, rhs:reg6
-  [  30] Return value:reg7
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `x`
+  [  18] DynamicGetBinding dst:reg6, `y`
+  [  28] Add dst:reg7, lhs:reg5, rhs:reg6
+  [  38] Return value:reg7

--- a/Tests/LibJS/Bytecode/expected/argument-postfix-self-move.txt
+++ b/Tests/LibJS/Bytecode/expected/argument-postfix-self-move.txt
@@ -1,4 +1,4 @@
-$12cfcca1 argument-postfix-self-move.js:5:1
+$9431c529 argument-postfix-self-move.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,16 +6,18 @@ $12cfcca1 argument-postfix-self-move.js:5:1
     [1] = Int32(10)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(10)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(10)]
+  [  40] End value:reg5
 
 
-f$833b82e7 argument-postfix-self-move.js:2:6
+f$01d98a5f argument-postfix-self-move.js:2:6
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] PostfixDecrement dst:reg5, src:arg0
-  [  10] Mov dst:arg0, src:arg0
-  [  20] Return value:arg0
+  [   0] Enter
+  [   8] PostfixDecrement dst:reg5, src:arg0
+  [  18] Mov dst:arg0, src:arg0
+  [  28] Return value:arg0

--- a/Tests/LibJS/Bytecode/expected/argument-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/argument-variables.txt
@@ -1,4 +1,4 @@
-$495ef8a0 argument-variables.js:12:1
+$bced3bd8 argument-variables.js:12:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,25 +7,28 @@ $495ef8a0 argument-variables.js:12:1
     [2] = Int32(2)
 
 block0:
-  [   0] GetGlobal dst:reg6, `identity`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, identity, arguments:[Int32(1)]
-  [  38] GetGlobal dst:reg7, `swap`
-  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, swap, arguments:[Int32(1), Int32(2)]
-  [  70] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `identity`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, identity, arguments:[Int32(1)]
+  [  40] GetGlobal dst:reg7, `swap`
+  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, swap, arguments:[Int32(1), Int32(2)]
+  [  78] End value:reg6
 
 
-identity$753f961b argument-variables.js:5:5
+identity$f6a18ea3 argument-variables.js:5:5
   Registers: 5
   Blocks:    1
 
 block0:
-  [   0] Return value:arg0
+  [   0] Enter
+  [   8] Return value:arg0
 
 
-swap$556fb42c argument-variables.js:9:5
+swap$d149ca94 argument-variables.js:9:5
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] Add dst:reg5, lhs:arg1, rhs:arg0
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] Add dst:reg5, lhs:arg1, rhs:arg0
+  [  18] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/arguments-with-arguments-fn.txt
+++ b/Tests/LibJS/Bytecode/expected/arguments-with-arguments-fn.txt
@@ -1,16 +1,17 @@
-$bacf2c68 arguments-with-arguments-fn.js:4:1
+$2b997e90 arguments-with-arguments-fn.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  38] End value:reg5
 
 
-f$6cd6eab3
+f$f684b66b
   Registers: 6
   Blocks:    3
   Locals:    arguments~0
@@ -19,12 +20,13 @@ f$6cd6eab3
     [1] = Undefined
 
 block0:
-  [   0] JumpUndefined condition:arg0, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] JumpUndefined condition:arg0, true_target:block1, false_target:block2
 
 block1:
-  [  10] Mov dst:arg0, src:Int32(1)
+  [  18] Mov dst:arg0, src:Int32(1)
 
 block2:
-  [  20] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:arguments~0, c1_src:reg5
-  [  38] NewFunction dst:arguments~0, shared_function_data_index:0
-  [  50] End value:Undefined
+  [  28] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:arguments~0, c1_src:reg5
+  [  40] NewFunction dst:arguments~0, shared_function_data_index:0
+  [  58] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/assign-to-argument-no-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-argument-no-tdz.txt
@@ -1,4 +1,4 @@
-$ba9d77cf assign-to-argument-no-tdz.js:11:1
+$393b7f47 assign-to-argument-no-tdz.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $ba9d77cf assign-to-argument-no-tdz.js:11:1
     [1] = Int32(0)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(0)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(0)]
+  [  40] End value:reg5
 
 
-f$44906188 assign-to-argument-no-tdz.js:6:5
+f$c32e6900 assign-to-argument-no-tdz.js:6:5
   Registers: 5
   Blocks:    1
   Locals:    y~0
@@ -19,5 +20,6 @@ f$44906188 assign-to-argument-no-tdz.js:6:5
     [0] = Int32(1)
 
 block0:
-  [   0] Mov2 c0_dst:y~0, c0_src:Int32(1), c1_dst:arg0, c1_src:y~0
-  [  18] Return value:arg0
+  [   0] Enter
+  [   8] Mov2 c0_dst:y~0, c0_src:Int32(1), c1_dst:arg0, c1_src:y~0
+  [  20] Return value:arg0

--- a/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
@@ -1,4 +1,4 @@
-$495ef8a0 assign-to-let-variable-tdz.js:12:1
+$bced3bd8 assign-to-let-variable-tdz.js:12:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,15 +6,16 @@ $495ef8a0 assign-to-let-variable-tdz.js:12:1
     [1] = String("hello")
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] NewObject dst:reg7
-  [  20] InitObjectLiteralProperty object:reg7, `location`, src:String("hello"), shape_cache_index:0, property_slot:0
-  [  38] CacheObjectShape object:reg7
-  [  48] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  70] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] NewObject dst:reg7
+  [  28] InitObjectLiteralProperty object:reg7, `location`, src:String("hello"), shape_cache_index:0, property_slot:0
+  [  40] CacheObjectShape object:reg7
+  [  50] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  78] End value:reg5
 
 
-f$d3dfd701 assign-to-let-variable-tdz.js:7:5
+f$4cf5fc59 assign-to-let-variable-tdz.js:7:5
   Registers: 10
   Blocks:    3
   Locals:    a~0
@@ -23,27 +24,29 @@ f$d3dfd701 assign-to-let-variable-tdz.js:7:5
     [1] = Undefined
 
 block0:
-  [   0] ThrowIfNullish src:arg0
-  [   8] GetById dst:reg5, base:arg0, `location`
-  [  20] Mov dst:a~0, src:reg5
-  [  30] Typeof dst:reg5, src:a~0
-  [  40] LooselyEquals dst:reg6, lhs:String("string"), rhs:reg5
-  [  50] Mov dst:reg5, src:reg6
-  [  60] JumpFalse condition:reg6, target:block2
+  [   0] Enter
+  [   8] ThrowIfNullish src:arg0
+  [  10] GetById dst:reg5, base:arg0, `location`
+  [  28] Mov dst:a~0, src:reg5
+  [  38] Typeof dst:reg5, src:a~0
+  [  48] LooselyEquals dst:reg6, lhs:String("string"), rhs:reg5
+  [  58] Mov dst:reg5, src:reg6
+  [  68] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  70] GetGlobal dst:reg8, `g`
-  [  80] Mov dst:reg9, src:a~0
-  [  90] Call dst:reg7, callee:reg8, this_value:Undefined, g, arguments:[reg9]
-  [  b8] Mov2 c0_dst:a~0, c0_src:reg7, c1_dst:reg5, c1_src:reg7
+  [  78] GetGlobal dst:reg8, `g`
+  [  88] Mov dst:reg9, src:a~0
+  [  98] Call dst:reg7, callee:reg8, this_value:Undefined, g, arguments:[reg9]
+  [  c0] Mov2 c0_dst:a~0, c0_src:reg7, c1_dst:reg5, c1_src:reg7
 
 block2:
-  [  d0] Return value:a~0
+  [  d8] Return value:a~0
 
 
-g$f452072f assign-to-let-variable-tdz.js:4:17
+g$702c1d97 assign-to-let-variable-tdz.js:4:17
   Registers: 5
   Blocks:    1
 
 block0:
-  [   0] Return value:arg0
+  [   0] Enter
+  [   8] Return value:arg0

--- a/Tests/LibJS/Bytecode/expected/assign-to-parameter.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-parameter.txt
@@ -1,21 +1,23 @@
-$a2a07da4 assign-to-parameter.js:8:1
+$162ec0dc assign-to-parameter.js:8:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `isect`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, isect
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `isect`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, isect
+  [  38] End value:reg5
 
 
-isect$41c8d351 assign-to-parameter.js:5:9
+isect$cb769f09 assign-to-parameter.js:5:9
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Mov dst:arg0, src:arg1
-  [  10] End value:Undefined
+  [   0] Enter
+  [   8] Mov dst:arg0, src:arg1
+  [  18] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/async-await-in-try-catch.txt
+++ b/Tests/LibJS/Bytecode/expected/async-await-in-try-catch.txt
@@ -1,17 +1,18 @@
-$faa11ddd async-await-in-try-catch.js:9:1
+$793f2555 async-await-in-try-catch.js:9:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] NewObject dst:reg7
-  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  48] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] NewObject dst:reg7
+  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  50] End value:reg5
 
 
-f$8982c134 async-await-in-try-catch.js:2:5
+f$0298e68c async-await-in-try-catch.js:2:5
   Registers: 10
   Blocks:    8
   Locals:    e~0
@@ -20,37 +21,38 @@ f$8982c134 async-await-in-try-catch.js:2:5
     [1] = Int32(1)
 
 block0:
-  [   0] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  10] GetLexicalEnvironment dst:reg4
-  [  18] Jump target:block4
+  [  18] GetLexicalEnvironment dst:reg4
+  [  20] Jump target:block4
 
 block2:
-  [  20] Catch dst:reg5
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Mov dst:e~0, src:reg5
+  [  28] Catch dst:reg5
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Mov dst:e~0, src:reg5
 
 block3:
-  [  40] Yield value:Undefined
+  [  48] Yield value:Undefined
 
 block4:
-  [  50] EnterObjectEnvironment dst:reg5, object:arg0
-  [  60] Mov dst:reg6, src:reg0
-  [  70] Await continuation_label:block5, argument:Int32(1)
+  [  58] EnterObjectEnvironment dst:reg5, object:arg0
+  [  68] Mov dst:reg6, src:reg0
+  [  78] Await continuation_label:block5, argument:Int32(1)
 
 block5:
-  [  80] Mov dst:reg6, src:reg0
-  [  90] GetCompletionFields type_dst:reg7, value_dst:reg8, completion:reg6
-  [  a0] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:1, true_target:block6, false_target:block7
+  [  88] Mov dst:reg6, src:reg0
+  [  98] GetCompletionFields type_dst:reg7, value_dst:reg8, completion:reg6
+  [  a8] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:1, true_target:block6, false_target:block7
 
 block6:
-  [  b8] SetLexicalEnvironment environment:reg4
-  [  c0] Jump target:block3
+  [  c0] SetLexicalEnvironment environment:reg4
+  [  c8] Jump target:block3
 
 block7:
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] Throw src:reg8
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] Throw src:reg8
 
 Exception handlers:
-  [  50 ..   d8] => handler block2
+  [  58 ..   e0] => handler block2

--- a/Tests/LibJS/Bytecode/expected/async-await.txt
+++ b/Tests/LibJS/Bytecode/expected/async-await.txt
@@ -1,16 +1,17 @@
-$89d6cbb5 async-await.js:9:1
+$fd650eed async-await.js:9:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  38] End value:reg5
 
 
-f$5541cf89 async-await.js:7:5
+f$d3dfd701 async-await.js:7:5
   Registers: 10
   Blocks:    5
   Constants:
@@ -19,22 +20,23 @@ f$5541cf89 async-await.js:7:5
     [2] = Int32(1)
 
 block0:
-  [   0] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  10] GetGlobal dst:reg6, `Promise`
-  [  20] GetById dst:reg7, base:reg6, `resolve` (Promise.resolve)
-  [  38] Call dst:reg5, callee:reg7, this_value:reg6, Promise.resolve, arguments:[Int32(42)]
-  [  60] Mov dst:reg7, src:reg0
-  [  70] Await continuation_label:block2, argument:reg5
+  [  18] GetGlobal dst:reg6, `Promise`
+  [  28] GetById dst:reg7, base:reg6, `resolve` (Promise.resolve)
+  [  40] Call dst:reg5, callee:reg7, this_value:reg6, Promise.resolve, arguments:[Int32(42)]
+  [  68] Mov dst:reg7, src:reg0
+  [  78] Await continuation_label:block2, argument:reg5
 
 block2:
-  [  80] Mov dst:reg7, src:reg0
-  [  90] GetCompletionFields type_dst:reg6, value_dst:reg8, completion:reg7
-  [  a0] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block3, false_target:block4
+  [  88] Mov dst:reg7, src:reg0
+  [  98] GetCompletionFields type_dst:reg6, value_dst:reg8, completion:reg7
+  [  a8] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block3, false_target:block4
 
 block3:
-  [  b8] Yield value:reg8
+  [  c0] Yield value:reg8
 
 block4:
-  [  c8] Throw src:reg8
+  [  d0] Throw src:reg8

--- a/Tests/LibJS/Bytecode/expected/async-generator-yield-await.txt
+++ b/Tests/LibJS/Bytecode/expected/async-generator-yield-await.txt
@@ -1,4 +1,4 @@
-$e8d1e772 async-generator-yield-await.js:6:1
+$6a33dffa async-generator-yield-await.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $e8d1e772 async-generator-yield-await.js:6:1
     [1] = Int32(1)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  40] End value:reg5
 
 
-f$7363bd74 async-generator-yield-await.js:4:5
+f$f201c4ec async-generator-yield-await.js:4:5
   Registers: 12
   Blocks:    19
   Constants:
@@ -21,70 +22,71 @@ f$7363bd74 async-generator-yield-await.js:4:5
     [3] = Int32(5)
 
 block0:
-  [   0] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  10] Mov dst:reg8, src:reg0
-  [  20] Await continuation_label:block2, argument:arg0
+  [  18] Mov dst:reg8, src:reg0
+  [  28] Await continuation_label:block2, argument:arg0
 
 block2:
-  [  30] Mov dst:reg8, src:reg0
-  [  40] GetCompletionFields type_dst:reg9, value_dst:reg10, completion:reg8
-  [  50] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:1, true_target:block3, false_target:block4
+  [  38] Mov dst:reg8, src:reg0
+  [  48] GetCompletionFields type_dst:reg9, value_dst:reg10, completion:reg8
+  [  58] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:1, true_target:block3, false_target:block4
 
 block3:
-  [  68] Await continuation_label:block6, argument:reg10
+  [  70] Await continuation_label:block6, argument:reg10
 
 block4:
-  [  78] Throw src:reg10
+  [  80] Throw src:reg10
 
 block5:
-  [  80] Mov dst:reg5, src:reg0
-  [  90] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  a0] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block15, false_target:block16
+  [  88] Mov dst:reg5, src:reg0
+  [  98] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [  a8] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block15, false_target:block16
 
 block6:
-  [  b8] Mov dst:reg5, src:reg0
-  [  c8] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  d8] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block7, false_target:block8
+  [  c0] Mov dst:reg5, src:reg0
+  [  d0] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [  e0] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block7, false_target:block8
 
 block7:
-  [  f0] Yield continuation_label:block9, value:reg7
+  [  f8] Yield continuation_label:block9, value:reg7
 
 block8:
-  [ 100] Throw src:reg7
+  [ 108] Throw src:reg7
 
 block9:
-  [ 108] Mov dst:reg5, src:reg0
-  [ 118] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [ 128] JumpStrictlyInequalsRhsInt32 lhs:reg6, rhs:4, true_target:block5, false_target:block10
+  [ 110] Mov dst:reg5, src:reg0
+  [ 120] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [ 130] JumpStrictlyInequalsRhsInt32 lhs:reg6, rhs:4, true_target:block5, false_target:block10
 
 block10:
-  [ 140] Await continuation_label:block11, argument:reg7
+  [ 148] Await continuation_label:block11, argument:reg7
 
 block11:
-  [ 150] Mov dst:reg5, src:reg0
-  [ 160] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [ 170] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block12, false_target:block13
+  [ 158] Mov dst:reg5, src:reg0
+  [ 168] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [ 178] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block12, false_target:block13
 
 block12:
-  [ 188] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block5, false_target:block14
+  [ 190] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block5, false_target:block14
 
 block13:
-  [ 1a0] Throw src:reg7
+  [ 1a8] Throw src:reg7
 
 block14:
-  [ 1a8] SetCompletionType completion:reg5
-  [ 1b8] Jump target:block5
+  [ 1b0] SetCompletionType completion:reg5
+  [ 1c0] Jump target:block5
 
 block15:
-  [ 1c0] Yield value:Undefined
+  [ 1c8] Yield value:Undefined
 
 block16:
-  [ 1d0] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block17, false_target:block18
+  [ 1d8] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block17, false_target:block18
 
 block17:
-  [ 1e8] Throw src:reg7
+  [ 1f0] Throw src:reg7
 
 block18:
-  [ 1f0] Yield value:reg7
+  [ 1f8] Yield value:reg7

--- a/Tests/LibJS/Bytecode/expected/async-generator-yield.txt
+++ b/Tests/LibJS/Bytecode/expected/async-generator-yield.txt
@@ -1,4 +1,4 @@
-$d0083583 async-generator-yield.js:7:1
+$516a2e0b async-generator-yield.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $d0083583 async-generator-yield.js:7:1
     [1] = Int32(1)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  40] End value:reg5
 
 
-f$aa186530 async-generator-yield.js:5:5
+f$28b66ca8 async-generator-yield.js:5:5
   Registers: 10
   Blocks:    16
   Constants:
@@ -21,58 +22,59 @@ f$aa186530 async-generator-yield.js:5:5
     [3] = Int32(5)
 
 block0:
-  [   0] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  10] Await continuation_label:block3, argument:arg0
+  [  18] Await continuation_label:block3, argument:arg0
 
 block2:
-  [  20] Mov dst:reg5, src:reg0
-  [  30] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  40] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block12, false_target:block13
+  [  28] Mov dst:reg5, src:reg0
+  [  38] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [  48] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block12, false_target:block13
 
 block3:
-  [  58] Mov dst:reg5, src:reg0
-  [  68] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  78] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block4, false_target:block5
+  [  60] Mov dst:reg5, src:reg0
+  [  70] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [  80] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block4, false_target:block5
 
 block4:
-  [  90] Yield continuation_label:block6, value:reg7
+  [  98] Yield continuation_label:block6, value:reg7
 
 block5:
-  [  a0] Throw src:reg7
+  [  a8] Throw src:reg7
 
 block6:
-  [  a8] Mov dst:reg5, src:reg0
-  [  b8] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  c8] JumpStrictlyInequalsRhsInt32 lhs:reg6, rhs:4, true_target:block2, false_target:block7
+  [  b0] Mov dst:reg5, src:reg0
+  [  c0] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [  d0] JumpStrictlyInequalsRhsInt32 lhs:reg6, rhs:4, true_target:block2, false_target:block7
 
 block7:
-  [  e0] Await continuation_label:block8, argument:reg7
+  [  e8] Await continuation_label:block8, argument:reg7
 
 block8:
-  [  f0] Mov dst:reg5, src:reg0
-  [ 100] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [ 110] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block9, false_target:block10
+  [  f8] Mov dst:reg5, src:reg0
+  [ 108] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [ 118] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block9, false_target:block10
 
 block9:
-  [ 128] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block2, false_target:block11
+  [ 130] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block2, false_target:block11
 
 block10:
-  [ 140] Throw src:reg7
+  [ 148] Throw src:reg7
 
 block11:
-  [ 148] SetCompletionType completion:reg5
-  [ 158] Jump target:block2
+  [ 150] SetCompletionType completion:reg5
+  [ 160] Jump target:block2
 
 block12:
-  [ 160] Yield value:Undefined
+  [ 168] Yield value:Undefined
 
 block13:
-  [ 170] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block14, false_target:block15
+  [ 178] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block14, false_target:block15
 
 block14:
-  [ 188] Throw src:reg7
+  [ 190] Throw src:reg7
 
 block15:
-  [ 190] Yield value:reg7
+  [ 198] Yield value:reg7

--- a/Tests/LibJS/Bytecode/expected/async-return-bare.txt
+++ b/Tests/LibJS/Bytecode/expected/async-return-bare.txt
@@ -1,23 +1,25 @@
-$bacf2c68 async-return-bare.js:4:1
+$2b997e90 async-return-bare.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  38] End value:reg5
 
 
-f$e16999cc async-return-bare.js:2:5
+f$6007a144 async-return-bare.js:2:5
   Registers: 5
   Blocks:    2
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  10] Yield value:Undefined
+  [  18] Yield value:Undefined

--- a/Tests/LibJS/Bytecode/expected/baseline.txt
+++ b/Tests/LibJS/Bytecode/expected/baseline.txt
@@ -1,4 +1,4 @@
-$04fc1751 baseline.js:5:1
+$865e0fd9 baseline.js:5:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -7,21 +7,23 @@ $04fc1751 baseline.js:5:1
     [2] = Int32(2)
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `add`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, add, arguments:[Int32(1), Int32(2)]
-  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  88] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `add`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, add, arguments:[Int32(1), Int32(2)]
+  [  68] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  90] End value:reg5
 
 
-add$9f351e1b baseline.js:2:5
+add$1b0f3483 baseline.js:2:5
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] Add dst:reg5, lhs:arg0, rhs:arg1
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] Add dst:reg5, lhs:arg0, rhs:arg1
+  [  18] Return value:reg5
 
 
 3

--- a/Tests/LibJS/Bytecode/expected/bigint-binary-literal-fold.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-binary-literal-fold.txt
@@ -1,4 +1,4 @@
-$ccf7ed9d
+$4e59e625
   Registers: 5
   Blocks:    1
   Constants:
@@ -7,4 +7,5 @@ $ccf7ed9d
     [2] = BigInt(1n)
 
 block0:
-  [   0] End value:BigInt(1n)
+  [   0] Enter
+  [   8] End value:BigInt(1n)

--- a/Tests/LibJS/Bytecode/expected/bigint-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-constant-folding.txt
@@ -1,4 +1,4 @@
-$00cee19d bigint-constant-folding.js:1:1
+$87b8bc45 bigint-constant-folding.js:1:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -30,13 +30,14 @@ $00cee19d bigint-constant-folding.js:1:1
     [25] = Undefined
 
 block0:
-  [   0] SetGlobal `a`, src:BigInt(3n)
-  [  10] SetGlobal `b`, src:BigInt(7n)
-  [  20] SetGlobal `c`, src:BigInt(6n)
-  [  30] SetGlobal `d`, src:BigInt(3n)
-  [  40] SetGlobal `e`, src:BigInt(1n)
-  [  50] SetGlobal `f`, src:BigInt(8n)
-  [  60] SetGlobal `g`, src:Bool(true)
-  [  70] SetGlobal `h`, src:Bool(true)
-  [  80] SetGlobal `i`, src:BigInt(-2n)
-  [  90] End value:Undefined
+  [   0] Enter
+  [   8] SetGlobal `a`, src:BigInt(3n)
+  [  18] SetGlobal `b`, src:BigInt(7n)
+  [  28] SetGlobal `c`, src:BigInt(6n)
+  [  38] SetGlobal `d`, src:BigInt(3n)
+  [  48] SetGlobal `e`, src:BigInt(1n)
+  [  58] SetGlobal `f`, src:BigInt(8n)
+  [  68] SetGlobal `g`, src:Bool(true)
+  [  78] SetGlobal `h`, src:Bool(true)
+  [  88] SetGlobal `i`, src:BigInt(-2n)
+  [  98] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/bigint-large-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-large-constant-folding.txt
@@ -1,4 +1,4 @@
-$b019cd8e bigint-large-constant-folding.js:2:1
+$3703a836 bigint-large-constant-folding.js:2:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -14,7 +14,8 @@ $b019cd8e bigint-large-constant-folding.js:2:1
     [9] = Undefined
 
 block0:
-  [   0] SetGlobal `a`, src:BigInt(337264356397531028994973048178108678400n)
-  [  10] SetGlobal `b`, src:BigInt(340282366920938463463374607431768211456n)
-  [  20] SetGlobal `c`, src:BigInt(6193778470904512180693671865081363252814433915244866048000n)
-  [  30] End value:Undefined
+  [   0] Enter
+  [   8] SetGlobal `a`, src:BigInt(337264356397531028994973048178108678400n)
+  [  18] SetGlobal `b`, src:BigInt(340282366920938463463374607431768211456n)
+  [  28] SetGlobal `c`, src:BigInt(6193778470904512180693671865081363252814433915244866048000n)
+  [  38] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/bigint-truthiness.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-truthiness.txt
@@ -1,4 +1,4 @@
-$947262ee bigint-truthiness.js:2:1
+$1b5c3d96 bigint-truthiness.js:2:1
   Registers: 6
   Blocks:    1
   Constants:
@@ -18,13 +18,14 @@ $947262ee bigint-truthiness.js:2:1
     [13] = Undefined
 
 block0:
-  [   0] SetGlobal `a`, src:String("falsy")
-  [  10] SetGlobal `b`, src:String("falsy")
-  [  20] SetGlobal `c`, src:String("falsy")
-  [  30] SetGlobal `d`, src:String("falsy")
-  [  40] SetGlobal `e`, src:String("truthy")
-  [  50] SetGlobal `f`, src:String("truthy")
-  [  60] SetGlobal `g`, src:String("truthy")
-  [  70] SetGlobal `h`, src:Bool(true)
-  [  80] SetGlobal `i`, src:Bool(false)
-  [  90] End value:Undefined
+  [   0] Enter
+  [   8] SetGlobal `a`, src:String("falsy")
+  [  18] SetGlobal `b`, src:String("falsy")
+  [  28] SetGlobal `c`, src:String("falsy")
+  [  38] SetGlobal `d`, src:String("falsy")
+  [  48] SetGlobal `e`, src:String("truthy")
+  [  58] SetGlobal `f`, src:String("truthy")
+  [  68] SetGlobal `g`, src:String("truthy")
+  [  78] SetGlobal `h`, src:Bool(true)
+  [  88] SetGlobal `i`, src:Bool(false)
+  [  98] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/bitwise-numeric-preconvert.txt
+++ b/Tests/LibJS/Bytecode/expected/bitwise-numeric-preconvert.txt
@@ -1,4 +1,4 @@
-$2b997e90 bitwise-numeric-preconvert.js:4:1
+$acfb7718 bitwise-numeric-preconvert.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,17 +6,19 @@ $2b997e90 bitwise-numeric-preconvert.js:4:1
     [1] = Int32(1)
 
 block0:
-  [   0] GetGlobal dst:reg6, `test`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[Int32(1)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `test`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[Int32(1)]
+  [  40] End value:reg5
 
 
-test$e718c164 bitwise-numeric-preconvert.js:2:5
+test$65b6c8dc bitwise-numeric-preconvert.js:2:5
   Registers: 6
   Blocks:    1
   Constants:
     [0] = Int32(-2147483648)
 
 block0:
-  [   0] RightShift dst:reg5, lhs:Int32(-2147483648), rhs:arg0
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] RightShift dst:reg5, lhs:Int32(-2147483648), rhs:arg0
+  [  18] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
+++ b/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
@@ -1,21 +1,22 @@
-$2d2a9e5a block-function-declaration-order.js:1:1
+$ae8c96e2 block-function-declaration-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateMutableBinding environment:reg5, `f1`, can_be_deleted:false
-  [  30] NewFunction dst:reg6, shared_function_data_index:0
-  [  48] InitializeLexicalBinding `f1`, src:reg6
-  [  60] CreateMutableBinding environment:reg5, `f2`, can_be_deleted:false
-  [  70] NewFunction dst:reg6, shared_function_data_index:1
-  [  88] InitializeLexicalBinding `f2`, src:reg6
-  [  a0] GetBinding dst:reg6, `f1`
-  [  b8] DynamicSetVariableBinding `f1`, src:reg6
-  [  c8] GetBinding dst:reg6, `f2`
-  [  e0] DynamicSetVariableBinding `f2`, src:reg6
-  [  f0] SetLexicalEnvironment environment:reg4
-  [  f8] End value:Undefined
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateMutableBinding environment:reg5, `f1`, can_be_deleted:false
+  [  38] NewFunction dst:reg6, shared_function_data_index:0
+  [  50] InitializeLexicalBinding `f1`, src:reg6
+  [  68] CreateMutableBinding environment:reg5, `f2`, can_be_deleted:false
+  [  78] NewFunction dst:reg6, shared_function_data_index:1
+  [  90] InitializeLexicalBinding `f2`, src:reg6
+  [  a8] GetBinding dst:reg6, `f1`
+  [  c0] DynamicSetVariableBinding `f1`, src:reg6
+  [  d0] GetBinding dst:reg6, `f2`
+  [  e8] DynamicSetVariableBinding `f2`, src:reg6
+  [  f8] SetLexicalEnvironment environment:reg4
+  [ 100] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
@@ -1,4 +1,4 @@
-$49b95e06 block-scoped-function-no-tdz.js:10:1
+$d36729be block-scoped-function-no-tdz.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $49b95e06 block-scoped-function-no-tdz.js:10:1
     [1] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `test`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `test`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  38] End value:reg5
 
 
-test$65d0907d block-scoped-function-no-tdz.js:3:5
+test$e46e97f5 block-scoped-function-no-tdz.js:3:5
   Registers: 7
   Blocks:    1
   Locals:    foo~0, result~1
@@ -19,22 +20,24 @@ test$65d0907d block-scoped-function-no-tdz.js:3:5
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] MovSrcUndefined dst:result~1
-  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  28] NewFunction dst:reg6, shared_function_data_index:0
-  [  40] Mov dst:foo~0, src:reg6
-  [  50] Call dst:reg6, callee:foo~0, this_value:Undefined, foo
-  [  70] Mov dst:result~1, src:reg6
-  [  80] SetLexicalEnvironment environment:reg4
-  [  88] Return value:result~1
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] MovSrcUndefined dst:result~1
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  30] NewFunction dst:reg6, shared_function_data_index:0
+  [  48] Mov dst:foo~0, src:reg6
+  [  58] Call dst:reg6, callee:foo~0, this_value:Undefined, foo
+  [  78] Mov dst:result~1, src:reg6
+  [  88] SetLexicalEnvironment environment:reg4
+  [  90] Return value:result~1
 
 
-foo$f46a9b04 block-scoped-function-no-tdz.js:5:26
+foo$7890849c block-scoped-function-no-tdz.js:5:26
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(42)
 
 block0:
-  [   0] Return value:Int32(42)
+  [   0] Enter
+  [   8] Return value:Int32(42)

--- a/Tests/LibJS/Bytecode/expected/block-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoping.txt
@@ -1,24 +1,25 @@
-$f9fa6696 block-scoping.js:13:1
+$78986e0e block-scoping.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `closureOverBlockScope`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, closureOverBlockScope
-  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  80] GetGlobal dst:reg6, `console`
-  [  90] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  a8] GetGlobal dst:reg10, `breakThroughBlockScopes`
-  [  b8] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughBlockScopes
-  [  d8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 100] End value:reg7
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `closureOverBlockScope`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, closureOverBlockScope
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] GetGlobal dst:reg6, `console`
+  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b0] GetGlobal dst:reg10, `breakThroughBlockScopes`
+  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughBlockScopes
+  [  e0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 108] End value:reg7
 
 
-closureOverBlockScope$61104af2 block-scoping.js:2:15
+closureOverBlockScope$dfae526a block-scoping.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    fns~0
@@ -28,51 +29,54 @@ closureOverBlockScope$61104af2 block-scoping.js:2:15
     [2] = Int32(0)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewArray dst:fns~0
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  30] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
-  [  40] InitializeLexicalBinding `x`, src:Int32(1)
-  [  58] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  70] Mov dst:reg8, src:fns~0
-  [  80] NewFunction dst:reg9, shared_function_data_index:0
-  [  98] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [  c0] SetLexicalEnvironment environment:reg4
-  [  c8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  e0] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
-  [  f0] InitializeLexicalBinding `y`, src:Int32(2)
-  [ 108] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [ 120] Mov dst:reg8, src:fns~0
-  [ 130] NewFunction dst:reg9, shared_function_data_index:1
-  [ 148] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 170] SetLexicalEnvironment environment:reg4
-  [ 178] GetByValue dst:reg6, base:fns~0, property:Int32(0)
-  [ 190] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
-  [ 1b0] GetByValue dst:reg7, base:fns~0, property:Int32(1)
-  [ 1c8] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
-  [ 1e8] Add dst:reg7, lhs:reg5, rhs:reg6
-  [ 1f8] Return value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewArray dst:fns~0
+  [  20] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  38] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
+  [  48] InitializeLexicalBinding `x`, src:Int32(1)
+  [  60] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [  78] Mov dst:reg8, src:fns~0
+  [  88] NewFunction dst:reg9, shared_function_data_index:0
+  [  a0] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [  c8] SetLexicalEnvironment environment:reg4
+  [  d0] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  e8] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
+  [  f8] InitializeLexicalBinding `y`, src:Int32(2)
+  [ 110] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [ 128] Mov dst:reg8, src:fns~0
+  [ 138] NewFunction dst:reg9, shared_function_data_index:1
+  [ 150] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 178] SetLexicalEnvironment environment:reg4
+  [ 180] GetByValue dst:reg6, base:fns~0, property:Int32(0)
+  [ 198] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
+  [ 1b8] GetByValue dst:reg7, base:fns~0, property:Int32(1)
+  [ 1d0] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
+  [ 1f0] Add dst:reg7, lhs:reg5, rhs:reg6
+  [ 200] Return value:reg7
 
 
-$cff4e98a block-scoping.js:5:18
+$4bcefff2 block-scoping.js:5:18
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `x`
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `x`
+  [  18] Return value:reg5
 
 
-$b7c63ac6 block-scoping.js:9:18
+$3664423e block-scoping.js:9:18
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `y`
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `y`
+  [  18] Return value:reg5
 
 
-breakThroughBlockScopes$3fb5dfc7 block-scoping.js:16:5
+breakThroughBlockScopes$be53e73f block-scoping.js:16:5
   Registers: 8
   Blocks:    7
   Locals:    f~0, i~1, result~2
@@ -83,45 +87,47 @@ breakThroughBlockScopes$3fb5dfc7 block-scoping.js:16:5
     [3] = Int32(1)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov2 c0_dst:result~2, c0_src:Undefined, c1_dst:i~1, c1_src:Int32(0)
-  [  20] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov2 c0_dst:result~2, c0_src:Undefined, c1_dst:i~1, c1_src:Int32(0)
+  [  28] Jump target:block3
 
 block1:
-  [  28] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  40] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
-  [  50] InitializeLexicalBinding `x`, src:i~1
-  [  68] NewFunction dst:f~0, shared_function_data_index:0 (f)
-  [  80] GetBinding dst:reg6, `x`
-  [  98] JumpGreaterThanRhsInt32 lhs:reg6, rhs:1, true_target:block5, false_target:block6
+  [  30] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  48] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
+  [  58] InitializeLexicalBinding `x`, src:i~1
+  [  70] NewFunction dst:f~0, shared_function_data_index:0 (f)
+  [  88] GetBinding dst:reg6, `x`
+  [  a0] JumpGreaterThanRhsInt32 lhs:reg6, rhs:1, true_target:block5, false_target:block6
 
 block2:
-  [  b0] PostfixIncrement dst:reg5, src:i~1
+  [  b8] PostfixIncrement dst:reg5, src:i~1
 
 block3:
-  [  c0] JumpLessThanRhsInt32 lhs:i~1, rhs:3, true_target:block1, false_target:block4
+  [  c8] JumpLessThanRhsInt32 lhs:i~1, rhs:3, true_target:block1, false_target:block4
 
 block4:
-  [  d8] Call dst:reg5, callee:result~2, this_value:Undefined, result
-  [  f8] Return value:reg5
+  [  e0] Call dst:reg5, callee:result~2, this_value:Undefined, result
+  [ 100] Return value:reg5
 
 block5:
-  [ 100] Mov dst:result~2, src:f~0
-  [ 110] SetLexicalEnvironment environment:reg4
-  [ 118] Jump target:block4
+  [ 108] Mov dst:result~2, src:f~0
+  [ 118] SetLexicalEnvironment environment:reg4
+  [ 120] Jump target:block4
 
 block6:
-  [ 120] SetLexicalEnvironment environment:reg4
-  [ 128] Jump target:block2
+  [ 128] SetLexicalEnvironment environment:reg4
+  [ 130] Jump target:block2
 
 
-f$63b62772 block-scoping.js:20:21
+f$e7dc110a block-scoping.js:20:21
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `x`
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `x`
+  [  18] Return value:reg5
 
 
 3

--- a/Tests/LibJS/Bytecode/expected/call-spread-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/call-spread-register-order.txt
@@ -1,4 +1,4 @@
-$15d45b76 call-spread-register-order.js:2:1
+$973653fe call-spread-register-order.js:2:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -6,20 +6,22 @@ $15d45b76 call-spread-register-order.js:2:1
     [1] = Int32(42)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Mov dst:reg8, src:Int32(42)
-  [  20] NewArray dst:reg7, elements:[reg8]
-  [  38] NewPrimitiveArray dst:reg9, elements:[1]
-  [  50] ArrayAppend dst:reg7, src:reg9, is_spread:true
-  [  60] CallWithArgumentArray dst:reg5, callee:reg6, this_value:Undefined, arguments:reg7, f
-  [  78] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Mov dst:reg8, src:Int32(42)
+  [  28] NewArray dst:reg7, elements:[reg8]
+  [  40] NewPrimitiveArray dst:reg9, elements:[1]
+  [  58] ArrayAppend dst:reg7, src:reg9, is_spread:true
+  [  68] CallWithArgumentArray dst:reg5, callee:reg6, this_value:Undefined, arguments:reg7, f
+  [  80] End value:reg5
 
 
-f$7aaaa003
+f$f948a77b
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/captured-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/captured-variables.txt
@@ -1,16 +1,17 @@
-$546ebce0 captured-variables.js:12:1
+$c7fd0018 captured-variables.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `outer`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, outer
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `outer`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, outer
+  [  38] End value:reg5
 
 
-outer$e7583c0c captured-variables.js:5:5
+outer$65f64384 captured-variables.js:5:5
   Registers: 7
   Blocks:    1
   Locals:    inner~0
@@ -19,20 +20,22 @@ outer$e7583c0c captured-variables.js:5:5
     [1] = Int32(1)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] MovSrcUndefined dst:inner~0
-  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
-  [  28] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
-  [  38] NewFunction dst:inner~0, shared_function_data_index:0
-  [  50] InitializeLexicalBinding `captured`, src:Int32(1)
-  [  68] Call dst:reg6, callee:inner~0, this_value:Undefined, inner
-  [  88] Return value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] MovSrcUndefined dst:inner~0
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
+  [  30] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
+  [  40] NewFunction dst:inner~0, shared_function_data_index:0
+  [  58] InitializeLexicalBinding `captured`, src:Int32(1)
+  [  70] Call dst:reg6, callee:inner~0, this_value:Undefined, inner
+  [  90] Return value:reg6
 
 
-inner$6897e27d captured-variables.js:7:9
+inner$e471f8e5 captured-variables.js:7:9
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `captured`
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `captured`
+  [  18] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
+++ b/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
@@ -1,24 +1,25 @@
-$37aa5f7d catch-scope-boundary.js:14:1
+$b64866f5 catch-scope-boundary.js:14:1
   Registers: 11
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `throwInCatch`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, throwInCatch
-  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  80] GetGlobal dst:reg6, `console`
-  [  90] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  a8] GetGlobal dst:reg10, `throwInCatchWithLocals`
-  [  b8] Call dst:reg9, callee:reg10, this_value:Undefined, throwInCatchWithLocals
-  [  d8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 100] End value:reg7
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `throwInCatch`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, throwInCatch
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] GetGlobal dst:reg6, `console`
+  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b0] GetGlobal dst:reg10, `throwInCatchWithLocals`
+  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, throwInCatchWithLocals
+  [  e0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 108] End value:reg7
 
 
-throwInCatch$94c0d746 catch-scope-boundary.js:2:5
+throwInCatch$1622cfce catch-scope-boundary.js:2:5
   Registers: 7
   Blocks:    6
   Locals:    e2~0, e~1, result~2
@@ -29,37 +30,38 @@ throwInCatch$94c0d746 catch-scope-boundary.js:2:5
     [3] = Int32(1)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:result~2, src:String("bad")
-  [  18] Jump target:block5
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:result~2, src:String("bad")
+  [  20] Jump target:block5
 
 block1:
-  [  20] Catch dst:reg5
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Mov dst:e~1, src:reg5
-  [  40] Jump target:block3
+  [  28] Catch dst:reg5
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Mov dst:e~1, src:reg5
+  [  48] Jump target:block3
 
 block2:
-  [  48] Catch dst:reg6
-  [  50] SetLexicalEnvironment environment:reg4
-  [  58] Mov2 c0_dst:e2~0, c0_src:reg6, c1_dst:result~2, c1_src:String("good")
-  [  70] Return value:result~2
+  [  50] Catch dst:reg6
+  [  58] SetLexicalEnvironment environment:reg4
+  [  60] Mov2 c0_dst:e2~0, c0_src:reg6, c1_dst:result~2, c1_src:String("good")
+  [  78] Return value:result~2
 
 block3:
-  [  78] Throw src:Int32(2)
+  [  80] Throw src:Int32(2)
 
 block4:
-  [  80] Return value:result~2
+  [  88] Return value:result~2
 
 block5:
-  [  88] Throw src:Int32(1)
+  [  90] Throw src:Int32(1)
 
 Exception handlers:
-  [  78 ..   80] => handler block2
-  [  88 ..   90] => handler block1
+  [  80 ..   88] => handler block2
+  [  90 ..   98] => handler block1
 
 
-throwInCatchWithLocals$35b0d9e9 catch-scope-boundary.js:17:5
+throwInCatchWithLocals$b44ee161 catch-scope-boundary.js:17:5
   Registers: 9
   Blocks:    5
   Locals:    inner~0, catchLocal~1, e~2, outerVar~3
@@ -71,36 +73,37 @@ throwInCatchWithLocals$35b0d9e9 catch-scope-boundary.js:17:5
     [4] = String("first")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:outerVar~3, src:String("outer")
-  [  18] Jump target:block4
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:outerVar~3, src:String("outer")
+  [  20] Jump target:block4
 
 block1:
-  [  20] Catch dst:reg5
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Mov dst:e~2, src:reg5
-  [  40] Add dst:catchLocal~1, lhs:String("local:"), rhs:e~2
-  [  50] Jump target:block3
+  [  28] Catch dst:reg5
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Mov dst:e~2, src:reg5
+  [  48] Add dst:catchLocal~1, lhs:String("local:"), rhs:e~2
+  [  58] Jump target:block3
 
 block2:
-  [  58] Catch dst:reg6
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] Mov dst:inner~0, src:reg6
-  [  78] Add dst:reg7, lhs:outerVar~3, rhs:String(",")
-  [  88] Add dst:reg8, lhs:reg7, rhs:catchLocal~1
-  [  98] Add dst:reg7, lhs:reg8, rhs:String(",")
-  [  a8] Add dst:reg8, lhs:reg7, rhs:inner~0
-  [  b8] Return value:reg8
+  [  60] Catch dst:reg6
+  [  68] SetLexicalEnvironment environment:reg4
+  [  70] Mov dst:inner~0, src:reg6
+  [  80] Add dst:reg7, lhs:outerVar~3, rhs:String(",")
+  [  90] Add dst:reg8, lhs:reg7, rhs:catchLocal~1
+  [  a0] Add dst:reg7, lhs:reg8, rhs:String(",")
+  [  b0] Add dst:reg8, lhs:reg7, rhs:inner~0
+  [  c0] Return value:reg8
 
 block3:
-  [  c0] Throw src:String("second")
+  [  c8] Throw src:String("second")
 
 block4:
-  [  c8] Throw src:String("first")
+  [  d0] Throw src:String("first")
 
 Exception handlers:
-  [  c0 ..   c8] => handler block2
-  [  c8 ..   d0] => handler block1
+  [  c8 ..   d0] => handler block2
+  [  d0 ..   d8] => handler block1
 
 
 "good"

--- a/Tests/LibJS/Bytecode/expected/chained-member-call.txt
+++ b/Tests/LibJS/Bytecode/expected/chained-member-call.txt
@@ -1,4 +1,4 @@
-$9355702b chained-member-call.js:12:1
+$06e3b363 chained-member-call.js:12:1
   Registers: 10
   Blocks:    6
   Constants:
@@ -6,63 +6,66 @@ $9355702b chained-member-call.js:12:1
     [1] = Int32(0)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Jump target:block3
 
 block1:
-  [  10] Catch dst:reg5
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] Mov2 c0_dst:reg6, c0_src:Undefined, c1_dst:reg7, c1_src:reg6
+  [  18] Catch dst:reg5
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] Mov2 c0_dst:reg6, c0_src:Undefined, c1_dst:reg7, c1_src:reg6
 
 block2:
-  [  38] Jump target:block5
+  [  40] Jump target:block5
 
 block3:
-  [  40] MovSrcUndefined dst:reg5
-  [  48] GetGlobal dst:reg8, `chained_computed_call`
-  [  58] Call dst:reg6, callee:reg8, this_value:Undefined, chained_computed_call, arguments:[Int32(0), Int32(0), Int32(0)]
-  [  88] Mov2 c0_dst:reg5, c0_src:reg6, c1_dst:reg6, c1_src:reg5
-  [  a0] Jump target:block2
+  [  48] MovSrcUndefined dst:reg5
+  [  50] GetGlobal dst:reg8, `chained_computed_call`
+  [  60] Call dst:reg6, callee:reg8, this_value:Undefined, chained_computed_call, arguments:[Int32(0), Int32(0), Int32(0)]
+  [  90] Mov2 c0_dst:reg5, c0_src:reg6, c1_dst:reg6, c1_src:reg5
+  [  a8] Jump target:block2
 
 block4:
-  [  a8] Catch dst:reg5
-  [  b0] SetLexicalEnvironment environment:reg4
-  [  b8] Mov2 c0_dst:reg7, c0_src:Undefined, c1_dst:reg8, c1_src:reg7
-  [  d0] End value:reg7
+  [  b0] Catch dst:reg5
+  [  b8] SetLexicalEnvironment environment:reg4
+  [  c0] Mov2 c0_dst:reg7, c0_src:Undefined, c1_dst:reg8, c1_src:reg7
+  [  d8] End value:reg7
 
 block5:
-  [  d8] MovSrcUndefined dst:reg5
-  [  e0] GetGlobal dst:reg9, `chained_dot_call`
-  [  f0] Call dst:reg7, callee:reg9, this_value:Undefined, chained_dot_call, arguments:[Int32(0)]
-  [ 118] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg7, c1_src:reg5
-  [ 130] End value:reg7
+  [  e0] MovSrcUndefined dst:reg5
+  [  e8] GetGlobal dst:reg9, `chained_dot_call`
+  [  f8] Call dst:reg7, callee:reg9, this_value:Undefined, chained_dot_call, arguments:[Int32(0)]
+  [ 120] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg7, c1_src:reg5
+  [ 138] End value:reg7
 
 Exception handlers:
-  [  40 ..   a8] => handler block1
-  [  d8 ..  138] => handler block4
+  [  48 ..   b0] => handler block1
+  [  e0 ..  140] => handler block4
 
 
-chained_computed_call$f75d09e2 chained-member-call.js:5:5
+chained_computed_call$78bf026a chained-member-call.js:5:5
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] Mov dst:reg6, src:arg0
-  [  10] GetByValue dst:reg7, base:reg6, property:arg1 (a[arg1])
-  [  28] GetByValue dst:reg6, base:reg7, property:arg2 (a[j][arg2])
-  [  40] GetById dst:reg7, base:reg6, `foo` (a[j][k].foo)
-  [  58] Call dst:reg5, callee:reg7, this_value:reg6, a[j][k].foo
-  [  78] Return value:reg5
+  [   0] Enter
+  [   8] Mov dst:reg6, src:arg0
+  [  18] GetByValue dst:reg7, base:reg6, property:arg1 (a[arg1])
+  [  30] GetByValue dst:reg6, base:reg7, property:arg2 (a[j][arg2])
+  [  48] GetById dst:reg7, base:reg6, `foo` (a[j][k].foo)
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, a[j][k].foo
+  [  80] Return value:reg5
 
 
-chained_dot_call$d315f2d8 chained-member-call.js:9:5
+chained_dot_call$51b3fa50 chained-member-call.js:9:5
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] Mov dst:reg6, src:arg0
-  [  10] GetById dst:reg7, base:reg6, `b` (a.b)
-  [  28] GetById dst:reg6, base:reg7, `c` (a.b.c)
-  [  40] GetById dst:reg7, base:reg6, `bar` (a.b.c.bar)
-  [  58] Call dst:reg5, callee:reg7, this_value:reg6, a.b.c.bar
-  [  78] Return value:reg5
+  [   0] Enter
+  [   8] Mov dst:reg6, src:arg0
+  [  18] GetById dst:reg7, base:reg6, `b` (a.b)
+  [  30] GetById dst:reg6, base:reg7, `c` (a.b.c)
+  [  48] GetById dst:reg7, base:reg6, `bar` (a.b.c.bar)
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, a.b.c.bar
+  [  80] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
@@ -1,4 +1,4 @@
-$7f6ce915 class-computed-field-lhs-name.js:1:1
+$00cee19d class-computed-field-lhs-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -8,30 +8,33 @@ $7f6ce915 class-computed-field-lhs-name.js:1:1
     [3] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] SetLexicalEnvironment environment:reg4
-  [  28] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (C), element_keys:[element_keys:Int32(3)]
-  [  50] SetGlobal `C`, src:reg6
-  [  60] GetGlobal dst:reg5, `C`
-  [  70] CallConstruct dst:reg6, callee:reg5, C
-  [  88] End value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] SetLexicalEnvironment environment:reg4
+  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (C), element_keys:[element_keys:Int32(3)]
+  [  58] SetGlobal `C`, src:reg6
+  [  68] GetGlobal dst:reg5, `C`
+  [  78] CallConstruct dst:reg6, callee:reg5, C
+  [  90] End value:reg6
 
 
-C$e7b179de
+C$638b9046
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-field$e1b95ffa class-computed-field-lhs-name.js:2:15
+field$60576772 class-computed-field-lhs-name.js:2:15
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] NewFunction dst:reg5, shared_function_data_index:0
-  [  18] Return value:reg5
+  [   0] Enter
+  [   8] NewFunction dst:reg5, shared_function_data_index:0
+  [  20] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/class-computed-key.txt
+++ b/Tests/LibJS/Bytecode/expected/class-computed-key.txt
@@ -1,25 +1,27 @@
-$49b95e06 class-computed-key.js:10:1
+$d36729be class-computed-key.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  38] End value:reg5
 
 
-f$0a149d9a class-computed-key.js:4:5
+f$88b2a512 class-computed-key.js:4:5
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable ``, is_immutable:true, is_global:false, is_strict:true
-  [  30] GetGlobal dst:reg6, `Symbol`
-  [  40] GetById dst:reg7, base:reg6, `iterator` (Symbol.iterator)
-  [  58] SetLexicalEnvironment environment:reg4
-  [  60] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:reg7]
-  [  88] Return value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable ``, is_immutable:true, is_global:false, is_strict:true
+  [  38] GetGlobal dst:reg6, `Symbol`
+  [  48] GetById dst:reg7, base:reg6, `iterator` (Symbol.iterator)
+  [  60] SetLexicalEnvironment environment:reg4
+  [  68] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:reg7]
+  [  90] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/class-environment.txt
+++ b/Tests/LibJS/Bytecode/expected/class-environment.txt
@@ -1,19 +1,20 @@
-$9d326325 class-environment.js:9:1
+$1bd06a9d class-environment.js:9:1
   Registers: 10
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `classWithName`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, classWithName
-  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  80] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `classWithName`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, classWithName
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] End value:reg5
 
 
-classWithName$155d62f1 class-environment.js:2:13
+classWithName$99834c89 class-environment.js:2:13
   Registers: 8
   Blocks:    1
   Locals:    C~0
@@ -22,35 +23,38 @@ classWithName$155d62f1 class-environment.js:2:13
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:C~0, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
-  [  60] CallConstruct dst:reg6, callee:C~0, C
-  [  78] GetById dst:reg7, base:reg6, `method`
-  [  90] Call dst:reg5, callee:reg7, this_value:reg6, <object>.method
-  [  b0] StrictlyEquals dst:reg7, lhs:reg5, rhs:C~0
-  [  c0] Return value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:C~0, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
+  [  68] CallConstruct dst:reg6, callee:C~0, C
+  [  80] GetById dst:reg7, base:reg6, `method`
+  [  98] Call dst:reg5, callee:reg7, this_value:reg6, <object>.method
+  [  b8] StrictlyEquals dst:reg7, lhs:reg5, rhs:C~0
+  [  c8] Return value:reg7
 
 
-Foo$534d924b
+Foo$cf27a8b3
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-method$67eb02f3 class-environment.js:4:13
+method$f198ceab class-environment.js:4:13
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `Foo`
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `Foo`
+  [  18] Return value:reg5
 
 
 true

--- a/Tests/LibJS/Bytecode/expected/class-lhs-name-no-createvariable.txt
+++ b/Tests/LibJS/Bytecode/expected/class-lhs-name-no-createvariable.txt
@@ -1,4 +1,4 @@
-$e7eb680d class-lhs-name-no-createvariable.js:1:1
+$63c57e75 class-lhs-name-no-createvariable.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,9 +6,10 @@ $e7eb680d class-lhs-name-no-createvariable.js:1:1
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] SetLexicalEnvironment environment:reg4
-  [  28] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (x), element_keys:[element_keys:String("method")]
-  [  50] SetGlobal `x`, src:reg6
-  [  60] End value:Undefined
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] SetLexicalEnvironment environment:reg4
+  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (x), element_keys:[element_keys:String("method")]
+  [  58] SetGlobal `x`, src:reg6
+  [  68] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
+++ b/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
@@ -1,32 +1,33 @@
-$77ae058b class-literal-fields.js:12:1
+$015bd143 class-literal-fields.js:12:1
   Registers: 15
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `test`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  30] DynamicInitializeLexicalBinding `a`, src:reg5
-  [  40] GetGlobal dst:reg6, `console`
-  [  50] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  68] GetGlobal dst:reg8, `a`
-  [  78] GetById dst:reg9, base:reg8, `x` (a.x)
-  [  90] GetGlobal dst:reg8, `a`
-  [  a0] GetById dst:reg10, base:reg8, `y` (a.y)
-  [  b8] GetGlobal dst:reg8, `a`
-  [  c8] GetById dst:reg11, base:reg8, `z` (a.z)
-  [  e0] GetGlobal dst:reg8, `a`
-  [  f0] GetById dst:reg12, base:reg8, `w` (a.w)
-  [ 108] GetGlobal dst:reg8, `a`
-  [ 118] GetById dst:reg13, base:reg8, `s` (a.s)
-  [ 130] GetGlobal dst:reg8, `a`
-  [ 140] GetById dst:reg14, base:reg8, `computed` (a.computed)
-  [ 158] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg9, reg10, reg11, reg12, reg13, reg14]
-  [ 190] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `test`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  38] DynamicInitializeLexicalBinding `a`, src:reg5
+  [  48] GetGlobal dst:reg6, `console`
+  [  58] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  70] GetGlobal dst:reg8, `a`
+  [  80] GetById dst:reg9, base:reg8, `x` (a.x)
+  [  98] GetGlobal dst:reg8, `a`
+  [  a8] GetById dst:reg10, base:reg8, `y` (a.y)
+  [  c0] GetGlobal dst:reg8, `a`
+  [  d0] GetById dst:reg11, base:reg8, `z` (a.z)
+  [  e8] GetGlobal dst:reg8, `a`
+  [  f8] GetById dst:reg12, base:reg8, `w` (a.w)
+  [ 110] GetGlobal dst:reg8, `a`
+  [ 120] GetById dst:reg13, base:reg8, `s` (a.s)
+  [ 138] GetGlobal dst:reg8, `a`
+  [ 148] GetById dst:reg14, base:reg8, `computed` (a.computed)
+  [ 160] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg9, reg10, reg11, reg12, reg13, reg14]
+  [ 198] End value:reg5
 
 
-test$fa7458d4 class-literal-fields.js:2:5
+test$7912604c class-literal-fields.js:2:5
   Registers: 7
   Blocks:    1
   Locals:    A~0
@@ -40,28 +41,30 @@ test$fa7458d4 class-literal-fields.js:2:5
     [6] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("x"), element_keys:String("y"), element_keys:String("z"), element_keys:String("w"), element_keys:String("s"), element_keys:String("computed")]
-  [  70] Mov dst:A~0, src:reg6
-  [  80] ThrowIfTDZ src:A~0
-  [  88] CallConstruct dst:reg6, callee:A~0, A
-  [  a0] Return value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("x"), element_keys:String("y"), element_keys:String("z"), element_keys:String("w"), element_keys:String("s"), element_keys:String("computed")]
+  [  78] Mov dst:A~0, src:reg6
+  [  88] ThrowIfTDZ src:A~0
+  [  90] CallConstruct dst:reg6, callee:A~0, A
+  [  a8] Return value:reg6
 
 
-A$ef0589ec
+A$70678274
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-field$d016a301 class-literal-fields.js:8:22
+field$4eb4aa79 class-literal-fields.js:8:22
   Registers: 5
   Blocks:    1
   Constants:
@@ -70,7 +73,8 @@ field$d016a301 class-literal-fields.js:8:22
     [2] = Int32(3)
 
 block0:
-  [   0] Return value:Int32(3)
+  [   0] Enter
+  [   8] Return value:Int32(3)
 
 
 42 -1 true null "hi" 3

--- a/Tests/LibJS/Bytecode/expected/computed-compound-assign-register-reuse.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-compound-assign-register-reuse.txt
@@ -1,18 +1,19 @@
-$1e945bad computed-compound-assign-register-reuse.js:9:1
+$9d326325 computed-compound-assign-register-reuse.js:9:1
   Registers: 9
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `subVector`
-  [  10] NewPrimitiveArray dst:reg7, elements:[1, 2]
-  [  30] NewPrimitiveArray dst:reg8, elements:[3, 4]
-  [  50] Call dst:reg5, callee:reg6, this_value:Undefined, subVector, arguments:[reg7, reg8]
-  [  78] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `subVector`
+  [  18] NewPrimitiveArray dst:reg7, elements:[1, 2]
+  [  38] NewPrimitiveArray dst:reg8, elements:[3, 4]
+  [  58] Call dst:reg5, callee:reg6, this_value:Undefined, subVector, arguments:[reg7, reg8]
+  [  80] End value:reg5
 
 
-subVector$3599dc10 computed-compound-assign-register-reuse.js:5:13
+subVector$b437e388 computed-compound-assign-register-reuse.js:5:13
   Registers: 9
   Blocks:    1
   Constants:
@@ -21,14 +22,15 @@ subVector$3599dc10 computed-compound-assign-register-reuse.js:5:13
     [2] = Undefined
 
 block0:
-  [   0] GetByValue dst:reg5, base:arg0, property:Int32(0) (self[Int32(0)])
-  [  18] Mov2 c0_dst:reg6, c0_src:Int32(0), c1_dst:reg7, c1_src:arg1
-  [  30] GetByValue dst:reg8, base:reg7, property:Int32(0) (v[Int32(0)])
-  [  48] Sub dst:reg7, lhs:reg5, rhs:reg8
-  [  58] PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
-  [  70] GetByValue dst:reg7, base:arg0, property:Int32(1) (self[Int32(1)])
-  [  88] Mov2 c0_dst:reg5, c0_src:Int32(1), c1_dst:reg6, c1_src:arg1
-  [  a0] GetByValue dst:reg8, base:reg6, property:Int32(1) (v[Int32(1)])
-  [  b8] Sub dst:reg6, lhs:reg7, rhs:reg8
-  [  c8] PutByValue base:arg0, property:reg5, src:reg6, kind:Normal
-  [  e0] End value:Undefined
+  [   0] Enter
+  [   8] GetByValue dst:reg5, base:arg0, property:Int32(0) (self[Int32(0)])
+  [  20] Mov2 c0_dst:reg6, c0_src:Int32(0), c1_dst:reg7, c1_src:arg1
+  [  38] GetByValue dst:reg8, base:reg7, property:Int32(0) (v[Int32(0)])
+  [  50] Sub dst:reg7, lhs:reg5, rhs:reg8
+  [  60] PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
+  [  78] GetByValue dst:reg7, base:arg0, property:Int32(1) (self[Int32(1)])
+  [  90] Mov2 c0_dst:reg5, c0_src:Int32(1), c1_dst:reg6, c1_src:arg1
+  [  a8] GetByValue dst:reg8, base:reg6, property:Int32(1) (v[Int32(1)])
+  [  c0] Sub dst:reg6, lhs:reg7, rhs:reg8
+  [  d0] PutByValue base:arg0, property:reg5, src:reg6, kind:Normal
+  [  e8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/computed-member-access.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-member-access.txt
@@ -1,4 +1,4 @@
-$41132570 computed-member-access.js:12:1
+$bfb12ce8 computed-member-access.js:12:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,32 +6,35 @@ $41132570 computed-member-access.js:12:1
     [1] = Int32(0)
 
 block0:
-  [   0] GetGlobal dst:reg6, `computed_read`
-  [  10] NewPrimitiveArray dst:reg7, elements:[1]
-  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, computed_read, arguments:[reg7]
-  [  50] GetGlobal dst:reg7, `computed_read_expression`
-  [  60] NewPrimitiveArray dst:reg8, elements:[1]
-  [  78] Call dst:reg6, callee:reg7, this_value:Undefined, computed_read_expression, arguments:[reg8, Int32(0)]
-  [  a0] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `computed_read`
+  [  18] NewPrimitiveArray dst:reg7, elements:[1]
+  [  30] Call dst:reg5, callee:reg6, this_value:Undefined, computed_read, arguments:[reg7]
+  [  58] GetGlobal dst:reg7, `computed_read_expression`
+  [  68] NewPrimitiveArray dst:reg8, elements:[1]
+  [  80] Call dst:reg6, callee:reg7, this_value:Undefined, computed_read_expression, arguments:[reg8, Int32(0)]
+  [  a8] End value:reg6
 
 
-computed_read$f0ef6ac1 computed-member-access.js:5:5
+computed_read$72516349 computed-member-access.js:5:5
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Int32(0)
 
 block0:
-  [   0] Mov dst:reg5, src:arg0
-  [  10] GetByValue dst:reg6, base:reg5, property:Int32(0) (a[Int32(0)])
-  [  28] Return value:reg6
+  [   0] Enter
+  [   8] Mov dst:reg5, src:arg0
+  [  18] GetByValue dst:reg6, base:reg5, property:Int32(0) (a[Int32(0)])
+  [  30] Return value:reg6
 
 
-computed_read_expression$c18fd380 computed-member-access.js:9:5
+computed_read_expression$42f1cc08 computed-member-access.js:9:5
   Registers: 7
   Blocks:    1
 
 block0:
-  [   0] Mov dst:reg5, src:arg0
-  [  10] GetByValue dst:reg6, base:reg5, property:arg1 (a[arg1])
-  [  28] Return value:reg6
+  [   0] Enter
+  [   8] Mov dst:reg5, src:arg0
+  [  18] GetByValue dst:reg6, base:reg5, property:arg1 (a[arg1])
+  [  30] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
@@ -1,4 +1,4 @@
-$828b3f8b computed-member-compound-assign.js:15:1
+$01294703 computed-member-compound-assign.js:15:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -7,18 +7,19 @@ $828b3f8b computed-member-compound-assign.js:15:1
     [2] = Int32(1)
 
 block0:
-  [   0] GetGlobal dst:reg6, `compound_computed`
-  [  10] NewObject dst:reg7
-  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, compound_computed, arguments:[reg7, String("x")]
-  [  48] GetGlobal dst:reg7, `compound_then_assign`
-  [  58] NewObject dst:reg8
-  [  68] InitObjectLiteralProperty object:reg8, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  80] CacheObjectShape object:reg8
-  [  90] Call dst:reg6, callee:reg7, this_value:Undefined, compound_then_assign, arguments:[reg8, String("x")]
-  [  b8] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `compound_computed`
+  [  18] NewObject dst:reg7
+  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, compound_computed, arguments:[reg7, String("x")]
+  [  50] GetGlobal dst:reg7, `compound_then_assign`
+  [  60] NewObject dst:reg8
+  [  70] InitObjectLiteralProperty object:reg8, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  88] CacheObjectShape object:reg8
+  [  98] Call dst:reg6, callee:reg7, this_value:Undefined, compound_then_assign, arguments:[reg8, String("x")]
+  [  c0] End value:reg6
 
 
-compound_computed$811bdddb computed-member-compound-assign.js:7:14
+compound_computed$fcf5f443 computed-member-compound-assign.js:7:14
   Registers: 8
   Blocks:    1
   Constants:
@@ -26,14 +27,15 @@ compound_computed$811bdddb computed-member-compound-assign.js:7:14
     [1] = Undefined
 
 block0:
-  [   0] GetByValue dst:reg5, base:arg0, property:arg1 (obj[arg1])
-  [  18] Mov dst:reg6, src:arg1
-  [  28] AddRhsInt32 dst:reg7, lhs:reg5, rhs:1
-  [  38] PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
-  [  50] End value:Undefined
+  [   0] Enter
+  [   8] GetByValue dst:reg5, base:arg0, property:arg1 (obj[arg1])
+  [  20] Mov dst:reg6, src:arg1
+  [  30] AddRhsInt32 dst:reg7, lhs:reg5, rhs:1
+  [  40] PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
+  [  58] End value:Undefined
 
 
-compound_then_assign$aead8c3c computed-member-compound-assign.js:11:13
+compound_then_assign$2a87a2a4 computed-member-compound-assign.js:11:13
   Registers: 8
   Blocks:    1
   Constants:
@@ -41,10 +43,11 @@ compound_then_assign$aead8c3c computed-member-compound-assign.js:11:13
     [1] = Undefined
 
 block0:
-  [   0] GetByValue dst:reg5, base:arg0, property:arg1 (imag[arg1])
-  [  18] Mov dst:reg6, src:arg1
-  [  28] AddRhsInt32 dst:reg7, lhs:reg5, rhs:0
-  [  38] PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
-  [  50] Mov2 c0_dst:reg7, c0_src:arg0, c1_dst:reg5, c1_src:arg1
-  [  68] PutByValue base:reg7, property:reg5, src:arg1, kind:Normal (imag[reg5])
-  [  80] End value:Undefined
+  [   0] Enter
+  [   8] GetByValue dst:reg5, base:arg0, property:arg1 (imag[arg1])
+  [  20] Mov dst:reg6, src:arg1
+  [  30] AddRhsInt32 dst:reg7, lhs:reg5, rhs:0
+  [  40] PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
+  [  58] Mov2 c0_dst:reg7, c0_src:arg0, c1_dst:reg5, c1_src:arg1
+  [  70] PutByValue base:reg7, property:reg5, src:arg1, kind:Normal (imag[reg5])
+  [  88] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/computed-string-object-literal.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-string-object-literal.txt
@@ -1,4 +1,4 @@
-$7d035d6b computed-string-object-literal.js:15:1
+$fba164e3 computed-string-object-literal.js:15:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,29 +6,31 @@ $7d035d6b computed-string-object-literal.js:15:1
     [1] = String("x")
 
 block0:
-  [   0] GetGlobal dst:reg6, `simple_computed`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, simple_computed
-  [  30] GetGlobal dst:reg7, `mixed`
-  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, mixed
-  [  60] GetGlobal dst:reg7, `dynamic`
-  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, dynamic, arguments:[String("x")]
-  [  98] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `simple_computed`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, simple_computed
+  [  38] GetGlobal dst:reg7, `mixed`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, mixed
+  [  68] GetGlobal dst:reg7, `dynamic`
+  [  78] Call dst:reg5, callee:reg7, this_value:Undefined, dynamic, arguments:[String("x")]
+  [  a0] End value:reg5
 
 
-simple_computed$ee1d99de computed-string-object-literal.js:6:5
+simple_computed$6cbba156 computed-string-object-literal.js:6:5
   Registers: 6
   Blocks:    1
   Constants:
     [0] = Int32(1)
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] InitObjectLiteralProperty object:reg5, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  28] CacheObjectShape object:reg5
-  [  38] Return value:reg5
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] InitObjectLiteralProperty object:reg5, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  30] CacheObjectShape object:reg5
+  [  40] Return value:reg5
 
 
-mixed$9f3e333c computed-string-object-literal.js:9:5
+mixed$15906784 computed-string-object-literal.js:9:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -36,22 +38,24 @@ mixed$9f3e333c computed-string-object-literal.js:9:5
     [1] = Int32(2)
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] InitObjectLiteralProperty object:reg5, `a`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  28] InitObjectLiteralProperty object:reg5, `b`, src:Int32(2), shape_cache_index:0, property_slot:1
-  [  40] CacheObjectShape object:reg5
-  [  50] Return value:reg5
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] InitObjectLiteralProperty object:reg5, `a`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  30] InitObjectLiteralProperty object:reg5, `b`, src:Int32(2), shape_cache_index:0, property_slot:1
+  [  48] CacheObjectShape object:reg5
+  [  58] Return value:reg5
 
 
-dynamic$fd0d2731 computed-string-object-literal.js:12:5
+dynamic$7e6f1fb9 computed-string-object-literal.js:12:5
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Int32(1)
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] Mov dst:reg6, src:arg0
-  [  20] ToPrimitiveWithStringHint dst:reg6, value:reg6
-  [  30] PutByValue base:reg5, property:reg6, src:Int32(1), kind:Own
-  [  48] Return value:reg5
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] Mov dst:reg6, src:arg0
+  [  28] ToPrimitiveWithStringHint dst:reg6, value:reg6
+  [  38] PutByValue base:reg5, property:reg6, src:Int32(1), kind:Own
+  [  50] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/computed-string-to-ById.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-string-to-ById.txt
@@ -1,38 +1,40 @@
-$e1cbb7d2 computed-string-to-ById.js:17:1
+$632db05a computed-string-to-ById.js:17:1
   Registers: 9
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `get_string_prop`
-  [  10] NewObject dst:reg7
-  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, get_string_prop, arguments:[reg7]
-  [  48] GetGlobal dst:reg7, `set_string_prop`
-  [  58] NewObject dst:reg8
-  [  68] Call dst:reg6, callee:reg7, this_value:Undefined, set_string_prop, arguments:[reg8]
-  [  90] GetGlobal dst:reg7, `get_index_prop`
-  [  a0] NewArray dst:reg8
-  [  b0] Call dst:reg5, callee:reg7, this_value:Undefined, get_index_prop, arguments:[reg8]
-  [  d8] GetGlobal dst:reg7, `get_length_prop`
-  [  e8] NewArray dst:reg8
-  [  f8] Call dst:reg6, callee:reg7, this_value:Undefined, get_length_prop, arguments:[reg8]
-  [ 120] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `get_string_prop`
+  [  18] NewObject dst:reg7
+  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, get_string_prop, arguments:[reg7]
+  [  50] GetGlobal dst:reg7, `set_string_prop`
+  [  60] NewObject dst:reg8
+  [  70] Call dst:reg6, callee:reg7, this_value:Undefined, set_string_prop, arguments:[reg8]
+  [  98] GetGlobal dst:reg7, `get_index_prop`
+  [  a8] NewArray dst:reg8
+  [  b8] Call dst:reg5, callee:reg7, this_value:Undefined, get_index_prop, arguments:[reg8]
+  [  e0] GetGlobal dst:reg7, `get_length_prop`
+  [  f0] NewArray dst:reg8
+  [ 100] Call dst:reg6, callee:reg7, this_value:Undefined, get_length_prop, arguments:[reg8]
+  [ 128] End value:reg6
 
 
-get_string_prop$5816262b computed-string-to-ById.js:5:5
+get_string_prop$d6b42da3 computed-string-to-ById.js:5:5
   Registers: 7
   Blocks:    1
   Constants:
     [0] = String("hello")
 
 block0:
-  [   0] Mov dst:reg5, src:arg0
-  [  10] GetById dst:reg6, base:reg5, `hello` (o.hello)
-  [  28] Return value:reg6
+  [   0] Enter
+  [   8] Mov dst:reg5, src:arg0
+  [  18] GetById dst:reg6, base:reg5, `hello` (o.hello)
+  [  30] Return value:reg6
 
 
-set_string_prop$d240471f computed-string-to-ById.js:8:16
+set_string_prop$592a21c7 computed-string-to-ById.js:8:16
   Registers: 6
   Blocks:    1
   Constants:
@@ -41,30 +43,33 @@ set_string_prop$d240471f computed-string-to-ById.js:8:16
     [2] = Undefined
 
 block0:
-  [   0] Mov dst:reg5, src:arg0
-  [  10] PutById base:reg5, `hello`, src:Int32(42), kind:Normal (o.hello)
-  [  30] End value:Undefined
+  [   0] Enter
+  [   8] Mov dst:reg5, src:arg0
+  [  18] PutById base:reg5, `hello`, src:Int32(42), kind:Normal (o.hello)
+  [  38] End value:Undefined
 
 
-get_index_prop$a54df54e computed-string-to-ById.js:11:5
+get_index_prop$23ebfcc6 computed-string-to-ById.js:11:5
   Registers: 7
   Blocks:    1
   Constants:
     [0] = String("0")
 
 block0:
-  [   0] Mov dst:reg5, src:arg0
-  [  10] GetByValue dst:reg6, base:reg5, property:String("0") (o[String("0")])
-  [  28] Return value:reg6
+  [   0] Enter
+  [   8] Mov dst:reg5, src:arg0
+  [  18] GetByValue dst:reg6, base:reg5, property:String("0") (o[String("0")])
+  [  30] Return value:reg6
 
 
-get_length_prop$813e14f1 computed-string-to-ById.js:14:5
+get_length_prop$02a00d79 computed-string-to-ById.js:14:5
   Registers: 7
   Blocks:    1
   Constants:
     [0] = String("length")
 
 block0:
-  [   0] Mov dst:reg5, src:arg0
-  [  10] GetLength dst:reg6, base:reg5 (o.length)
-  [  28] Return value:reg6
+  [   0] Enter
+  [   8] Mov dst:reg5, src:arg0
+  [  18] GetLength dst:reg6, base:reg5 (o.length)
+  [  30] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/computed-update-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-update-register-order.txt
@@ -1,17 +1,18 @@
-$18f2b1ec computed-update-register-order.js:8:1
+$9790b964 computed-update-register-order.js:8:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `test`
-  [  10] NewPrimitiveArray dst:reg7, elements:[1, 2, 3, 4]
-  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[reg7]
-  [  68] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `test`
+  [  18] NewPrimitiveArray dst:reg7, elements:[1, 2, 3, 4]
+  [  48] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[reg7]
+  [  70] End value:reg5
 
 
-test$fa8abc17 computed-update-register-order.js:5:9
+test$7becb49f computed-update-register-order.js:5:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -19,18 +20,20 @@ test$fa8abc17 computed-update-register-order.js:5:9
     [1] = Undefined
 
 block0:
-  [   0] GetByValue dst:reg5, base:arg0, property:Int32(3) (c[Int32(3)])
-  [  18] PostfixIncrement dst:reg6, src:reg5
-  [  28] PutByValue base:arg0, property:Int32(3), src:reg5, kind:Normal
-  [  40] GetGlobal dst:reg5, `foo`
-  [  50] Mov dst:reg7, src:arg0
-  [  60] Call dst:reg6, callee:reg5, this_value:Undefined, foo, arguments:[reg7]
-  [  88] End value:Undefined
+  [   0] Enter
+  [   8] GetByValue dst:reg5, base:arg0, property:Int32(3) (c[Int32(3)])
+  [  20] PostfixIncrement dst:reg6, src:reg5
+  [  30] PutByValue base:arg0, property:Int32(3), src:reg5, kind:Normal
+  [  48] GetGlobal dst:reg5, `foo`
+  [  58] Mov dst:reg7, src:arg0
+  [  68] Call dst:reg6, callee:reg5, this_value:Undefined, foo, arguments:[reg7]
+  [  90] End value:Undefined
 
 
-foo$93622fcc computed-update-register-order.js:2:5
+foo$14c42854 computed-update-register-order.js:2:5
   Registers: 5
   Blocks:    1
 
 block0:
-  [   0] Return value:arg0
+  [   0] Enter
+  [   8] Return value:arg0

--- a/Tests/LibJS/Bytecode/expected/condition-dead-code-elim.txt
+++ b/Tests/LibJS/Bytecode/expected/condition-dead-code-elim.txt
@@ -1,4 +1,4 @@
-$7bc57573 condition-dead-code-elim.js:141:1
+$fa637ceb condition-dead-code-elim.js:141:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,32 +6,33 @@ $7bc57573 condition-dead-code-elim.js:141:1
     [1] = Bool(true)
 
 block0:
-  [   0] GetGlobal dst:reg6, `ternary_true`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, ternary_true
-  [  30] GetGlobal dst:reg7, `ternary_truthy`
-  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, ternary_truthy
-  [  60] GetGlobal dst:reg7, `ternary_false`
-  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, ternary_false
-  [  90] GetGlobal dst:reg7, `ternary_falsey`
-  [  a0] Call dst:reg6, callee:reg7, this_value:Undefined, ternary_falsey
-  [  c0] GetGlobal dst:reg7, `while_falsey`
-  [  d0] Call dst:reg5, callee:reg7, this_value:Undefined, while_falsey
-  [  f0] GetGlobal dst:reg7, `do_while_falsey`
-  [ 100] Call dst:reg6, callee:reg7, this_value:Undefined, do_while_falsey
-  [ 120] GetGlobal dst:reg7, `if_falsely`
-  [ 130] Call dst:reg5, callee:reg7, this_value:Undefined, if_falsely
-  [ 150] GetGlobal dst:reg7, `if_truthy`
-  [ 160] Call dst:reg6, callee:reg7, this_value:Undefined, if_truthy
-  [ 180] GetGlobal dst:reg7, `if_exhausted`
-  [ 190] Call dst:reg5, callee:reg7, this_value:Undefined, if_exhausted
-  [ 1b0] GetGlobal dst:reg7, `for_false`
-  [ 1c0] Call dst:reg6, callee:reg7, this_value:Undefined, for_false
-  [ 1e0] GetGlobal dst:reg7, `for_true`
-  [ 1f0] Call dst:reg5, callee:reg7, this_value:Undefined, for_true, arguments:[Bool(true)]
-  [ 218] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `ternary_true`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, ternary_true
+  [  38] GetGlobal dst:reg7, `ternary_truthy`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, ternary_truthy
+  [  68] GetGlobal dst:reg7, `ternary_false`
+  [  78] Call dst:reg5, callee:reg7, this_value:Undefined, ternary_false
+  [  98] GetGlobal dst:reg7, `ternary_falsey`
+  [  a8] Call dst:reg6, callee:reg7, this_value:Undefined, ternary_falsey
+  [  c8] GetGlobal dst:reg7, `while_falsey`
+  [  d8] Call dst:reg5, callee:reg7, this_value:Undefined, while_falsey
+  [  f8] GetGlobal dst:reg7, `do_while_falsey`
+  [ 108] Call dst:reg6, callee:reg7, this_value:Undefined, do_while_falsey
+  [ 128] GetGlobal dst:reg7, `if_falsely`
+  [ 138] Call dst:reg5, callee:reg7, this_value:Undefined, if_falsely
+  [ 158] GetGlobal dst:reg7, `if_truthy`
+  [ 168] Call dst:reg6, callee:reg7, this_value:Undefined, if_truthy
+  [ 188] GetGlobal dst:reg7, `if_exhausted`
+  [ 198] Call dst:reg5, callee:reg7, this_value:Undefined, if_exhausted
+  [ 1b8] GetGlobal dst:reg7, `for_false`
+  [ 1c8] Call dst:reg6, callee:reg7, this_value:Undefined, for_false
+  [ 1e8] GetGlobal dst:reg7, `for_true`
+  [ 1f8] Call dst:reg5, callee:reg7, this_value:Undefined, for_true, arguments:[Bool(true)]
+  [ 220] End value:reg5
 
 
-ternary_true$cd62d477 condition-dead-code-elim.js:9:5
+ternary_true$5188be0f condition-dead-code-elim.js:9:5
   Registers: 5
   Blocks:    1
   Constants:
@@ -39,20 +40,22 @@ ternary_true$cd62d477 condition-dead-code-elim.js:9:5
     [1] = Int32(1)
 
 block0:
-  [   0] Return value:Int32(1)
+  [   0] Enter
+  [   8] Return value:Int32(1)
 
 
-ternary_truthy$8c4636c2 condition-dead-code-elim.js:12:5
+ternary_truthy$106c205a condition-dead-code-elim.js:12:5
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(1)
 
 block0:
-  [   0] Return value:Int32(1)
+  [   0] Enter
+  [   8] Return value:Int32(1)
 
 
-ternary_false$0ff09522 condition-dead-code-elim.js:15:5
+ternary_false$94167eba condition-dead-code-elim.js:15:5
   Registers: 5
   Blocks:    1
   Constants:
@@ -60,10 +63,11 @@ ternary_false$0ff09522 condition-dead-code-elim.js:15:5
     [1] = Int32(1)
 
 block0:
-  [   0] Return value:Int32(1)
+  [   0] Enter
+  [   8] Return value:Int32(1)
 
 
-ternary_falsey$47046b1e condition-dead-code-elim.js:18:5
+ternary_falsey$c2de8186 condition-dead-code-elim.js:18:5
   Registers: 5
   Blocks:    1
   Constants:
@@ -71,10 +75,11 @@ ternary_falsey$47046b1e condition-dead-code-elim.js:18:5
     [1] = Int32(1)
 
 block0:
-  [   0] Return value:Int32(1)
+  [   0] Enter
+  [   8] Return value:Int32(1)
 
 
-while_falsey$95f7160d condition-dead-code-elim.js:33:5
+while_falsey$17590e95 condition-dead-code-elim.js:33:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -83,22 +88,24 @@ while_falsey$95f7160d condition-dead-code-elim.js:33:5
     [2] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `alive`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  30] End value:Undefined
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `alive`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  38] End value:Undefined
 
 
-alive$dfea904d condition-dead-code-elim.js:2:5
+alive$5bc4a6b5 condition-dead-code-elim.js:2:5
   Registers: 5
   Blocks:    1
   Constants:
     [0] = String("alive")
 
 block0:
-  [   0] Return value:String("alive")
+  [   0] Enter
+  [   8] Return value:String("alive")
 
 
-do_while_falsey$30aabdc1 condition-dead-code-elim.js:37:9
+do_while_falsey$af48c539 condition-dead-code-elim.js:37:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -107,18 +114,19 @@ do_while_falsey$30aabdc1 condition-dead-code-elim.js:37:9
     [2] = Null
 
 block0:
-  [   0] GetGlobal dst:reg6, `alive`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  30] GetGlobal dst:reg6, `alive`
-  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  60] GetGlobal dst:reg6, `alive`
-  [  70] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  90] GetGlobal dst:reg6, `alive`
-  [  a0] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  c0] End value:Undefined
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `alive`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  38] GetGlobal dst:reg6, `alive`
+  [  48] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  68] GetGlobal dst:reg6, `alive`
+  [  78] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  98] GetGlobal dst:reg6, `alive`
+  [  a8] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  c8] End value:Undefined
 
 
-if_falsely$c17997ee condition-dead-code-elim.js:62:5
+if_falsely$537336d6 condition-dead-code-elim.js:62:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -127,12 +135,13 @@ if_falsely$c17997ee condition-dead-code-elim.js:62:5
     [2] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `alive`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  30] End value:Undefined
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `alive`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  38] End value:Undefined
 
 
-if_truthy$a0f05550 condition-dead-code-elim.js:66:9
+if_truthy$1f8e5cc8 condition-dead-code-elim.js:66:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -142,18 +151,19 @@ if_truthy$a0f05550 condition-dead-code-elim.js:66:9
     [3] = Int32(123)
 
 block0:
-  [   0] GetGlobal dst:reg6, `alive`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  30] GetGlobal dst:reg6, `alive`
-  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  60] GetGlobal dst:reg6, `alive`
-  [  70] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  90] GetGlobal dst:reg6, `alive`
-  [  a0] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  c0] End value:Undefined
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `alive`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  38] GetGlobal dst:reg6, `alive`
+  [  48] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  68] GetGlobal dst:reg6, `alive`
+  [  78] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  98] GetGlobal dst:reg6, `alive`
+  [  a8] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  c8] End value:Undefined
 
 
-if_exhausted$19293969 condition-dead-code-elim.js:90:9
+if_exhausted$9a8b31f1 condition-dead-code-elim.js:90:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -162,16 +172,17 @@ if_exhausted$19293969 condition-dead-code-elim.js:90:9
     [2] = Bool(true)
 
 block0:
-  [   0] GetGlobal dst:reg6, `alive`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  30] GetGlobal dst:reg6, `alive`
-  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  60] GetGlobal dst:reg6, `alive`
-  [  70] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  90] End value:Undefined
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `alive`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  38] GetGlobal dst:reg6, `alive`
+  [  48] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  68] GetGlobal dst:reg6, `alive`
+  [  78] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  98] End value:Undefined
 
 
-for_false$20a32ecc condition-dead-code-elim.js:109:5
+for_false$a2052754 condition-dead-code-elim.js:109:5
   Registers: 7
   Blocks:    9
   Locals:    x~0
@@ -181,48 +192,50 @@ for_false$20a32ecc condition-dead-code-elim.js:109:5
     [2] = Undefined
 
 block0:
-  [   0] Jump target:block2
+  [   0] Enter
+  [   8] Jump target:block2
 
 block1:
-  [   8] End value:Undefined
+  [  10] End value:Undefined
 
 block2:
-  [  10] Jump target:block4
+  [  18] Jump target:block4
 
 block3:
-  [  18] End value:Undefined
+  [  20] End value:Undefined
 
 block4:
-  [  20] Jump target:block6
+  [  28] Jump target:block6
 
 block5:
-  [  28] End value:Undefined
+  [  30] End value:Undefined
 
 block6:
-  [  30] GetGlobal dst:reg5, `call_this`
-  [  40] Call dst:x~0, callee:reg5, this_value:Undefined, call_this
-  [  60] Jump target:block8
+  [  38] GetGlobal dst:reg5, `call_this`
+  [  48] Call dst:x~0, callee:reg5, this_value:Undefined, call_this
+  [  68] Jump target:block8
 
 block7:
-  [  68] End value:Undefined
+  [  70] End value:Undefined
 
 block8:
-  [  70] GetGlobal dst:reg6, `alive`
-  [  80] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  a0] End value:Undefined
+  [  78] GetGlobal dst:reg6, `alive`
+  [  88] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  a8] End value:Undefined
 
 
-call_this$7cdf005a condition-dead-code-elim.js:105:5
+call_this$f8b916c2 condition-dead-code-elim.js:105:5
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(1)
 
 block0:
-  [   0] Return value:Int32(1)
+  [   0] Enter
+  [   8] Return value:Int32(1)
 
 
-for_true$3f41bfe2 condition-dead-code-elim.js:128:5
+for_true$e6a6f225 condition-dead-code-elim.js:128:5
   Registers: 7
   Blocks:    11
   Constants:
@@ -231,40 +244,41 @@ for_true$3f41bfe2 condition-dead-code-elim.js:128:5
     [2] = Int32(1)
 
 block0:
-  [   0] Jump target:block2
+  [   0] Enter
+  [   8] Jump target:block2
 
 block1:
-  [   8] GetGlobal dst:reg6, `alive`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  38] JumpIf condition:arg0, true_target:block4, false_target:block5
+  [  10] GetGlobal dst:reg6, `alive`
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  40] JumpIf condition:arg0, true_target:block4, false_target:block5
 
 block2:
-  [  48] Jump target:block1
+  [  50] Jump target:block1
 
 block3:
-  [  50] Jump target:block7
+  [  58] Jump target:block7
 
 block4:
-  [  58] Jump target:block3
+  [  60] Jump target:block3
 
 block5:
-  [  60] Jump target:block2
+  [  68] Jump target:block2
 
 block6:
-  [  68] GetGlobal dst:reg6, `alive`
-  [  78] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  98] JumpIf condition:arg0, true_target:block9, false_target:block10
+  [  70] GetGlobal dst:reg6, `alive`
+  [  80] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  a0] JumpIf condition:arg0, true_target:block9, false_target:block10
 
 block7:
-  [  a8] Jump target:block6
+  [  b0] Jump target:block6
 
 block8:
-  [  b0] GetGlobal dst:reg6, `alive`
-  [  c0] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  e0] End value:Undefined
+  [  b8] GetGlobal dst:reg6, `alive`
+  [  c8] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  e8] End value:Undefined
 
 block9:
-  [  e8] Jump target:block8
+  [  f0] Jump target:block8
 
 block10:
-  [  f0] Jump target:block7
+  [  f8] Jump target:block7

--- a/Tests/LibJS/Bytecode/expected/conditional-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/conditional-register-order.txt
@@ -1,16 +1,17 @@
-$bacf2c68 conditional-register-order.js:4:1
+$2b997e90 conditional-register-order.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `foo`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `foo`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo
+  [  38] End value:reg5
 
 
-foo$1d0ffb84 conditional-register-order.js:2:5
+foo$9e71f40c conditional-register-order.js:2:5
   Registers: 6
   Blocks:    3
   Constants:
@@ -18,12 +19,13 @@ foo$1d0ffb84 conditional-register-order.js:2:5
     [1] = Int32(2)
 
 block0:
-  [   0] JumpFalse condition:arg0, target:block2
+  [   0] Enter
+  [   8] JumpFalse condition:arg0, target:block2
 
 block1:
-  [  10] Mov dst:reg5, src:Int32(1)
-  [  20] Return value:reg5
+  [  18] Mov dst:reg5, src:Int32(1)
+  [  28] Return value:reg5
 
 block2:
-  [  28] Mov dst:reg5, src:Int32(2)
-  [  38] Return value:reg5
+  [  30] Mov dst:reg5, src:Int32(2)
+  [  40] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
@@ -1,4 +1,4 @@
-$0d47ea81 const-assignment-no-extra-tdz.js:5:1
+$8ea9e309 const-assignment-no-extra-tdz.js:5:1
   Registers: 9
   Blocks:    3
   Locals:    e~0
@@ -6,27 +6,28 @@ $0d47ea81 const-assignment-no-extra-tdz.js:5:1
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Jump target:block2
 
 block1:
-  [  10] Catch dst:reg5
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] Mov3 c0_dst:e~0, c0_src:reg5, c1_dst:reg6, c1_src:Undefined, c2_dst:reg7, c2_src:reg6
-  [  40] End value:reg6
+  [  18] Catch dst:reg5
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] Mov3 c0_dst:e~0, c0_src:reg5, c1_dst:reg6, c1_src:Undefined, c2_dst:reg7, c2_src:reg6
+  [  48] End value:reg6
 
 block2:
-  [  48] MovSrcUndefined dst:reg5
-  [  50] GetGlobal dst:reg8, `f`
-  [  60] Call dst:reg6, callee:reg8, this_value:Undefined, f
-  [  80] Mov2 c0_dst:reg5, c0_src:reg6, c1_dst:reg6, c1_src:reg5
-  [  98] End value:reg6
+  [  50] MovSrcUndefined dst:reg5
+  [  58] GetGlobal dst:reg8, `f`
+  [  68] Call dst:reg6, callee:reg8, this_value:Undefined, f
+  [  88] Mov2 c0_dst:reg5, c0_src:reg6, c1_dst:reg6, c1_src:reg5
+  [  a0] End value:reg6
 
 Exception handlers:
-  [  48 ..   a0] => handler block1
+  [  50 ..   a8] => handler block1
 
 
-f$e16999cc const-assignment-no-extra-tdz.js:2:5
+f$6007a144 const-assignment-no-extra-tdz.js:2:5
   Registers: 5
   Blocks:    1
   Locals:    x~0
@@ -36,6 +37,7 @@ f$e16999cc const-assignment-no-extra-tdz.js:2:5
     [2] = Undefined
 
 block0:
-  [   0] Mov dst:x~0, src:Int32(1)
-  [  10] ThrowConstAssignment
-  [  18] End value:Undefined
+  [   0] Enter
+  [   8] Mov dst:x~0, src:Int32(1)
+  [  18] ThrowConstAssignment
+  [  20] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/const-fold-exponentiation.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-exponentiation.txt
@@ -1,4 +1,4 @@
-$e26385ed const-fold-exponentiation.js:1:1
+$5e3d9c55 const-fold-exponentiation.js:1:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -13,8 +13,9 @@ $e26385ed const-fold-exponentiation.js:1:1
     [8] = Undefined
 
 block0:
-  [   0] DynamicInitializeLexicalBinding `a`, src:Double(nan)
-  [  10] DynamicInitializeLexicalBinding `b`, src:Double(nan)
-  [  20] DynamicInitializeLexicalBinding `c`, src:Double(nan)
-  [  30] DynamicInitializeLexicalBinding `d`, src:Int32(1024)
-  [  40] End value:Undefined
+  [   0] Enter
+  [   8] DynamicInitializeLexicalBinding `a`, src:Double(nan)
+  [  18] DynamicInitializeLexicalBinding `b`, src:Double(nan)
+  [  28] DynamicInitializeLexicalBinding `c`, src:Double(nan)
+  [  38] DynamicInitializeLexicalBinding `d`, src:Int32(1024)
+  [  48] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
@@ -1,4 +1,4 @@
-$e22de836 const-fold-template-literals.js:20:1
+$638fe0be const-fold-template-literals.js:20:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -12,95 +12,102 @@ $e22de836 const-fold-template-literals.js:20:1
     [7] = Int32(3)
 
 block0:
-  [   0] DynamicInitializeLexicalBinding `a`, src:String("abcxyz")
-  [  10] DynamicInitializeLexicalBinding `b`, src:String("abcxyz")
-  [  20] DynamicInitializeLexicalBinding `c`, src:String("abcxyz")
-  [  30] DynamicInitializeLexicalBinding `d`, src:String("abcxyz")
-  [  40] DynamicInitializeLexicalBinding `e`, src:String("abcxyz")
-  [  50] DynamicInitializeLexicalBinding `f`, src:String("abcxyz")
-  [  60] Mov dst:reg5, src:String("abc")
-  [  70] ConcatString dst:reg5, src:String("xyz")
-  [  80] DynamicInitializeLexicalBinding `g`, src:reg5
-  [  90] GetGlobal dst:reg6, `prefix`
-  [  a0] Call dst:reg5, callee:reg6, this_value:Undefined, prefix, arguments:[String("abc")]
-  [  c8] DynamicInitializeLexicalBinding `_prefix`, src:reg5
-  [  d8] GetGlobal dst:reg6, `suffix`
-  [  e8] Call dst:reg5, callee:reg6, this_value:Undefined, suffix, arguments:[String("abc")]
-  [ 110] DynamicInitializeLexicalBinding `_suffix`, src:reg5
-  [ 120] GetGlobal dst:reg6, `tostring`
-  [ 130] Call dst:reg5, callee:reg6, this_value:Undefined, tostring, arguments:[String("abc")]
-  [ 158] DynamicInitializeLexicalBinding `_tostring`, src:reg5
-  [ 168] GetGlobal dst:reg6, `multi`
-  [ 178] Call dst:reg5, callee:reg6, this_value:Undefined, multi, arguments:[Int32(1), Int32(2), Int32(3)]
-  [ 1a8] DynamicInitializeLexicalBinding `_multi`, src:reg5
-  [ 1b8] GetGlobal dst:reg6, `literal`
-  [ 1c8] Call dst:reg5, callee:reg6, this_value:Undefined, literal
-  [ 1e8] DynamicInitializeLexicalBinding `_literal`, src:reg5
-  [ 1f8] GetGlobal dst:reg6, `empty`
-  [ 208] Call dst:reg5, callee:reg6, this_value:Undefined, empty
-  [ 228] DynamicInitializeLexicalBinding `_empty`, src:reg5
-  [ 238] End value:Undefined
+  [   0] Enter
+  [   8] DynamicInitializeLexicalBinding `a`, src:String("abcxyz")
+  [  18] DynamicInitializeLexicalBinding `b`, src:String("abcxyz")
+  [  28] DynamicInitializeLexicalBinding `c`, src:String("abcxyz")
+  [  38] DynamicInitializeLexicalBinding `d`, src:String("abcxyz")
+  [  48] DynamicInitializeLexicalBinding `e`, src:String("abcxyz")
+  [  58] DynamicInitializeLexicalBinding `f`, src:String("abcxyz")
+  [  68] Mov dst:reg5, src:String("abc")
+  [  78] ConcatString dst:reg5, src:String("xyz")
+  [  88] DynamicInitializeLexicalBinding `g`, src:reg5
+  [  98] GetGlobal dst:reg6, `prefix`
+  [  a8] Call dst:reg5, callee:reg6, this_value:Undefined, prefix, arguments:[String("abc")]
+  [  d0] DynamicInitializeLexicalBinding `_prefix`, src:reg5
+  [  e0] GetGlobal dst:reg6, `suffix`
+  [  f0] Call dst:reg5, callee:reg6, this_value:Undefined, suffix, arguments:[String("abc")]
+  [ 118] DynamicInitializeLexicalBinding `_suffix`, src:reg5
+  [ 128] GetGlobal dst:reg6, `tostring`
+  [ 138] Call dst:reg5, callee:reg6, this_value:Undefined, tostring, arguments:[String("abc")]
+  [ 160] DynamicInitializeLexicalBinding `_tostring`, src:reg5
+  [ 170] GetGlobal dst:reg6, `multi`
+  [ 180] Call dst:reg5, callee:reg6, this_value:Undefined, multi, arguments:[Int32(1), Int32(2), Int32(3)]
+  [ 1b0] DynamicInitializeLexicalBinding `_multi`, src:reg5
+  [ 1c0] GetGlobal dst:reg6, `literal`
+  [ 1d0] Call dst:reg5, callee:reg6, this_value:Undefined, literal
+  [ 1f0] DynamicInitializeLexicalBinding `_literal`, src:reg5
+  [ 200] GetGlobal dst:reg6, `empty`
+  [ 210] Call dst:reg5, callee:reg6, this_value:Undefined, empty
+  [ 230] DynamicInitializeLexicalBinding `_empty`, src:reg5
+  [ 240] End value:Undefined
 
 
-prefix$722bd91a const-fold-template-literals.js:2:5
+prefix$ee05ef82 const-fold-template-literals.js:2:5
   Registers: 6
   Blocks:    1
   Constants:
     [0] = String("prefix-")
 
 block0:
-  [   0] Mov dst:reg5, src:String("prefix-")
-  [  10] ConcatString dst:reg5, src:arg0
-  [  20] Return value:reg5
+  [   0] Enter
+  [   8] Mov dst:reg5, src:String("prefix-")
+  [  18] ConcatString dst:reg5, src:arg0
+  [  28] Return value:reg5
 
 
-suffix$a92a9be2 const-fold-template-literals.js:5:5
+suffix$2d50857a const-fold-template-literals.js:5:5
   Registers: 6
   Blocks:    1
   Constants:
     [0] = String("-suffix")
 
 block0:
-  [   0] ToString dst:reg5, value:arg0
-  [  10] ConcatString dst:reg5, src:String("-suffix")
-  [  20] Return value:reg5
+  [   0] Enter
+  [   8] ToString dst:reg5, value:arg0
+  [  18] ConcatString dst:reg5, src:String("-suffix")
+  [  28] Return value:reg5
 
 
-tostring$ba142bc6 const-fold-template-literals.js:8:5
+tostring$38b2333e const-fold-template-literals.js:8:5
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] ToString dst:reg5, value:arg0
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] ToString dst:reg5, value:arg0
+  [  18] Return value:reg5
 
 
-multi$05431102 const-fold-template-literals.js:11:5
+multi$78d1543a const-fold-template-literals.js:11:5
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] ToString dst:reg5, value:arg0
-  [  10] ConcatString dst:reg5, src:arg1
-  [  20] ConcatString dst:reg5, src:arg2
-  [  30] Return value:reg5
+  [   0] Enter
+  [   8] ToString dst:reg5, value:arg0
+  [  18] ConcatString dst:reg5, src:arg1
+  [  28] ConcatString dst:reg5, src:arg2
+  [  38] Return value:reg5
 
 
-literal$12c5c655 const-fold-template-literals.js:14:5
+literal$96ebafed const-fold-template-literals.js:14:5
   Registers: 6
   Blocks:    1
   Constants:
     [0] = String("hello world")
 
 block0:
-  [   0] Return value:String("hello world")
+  [   0] Enter
+  [   8] Return value:String("hello world")
 
 
-empty$4890c274 const-fold-template-literals.js:17:5
+empty$c72ec9ec const-fold-template-literals.js:17:5
   Registers: 5
   Blocks:    1
   Constants:
     [0] = String("")
 
 block0:
-  [   0] Return value:String("")
+  [   0] Enter
+  [   8] Return value:String("")

--- a/Tests/LibJS/Bytecode/expected/constant-fold-large-string-to-number.txt
+++ b/Tests/LibJS/Bytecode/expected/constant-fold-large-string-to-number.txt
@@ -1,4 +1,4 @@
-$e26385ed constant-fold-large-string-to-number.js:1:1
+$5e3d9c55 constant-fold-large-string-to-number.js:1:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -10,8 +10,9 @@ $e26385ed constant-fold-large-string-to-number.js:1:1
     [5] = Undefined
 
 block0:
-  [   0] SetGlobal `a`, src:Double(18446744073709552000)
-  [  10] SetGlobal `b`, src:Double(18446744073709552000)
-  [  20] SetGlobal `c`, src:Double(18446744073709552000)
-  [  30] SetGlobal `d`, src:Double(18446744073709552000)
-  [  40] End value:Undefined
+  [   0] Enter
+  [   8] SetGlobal `a`, src:Double(18446744073709552000)
+  [  18] SetGlobal `b`, src:Double(18446744073709552000)
+  [  28] SetGlobal `c`, src:Double(18446744073709552000)
+  [  38] SetGlobal `d`, src:Double(18446744073709552000)
+  [  48] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/constant-fold-string-to-number.txt
+++ b/Tests/LibJS/Bytecode/expected/constant-fold-string-to-number.txt
@@ -1,4 +1,4 @@
-$e26385ed constant-fold-string-to-number.js:1:1
+$5e3d9c55 constant-fold-string-to-number.js:1:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -13,8 +13,9 @@ $e26385ed constant-fold-string-to-number.js:1:1
     [8] = Undefined
 
 block0:
-  [   0] SetGlobal `a`, src:Int32(12345)
-  [  10] SetGlobal `b`, src:Int32(123450)
-  [  20] SetGlobal `c`, src:Int32(-42)
-  [  30] SetGlobal `d`, src:Int32(-6)
-  [  40] End value:Undefined
+  [   0] Enter
+  [   8] SetGlobal `a`, src:Int32(12345)
+  [  18] SetGlobal `b`, src:Int32(123450)
+  [  28] SetGlobal `c`, src:Int32(-42)
+  [  38] SetGlobal `d`, src:Int32(-6)
+  [  48] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/debugger-statement.txt
+++ b/Tests/LibJS/Bytecode/expected/debugger-statement.txt
@@ -1,22 +1,23 @@
-$61e80cca debugger-statement.js:6:1
+$e8d1e772 debugger-statement.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `run`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, run
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `run`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, run
+  [  38] End value:reg5
 
 
-run$47755fb3 debugger-statement.js:2:5
+run$c8d7583b debugger-statement.js:2:5
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(42)
 
 block0:
-  [   0] Debugger
-  [   8] Return value:Int32(42)
-
+  [   0] Enter
+  [   8] Debugger
+  [  10] Return value:Int32(42)

--- a/Tests/LibJS/Bytecode/expected/default-param-self-reference.txt
+++ b/Tests/LibJS/Bytecode/expected/default-param-self-reference.txt
@@ -1,4 +1,4 @@
-$3703a836 default-param-self-reference.js:2:1
+$b865a0be default-param-self-reference.js:2:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $3703a836 default-param-self-reference.js:2:1
     [1] = Int32(1)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  40] End value:reg5
 
 
-f$d753a0ea default-param-self-reference.js:1:16
+f$55f1a862 default-param-self-reference.js:1:16
   Registers: 5
   Blocks:    3
   Constants:
@@ -19,12 +20,13 @@ f$d753a0ea default-param-self-reference.js:1:16
     [1] = Undefined
 
 block0:
-  [   0] JumpUndefined condition:arg0, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] JumpUndefined condition:arg0, true_target:block1, false_target:block2
 
 block1:
-  [  10] Mov dst:arg0, src:<Empty>
-  [  20] ThrowIfTDZ src:arg0
-  [  28] Mov dst:arg0, src:arg0
+  [  18] Mov dst:arg0, src:<Empty>
+  [  28] ThrowIfTDZ src:arg0
+  [  30] Mov dst:arg0, src:arg0
 
 block2:
-  [  38] End value:Undefined
+  [  40] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
@@ -1,4 +1,4 @@
-$e8d1e772 delete-expression-register.js:6:1
+$6a33dffa delete-expression-register.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $e8d1e772 delete-expression-register.js:6:1
     [1] = Int32(1)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  40] End value:reg5
 
 
-f$04c49ea7 delete-expression-register.js:3:7
+f$9f0a10bf delete-expression-register.js:3:7
   Registers: 7
   Blocks:    3
   Locals:    x~0, arguments~1
@@ -21,14 +22,15 @@ f$04c49ea7 delete-expression-register.js:3:7
     [2] = Int32(0)
 
 block0:
-  [   0] CreateArguments dst:arguments~1, is_immutable:false
-  [  10] Mov3 c0_dst:x~0, c0_src:Undefined, c1_dst:x~0, c1_src:Bool(false), c2_dst:reg5, c2_src:x~0
-  [  30] JumpTrue condition:x~0, target:block2
+  [   0] Enter
+  [   8] CreateArguments dst:arguments~1, is_immutable:false
+  [  18] Mov3 c0_dst:x~0, c0_src:Undefined, c1_dst:x~0, c1_src:Bool(false), c2_dst:reg5, c2_src:x~0
+  [  38] JumpTrue condition:x~0, target:block2
 
 block1:
-  [  40] DeleteByValue dst:reg6, base:arguments~1, property:Int32(0)
-  [  50] Mov dst:reg5, src:reg6
+  [  48] DeleteByValue dst:reg6, base:arguments~1, property:Int32(0)
+  [  58] Mov dst:reg5, src:reg6
 
 block2:
-  [  60] Mov dst:x~0, src:reg5
-  [  70] Return value:x~0
+  [  68] Mov dst:x~0, src:reg5
+  [  78] Return value:x~0

--- a/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
@@ -1,4 +1,4 @@
-$f9b5dfb3 delete-super-eval-order.js:4:1
+$6a8031db delete-super-eval-order.js:4:1
   Registers: 10
   Blocks:    3
   Constants:
@@ -7,54 +7,57 @@ $f9b5dfb3 delete-super-eval-order.js:4:1
     [2] = String("x")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("m")]
-  [  60] DynamicInitializeLexicalBinding `A`, src:reg6
-  [  70] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("m")]
+  [  68] DynamicInitializeLexicalBinding `A`, src:reg6
+  [  78] Jump target:block2
 
 block1:
-  [  78] Catch dst:reg6
-  [  80] SetLexicalEnvironment environment:reg4
-  [  88] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg7, c1_src:reg5
-  [  a0] End value:reg5
+  [  80] Catch dst:reg6
+  [  88] SetLexicalEnvironment environment:reg4
+  [  90] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg7, c1_src:reg5
+  [  a8] End value:reg5
 
 block2:
-  [  a8] MovSrcUndefined dst:reg6
-  [  b0] GetGlobal dst:reg9, `A`
-  [  c0] CallConstruct dst:reg8, callee:reg9, A
-  [  d8] GetById dst:reg9, base:reg8, `m`
-  [  f0] Call dst:reg5, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
-  [ 118] Mov2 c0_dst:reg6, c0_src:reg5, c1_dst:reg5, c1_src:reg6
-  [ 130] End value:reg5
+  [  b0] MovSrcUndefined dst:reg6
+  [  b8] GetGlobal dst:reg9, `A`
+  [  c8] CallConstruct dst:reg8, callee:reg9, A
+  [  e0] GetById dst:reg9, base:reg8, `m`
+  [  f8] Call dst:reg5, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
+  [ 120] Mov2 c0_dst:reg6, c0_src:reg5, c1_dst:reg5, c1_src:reg6
+  [ 138] End value:reg5
 
 Exception handlers:
-  [  a8 ..  138] => handler block1
+  [  b0 ..  140] => handler block1
 
 
-A$ef0589ec
+A$70678274
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-m$0f7c4977 delete-super-eval-order.js:6:9
+m$90de41ff delete-super-eval-order.js:6:9
   Registers: 7
   Blocks:    2
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg5
-  [  10] NewReferenceError dst:reg6, Can't delete a property on 'super'
-  [  20] Throw src:reg6
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg5
+  [  18] NewReferenceError dst:reg6, Can't delete a property on 'super'
+  [  28] Throw src:reg6
 
 block1:
-  [  28] End value:Undefined
+  [  30] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/delete-super-property.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-property.txt
@@ -1,4 +1,4 @@
-$bc604c32 delete-super-property.js:1:1
+$ee43eb0f delete-super-property.js:1:1
   Registers: 11
   Blocks:    6
   Locals:    e~0, e~1
@@ -8,78 +8,81 @@ $bc604c32 delete-super-property.js:1:1
     [2] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("foo"), element_keys:String("baz")]
-  [  60] DynamicInitializeLexicalBinding `A`, src:reg6
-  [  70] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("foo"), element_keys:String("baz")]
+  [  68] DynamicInitializeLexicalBinding `A`, src:reg6
+  [  78] Jump target:block3
 
 block1:
-  [  78] Catch dst:reg6
-  [  80] SetLexicalEnvironment environment:reg4
-  [  88] Mov3 c0_dst:e~0, c0_src:reg6, c1_dst:reg5, c1_src:Undefined, c2_dst:reg7, c2_src:reg5
+  [  80] Catch dst:reg6
+  [  88] SetLexicalEnvironment environment:reg4
+  [  90] Mov3 c0_dst:e~0, c0_src:reg6, c1_dst:reg5, c1_src:Undefined, c2_dst:reg7, c2_src:reg5
 
 block2:
-  [  a8] Jump target:block5
+  [  b0] Jump target:block5
 
 block3:
-  [  b0] MovSrcUndefined dst:reg6
-  [  b8] GetGlobal dst:reg9, `A`
-  [  c8] CallConstruct dst:reg8, callee:reg9, A
-  [  e0] GetById dst:reg9, base:reg8, `foo`
-  [  f8] Call dst:reg5, callee:reg9, this_value:reg8, <object>.foo
-  [ 118] Mov2 c0_dst:reg6, c0_src:reg5, c1_dst:reg5, c1_src:reg6
-  [ 130] Jump target:block2
+  [  b8] MovSrcUndefined dst:reg6
+  [  c0] GetGlobal dst:reg9, `A`
+  [  d0] CallConstruct dst:reg8, callee:reg9, A
+  [  e8] GetById dst:reg9, base:reg8, `foo`
+  [ 100] Call dst:reg5, callee:reg9, this_value:reg8, <object>.foo
+  [ 120] Mov2 c0_dst:reg6, c0_src:reg5, c1_dst:reg5, c1_src:reg6
+  [ 138] Jump target:block2
 
 block4:
-  [ 138] Catch dst:reg6
-  [ 140] SetLexicalEnvironment environment:reg4
-  [ 148] Mov3 c0_dst:e~1, c0_src:reg6, c1_dst:reg7, c1_src:Undefined, c2_dst:reg9, c2_src:reg7
-  [ 168] End value:reg7
+  [ 140] Catch dst:reg6
+  [ 148] SetLexicalEnvironment environment:reg4
+  [ 150] Mov3 c0_dst:e~1, c0_src:reg6, c1_dst:reg7, c1_src:Undefined, c2_dst:reg9, c2_src:reg7
+  [ 170] End value:reg7
 
 block5:
-  [ 170] MovSrcUndefined dst:reg6
-  [ 178] GetGlobal dst:reg10, `A`
-  [ 188] CallConstruct dst:reg8, callee:reg10, A
-  [ 1a0] GetById dst:reg10, base:reg8, `baz`
-  [ 1b8] Call dst:reg7, callee:reg10, this_value:reg8, <object>.baz
-  [ 1d8] Mov2 c0_dst:reg6, c0_src:reg7, c1_dst:reg7, c1_src:reg6
-  [ 1f0] End value:reg7
+  [ 178] MovSrcUndefined dst:reg6
+  [ 180] GetGlobal dst:reg10, `A`
+  [ 190] CallConstruct dst:reg8, callee:reg10, A
+  [ 1a8] GetById dst:reg10, base:reg8, `baz`
+  [ 1c0] Call dst:reg7, callee:reg10, this_value:reg8, <object>.baz
+  [ 1e0] Mov2 c0_dst:reg6, c0_src:reg7, c1_dst:reg7, c1_src:reg6
+  [ 1f8] End value:reg7
 
 Exception handlers:
-  [  b0 ..  138] => handler block1
-  [ 170 ..  1f8] => handler block4
+  [  b8 ..  140] => handler block1
+  [ 178 ..  200] => handler block4
 
 
-A$ef0589ec
+A$70678274
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-foo$7707d509 delete-super-property.js:3:9
+foo$f5a5dc81 delete-super-property.js:3:9
   Registers: 7
   Blocks:    2
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg5
-  [  10] NewReferenceError dst:reg6, Can't delete a property on 'super'
-  [  20] Throw src:reg6
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg5
+  [  18] NewReferenceError dst:reg6, Can't delete a property on 'super'
+  [  28] Throw src:reg6
 
 block1:
-  [  28] End value:Undefined
+  [  30] End value:Undefined
 
 
-baz$8acb3acb delete-super-property.js:6:9
+baz$09694243 delete-super-property.js:6:9
   Registers: 7
   Blocks:    2
   Constants:
@@ -87,10 +90,11 @@ baz$8acb3acb delete-super-property.js:6:9
     [1] = Undefined
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg5
-  [  10] NewReferenceError dst:reg6, Can't delete a property on 'super'
-  [  20] Throw src:reg6
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg5
+  [  18] NewReferenceError dst:reg6, Can't delete a property on 'super'
+  [  28] Throw src:reg6
 
 block1:
-  [  28] End value:Undefined
+  [  30] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/destructure-array-rest.txt
+++ b/Tests/LibJS/Bytecode/expected/destructure-array-rest.txt
@@ -1,16 +1,17 @@
-$89d6cbb5 destructure-array-rest.js:9:1
+$fd650eed destructure-array-rest.js:9:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  38] End value:reg5
 
 
-f$a76a52a3 destructure-array-rest.js:6:5
+f$26085a1b destructure-array-rest.js:6:5
   Registers: 14
   Blocks:    19
   Locals:    a~0, b~1
@@ -21,77 +22,78 @@ f$a76a52a3 destructure-array-rest.js:6:5
     [3] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewPrimitiveArray dst:reg5, elements:[1, 2, 3]
-  [  30] Mov dst:reg6, src:Bool(false)
-  [  40] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
-  [  58] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewPrimitiveArray dst:reg5, elements:[1, 2, 3]
+  [  38] Mov dst:reg6, src:Bool(false)
+  [  48] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
+  [  60] Jump target:block3
 
 block1:
-  [  60] Catch dst:reg11
-  [  68] SetLexicalEnvironment environment:reg4
-  [  70] Mov dst:reg10, src:Int32(1)
-  [  80] JumpIf condition:reg9, true_target:block14, false_target:block13
+  [  68] Catch dst:reg11
+  [  70] SetLexicalEnvironment environment:reg4
+  [  78] Mov dst:reg10, src:Int32(1)
+  [  88] JumpIf condition:reg9, true_target:block14, false_target:block13
 
 block2:
-  [  90] Return value:b~1
+  [  98] Return value:b~1
 
 block3:
-  [  98] Jump target:block5
+  [  a0] Jump target:block5
 
 block4:
-  [  a0] MovSrcUndefined dst:reg12
-  [  a8] Jump target:block6
+  [  a8] MovSrcUndefined dst:reg12
+  [  b0] Jump target:block6
 
 block5:
-  [  b0] IteratorNextUnpack dst_value:reg12, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
-  [  c8] JumpTrue condition:reg6, target:block4
+  [  b8] IteratorNextUnpack dst_value:reg12, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
+  [  d0] JumpTrue condition:reg6, target:block4
 
 block6:
-  [  d8] Mov dst:a~0, src:reg12
-  [  e8] JumpFalse condition:reg6, target:block8
+  [  e0] Mov dst:a~0, src:reg12
+  [  f0] JumpFalse condition:reg6, target:block8
 
 block7:
-  [  f8] NewArray dst:reg13
-  [ 108] Jump target:block9
+  [ 100] NewArray dst:reg13
+  [ 110] Jump target:block9
 
 block8:
-  [ 110] IteratorToArray dst:reg13, iterator_object:reg7, iterator_next_method:reg8, iterator_done_property:reg9
+  [ 118] IteratorToArray dst:reg13, iterator_object:reg7, iterator_next_method:reg8, iterator_done_property:reg9
 
 block9:
-  [ 128] Mov dst:b~1, src:reg13
+  [ 130] Mov dst:b~1, src:reg13
 
 block10:
-  [ 138] JumpFalse condition:reg9, target:block12
+  [ 140] JumpFalse condition:reg9, target:block12
 
 block11:
-  [ 148] Return value:b~1
+  [ 150] Return value:b~1
 
 block12:
-  [ 150] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 168] Jump target:block11
+  [ 158] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 170] Jump target:block11
 
 block13:
-  [ 170] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block15, false_target:block16
+  [ 178] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block15, false_target:block16
 
 block14:
-  [ 188] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block17, false_target:block18
+  [ 190] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block17, false_target:block18
 
 block15:
-  [ 1a0] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
-  [ 1b8] Throw src:reg11
+  [ 1a8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
+  [ 1c0] Throw src:reg11
 
 block16:
-  [ 1c0] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 1d8] Jump target:block14
+  [ 1c8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 1e0] Jump target:block14
 
 block17:
-  [ 1e0] Return value:reg11
+  [ 1e8] Return value:reg11
 
 block18:
-  [ 1e8] Throw src:reg11
+  [ 1f0] Throw src:reg11
 
 Exception handlers:
-  [  98 ..   b0] => handler block1
-  [  d8 ..  110] => handler block1
-  [ 128 ..  138] => handler block1
+  [  a0 ..   b8] => handler block1
+  [  e0 ..  118] => handler block1
+  [ 130 ..  140] => handler block1

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment-in-logical-and.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment-in-logical-and.txt
@@ -1,4 +1,4 @@
-$12cfcca1 destructuring-assignment-in-logical-and.js:5:1
+$9431c529 destructuring-assignment-in-logical-and.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,12 +7,13 @@ $12cfcca1 destructuring-assignment-in-logical-and.js:5:1
     [2] = Int32(0)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Null, Int32(0)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Null, Int32(0)]
+  [  40] End value:reg5
 
 
-f$f1309f4a destructuring-assignment-in-logical-and.js:2:5
+f$6a46c4a2 destructuring-assignment-in-logical-and.js:2:5
   Registers: 14
   Blocks:    21
   Locals:    a~0, b~1
@@ -23,87 +24,88 @@ f$f1309f4a destructuring-assignment-in-logical-and.js:2:5
     [3] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov3 c0_dst:a~0, c0_src:Undefined, c1_dst:b~1, c1_src:Undefined, c2_dst:reg5, c2_src:arg0
-  [  28] JumpFalse condition:arg0, target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov3 c0_dst:a~0, c0_src:Undefined, c1_dst:b~1, c1_src:Undefined, c2_dst:reg5, c2_src:arg0
+  [  30] JumpFalse condition:arg0, target:block2
 
 block1:
-  [  38] Mov2 c0_dst:reg7, c0_src:arg0, c1_dst:reg8, c1_src:arg1
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, t, arguments:[reg8]
-  [  78] Mov dst:reg7, src:Bool(false)
-  [  88] GetIterator dst_iterator_object:reg8, dst_iterator_next:reg9, dst_iterator_done:reg10, iterable:reg6
-  [  a0] Jump target:block5
+  [  40] Mov2 c0_dst:reg7, c0_src:arg0, c1_dst:reg8, c1_src:arg1
+  [  58] Call dst:reg6, callee:reg7, this_value:Undefined, t, arguments:[reg8]
+  [  80] Mov dst:reg7, src:Bool(false)
+  [  90] GetIterator dst_iterator_object:reg8, dst_iterator_next:reg9, dst_iterator_done:reg10, iterable:reg6
+  [  a8] Jump target:block5
 
 block2:
-  [  a8] End value:Undefined
+  [  b0] End value:Undefined
 
 block3:
-  [  b0] Catch dst:reg12
-  [  b8] SetLexicalEnvironment environment:reg4
-  [  c0] Mov dst:reg11, src:Int32(1)
-  [  d0] JumpIf condition:reg10, true_target:block16, false_target:block15
+  [  b8] Catch dst:reg12
+  [  c0] SetLexicalEnvironment environment:reg4
+  [  c8] Mov dst:reg11, src:Int32(1)
+  [  d8] JumpIf condition:reg10, true_target:block16, false_target:block15
 
 block4:
-  [  e0] Mov dst:reg5, src:reg6
-  [  f0] Jump target:block2
+  [  e8] Mov dst:reg5, src:reg6
+  [  f8] Jump target:block2
 
 block5:
-  [  f8] Jump target:block7
+  [ 100] Jump target:block7
 
 block6:
-  [ 100] MovSrcUndefined dst:reg13
-  [ 108] Jump target:block8
+  [ 108] MovSrcUndefined dst:reg13
+  [ 110] Jump target:block8
 
 block7:
-  [ 110] IteratorNextUnpack dst_value:reg13, dst_done:reg7, iterator_object:reg8, iterator_next:reg9, iterator_done:reg10
-  [ 128] JumpTrue condition:reg7, target:block6
+  [ 118] IteratorNextUnpack dst_value:reg13, dst_done:reg7, iterator_object:reg8, iterator_next:reg9, iterator_done:reg10
+  [ 130] JumpTrue condition:reg7, target:block6
 
 block8:
-  [ 138] Mov dst:a~0, src:reg13
-  [ 148] JumpFalse condition:reg7, target:block10
+  [ 140] Mov dst:a~0, src:reg13
+  [ 150] JumpFalse condition:reg7, target:block10
 
 block9:
-  [ 158] MovSrcUndefined dst:reg13
-  [ 160] Jump target:block11
+  [ 160] MovSrcUndefined dst:reg13
+  [ 168] Jump target:block11
 
 block10:
-  [ 168] IteratorNextUnpack dst_value:reg13, dst_done:reg7, iterator_object:reg8, iterator_next:reg9, iterator_done:reg10
-  [ 180] JumpTrue condition:reg7, target:block9
+  [ 170] IteratorNextUnpack dst_value:reg13, dst_done:reg7, iterator_object:reg8, iterator_next:reg9, iterator_done:reg10
+  [ 188] JumpTrue condition:reg7, target:block9
 
 block11:
-  [ 190] Mov dst:b~1, src:reg13
+  [ 198] Mov dst:b~1, src:reg13
 
 block12:
-  [ 1a0] JumpFalse condition:reg10, target:block14
+  [ 1a8] JumpFalse condition:reg10, target:block14
 
 block13:
-  [ 1b0] Jump target:block4
+  [ 1b8] Jump target:block4
 
 block14:
-  [ 1b8] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg10, completion_value:Undefined
-  [ 1d0] Jump target:block13
+  [ 1c0] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg10, completion_value:Undefined
+  [ 1d8] Jump target:block13
 
 block15:
-  [ 1d8] JumpStrictlyEqualsRhsInt32 lhs:reg11, rhs:1, true_target:block17, false_target:block18
+  [ 1e0] JumpStrictlyEqualsRhsInt32 lhs:reg11, rhs:1, true_target:block17, false_target:block18
 
 block16:
-  [ 1f0] JumpStrictlyEqualsRhsInt32 lhs:reg11, rhs:2, true_target:block19, false_target:block20
+  [ 1f8] JumpStrictlyEqualsRhsInt32 lhs:reg11, rhs:2, true_target:block19, false_target:block20
 
 block17:
-  [ 208] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg10, completion_value:reg12
-  [ 220] Throw src:reg12
+  [ 210] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg10, completion_value:reg12
+  [ 228] Throw src:reg12
 
 block18:
-  [ 228] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg10, completion_value:Undefined
-  [ 240] Jump target:block16
+  [ 230] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg10, completion_value:Undefined
+  [ 248] Jump target:block16
 
 block19:
-  [ 248] Return value:reg12
+  [ 250] Return value:reg12
 
 block20:
-  [ 250] Throw src:reg12
+  [ 258] Throw src:reg12
 
 Exception handlers:
-  [  f8 ..  110] => handler block3
-  [ 138 ..  168] => handler block3
-  [ 190 ..  1a0] => handler block3
+  [ 100 ..  118] => handler block3
+  [ 140 ..  170] => handler block3
+  [ 198 ..  1a8] => handler block3

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
@@ -1,20 +1,21 @@
-$77163770 destructuring-assignment.js:28:1
+$f02c5cc8 destructuring-assignment.js:28:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `array_destructuring_with_class_default`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, array_destructuring_with_class_default
-  [  30] GetGlobal dst:reg7, `object_destructuring_with_function_default`
-  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, object_destructuring_with_function_default
-  [  60] GetGlobal dst:reg7, `setter_parameter_resolution`
-  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, setter_parameter_resolution
-  [  90] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `array_destructuring_with_class_default`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, array_destructuring_with_class_default
+  [  38] GetGlobal dst:reg7, `object_destructuring_with_function_default`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, object_destructuring_with_function_default
+  [  68] GetGlobal dst:reg7, `setter_parameter_resolution`
+  [  78] Call dst:reg5, callee:reg7, this_value:Undefined, setter_parameter_resolution
+  [  98] End value:reg5
 
 
-array_destructuring_with_class_default$612b3688 destructuring-assignment.js:6:10
+array_destructuring_with_class_default$dd054cf0 destructuring-assignment.js:6:10
   Registers: 15
   Blocks:    18
   Locals:    x~0
@@ -25,82 +26,83 @@ array_destructuring_with_class_default$612b3688 destructuring-assignment.js:6:10
     [3] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] MovSrcUndefined dst:x~0
-  [  10] NewArray dst:reg5, elements:[Undefined]
-  [  28] Mov dst:reg6, src:Bool(false)
-  [  38] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
-  [  50] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] MovSrcUndefined dst:x~0
+  [  18] NewArray dst:reg5, elements:[Undefined]
+  [  30] Mov dst:reg6, src:Bool(false)
+  [  40] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
+  [  58] Jump target:block3
 
 block1:
-  [  58] Catch dst:reg11
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] Mov dst:reg10, src:Int32(1)
-  [  78] JumpIf condition:reg9, true_target:block13, false_target:block12
+  [  60] Catch dst:reg11
+  [  68] SetLexicalEnvironment environment:reg4
+  [  70] Mov dst:reg10, src:Int32(1)
+  [  80] JumpIf condition:reg9, true_target:block13, false_target:block12
 
 block2:
-  [  88] Return value:x~0
+  [  90] Return value:x~0
 
 block3:
-  [  90] Jump target:block5
+  [  98] Jump target:block5
 
 block4:
-  [  98] MovSrcUndefined dst:reg12
-  [  a0] Jump target:block6
+  [  a0] MovSrcUndefined dst:reg12
+  [  a8] Jump target:block6
 
 block5:
-  [  a8] IteratorNextUnpack dst_value:reg12, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
-  [  c0] JumpTrue condition:reg6, target:block4
+  [  b0] IteratorNextUnpack dst_value:reg12, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
+  [  c8] JumpTrue condition:reg6, target:block4
 
 block6:
-  [  d0] JumpUndefined condition:reg12, true_target:block7, false_target:block8
+  [  d8] JumpUndefined condition:reg12, true_target:block7, false_target:block8
 
 block7:
-  [  e0] CreateLexicalEnvironment dst:reg13, parent:reg4, capacity:0, is_catch_environment:false
-  [  f8] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
-  [ 108] SetLexicalEnvironment environment:reg4
-  [ 110] NewClass dst:reg14, class_environment:reg13, class_blueprint_index:0
-  [ 130] Mov dst:reg12, src:reg14
+  [  e8] CreateLexicalEnvironment dst:reg13, parent:reg4, capacity:0, is_catch_environment:false
+  [ 100] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
+  [ 110] SetLexicalEnvironment environment:reg4
+  [ 118] NewClass dst:reg14, class_environment:reg13, class_blueprint_index:0
+  [ 138] Mov dst:reg12, src:reg14
 
 block8:
-  [ 140] Mov dst:x~0, src:reg12
+  [ 148] Mov dst:x~0, src:reg12
 
 block9:
-  [ 150] JumpFalse condition:reg9, target:block11
+  [ 158] JumpFalse condition:reg9, target:block11
 
 block10:
-  [ 160] Return value:x~0
+  [ 168] Return value:x~0
 
 block11:
-  [ 168] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 180] Jump target:block10
+  [ 170] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 188] Jump target:block10
 
 block12:
-  [ 188] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block14, false_target:block15
+  [ 190] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block14, false_target:block15
 
 block13:
-  [ 1a0] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block16, false_target:block17
+  [ 1a8] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block16, false_target:block17
 
 block14:
-  [ 1b8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
-  [ 1d0] Throw src:reg11
+  [ 1c0] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
+  [ 1d8] Throw src:reg11
 
 block15:
-  [ 1d8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 1f0] Jump target:block13
+  [ 1e0] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 1f8] Jump target:block13
 
 block16:
-  [ 1f8] Return value:reg11
+  [ 200] Return value:reg11
 
 block17:
-  [ 200] Throw src:reg11
+  [ 208] Throw src:reg11
 
 Exception handlers:
-  [  90 ..   a8] => handler block1
-  [  d0 ..  150] => handler block1
+  [  98 ..   b0] => handler block1
+  [  d8 ..  158] => handler block1
 
 
-object_destructuring_with_function_default$46b68f82 destructuring-assignment.js:12:12
+object_destructuring_with_function_default$cadc791a destructuring-assignment.js:12:12
   Registers: 8
   Blocks:    3
   Locals:    x~0
@@ -108,22 +110,23 @@ object_destructuring_with_function_default$46b68f82 destructuring-assignment.js:
     [0] = Undefined
 
 block0:
-  [   0] MovSrcUndefined dst:x~0
-  [   8] NewObject dst:reg5
-  [  18] ThrowIfNullish src:reg5
-  [  20] GetById dst:reg6, base:reg5, `x`
-  [  38] JumpUndefined condition:reg6, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] MovSrcUndefined dst:x~0
+  [  10] NewObject dst:reg5
+  [  20] ThrowIfNullish src:reg5
+  [  28] GetById dst:reg6, base:reg5, `x`
+  [  40] JumpUndefined condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  48] NewFunction dst:reg7, shared_function_data_index:0 (x)
-  [  60] Mov dst:reg6, src:reg7
+  [  50] NewFunction dst:reg7, shared_function_data_index:0 (x)
+  [  68] Mov dst:reg6, src:reg7
 
 block2:
-  [  70] Mov dst:x~0, src:reg6
-  [  80] Return value:x~0
+  [  78] Mov dst:x~0, src:reg6
+  [  88] Return value:x~0
 
 
-setter_parameter_resolution$62c83e13 destructuring-assignment.js:19:9
+setter_parameter_resolution$dea2547b destructuring-assignment.js:19:9
   Registers: 14
   Blocks:    16
   Constants:
@@ -133,83 +136,85 @@ setter_parameter_resolution$62c83e13 destructuring-assignment.js:19:9
     [3] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateVariable `setValue`, is_immutable:false, is_global:false, is_strict:false
-  [  18] InitializeVariableBinding `setValue`, src:Undefined
-  [  30] NewPrimitiveArray dst:reg5, elements:[23]
-  [  48] Mov dst:reg6, src:Bool(false)
-  [  58] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
-  [  70] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateVariable `setValue`, is_immutable:false, is_global:false, is_strict:false
+  [  20] InitializeVariableBinding `setValue`, src:Undefined
+  [  38] NewPrimitiveArray dst:reg5, elements:[23]
+  [  50] Mov dst:reg6, src:Bool(false)
+  [  60] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
+  [  78] Jump target:block3
 
 block1:
-  [  78] Catch dst:reg11
-  [  80] SetLexicalEnvironment environment:reg4
-  [  88] Mov dst:reg10, src:Int32(1)
-  [  98] JumpIf condition:reg9, true_target:block11, false_target:block10
+  [  80] Catch dst:reg11
+  [  88] SetLexicalEnvironment environment:reg4
+  [  90] Mov dst:reg10, src:Int32(1)
+  [  a0] JumpIf condition:reg9, true_target:block11, false_target:block10
 
 block2:
-  [  a8] GetInitializedBinding dst:reg5, `setValue`
-  [  c0] Return value:reg5
+  [  b0] GetInitializedBinding dst:reg5, `setValue`
+  [  c8] Return value:reg5
 
 block3:
-  [  c8] NewObject dst:reg12
-  [  d8] NewFunction dst:reg13, shared_function_data_index:0 (set y), home_object:reg12
-  [  f0] PutById base:reg12, `y`, src:reg13, kind:Setter
-  [ 110] Jump target:block5
+  [  d0] NewObject dst:reg12
+  [  e0] NewFunction dst:reg13, shared_function_data_index:0 (set y), home_object:reg12
+  [  f8] PutById base:reg12, `y`, src:reg13, kind:Setter
+  [ 118] Jump target:block5
 
 block4:
-  [ 118] MovSrcUndefined dst:reg13
-  [ 120] Jump target:block6
+  [ 120] MovSrcUndefined dst:reg13
+  [ 128] Jump target:block6
 
 block5:
-  [ 128] IteratorNextUnpack dst_value:reg13, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
-  [ 140] JumpTrue condition:reg6, target:block4
+  [ 130] IteratorNextUnpack dst_value:reg13, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
+  [ 148] JumpTrue condition:reg6, target:block4
 
 block6:
-  [ 150] PutById base:reg12, `y`, src:reg13, kind:Normal
+  [ 158] PutById base:reg12, `y`, src:reg13, kind:Normal
 
 block7:
-  [ 170] JumpFalse condition:reg9, target:block9
+  [ 178] JumpFalse condition:reg9, target:block9
 
 block8:
-  [ 180] Jump target:block2
+  [ 188] Jump target:block2
 
 block9:
-  [ 188] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 1a0] Jump target:block8
+  [ 190] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 1a8] Jump target:block8
 
 block10:
-  [ 1a8] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block12, false_target:block13
+  [ 1b0] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block12, false_target:block13
 
 block11:
-  [ 1c0] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block14, false_target:block15
+  [ 1c8] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block14, false_target:block15
 
 block12:
-  [ 1d8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
-  [ 1f0] Throw src:reg11
+  [ 1e0] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
+  [ 1f8] Throw src:reg11
 
 block13:
-  [ 1f8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 210] Jump target:block11
+  [ 200] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 218] Jump target:block11
 
 block14:
-  [ 218] Return value:reg11
+  [ 220] Return value:reg11
 
 block15:
-  [ 220] Throw src:reg11
+  [ 228] Throw src:reg11
 
 Exception handlers:
-  [  c8 ..  128] => handler block1
-  [ 150 ..  170] => handler block1
+  [  d0 ..  130] => handler block1
+  [ 158 ..  178] => handler block1
 
 
-set y$f1335721 destructuring-assignment.js:21:26
+set y$6fd15e99 destructuring-assignment.js:21:26
   Registers: 6
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] ResolveBinding dst:reg5, `setValue`
-  [  10] SetResolvedBinding environment:reg5, `setValue`, src:arg0
-  [  20] End value:Undefined
+  [   0] Enter
+  [   8] ResolveBinding dst:reg5, `setValue`
+  [  18] SetResolvedBinding environment:reg5, `setValue`, src:arg0
+  [  28] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/destructuring-let-compound-assign.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-let-compound-assign.txt
@@ -1,18 +1,19 @@
-$1857aec1 destructuring-let-compound-assign.js:5:1
+$99b9a749 destructuring-let-compound-assign.js:5:1
   Registers: 9
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] NewObject dst:reg7
-  [  20] NewObject dst:reg8
-  [  30] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7, reg8]
-  [  58] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] NewObject dst:reg7
+  [  28] NewObject dst:reg8
+  [  38] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7, reg8]
+  [  60] End value:reg5
 
 
-f$ffd4f57c destructuring-let-compound-assign.js:2:5
+f$7e72fcf4 destructuring-let-compound-assign.js:2:5
   Registers: 8
   Blocks:    1
   Locals:    a~0
@@ -21,11 +22,12 @@ f$ffd4f57c destructuring-let-compound-assign.js:2:5
     [1] = Undefined
 
 block0:
-  [   0] ThrowIfNullish src:arg0
-  [   8] GetById dst:reg5, base:arg0, `patchFlag`
-  [  20] Mov3 c0_dst:a~0, c0_src:reg5, c1_dst:reg5, c1_src:a~0, c2_dst:reg6, c2_src:arg1
-  [  40] GetById dst:reg7, base:reg6, `patchFlag` (e.patchFlag)
-  [  58] BitwiseAnd dst:reg6, lhs:Int32(16), rhs:reg7
-  [  68] BitwiseOr dst:reg7, lhs:reg5, rhs:reg6
-  [  78] Mov dst:a~0, src:reg7
-  [  88] End value:Undefined
+  [   0] Enter
+  [   8] ThrowIfNullish src:arg0
+  [  10] GetById dst:reg5, base:arg0, `patchFlag`
+  [  28] Mov3 c0_dst:a~0, c0_src:reg5, c1_dst:reg5, c1_src:a~0, c2_dst:reg6, c2_src:arg1
+  [  48] GetById dst:reg7, base:reg6, `patchFlag` (e.patchFlag)
+  [  60] BitwiseAnd dst:reg6, lhs:Int32(16), rhs:reg7
+  [  70] BitwiseOr dst:reg7, lhs:reg5, rhs:reg6
+  [  80] Mov dst:a~0, src:reg7
+  [  90] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/destructuring-no-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-no-base-identifier.txt
@@ -1,4 +1,4 @@
-$3576718a destructuring-no-base-identifier.js:1:1
+$b6d86a12 destructuring-no-base-identifier.js:1:1
   Registers: 14
   Blocks:    16
   Constants:
@@ -8,68 +8,69 @@ $3576718a destructuring-no-base-identifier.js:1:1
     [3] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewObject dst:reg5
-  [  18] SetGlobal `x`, src:reg5
-  [  28] NewPrimitiveArray dst:reg5, elements:[42]
-  [  40] Mov dst:reg6, src:Bool(false)
-  [  50] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
-  [  68] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewObject dst:reg5
+  [  20] SetGlobal `x`, src:reg5
+  [  30] NewPrimitiveArray dst:reg5, elements:[42]
+  [  48] Mov dst:reg6, src:Bool(false)
+  [  58] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
+  [  70] Jump target:block3
 
 block1:
-  [  70] Catch dst:reg11
-  [  78] SetLexicalEnvironment environment:reg4
-  [  80] Mov dst:reg10, src:Int32(1)
-  [  90] JumpIf condition:reg9, true_target:block11, false_target:block10
+  [  78] Catch dst:reg11
+  [  80] SetLexicalEnvironment environment:reg4
+  [  88] Mov dst:reg10, src:Int32(1)
+  [  98] JumpIf condition:reg9, true_target:block11, false_target:block10
 
 block2:
-  [  a0] End value:reg5
+  [  a8] End value:reg5
 
 block3:
-  [  a8] GetGlobal dst:reg12, `x`
-  [  b8] Jump target:block5
+  [  b0] GetGlobal dst:reg12, `x`
+  [  c0] Jump target:block5
 
 block4:
-  [  c0] MovSrcUndefined dst:reg13
-  [  c8] Jump target:block6
+  [  c8] MovSrcUndefined dst:reg13
+  [  d0] Jump target:block6
 
 block5:
-  [  d0] IteratorNextUnpack dst_value:reg13, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
-  [  e8] JumpTrue condition:reg6, target:block4
+  [  d8] IteratorNextUnpack dst_value:reg13, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
+  [  f0] JumpTrue condition:reg6, target:block4
 
 block6:
-  [  f8] PutById base:reg12, `y`, src:reg13, kind:Normal
+  [ 100] PutById base:reg12, `y`, src:reg13, kind:Normal
 
 block7:
-  [ 118] JumpFalse condition:reg9, target:block9
+  [ 120] JumpFalse condition:reg9, target:block9
 
 block8:
-  [ 128] End value:reg5
+  [ 130] End value:reg5
 
 block9:
-  [ 130] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 148] Jump target:block8
+  [ 138] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 150] Jump target:block8
 
 block10:
-  [ 150] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block12, false_target:block13
+  [ 158] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block12, false_target:block13
 
 block11:
-  [ 168] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block14, false_target:block15
+  [ 170] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block14, false_target:block15
 
 block12:
-  [ 180] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
-  [ 198] Throw src:reg11
+  [ 188] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
+  [ 1a0] Throw src:reg11
 
 block13:
-  [ 1a0] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 1b8] Jump target:block11
+  [ 1a8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 1c0] Jump target:block11
 
 block14:
-  [ 1c0] Return value:reg11
+  [ 1c8] Return value:reg11
 
 block15:
-  [ 1c8] Throw src:reg11
+  [ 1d0] Throw src:reg11
 
 Exception handlers:
-  [  a8 ..   d0] => handler block1
-  [  f8 ..  118] => handler block1
+  [  b0 ..   d8] => handler block1
+  [ 100 ..  120] => handler block1

--- a/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
@@ -1,4 +1,4 @@
-$af73ebee destructuring-param-no-param-expressions.js:10:1
+$2e11f366 destructuring-param-no-param-expressions.js:10:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,26 +7,28 @@ $af73ebee destructuring-param-no-param-expressions.js:10:1
     [2] = Int32(2)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] NewObject dst:reg7
-  [  20] InitObjectLiteralProperty object:reg7, `captured`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  38] InitObjectLiteralProperty object:reg7, `local`, src:Int32(2), shape_cache_index:0, property_slot:1
-  [  50] CacheObjectShape object:reg7
-  [  60] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  88] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] NewObject dst:reg7
+  [  28] InitObjectLiteralProperty object:reg7, `captured`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  40] InitObjectLiteralProperty object:reg7, `local`, src:Int32(2), shape_cache_index:0, property_slot:1
+  [  58] CacheObjectShape object:reg7
+  [  68] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  90] End value:reg5
 
 
-f$4a320b49 destructuring-param-no-param-expressions.js:7:5
+f$c8d012c1 destructuring-param-no-param-expressions.js:7:5
   Registers: 6
   Blocks:    1
   Locals:    local~0
 
 block0:
-  [   0] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
-  [  10] ThrowIfNullish src:arg0
-  [  18] GetById dst:reg5, base:arg0, `captured`
-  [  30] InitializeLexicalBinding `captured`, src:reg5
-  [  48] GetById dst:reg5, base:arg0, `local`
-  [  60] Mov dst:local~0, src:reg5
-  [  70] NewFunction dst:reg5, shared_function_data_index:0
-  [  88] Return value:reg5
+  [   0] Enter
+  [   8] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
+  [  18] ThrowIfNullish src:arg0
+  [  20] GetById dst:reg5, base:arg0, `captured`
+  [  38] InitializeLexicalBinding `captured`, src:reg5
+  [  50] GetById dst:reg5, base:arg0, `local`
+  [  68] Mov dst:local~0, src:reg5
+  [  78] NewFunction dst:reg5, shared_function_data_index:0
+  [  90] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/do-while-register-allocation.txt
+++ b/Tests/LibJS/Bytecode/expected/do-while-register-allocation.txt
@@ -1,16 +1,17 @@
-$e2bdeb53 do-while-register-allocation.js:15:1
+$6c6bb70b do-while-register-allocation.js:15:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `test`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `test`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  38] End value:reg5
 
 
-test$e6d8239f do-while-register-allocation.js:9:5
+test$62b23a07 do-while-register-allocation.js:9:5
   Registers: 9
   Blocks:    3
   Locals:    i~0
@@ -20,33 +21,36 @@ test$e6d8239f do-while-register-allocation.js:9:5
     [2] = Int32(7)
 
 block0:
-  [   0] Mov2 c0_dst:i~0, c0_src:Undefined, c1_dst:i~0, c1_src:Int32(0)
-  [  18] GetGlobal dst:reg6, `foo`
-  [  28] NewArray dst:reg7
-  [  38] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
+  [   0] Enter
+  [   8] Mov2 c0_dst:i~0, c0_src:Undefined, c1_dst:i~0, c1_src:Int32(0)
+  [  20] GetGlobal dst:reg6, `foo`
+  [  30] NewArray dst:reg7
+  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
 
 block1:
-  [  60] GetGlobal dst:reg7, `bar`
-  [  70] Mov dst:reg8, src:i~0
-  [  80] Call dst:reg6, callee:reg7, this_value:Undefined, bar, arguments:[reg8]
-  [  a8] PostfixIncrement dst:reg6, src:i~0
-  [  b8] JumpLessThanRhsInt32 lhs:i~0, rhs:7, true_target:block1, false_target:block2
+  [  68] GetGlobal dst:reg7, `bar`
+  [  78] Mov dst:reg8, src:i~0
+  [  88] Call dst:reg6, callee:reg7, this_value:Undefined, bar, arguments:[reg8]
+  [  b0] PostfixIncrement dst:reg6, src:i~0
+  [  c0] JumpLessThanRhsInt32 lhs:i~0, rhs:7, true_target:block1, false_target:block2
 
 block2:
-  [  d0] End value:Undefined
+  [  d8] End value:Undefined
 
 
-foo$93622fcc do-while-register-allocation.js:2:5
+foo$14c42854 do-while-register-allocation.js:2:5
   Registers: 5
   Blocks:    1
 
 block0:
-  [   0] Return value:arg0
+  [   0] Enter
+  [   8] Return value:arg0
 
 
-bar$cbf37924 do-while-register-allocation.js:5:5
+bar$501962bc do-while-register-allocation.js:5:5
   Registers: 5
   Blocks:    1
 
 block0:
-  [   0] Return value:arg0
+  [   0] Enter
+  [   8] Return value:arg0

--- a/Tests/LibJS/Bytecode/expected/double-constant-deduplication.txt
+++ b/Tests/LibJS/Bytecode/expected/double-constant-deduplication.txt
@@ -1,16 +1,17 @@
-$a2a07da4 double-constant-deduplication.js:8:1
+$162ec0dc double-constant-deduplication.js:8:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `foo`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `foo`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo
+  [  38] End value:reg5
 
 
-foo$9e71f40c double-constant-deduplication.js:2:5
+foo$1fd3ec94 double-constant-deduplication.js:2:5
   Registers: 7
   Blocks:    1
   Locals:    a~0, b~1, c~2
@@ -18,7 +19,8 @@ foo$9e71f40c double-constant-deduplication.js:2:5
     [0] = Double(0.5)
 
 block0:
-  [   0] Mov3 c0_dst:a~0, c0_src:Double(0.5), c1_dst:b~1, c1_src:Double(0.5), c2_dst:c~2, c2_src:Double(0.5)
-  [  20] Add dst:reg5, lhs:a~0, rhs:b~1
-  [  30] Add dst:reg6, lhs:reg5, rhs:c~2
-  [  40] Return value:reg6
+  [   0] Enter
+  [   8] Mov3 c0_dst:a~0, c0_src:Double(0.5), c1_dst:b~1, c1_src:Double(0.5), c2_dst:c~2, c2_src:Double(0.5)
+  [  28] Add dst:reg5, lhs:a~0, rhs:b~1
+  [  38] Add dst:reg6, lhs:reg5, rhs:c~2
+  [  48] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
@@ -1,18 +1,19 @@
-$9d7300ea eval-prevents-locals.js:22:1
+$1ed4f972 eval-prevents-locals.js:22:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `with_eval`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, with_eval
-  [  30] GetGlobal dst:reg7, `outer_eval`
-  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, outer_eval
-  [  60] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `with_eval`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, with_eval
+  [  38] GetGlobal dst:reg7, `outer_eval`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, outer_eval
+  [  68] End value:reg6
 
 
-with_eval$b4b96665 eval-prevents-locals.js:6:5
+with_eval$43ef143d eval-prevents-locals.js:6:5
   Registers: 9
   Blocks:    1
   Constants:
@@ -20,28 +21,30 @@ with_eval$b4b96665 eval-prevents-locals.js:6:5
     [1] = String("")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateArguments is_immutable:false
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
-  [  30] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  40] InitializeLexicalBinding `x`, src:Int32(1)
-  [  58] DynamicGetCalleeAndThisFromEnvironment callee:reg7, this_value:reg8, `eval`
-  [  70] CallDirectEval dst:reg6, callee:reg7, this_value:reg8, eval, arguments:[String("")]
-  [  98] GetBinding dst:reg6, `x`
-  [  b0] Return value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateArguments is_immutable:false
+  [  20] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
+  [  38] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  48] InitializeLexicalBinding `x`, src:Int32(1)
+  [  60] DynamicGetCalleeAndThisFromEnvironment callee:reg7, this_value:reg8, `eval`
+  [  78] CallDirectEval dst:reg6, callee:reg7, this_value:reg8, eval, arguments:[String("")]
+  [  a0] GetBinding dst:reg6, `x`
+  [  b8] Return value:reg6
 
 
-eval$b72141f3
+eval$3b472b8b
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-outer_eval$6785167a eval-prevents-locals.js:14:9
+outer_eval$e35f2ce2 eval-prevents-locals.js:14:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -49,29 +52,31 @@ outer_eval$6785167a eval-prevents-locals.js:14:9
     [1] = String("")
 
 block0:
-  [   0] CreateArguments is_immutable:false
-  [  10] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
-  [  20] InitializeVariableBinding `inner`, src:Undefined
-  [  38] NewFunction dst:reg5, shared_function_data_index:0
-  [  50] SetVariableBinding `inner`, src:reg5
-  [  68] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
-  [  80] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("")]
-  [  a8] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
-  [  c0] Call dst:reg5, callee:reg6, this_value:reg7, inner
-  [  e0] Return value:reg5
+  [   0] Enter
+  [   8] CreateArguments is_immutable:false
+  [  18] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
+  [  28] InitializeVariableBinding `inner`, src:Undefined
+  [  40] NewFunction dst:reg5, shared_function_data_index:0
+  [  58] SetVariableBinding `inner`, src:reg5
+  [  70] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
+  [  88] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("")]
+  [  b0] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
+  [  c8] Call dst:reg5, callee:reg6, this_value:reg7, inner
+  [  e8] Return value:reg5
 
 
-eval$b72141f3
+eval$3b472b8b
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-inner$1897993a eval-prevents-locals.js:16:9
+inner$99f991c2 eval-prevents-locals.js:16:9
   Registers: 5
   Blocks:    1
   Locals:    y~0
@@ -79,5 +84,6 @@ inner$1897993a eval-prevents-locals.js:16:9
     [0] = Int32(2)
 
 block0:
-  [   0] Mov dst:y~0, src:Int32(2)
-  [  10] Return value:y~0
+  [   0] Enter
+  [   8] Mov dst:y~0, src:Int32(2)
+  [  18] Return value:y~0

--- a/Tests/LibJS/Bytecode/expected/eval-same-function.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-same-function.txt
@@ -1,16 +1,17 @@
-$49b95e06 eval-same-function.js:10:1
+$d36729be eval-same-function.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `foo`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `foo`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo
+  [  38] End value:reg5
 
 
-foo$3e35f384 eval-same-function.js:6:9
+foo$c25bdd1c eval-same-function.js:6:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -19,15 +20,16 @@ foo$3e35f384 eval-same-function.js:6:9
     [2] = Int32(42)
 
 block0:
-  [   0] CreateArguments is_immutable:false
-  [  10] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
-  [  28] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("var x = 1")]
-  [  50] DynamicGetBinding dst:reg6, `Number`
-  [  60] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
-  [  80] Return value:reg5
+  [   0] Enter
+  [   8] CreateArguments is_immutable:false
+  [  18] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
+  [  30] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("var x = 1")]
+  [  58] DynamicGetBinding dst:reg6, `Number`
+  [  68] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
+  [  88] Return value:reg5
 
 
-eval$e1340763 line 1, column 1
+eval$5fd20edb line 1, column 1
   Registers: 6
   Blocks:    1
   Constants:
@@ -35,6 +37,7 @@ eval$e1340763 line 1, column 1
     [1] = Undefined
 
 block0:
-  [   0] ResolveBinding dst:reg5, `x`
-  [  10] SetResolvedBinding environment:reg5, `x`, src:Int32(1)
-  [  20] End value:Undefined
+  [   0] Enter
+  [   8] ResolveBinding dst:reg5, `x`
+  [  18] SetResolvedBinding environment:reg5, `x`, src:Int32(1)
+  [  28] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
@@ -1,16 +1,17 @@
-$546ebce0 eval-scope-optimization.js:12:1
+$c7fd0018 eval-scope-optimization.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `outer`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, outer
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `outer`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, outer
+  [  38] End value:reg5
 
 
-outer$ae1b8240 eval-scope-optimization.js:9:5
+outer$2f7d7ac8 eval-scope-optimization.js:9:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -18,10 +19,11 @@ outer$ae1b8240 eval-scope-optimization.js:9:5
     [1] = Int32(42)
 
 block0:
-  [   0] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
-  [  10] InitializeVariableBinding `inner`, src:Undefined
-  [  28] NewFunction dst:reg5, shared_function_data_index:0
-  [  40] SetVariableBinding `inner`, src:reg5
-  [  58] GetGlobal dst:reg6, `Number`
-  [  68] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
-  [  88] Return value:reg5
+  [   0] Enter
+  [   8] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
+  [  18] InitializeVariableBinding `inner`, src:Undefined
+  [  30] NewFunction dst:reg5, shared_function_data_index:0
+  [  48] SetVariableBinding `inner`, src:reg5
+  [  60] GetGlobal dst:reg6, `Number`
+  [  70] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
+  [  90] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/expression-identifier-number-format.txt
+++ b/Tests/LibJS/Bytecode/expected/expression-identifier-number-format.txt
@@ -1,4 +1,4 @@
-$091ab4cd expression-identifier-number-format.js:1:1
+$84f4cb35 expression-identifier-number-format.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $091ab4cd expression-identifier-number-format.js:1:1
     [1] = Int32(42)
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] SetGlobal `x`, src:reg5
-  [  20] GetGlobal dst:reg5, `x`
-  [  30] NewObject dst:reg6
-  [  40] PutByValue base:reg5, property:Double(1.1e-32), src:reg6, kind:Normal (x[Double(1.1e-32)])
-  [  58] GetGlobal dst:reg5, `x`
-  [  68] GetByValue dst:reg7, base:reg5, property:Double(1.1e-32) (x[Double(1.1e-32)])
-  [  80] PutById base:reg7, `foo`, src:Int32(42), kind:Normal (x[1.1e-32].foo)
-  [  a0] End value:Int32(42)
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] SetGlobal `x`, src:reg5
+  [  28] GetGlobal dst:reg5, `x`
+  [  38] NewObject dst:reg6
+  [  48] PutByValue base:reg5, property:Double(1.1e-32), src:reg6, kind:Normal (x[Double(1.1e-32)])
+  [  60] GetGlobal dst:reg5, `x`
+  [  70] GetByValue dst:reg7, base:reg5, property:Double(1.1e-32) (x[Double(1.1e-32)])
+  [  88] PutById base:reg7, `foo`, src:Int32(42), kind:Normal (x[1.1e-32].foo)
+  [  a8] End value:Int32(42)

--- a/Tests/LibJS/Bytecode/expected/for-in-block-order.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-block-order.txt
@@ -1,17 +1,18 @@
-$100bdb91 for-in-block-order.js:5:1
+$916dd419 for-in-block-order.js:5:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `foo`
-  [  10] NewObject dst:reg7
-  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
-  [  48] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `foo`
+  [  18] NewObject dst:reg7
+  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
+  [  50] End value:reg5
 
 
-foo$43804f29 for-in-block-order.js:2:16
+foo$b9d28371 for-in-block-order.js:2:16
   Registers: 8
   Blocks:    6
   Locals:    k~0
@@ -19,23 +20,24 @@ foo$43804f29 for-in-block-order.js:2:16
     [0] = Undefined
 
 block0:
-  [   0] MovSrcUndefined dst:k~0
-  [   8] JumpNullish condition:arg0, true_target:block3, false_target:block4
+  [   0] Enter
+  [   8] MovSrcUndefined dst:k~0
+  [  10] JumpNullish condition:arg0, true_target:block3, false_target:block4
 
 block1:
-  [  18] End value:Undefined
+  [  20] End value:Undefined
 
 block2:
-  [  20] ObjectPropertyIteratorNext dst_value:reg6, dst_done:reg7, iterator_object:reg5
-  [  30] JumpIf condition:reg7, true_target:block1, false_target:block5
+  [  28] ObjectPropertyIteratorNext dst_value:reg6, dst_done:reg7, iterator_object:reg5
+  [  38] JumpIf condition:reg7, true_target:block1, false_target:block5
 
 block3:
-  [  40] Jump target:block1
+  [  48] Jump target:block1
 
 block4:
-  [  48] GetObjectPropertyIterator dst_iterator:reg5, object:arg0
-  [  58] Jump target:block2
+  [  50] GetObjectPropertyIterator dst_iterator:reg5, object:arg0
+  [  60] Jump target:block2
 
 block5:
-  [  60] Mov dst:k~0, src:reg6
-  [  70] Jump target:block2
+  [  68] Mov dst:k~0, src:reg6
+  [  78] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
@@ -1,4 +1,4 @@
-$3122836b for-in-lexical-scope.js:1:12
+$b5486d03 for-in-lexical-scope.js:1:12
   Registers: 12
   Blocks:    6
   Constants:
@@ -6,40 +6,41 @@ $3122836b for-in-lexical-scope.js:1:12
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  30] NewObject dst:reg6
-  [  40] InitObjectLiteralProperty object:reg6, `i`, src:Int32(0), shape_cache_index:0, property_slot:0
-  [  58] CacheObjectShape object:reg6
-  [  68] SetLexicalEnvironment environment:reg4
-  [  70] JumpNullish condition:reg6, true_target:block3, false_target:block4
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  38] NewObject dst:reg6
+  [  48] InitObjectLiteralProperty object:reg6, `i`, src:Int32(0), shape_cache_index:0, property_slot:0
+  [  60] CacheObjectShape object:reg6
+  [  70] SetLexicalEnvironment environment:reg4
+  [  78] JumpNullish condition:reg6, true_target:block3, false_target:block4
 
 block1:
-  [  80] End value:reg6
+  [  88] End value:reg6
 
 block2:
-  [  88] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg5
-  [  98] JumpIf condition:reg8, true_target:block1, false_target:block5
+  [  90] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg5
+  [  a0] JumpIf condition:reg8, true_target:block1, false_target:block5
 
 block3:
-  [  a8] End value:reg6
+  [  b0] End value:reg6
 
 block4:
-  [  b0] GetObjectPropertyIterator dst_iterator:reg5, object:reg6
-  [  c0] MovSrcUndefined dst:reg6
-  [  c8] Jump target:block2
+  [  b8] GetObjectPropertyIterator dst_iterator:reg5, object:reg6
+  [  c8] MovSrcUndefined dst:reg6
+  [  d0] Jump target:block2
 
 block5:
-  [  d0] CreateLexicalEnvironment dst:reg9, parent:reg4, capacity:0, is_catch_environment:false
-  [  e8] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  f8] InitializeLexicalBinding `x`, src:reg7
-  [ 110] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0, is_catch_environment:false
-  [ 128] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
-  [ 138] NewFunction dst:reg11, shared_function_data_index:0
-  [ 150] InitializeLexicalBinding `probeDecl`, src:reg11
-  [ 168] GetBinding dst:reg11, `probeDecl`
-  [ 180] DynamicSetVariableBinding `probeDecl`, src:reg11
-  [ 190] SetLexicalEnvironment environment:reg9
-  [ 198] SetLexicalEnvironment environment:reg4
-  [ 1a0] Jump target:block2
+  [  d8] CreateLexicalEnvironment dst:reg9, parent:reg4, capacity:0, is_catch_environment:false
+  [  f0] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [ 100] InitializeLexicalBinding `x`, src:reg7
+  [ 118] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0, is_catch_environment:false
+  [ 130] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
+  [ 140] NewFunction dst:reg11, shared_function_data_index:0
+  [ 158] InitializeLexicalBinding `probeDecl`, src:reg11
+  [ 170] GetBinding dst:reg11, `probeDecl`
+  [ 188] DynamicSetVariableBinding `probeDecl`, src:reg11
+  [ 198] SetLexicalEnvironment environment:reg9
+  [ 1a0] SetLexicalEnvironment environment:reg4
+  [ 1a8] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-object-property-iterator-next.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-object-property-iterator-next.txt
@@ -1,4 +1,4 @@
-$2c4e495c for-in-object-property-iterator-next.js:8:1
+$aaec50d4 for-in-object-property-iterator-next.js:8:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -10,43 +10,45 @@ $2c4e495c for-in-object-property-iterator-next.js:8:1
     [5] = String("seven")
 
 block0:
-  [   0] GetGlobal dst:reg6, `collect`
-  [  10] NewObject dst:reg7
-  [  20] ToPrimitiveWithStringHint dst:Int32(2), value:Int32(2)
-  [  30] PutByValue base:reg7, property:Int32(2), src:String("two"), kind:Own
-  [  48] PutById base:reg7, `foo`, src:String("foo"), kind:Own
-  [  68] ToPrimitiveWithStringHint dst:Int32(7), value:Int32(7)
-  [  78] PutByValue base:reg7, property:Int32(7), src:String("seven"), kind:Own
-  [  90] Call dst:reg5, callee:reg6, this_value:Undefined, collect, arguments:[reg7]
-  [  b8] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `collect`
+  [  18] NewObject dst:reg7
+  [  28] ToPrimitiveWithStringHint dst:Int32(2), value:Int32(2)
+  [  38] PutByValue base:reg7, property:Int32(2), src:String("two"), kind:Own
+  [  50] PutById base:reg7, `foo`, src:String("foo"), kind:Own
+  [  70] ToPrimitiveWithStringHint dst:Int32(7), value:Int32(7)
+  [  80] PutByValue base:reg7, property:Int32(7), src:String("seven"), kind:Own
+  [  98] Call dst:reg5, callee:reg6, this_value:Undefined, collect, arguments:[reg7]
+  [  c0] End value:reg5
 
 
-collect$a1c4c33b for-in-object-property-iterator-next.js:2:18
+collect$28ae9de3 for-in-object-property-iterator-next.js:2:18
   Registers: 12
   Blocks:    6
   Locals:    key~0, keys~1
 
 block0:
-  [   0] NewArray dst:keys~1
-  [  10] JumpNullish condition:arg0, true_target:block3, false_target:block4
+  [   0] Enter
+  [   8] NewArray dst:keys~1
+  [  18] JumpNullish condition:arg0, true_target:block3, false_target:block4
 
 block1:
-  [  20] Return value:keys~1
+  [  28] Return value:keys~1
 
 block2:
-  [  28] ObjectPropertyIteratorNext dst_value:reg6, dst_done:reg7, iterator_object:reg5
-  [  38] JumpIf condition:reg7, true_target:block1, false_target:block5
+  [  30] ObjectPropertyIteratorNext dst_value:reg6, dst_done:reg7, iterator_object:reg5
+  [  40] JumpIf condition:reg7, true_target:block1, false_target:block5
 
 block3:
-  [  48] Return value:keys~1
+  [  50] Return value:keys~1
 
 block4:
-  [  50] GetObjectPropertyIterator dst_iterator:reg5, object:arg0
-  [  60] Jump target:block2
+  [  58] GetObjectPropertyIterator dst_iterator:reg5, object:arg0
+  [  68] Jump target:block2
 
 block5:
-  [  68] Mov dst:key~0, src:reg6
-  [  78] GetById dst:reg9, base:keys~1, `push` (keys.push)
-  [  90] Mov2 c0_dst:reg10, c0_src:keys~1, c1_dst:reg11, c1_src:key~0
-  [  a8] Call dst:reg8, callee:reg9, this_value:reg10, keys.push, arguments:[reg11]
-  [  d0] Jump target:block2
+  [  70] Mov dst:key~0, src:reg6
+  [  80] GetById dst:reg9, base:keys~1, `push` (keys.push)
+  [  98] Mov2 c0_dst:reg10, c0_src:keys~1, c1_dst:reg11, c1_src:key~0
+  [  b0] Call dst:reg8, callee:reg9, this_value:reg10, keys.push, arguments:[reg11]
+  [  d8] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-of-lhs-patterns.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-of-lhs-patterns.txt
@@ -1,8 +1,9 @@
-$ccf7ed9d
+$4e59e625
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
@@ -1,4 +1,4 @@
-$ca340182 for-in-register-lifetime.js:1:1
+$460e17ea for-in-register-lifetime.js:1:1
   Registers: 14
   Blocks:    6
   Constants:
@@ -9,40 +9,41 @@ $ca340182 for-in-register-lifetime.js:1:1
     [4] = Undefined
 
 block0:
-  [   0] SetGlobal `result`, src:String("")
-  [  10] NewObject dst:reg5
-  [  20] InitObjectLiteralProperty object:reg5, `a`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  38] InitObjectLiteralProperty object:reg5, `b`, src:Int32(2), shape_cache_index:0, property_slot:1
-  [  50] InitObjectLiteralProperty object:reg5, `c`, src:Int32(3), shape_cache_index:0, property_slot:2
-  [  68] CacheObjectShape object:reg5
-  [  78] SetGlobal `obj`, src:reg5
-  [  88] GetGlobal dst:reg5, `obj`
-  [  98] JumpNullish condition:reg5, true_target:block3, false_target:block4
+  [   0] Enter
+  [   8] SetGlobal `result`, src:String("")
+  [  18] NewObject dst:reg5
+  [  28] InitObjectLiteralProperty object:reg5, `a`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  40] InitObjectLiteralProperty object:reg5, `b`, src:Int32(2), shape_cache_index:0, property_slot:1
+  [  58] InitObjectLiteralProperty object:reg5, `c`, src:Int32(3), shape_cache_index:0, property_slot:2
+  [  70] CacheObjectShape object:reg5
+  [  80] SetGlobal `obj`, src:reg5
+  [  90] GetGlobal dst:reg5, `obj`
+  [  a0] JumpNullish condition:reg5, true_target:block3, false_target:block4
 
 block1:
-  [  a8] End value:reg5
+  [  b0] End value:reg5
 
 block2:
-  [  b0] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg6
-  [  c0] JumpIf condition:reg8, true_target:block1, false_target:block5
+  [  b8] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg6
+  [  c8] JumpIf condition:reg8, true_target:block1, false_target:block5
 
 block3:
-  [  d0] End value:reg5
+  [  d8] End value:reg5
 
 block4:
-  [  d8] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
-  [  e8] MovSrcUndefined dst:reg5
-  [  f0] Jump target:block2
+  [  e0] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
+  [  f0] MovSrcUndefined dst:reg5
+  [  f8] Jump target:block2
 
 block5:
-  [  f8] SetGlobal `k`, src:reg7
-  [ 108] GetGlobal dst:reg9, `result`
-  [ 118] GetGlobal dst:reg10, `k`
-  [ 128] GetGlobal dst:reg11, `obj`
-  [ 138] GetGlobal dst:reg12, `k`
-  [ 148] GetByValue dst:reg13, base:reg11, property:reg12 (obj[reg12])
-  [ 160] Add dst:reg11, lhs:reg10, rhs:reg13
-  [ 170] Add dst:reg10, lhs:reg9, rhs:reg11
-  [ 180] SetGlobal `result`, src:reg10
-  [ 190] Mov dst:reg5, src:reg10
-  [ 1a0] Jump target:block2
+  [ 100] SetGlobal `k`, src:reg7
+  [ 110] GetGlobal dst:reg9, `result`
+  [ 120] GetGlobal dst:reg10, `k`
+  [ 130] GetGlobal dst:reg11, `obj`
+  [ 140] GetGlobal dst:reg12, `k`
+  [ 150] GetByValue dst:reg13, base:reg11, property:reg12 (obj[reg12])
+  [ 168] Add dst:reg11, lhs:reg10, rhs:reg13
+  [ 178] Add dst:reg10, lhs:reg9, rhs:reg11
+  [ 188] SetGlobal `result`, src:reg10
+  [ 198] Mov dst:reg5, src:reg10
+  [ 1a8] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-var-function-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-var-function-lhs-name.txt
@@ -1,16 +1,17 @@
-$491e5adb for-in-var-function-lhs-name.js:7:1
+$d0083583 for-in-var-function-lhs-name.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `fn`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, fn
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `fn`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, fn
+  [  38] End value:reg5
 
 
-fn$473b1a6a for-in-var-function-lhs-name.js:4:19
+fn$c5d921e2 for-in-var-function-lhs-name.js:4:19
   Registers: 8
   Blocks:    6
   Locals:    f~0
@@ -18,26 +19,27 @@ fn$473b1a6a for-in-var-function-lhs-name.js:4:19
     [0] = Undefined
 
 block0:
-  [   0] MovSrcUndefined dst:f~0
-  [   8] NewFunction dst:reg5, shared_function_data_index:0 (f)
-  [  20] Mov dst:f~0, src:reg5
-  [  30] NewObject dst:reg5
-  [  40] JumpNullish condition:reg5, true_target:block3, false_target:block4
+  [   0] Enter
+  [   8] MovSrcUndefined dst:f~0
+  [  10] NewFunction dst:reg5, shared_function_data_index:0 (f)
+  [  28] Mov dst:f~0, src:reg5
+  [  38] NewObject dst:reg5
+  [  48] JumpNullish condition:reg5, true_target:block3, false_target:block4
 
 block1:
-  [  50] End value:Undefined
+  [  58] End value:Undefined
 
 block2:
-  [  58] ObjectPropertyIteratorNext dst_value:reg5, dst_done:reg7, iterator_object:reg6
-  [  68] JumpIf condition:reg7, true_target:block1, false_target:block5
+  [  60] ObjectPropertyIteratorNext dst_value:reg5, dst_done:reg7, iterator_object:reg6
+  [  70] JumpIf condition:reg7, true_target:block1, false_target:block5
 
 block3:
-  [  78] Jump target:block1
+  [  80] Jump target:block1
 
 block4:
-  [  80] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
-  [  90] Jump target:block2
+  [  88] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
+  [  98] Jump target:block2
 
 block5:
-  [  98] Mov dst:f~0, src:reg5
-  [  a8] Jump target:block2
+  [  a0] Mov dst:f~0, src:reg5
+  [  b0] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-loop-break-after-if-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-break-after-if-continue.txt
@@ -1,4 +1,4 @@
-$ba9d77cf for-loop-break-after-if-continue.js:11:1
+$393b7f47 for-loop-break-after-if-continue.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,25 +6,29 @@ $ba9d77cf for-loop-break-after-if-continue.js:11:1
     [1] = Bool(false)
 
 block0:
-  [   0] GetGlobal dst:reg6, `bok`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, bok, arguments:[Bool(false)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `bok`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, bok, arguments:[Bool(false)]
+  [  40] End value:reg5
 
 
-bok$3c12db64 for-loop-break-after-if-continue.js:6:9
+bok$c038c4fc for-loop-break-after-if-continue.js:6:9
   Registers: 5
-  Blocks:    4
+  Blocks:    5
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] JumpIf condition:arg0, true_target:block2, false_target:block3
+  [   0] Enter
 
 block1:
-  [  10] End value:Undefined
+  [   8] JumpIf condition:arg0, true_target:block3, false_target:block4
 
 block2:
-  [  18] Jump target:block0
+  [  18] End value:Undefined
 
 block3:
   [  20] Jump target:block1
+
+block4:
+  [  28] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
@@ -1,19 +1,20 @@
-$b5fc1514 for-loop-scoping.js:8:1
+$349a1c8c for-loop-scoping.js:8:1
   Registers: 10
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `forLetClosure`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, forLetClosure
-  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  80] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `forLetClosure`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, forLetClosure
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] End value:reg5
 
 
-forLetClosure$1bcc2cf5 for-loop-scoping.js:2:15
+forLetClosure$9a6a346d for-loop-scoping.js:2:15
   Registers: 10
   Blocks:    4
   Locals:    fns~0
@@ -22,63 +23,66 @@ forLetClosure$1bcc2cf5 for-loop-scoping.js:2:15
     [1] = Int32(3)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewArray dst:fns~0
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  30] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [  40] InitializeLexicalBinding `i`, src:Int32(0)
-  [  58] GetBinding dst:reg6, `i`
-  [  70] SetLexicalEnvironment environment:reg4
-  [  78] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  90] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [  a0] InitializeLexicalBinding `i`, src:reg6
-  [  b8] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewArray dst:fns~0
+  [  20] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  38] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [  48] InitializeLexicalBinding `i`, src:Int32(0)
+  [  60] GetBinding dst:reg6, `i`
+  [  78] SetLexicalEnvironment environment:reg4
+  [  80] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  98] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [  a8] InitializeLexicalBinding `i`, src:reg6
+  [  c0] Jump target:block2
 
 block1:
-  [  c0] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  d8] Mov dst:reg8, src:fns~0
-  [  e8] NewFunction dst:reg9, shared_function_data_index:0
-  [ 100] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 128] GetBinding dst:reg6, `i`
-  [ 140] SetLexicalEnvironment environment:reg4
-  [ 148] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [ 160] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [ 170] InitializeLexicalBinding `i`, src:reg6
-  [ 188] GetBinding dst:reg7, `i`
-  [ 1a0] PostfixIncrement dst:reg6, src:reg7
-  [ 1b0] SetLexicalBinding `i`, src:reg7
+  [  c8] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [  e0] Mov dst:reg8, src:fns~0
+  [  f0] NewFunction dst:reg9, shared_function_data_index:0
+  [ 108] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 130] GetBinding dst:reg6, `i`
+  [ 148] SetLexicalEnvironment environment:reg4
+  [ 150] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [ 168] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [ 178] InitializeLexicalBinding `i`, src:reg6
+  [ 190] GetBinding dst:reg7, `i`
+  [ 1a8] PostfixIncrement dst:reg6, src:reg7
+  [ 1b8] SetLexicalBinding `i`, src:reg7
 
 block2:
-  [ 1c8] GetBinding dst:reg6, `i`
-  [ 1e0] JumpLessThanRhsInt32 lhs:reg6, rhs:3, true_target:block1, false_target:block3
+  [ 1d0] GetBinding dst:reg6, `i`
+  [ 1e8] JumpLessThanRhsInt32 lhs:reg6, rhs:3, true_target:block1, false_target:block3
 
 block3:
-  [ 1f8] SetLexicalEnvironment environment:reg4
-  [ 200] GetById dst:reg6, base:fns~0, `map` (fns.map)
-  [ 218] Mov dst:reg7, src:fns~0
-  [ 228] NewFunction dst:reg8, shared_function_data_index:1
-  [ 240] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
-  [ 268] Return value:reg5
+  [ 200] SetLexicalEnvironment environment:reg4
+  [ 208] GetById dst:reg6, base:fns~0, `map` (fns.map)
+  [ 220] Mov dst:reg7, src:fns~0
+  [ 230] NewFunction dst:reg8, shared_function_data_index:1
+  [ 248] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
+  [ 270] Return value:reg5
 
 
-$617ce76f for-loop-scoping.js:6:20
+$dd56fdd7 for-loop-scoping.js:6:20
   Registers: 6
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Call dst:reg5, callee:arg0, this_value:Undefined, f
-  [  20] Return value:reg5
+  [   0] Enter
+  [   8] Call dst:reg5, callee:arg0, this_value:Undefined, f
+  [  28] Return value:reg5
 
 
-$f755759b for-loop-scoping.js:4:18
+$732f8c03 for-loop-scoping.js:4:18
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `i`
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `i`
+  [  18] Return value:reg5
 
 
 [ 0, 1, 2 ]

--- a/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
@@ -1,4 +1,4 @@
-$e8d1e772 for-of-cond-rhs-block-order.js:6:1
+$6a33dffa for-of-cond-rhs-block-order.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $e8d1e772 for-of-cond-rhs-block-order.js:6:1
     [1] = Null
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Null, Null]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Null, Null]
+  [  40] End value:reg5
 
 
-f$8d171f4d for-of-cond-rhs-block-order.js:2:21
+f$0bb526c5 for-of-cond-rhs-block-order.js:2:21
   Registers: 19
   Blocks:    31
   Locals:    r~0, n~1
@@ -22,131 +23,132 @@ f$8d171f4d for-of-cond-rhs-block-order.js:2:21
     [3] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] JumpIf condition:arg0, true_target:block3, false_target:block4
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] JumpIf condition:arg0, true_target:block3, false_target:block4
 
 block1:
-  [  18] End value:Undefined
+  [  20] End value:Undefined
 
 block2:
-  [  20] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg5, iterator_next:reg8, iterator_done:reg6
-  [  38] JumpIf condition:reg11, true_target:block1, false_target:block8
+  [  28] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg5, iterator_next:reg8, iterator_done:reg6
+  [  40] JumpIf condition:reg11, true_target:block1, false_target:block8
 
 block3:
-  [  48] Mov dst:reg6, src:arg0
-  [  58] GetById dst:reg7, base:reg6, `x` (o.x)
-  [  70] Mov dst:reg5, src:reg7
-  [  80] Jump target:block5
+  [  50] Mov dst:reg6, src:arg0
+  [  60] GetById dst:reg7, base:reg6, `x` (o.x)
+  [  78] Mov dst:reg5, src:reg7
+  [  88] Jump target:block5
 
 block4:
-  [  88] Mov dst:reg5, src:arg1
+  [  90] Mov dst:reg5, src:arg1
 
 block5:
-  [  98] GetGlobal dst:reg6, `Object`
-  [  a8] GetById dst:reg8, base:reg6, `entries` (Object.entries)
-  [  c0] NewObject dst:reg9
-  [  d0] Call dst:reg7, callee:reg8, this_value:reg6, Object.entries, arguments:[reg9]
-  [  f8] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg8, dst_iterator_done:reg6, iterable:reg7
-  [ 110] Jump target:block2
+  [  a0] GetGlobal dst:reg6, `Object`
+  [  b0] GetById dst:reg8, base:reg6, `entries` (Object.entries)
+  [  c8] NewObject dst:reg9
+  [  d8] Call dst:reg7, callee:reg8, this_value:reg6, Object.entries, arguments:[reg9]
+  [ 100] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg8, dst_iterator_done:reg6, iterable:reg7
+  [ 118] Jump target:block2
 
 block6:
-  [ 118] Catch dst:reg9
-  [ 120] SetLexicalEnvironment environment:reg4
-  [ 128] Mov dst:reg7, src:Int32(1)
+  [ 120] Catch dst:reg9
+  [ 128] SetLexicalEnvironment environment:reg4
+  [ 130] Mov dst:reg7, src:Int32(1)
 
 block7:
-  [ 138] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:1, true_target:block27, false_target:block28
+  [ 140] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:1, true_target:block27, false_target:block28
 
 block8:
-  [ 150] Mov dst:reg12, src:Bool(false)
-  [ 160] GetIterator dst_iterator_object:reg13, dst_iterator_next:reg14, dst_iterator_done:reg15, iterable:reg10
-  [ 178] Jump target:block11
+  [ 158] Mov dst:reg12, src:Bool(false)
+  [ 168] GetIterator dst_iterator_object:reg13, dst_iterator_next:reg14, dst_iterator_done:reg15, iterable:reg10
+  [ 180] Jump target:block11
 
 block9:
-  [ 180] Catch dst:reg17
-  [ 188] SetLexicalEnvironment environment:reg4
-  [ 190] Mov dst:reg16, src:Int32(1)
-  [ 1a0] JumpIf condition:reg15, true_target:block22, false_target:block21
+  [ 188] Catch dst:reg17
+  [ 190] SetLexicalEnvironment environment:reg4
+  [ 198] Mov dst:reg16, src:Int32(1)
+  [ 1a8] JumpIf condition:reg15, true_target:block22, false_target:block21
 
 block10:
-  [ 1b0] Jump target:block2
+  [ 1b8] Jump target:block2
 
 block11:
-  [ 1b8] Jump target:block13
+  [ 1c0] Jump target:block13
 
 block12:
-  [ 1c0] MovSrcUndefined dst:reg18
-  [ 1c8] Jump target:block14
+  [ 1c8] MovSrcUndefined dst:reg18
+  [ 1d0] Jump target:block14
 
 block13:
-  [ 1d0] IteratorNextUnpack dst_value:reg18, dst_done:reg12, iterator_object:reg13, iterator_next:reg14, iterator_done:reg15
-  [ 1e8] JumpTrue condition:reg12, target:block12
+  [ 1d8] IteratorNextUnpack dst_value:reg18, dst_done:reg12, iterator_object:reg13, iterator_next:reg14, iterator_done:reg15
+  [ 1f0] JumpTrue condition:reg12, target:block12
 
 block14:
-  [ 1f8] Mov dst:r~0, src:reg18
-  [ 208] JumpFalse condition:reg12, target:block16
+  [ 200] Mov dst:r~0, src:reg18
+  [ 210] JumpFalse condition:reg12, target:block16
 
 block15:
-  [ 218] MovSrcUndefined dst:reg18
-  [ 220] Jump target:block17
+  [ 220] MovSrcUndefined dst:reg18
+  [ 228] Jump target:block17
 
 block16:
-  [ 228] IteratorNextUnpack dst_value:reg18, dst_done:reg12, iterator_object:reg13, iterator_next:reg14, iterator_done:reg15
-  [ 240] JumpTrue condition:reg12, target:block15
+  [ 230] IteratorNextUnpack dst_value:reg18, dst_done:reg12, iterator_object:reg13, iterator_next:reg14, iterator_done:reg15
+  [ 248] JumpTrue condition:reg12, target:block15
 
 block17:
-  [ 250] Mov dst:n~1, src:reg18
+  [ 258] Mov dst:n~1, src:reg18
 
 block18:
-  [ 260] JumpFalse condition:reg15, target:block20
+  [ 268] JumpFalse condition:reg15, target:block20
 
 block19:
-  [ 270] Jump target:block10
+  [ 278] Jump target:block10
 
 block20:
-  [ 278] IteratorClose iterator_object:reg13, iterator_next:reg14, iterator_done:reg15, completion_value:Undefined
-  [ 290] Jump target:block19
+  [ 280] IteratorClose iterator_object:reg13, iterator_next:reg14, iterator_done:reg15, completion_value:Undefined
+  [ 298] Jump target:block19
 
 block21:
-  [ 298] JumpStrictlyEqualsRhsInt32 lhs:reg16, rhs:1, true_target:block23, false_target:block24
+  [ 2a0] JumpStrictlyEqualsRhsInt32 lhs:reg16, rhs:1, true_target:block23, false_target:block24
 
 block22:
-  [ 2b0] JumpStrictlyEqualsRhsInt32 lhs:reg16, rhs:2, true_target:block25, false_target:block26
+  [ 2b8] JumpStrictlyEqualsRhsInt32 lhs:reg16, rhs:2, true_target:block25, false_target:block26
 
 block23:
-  [ 2c8] IteratorClose iterator_object:reg13, iterator_next:reg14, iterator_done:reg15, completion_value:reg17
-  [ 2e0] Throw src:reg17
+  [ 2d0] IteratorClose iterator_object:reg13, iterator_next:reg14, iterator_done:reg15, completion_value:reg17
+  [ 2e8] Throw src:reg17
 
 block24:
-  [ 2e8] IteratorClose iterator_object:reg13, iterator_next:reg14, iterator_done:reg15, completion_value:Undefined
-  [ 300] Jump target:block22
+  [ 2f0] IteratorClose iterator_object:reg13, iterator_next:reg14, iterator_done:reg15, completion_value:Undefined
+  [ 308] Jump target:block22
 
 block25:
-  [ 308] Mov2 c0_dst:reg7, c0_src:reg16, c1_dst:reg9, c1_src:reg17
-  [ 320] Jump target:block7
+  [ 310] Mov2 c0_dst:reg7, c0_src:reg16, c1_dst:reg9, c1_src:reg17
+  [ 328] Jump target:block7
 
 block26:
-  [ 328] Throw src:reg17
+  [ 330] Throw src:reg17
 
 block27:
-  [ 330] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:reg9
-  [ 348] Throw src:reg9
+  [ 338] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:reg9
+  [ 350] Throw src:reg9
 
 block28:
-  [ 350] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:Undefined
-  [ 368] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:2, true_target:block29, false_target:block30
+  [ 358] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:Undefined
+  [ 370] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:2, true_target:block29, false_target:block30
 
 block29:
-  [ 380] Return value:reg9
+  [ 388] Return value:reg9
 
 block30:
-  [ 388] Throw src:reg9
+  [ 390] Throw src:reg9
 
 Exception handlers:
-  [ 150 ..  1b8] => handler block6
-  [ 1b8 ..  1d0] => handler block9
-  [ 1d0 ..  1f8] => handler block6
-  [ 1f8 ..  228] => handler block9
-  [ 228 ..  250] => handler block6
-  [ 250 ..  260] => handler block9
-  [ 260 ..  330] => handler block6
+  [ 158 ..  1c0] => handler block6
+  [ 1c0 ..  1d8] => handler block9
+  [ 1d8 ..  200] => handler block6
+  [ 200 ..  230] => handler block9
+  [ 230 ..  258] => handler block6
+  [ 258 ..  268] => handler block9
+  [ 268 ..  338] => handler block6

--- a/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
@@ -1,17 +1,18 @@
-$ac6f5d19 for-of-continue-with-block-scope.js:13:1
+$2b0d6491 for-of-continue-with-block-scope.js:13:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] NewArray dst:reg7
-  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  48] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] NewArray dst:reg7
+  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  50] End value:reg5
 
 
-f$a6e23ba8 for-of-continue-with-block-scope.js:2:15
+f$28443430 for-of-continue-with-block-scope.js:2:15
   Registers: 18
   Blocks:    11
   Locals:    o~0, t~1
@@ -21,64 +22,65 @@ f$a6e23ba8 for-of-continue-with-block-scope.js:2:15
     [2] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewArray dst:t~1
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  30] CreateVariable `r`, is_immutable:false, is_global:false, is_strict:false
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg6, dst_iterator_done:reg7, iterable:arg0
-  [  60] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewArray dst:t~1
+  [  20] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  38] CreateVariable `r`, is_immutable:false, is_global:false, is_strict:false
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg6, dst_iterator_done:reg7, iterable:arg0
+  [  68] Jump target:block2
 
 block1:
-  [  68] Return value:t~1
+  [  70] Return value:t~1
 
 block2:
-  [  70] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg5, iterator_next:reg6, iterator_done:reg7
-  [  88] JumpIf condition:reg11, true_target:block1, false_target:block4
+  [  78] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg5, iterator_next:reg6, iterator_done:reg7
+  [  90] JumpIf condition:reg11, true_target:block1, false_target:block4
 
 block3:
-  [  98] Catch dst:reg9
-  [  a0] SetLexicalEnvironment environment:reg4
-  [  a8] Mov dst:reg8, src:Int32(1)
-  [  b8] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:1, true_target:block7, false_target:block8
+  [  a0] Catch dst:reg9
+  [  a8] SetLexicalEnvironment environment:reg4
+  [  b0] Mov dst:reg8, src:Int32(1)
+  [  c0] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:1, true_target:block7, false_target:block8
 
 block4:
-  [  d0] CreateLexicalEnvironment dst:reg12, parent:reg4, capacity:0, is_catch_environment:false
-  [  e8] CreateVariable `r`, is_immutable:true, is_global:false, is_strict:true
-  [  f8] InitializeLexicalBinding `r`, src:reg10
-  [ 110] GetBinding dst:reg14, `r`
-  [ 128] Not dst:reg13, src:reg14
-  [ 138] JumpFalse condition:reg13, target:block6
+  [  d8] CreateLexicalEnvironment dst:reg12, parent:reg4, capacity:0, is_catch_environment:false
+  [  f0] CreateVariable `r`, is_immutable:true, is_global:false, is_strict:true
+  [ 100] InitializeLexicalBinding `r`, src:reg10
+  [ 118] GetBinding dst:reg14, `r`
+  [ 130] Not dst:reg13, src:reg14
+  [ 140] JumpFalse condition:reg13, target:block6
 
 block5:
-  [ 148] GetById dst:reg15, base:t~1, `push` (t.push)
-  [ 160] Mov dst:reg16, src:t~1
-  [ 170] GetBinding dst:reg17, `r`
-  [ 188] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
-  [ 1b0] SetLexicalEnvironment environment:reg4
-  [ 1b8] Jump target:block2
+  [ 150] GetById dst:reg15, base:t~1, `push` (t.push)
+  [ 168] Mov dst:reg16, src:t~1
+  [ 178] GetBinding dst:reg17, `r`
+  [ 190] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
+  [ 1b8] SetLexicalEnvironment environment:reg4
+  [ 1c0] Jump target:block2
 
 block6:
-  [ 1c0] GetById dst:reg13, base:t~1, `find` (t.find)
-  [ 1d8] Mov dst:reg14, src:t~1
-  [ 1e8] NewFunction dst:reg15, shared_function_data_index:0
-  [ 200] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
-  [ 228] SetLexicalEnvironment environment:reg4
-  [ 230] Jump target:block2
+  [ 1c8] GetById dst:reg13, base:t~1, `find` (t.find)
+  [ 1e0] Mov dst:reg14, src:t~1
+  [ 1f0] NewFunction dst:reg15, shared_function_data_index:0
+  [ 208] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
+  [ 230] SetLexicalEnvironment environment:reg4
+  [ 238] Jump target:block2
 
 block7:
-  [ 238] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
-  [ 250] Throw src:reg9
+  [ 240] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
+  [ 258] Throw src:reg9
 
 block8:
-  [ 258] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
-  [ 270] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:2, true_target:block9, false_target:block10
+  [ 260] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
+  [ 278] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:2, true_target:block9, false_target:block10
 
 block9:
-  [ 288] Return value:reg9
+  [ 290] Return value:reg9
 
 block10:
-  [ 290] Throw src:reg9
+  [ 298] Throw src:reg9
 
 Exception handlers:
-  [  d0 ..  238] => handler block3
+  [  d8 ..  240] => handler block3

--- a/Tests/LibJS/Bytecode/expected/for-of-iteration-env-capacity.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-iteration-env-capacity.txt
@@ -1,4 +1,4 @@
-$88eea4d5 for-of-iteration-env-capacity.js:1:14
+$078cac4d for-of-iteration-env-capacity.js:1:14
   Registers: 13
   Blocks:    9
   Locals:    x~0
@@ -8,42 +8,43 @@ $88eea4d5 for-of-iteration-env-capacity.js:1:14
     [2] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewPrimitiveArray dst:reg5, elements:[1, 2, 3]
-  [  30] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
-  [  48] MovSrcUndefined dst:reg5
-  [  50] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewPrimitiveArray dst:reg5, elements:[1, 2, 3]
+  [  38] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
+  [  50] MovSrcUndefined dst:reg5
+  [  58] Jump target:block2
 
 block1:
-  [  58] End value:reg5
+  [  60] End value:reg5
 
 block2:
-  [  60] IteratorNextUnpack dst_value:reg11, dst_done:reg12, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
-  [  78] JumpIf condition:reg12, true_target:block1, false_target:block4
+  [  68] IteratorNextUnpack dst_value:reg11, dst_done:reg12, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
+  [  80] JumpIf condition:reg12, true_target:block1, false_target:block4
 
 block3:
-  [  88] Catch dst:reg10
-  [  90] SetLexicalEnvironment environment:reg4
-  [  98] Mov dst:reg9, src:Int32(1)
-  [  a8] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:1, true_target:block5, false_target:block6
+  [  90] Catch dst:reg10
+  [  98] SetLexicalEnvironment environment:reg4
+  [  a0] Mov dst:reg9, src:Int32(1)
+  [  b0] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:1, true_target:block5, false_target:block6
 
 block4:
-  [  c0] Mov2 c0_dst:x~0, c0_src:reg11, c1_dst:reg5, c1_src:x~0
-  [  d8] Jump target:block2
+  [  c8] Mov2 c0_dst:x~0, c0_src:reg11, c1_dst:reg5, c1_src:x~0
+  [  e0] Jump target:block2
 
 block5:
-  [  e0] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg10
-  [  f8] Throw src:reg10
+  [  e8] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg10
+  [ 100] Throw src:reg10
 
 block6:
-  [ 100] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
-  [ 118] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:2, true_target:block7, false_target:block8
+  [ 108] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
+  [ 120] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:2, true_target:block7, false_target:block8
 
 block7:
-  [ 130] Return value:reg10
+  [ 138] Return value:reg10
 
 block8:
-  [ 138] Throw src:reg10
+  [ 140] Throw src:reg10
 
 Exception handlers:
-  [  c0 ..   e0] => handler block3
+  [  c8 ..   e8] => handler block3

--- a/Tests/LibJS/Bytecode/expected/for-of-iterator-close.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-iterator-close.txt
@@ -1,21 +1,22 @@
-$8053687a for-of-iterator-close.js:6:1
+$fc2d7ee2 for-of-iterator-close.js:6:1
   Registers: 9
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `forOfBreak`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, forOfBreak
-  [  30] GetGlobal dst:reg7, `forOfReturn`
-  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, forOfReturn
-  [  60] GetGlobal dst:reg7, `forAwaitOfBreak`
-  [  70] NewPrimitiveArray dst:reg8, elements:[1, 2, 3]
-  [  98] Call dst:reg5, callee:reg7, this_value:Undefined, forAwaitOfBreak, arguments:[reg8]
-  [  c0] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `forOfBreak`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, forOfBreak
+  [  38] GetGlobal dst:reg7, `forOfReturn`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, forOfReturn
+  [  68] GetGlobal dst:reg7, `forAwaitOfBreak`
+  [  78] NewPrimitiveArray dst:reg8, elements:[1, 2, 3]
+  [  a0] Call dst:reg5, callee:reg7, this_value:Undefined, forAwaitOfBreak, arguments:[reg8]
+  [  c8] End value:reg5
 
 
-forOfBreak$7367477b for-of-iterator-close.js:2:18
+forOfBreak$0dacb993 for-of-iterator-close.js:2:18
   Registers: 13
   Blocks:    13
   Locals:    x~0
@@ -26,59 +27,60 @@ forOfBreak$7367477b for-of-iterator-close.js:2:18
     [3] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewPrimitiveArray dst:reg5, elements:[1, 2, 3]
-  [  30] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
-  [  48] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewPrimitiveArray dst:reg5, elements:[1, 2, 3]
+  [  38] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
+  [  50] Jump target:block2
 
 block1:
-  [  50] End value:Undefined
+  [  58] End value:Undefined
 
 block2:
-  [  58] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
-  [  70] JumpIf condition:reg11, true_target:block1, false_target:block5
+  [  60] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
+  [  78] JumpIf condition:reg11, true_target:block1, false_target:block5
 
 block3:
-  [  80] Catch dst:reg9
-  [  88] SetLexicalEnvironment environment:reg4
-  [  90] Mov dst:reg5, src:Int32(1)
+  [  88] Catch dst:reg9
+  [  90] SetLexicalEnvironment environment:reg4
+  [  98] Mov dst:reg5, src:Int32(1)
 
 block4:
-  [  a0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block8, false_target:block9
+  [  a8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block8, false_target:block9
 
 block5:
-  [  b8] Mov dst:x~0, src:reg10
-  [  c8] JumpStrictlyEqualsRhsInt32 lhs:x~0, rhs:2, true_target:block6, false_target:block7
+  [  c0] Mov dst:x~0, src:reg10
+  [  d0] JumpStrictlyEqualsRhsInt32 lhs:x~0, rhs:2, true_target:block6, false_target:block7
 
 block6:
-  [  e0] Mov dst:reg5, src:Int32(3)
-  [  f0] Jump target:block4
+  [  e8] Mov dst:reg5, src:Int32(3)
+  [  f8] Jump target:block4
 
 block7:
-  [  f8] Jump target:block2
+  [ 100] Jump target:block2
 
 block8:
-  [ 100] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
-  [ 118] Throw src:reg9
+  [ 108] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
+  [ 120] Throw src:reg9
 
 block9:
-  [ 120] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
-  [ 138] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block1, false_target:block10
+  [ 128] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
+  [ 140] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block1, false_target:block10
 
 block10:
-  [ 150] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block11, false_target:block12
+  [ 158] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block11, false_target:block12
 
 block11:
-  [ 168] Return value:reg9
+  [ 170] Return value:reg9
 
 block12:
-  [ 170] Throw src:reg9
+  [ 178] Throw src:reg9
 
 Exception handlers:
-  [  b8 ..  100] => handler block3
+  [  c0 ..  108] => handler block3
 
 
-forOfReturn$3ba37d59 for-of-iterator-close.js:9:18
+forOfReturn$ba4184d1 for-of-iterator-close.js:9:18
   Registers: 12
   Blocks:    10
   Locals:    x~0
@@ -88,49 +90,50 @@ forOfReturn$3ba37d59 for-of-iterator-close.js:9:18
     [2] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewPrimitiveArray dst:reg5, elements:[1, 2, 3]
-  [  30] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
-  [  48] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewPrimitiveArray dst:reg5, elements:[1, 2, 3]
+  [  38] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
+  [  50] Jump target:block2
 
 block1:
-  [  50] End value:Undefined
+  [  58] End value:Undefined
 
 block2:
-  [  58] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
-  [  70] JumpIf condition:reg11, true_target:block1, false_target:block5
+  [  60] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
+  [  78] JumpIf condition:reg11, true_target:block1, false_target:block5
 
 block3:
-  [  80] Catch dst:reg9
-  [  88] SetLexicalEnvironment environment:reg4
-  [  90] Mov dst:reg5, src:Int32(1)
+  [  88] Catch dst:reg9
+  [  90] SetLexicalEnvironment environment:reg4
+  [  98] Mov dst:reg5, src:Int32(1)
 
 block4:
-  [  a0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block6, false_target:block7
+  [  a8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block6, false_target:block7
 
 block5:
-  [  b8] Mov3 c0_dst:x~0, c0_src:reg10, c1_dst:reg9, c1_src:x~0, c2_dst:reg5, c2_src:Int32(2)
-  [  d8] Jump target:block4
+  [  c0] Mov3 c0_dst:x~0, c0_src:reg10, c1_dst:reg9, c1_src:x~0, c2_dst:reg5, c2_src:Int32(2)
+  [  e0] Jump target:block4
 
 block6:
-  [  e0] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
-  [  f8] Throw src:reg9
+  [  e8] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
+  [ 100] Throw src:reg9
 
 block7:
-  [ 100] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
-  [ 118] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block8, false_target:block9
+  [ 108] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
+  [ 120] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block8, false_target:block9
 
 block8:
-  [ 130] Return value:reg9
+  [ 138] Return value:reg9
 
 block9:
-  [ 138] Throw src:reg9
+  [ 140] Throw src:reg9
 
 Exception handlers:
-  [  b8 ..   e0] => handler block3
+  [  c0 ..   e8] => handler block3
 
 
-forAwaitOfBreak$976a8bbf for-of-iterator-close.js:16:24
+forAwaitOfBreak$16089337 for-of-iterator-close.js:16:24
   Registers: 18
   Blocks:    30
   Locals:    x~0
@@ -141,118 +144,119 @@ forAwaitOfBreak$976a8bbf for-of-iterator-close.js:16:24
     [3] = Int32(3)
 
 block0:
-  [   0] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  10] GetLexicalEnvironment dst:reg4
-  [  18] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg6, dst_iterator_done:reg7, iterable:arg0
-  [  30] Jump target:block3
+  [  18] GetLexicalEnvironment dst:reg4
+  [  20] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg6, dst_iterator_done:reg7, iterable:arg0
+  [  38] Jump target:block3
 
 block2:
-  [  38] Yield value:Undefined
+  [  40] Yield value:Undefined
 
 block3:
-  [  48] IteratorNext dst:reg12, iterator_object:reg5, iterator_next:reg6, iterator_done:reg7
-  [  60] Mov dst:reg13, src:reg0
-  [  70] Await continuation_label:block6, argument:reg12
+  [  50] IteratorNext dst:reg12, iterator_object:reg5, iterator_next:reg6, iterator_done:reg7
+  [  68] Mov dst:reg13, src:reg0
+  [  78] Await continuation_label:block6, argument:reg12
 
 block4:
-  [  80] Catch dst:reg9
-  [  88] SetLexicalEnvironment environment:reg4
-  [  90] Mov dst:reg8, src:Int32(1)
+  [  88] Catch dst:reg9
+  [  90] SetLexicalEnvironment environment:reg4
+  [  98] Mov dst:reg8, src:Int32(1)
 
 block5:
-  [  a0] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:1, true_target:block13, false_target:block14
+  [  a8] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:1, true_target:block13, false_target:block14
 
 block6:
-  [  b8] Mov dst:reg13, src:reg0
-  [  c8] GetCompletionFields type_dst:reg14, value_dst:reg15, completion:reg13
-  [  d8] JumpStrictlyEqualsRhsInt32 lhs:reg14, rhs:1, true_target:block7, false_target:block8
+  [  c0] Mov dst:reg13, src:reg0
+  [  d0] GetCompletionFields type_dst:reg14, value_dst:reg15, completion:reg13
+  [  e0] JumpStrictlyEqualsRhsInt32 lhs:reg14, rhs:1, true_target:block7, false_target:block8
 
 block7:
-  [  f0] Mov dst:reg12, src:reg15
-  [ 100] ThrowIfNotObject src:reg12
-  [ 108] GetById dst:reg11, base:reg12, `done`
-  [ 120] JumpIf condition:reg11, true_target:block2, false_target:block9
+  [  f8] Mov dst:reg12, src:reg15
+  [ 108] ThrowIfNotObject src:reg12
+  [ 110] GetById dst:reg11, base:reg12, `done`
+  [ 128] JumpIf condition:reg11, true_target:block2, false_target:block9
 
 block8:
-  [ 130] Throw src:reg15
+  [ 138] Throw src:reg15
 
 block9:
-  [ 138] GetById dst:reg10, base:reg12, `value`
+  [ 140] GetById dst:reg10, base:reg12, `value`
 
 block10:
-  [ 150] Mov dst:x~0, src:reg10
-  [ 160] JumpStrictlyEqualsRhsInt32 lhs:x~0, rhs:2, true_target:block11, false_target:block12
+  [ 158] Mov dst:x~0, src:reg10
+  [ 168] JumpStrictlyEqualsRhsInt32 lhs:x~0, rhs:2, true_target:block11, false_target:block12
 
 block11:
-  [ 178] Mov dst:reg8, src:Int32(3)
-  [ 188] Jump target:block5
+  [ 180] Mov dst:reg8, src:Int32(3)
+  [ 190] Jump target:block5
 
 block12:
-  [ 190] Jump target:block3
+  [ 198] Jump target:block3
 
 block13:
-  [ 198] Jump target:block25
+  [ 1a0] Jump target:block25
 
 block14:
-  [ 1a0] GetMethod dst:reg12, object:reg5, `return`
-  [ 1b0] JumpUndefined condition:reg12, true_target:block15, false_target:block16
+  [ 1a8] GetMethod dst:reg12, object:reg5, `return`
+  [ 1b8] JumpUndefined condition:reg12, true_target:block15, false_target:block16
 
 block15:
-  [ 1c0] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:3, true_target:block2, false_target:block20
+  [ 1c8] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:3, true_target:block2, false_target:block20
 
 block16:
-  [ 1d8] Call dst:reg13, callee:reg12, this_value:reg5
-  [ 1f8] Await continuation_label:block17, argument:reg13
+  [ 1e0] Call dst:reg13, callee:reg12, this_value:reg5
+  [ 200] Await continuation_label:block17, argument:reg13
 
 block17:
-  [ 208] Mov dst:reg14, src:reg0
-  [ 218] GetCompletionFields type_dst:reg15, value_dst:reg16, completion:reg14
-  [ 228] JumpStrictlyEqualsRhsInt32 lhs:reg15, rhs:1, true_target:block18, false_target:block19
+  [ 210] Mov dst:reg14, src:reg0
+  [ 220] GetCompletionFields type_dst:reg15, value_dst:reg16, completion:reg14
+  [ 230] JumpStrictlyEqualsRhsInt32 lhs:reg15, rhs:1, true_target:block18, false_target:block19
 
 block18:
-  [ 240] ThrowIfNotObject src:reg16
-  [ 248] Jump target:block15
+  [ 248] ThrowIfNotObject src:reg16
+  [ 250] Jump target:block15
 
 block19:
-  [ 250] Throw src:reg16
+  [ 258] Throw src:reg16
 
 block20:
-  [ 258] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:2, true_target:block21, false_target:block22
+  [ 260] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:2, true_target:block21, false_target:block22
 
 block21:
-  [ 270] Return value:reg9
+  [ 278] Return value:reg9
 
 block22:
-  [ 278] Throw src:reg9
-
-block23:
   [ 280] Throw src:reg9
 
+block23:
+  [ 288] Throw src:reg9
+
 block24:
-  [ 288] Catch dst:reg12
-  [ 290] Jump target:block23
+  [ 290] Catch dst:reg12
+  [ 298] Jump target:block23
 
 block25:
-  [ 298] GetMethod dst:reg12, object:reg5, `return`
-  [ 2a8] JumpUndefined condition:reg12, true_target:block23, false_target:block26
+  [ 2a0] GetMethod dst:reg12, object:reg5, `return`
+  [ 2b0] JumpUndefined condition:reg12, true_target:block23, false_target:block26
 
 block26:
-  [ 2b8] Call dst:reg13, callee:reg12, this_value:reg5
-  [ 2d8] Await continuation_label:block27, argument:reg13
+  [ 2c0] Call dst:reg13, callee:reg12, this_value:reg5
+  [ 2e0] Await continuation_label:block27, argument:reg13
 
 block27:
-  [ 2e8] Mov dst:reg14, src:reg0
-  [ 2f8] GetCompletionFields type_dst:reg15, value_dst:reg16, completion:reg14
-  [ 308] JumpStrictlyEqualsRhsInt32 lhs:reg15, rhs:1, true_target:block28, false_target:block29
+  [ 2f0] Mov dst:reg14, src:reg0
+  [ 300] GetCompletionFields type_dst:reg15, value_dst:reg16, completion:reg14
+  [ 310] JumpStrictlyEqualsRhsInt32 lhs:reg15, rhs:1, true_target:block28, false_target:block29
 
 block28:
-  [ 320] Jump target:block23
+  [ 328] Jump target:block23
 
 block29:
-  [ 328] Throw src:reg16
+  [ 330] Throw src:reg16
 
 Exception handlers:
-  [ 150 ..  198] => handler block4
-  [ 298 ..  330] => handler block24
+  [ 158 ..  1a0] => handler block4
+  [ 2a0 ..  338] => handler block24

--- a/Tests/LibJS/Bytecode/expected/for-of-rhs-precedence.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-rhs-precedence.txt
@@ -1,8 +1,9 @@
-$ccf7ed9d
+$4e59e625
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
@@ -1,4 +1,4 @@
-$b6d86a12 for-try-finally-continue.js:1:1
+$3dc244ba for-try-finally-continue.js:1:1
   Registers: 11
   Blocks:    16
   Locals:    e~0
@@ -12,71 +12,72 @@ $b6d86a12 for-try-finally-continue.js:1:1
     [6] = String("bad")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] SetGlobal `i`, src:Int32(0)
-  [  18] MovSrcUndefined dst:reg5
-  [  20] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] SetGlobal `i`, src:Int32(0)
+  [  20] MovSrcUndefined dst:reg5
+  [  28] Jump target:block3
 
 block1:
-  [  28] Jump target:block8
+  [  30] Jump target:block8
 
 block2:
-  [  30] GetGlobal dst:reg7, `i`
-  [  40] PostfixIncrement dst:reg6, src:reg7
-  [  50] SetGlobal `i`, src:reg7
+  [  38] GetGlobal dst:reg7, `i`
+  [  48] PostfixIncrement dst:reg6, src:reg7
+  [  58] SetGlobal `i`, src:reg7
 
 block3:
-  [  60] GetGlobal dst:reg6, `i`
-  [  70] JumpLessThanRhsInt32 lhs:reg6, rhs:5, true_target:block1, false_target:block4
+  [  68] GetGlobal dst:reg6, `i`
+  [  78] JumpLessThanRhsInt32 lhs:reg6, rhs:5, true_target:block1, false_target:block4
 
 block4:
-  [  88] GetGlobal dst:reg10, `i`
-  [  98] StrictlyInequalsRhsInt32 dst:reg8, lhs:reg10, rhs:5
-  [  a8] MovSrcUndefined dst:reg10
-  [  b0] JumpIf condition:reg8, true_target:block14, false_target:block15
+  [  90] GetGlobal dst:reg10, `i`
+  [  a0] StrictlyInequalsRhsInt32 dst:reg8, lhs:reg10, rhs:5
+  [  b0] MovSrcUndefined dst:reg10
+  [  b8] JumpIf condition:reg8, true_target:block14, false_target:block15
 
 block5:
-  [  c0] Catch dst:reg7
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] Mov dst:reg6, src:Int32(1)
+  [  c8] Catch dst:reg7
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] Mov dst:reg6, src:Int32(1)
 
 block6:
-  [  e0] MovSrcUndefined dst:reg9
-  [  e8] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:0, true_target:block9, false_target:block10
+  [  e8] MovSrcUndefined dst:reg9
+  [  f0] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:0, true_target:block9, false_target:block10
 
 block7:
-  [ 100] Catch dst:reg8
-  [ 108] SetLexicalEnvironment environment:reg4
-  [ 110] Mov3 c0_dst:e~0, c0_src:reg8, c1_dst:reg9, c1_src:Undefined, c2_dst:reg10, c2_src:reg9
-  [ 130] Mov dst:reg6, src:Int32(0)
-  [ 140] Jump target:block6
+  [ 108] Catch dst:reg8
+  [ 110] SetLexicalEnvironment environment:reg4
+  [ 118] Mov3 c0_dst:e~0, c0_src:reg8, c1_dst:reg9, c1_src:Undefined, c2_dst:reg10, c2_src:reg9
+  [ 138] Mov dst:reg6, src:Int32(0)
+  [ 148] Jump target:block6
 
 block8:
-  [ 148] Mov3 c0_dst:reg8, c0_src:Undefined, c1_dst:reg5, c1_src:reg8, c2_dst:reg6, c2_src:Int32(3)
-  [ 168] Jump target:block6
+  [ 150] Mov3 c0_dst:reg8, c0_src:Undefined, c1_dst:reg5, c1_src:reg8, c2_dst:reg6, c2_src:Int32(3)
+  [ 170] Jump target:block6
 
 block9:
-  [ 170] Mov dst:reg5, src:reg10
-  [ 180] Jump target:block2
+  [ 178] Mov dst:reg5, src:reg10
+  [ 188] Jump target:block2
 
 block10:
-  [ 188] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:3, true_target:block2, false_target:block11
+  [ 190] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:3, true_target:block2, false_target:block11
 
 block11:
-  [ 1a0] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:2, true_target:block12, false_target:block13
+  [ 1a8] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:2, true_target:block12, false_target:block13
 
 block12:
-  [ 1b8] Return value:reg7
+  [ 1c0] Return value:reg7
 
 block13:
-  [ 1c0] Throw src:reg7
+  [ 1c8] Throw src:reg7
 
 block14:
-  [ 1c8] Throw src:String("bad")
+  [ 1d0] Throw src:String("bad")
 
 block15:
-  [ 1d0] End value:reg10
+  [ 1d8] End value:reg10
 
 Exception handlers:
-  [ 100 ..  148] => handler block5
-  [ 148 ..  170] => handler block7
+  [ 108 ..  150] => handler block5
+  [ 150 ..  178] => handler block7

--- a/Tests/LibJS/Bytecode/expected/function-decl-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/function-decl-source-order.txt
@@ -1,74 +1,80 @@
-$df07c6c2 function-decl-source-order.js:17:1
+$5559fb0a function-decl-source-order.js:17:1
   Registers: 14
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `alpha`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, alpha
-  [  58] GetGlobal dst:reg10, `beta`
-  [  68] Call dst:reg9, callee:reg10, this_value:Undefined, beta
-  [  88] GetGlobal dst:reg11, `gamma`
-  [  98] Call dst:reg10, callee:reg11, this_value:Undefined, gamma
-  [  b8] GetGlobal dst:reg12, `delta`
-  [  c8] Call dst:reg11, callee:reg12, this_value:Undefined, delta
-  [  e8] GetGlobal dst:reg13, `dup`
-  [  f8] Call dst:reg12, callee:reg13, this_value:Undefined, dup
-  [ 118] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8, reg9, reg10, reg11, reg12]
-  [ 150] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `alpha`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, alpha
+  [  60] GetGlobal dst:reg10, `beta`
+  [  70] Call dst:reg9, callee:reg10, this_value:Undefined, beta
+  [  90] GetGlobal dst:reg11, `gamma`
+  [  a0] Call dst:reg10, callee:reg11, this_value:Undefined, gamma
+  [  c0] GetGlobal dst:reg12, `delta`
+  [  d0] Call dst:reg11, callee:reg12, this_value:Undefined, delta
+  [  f0] GetGlobal dst:reg13, `dup`
+  [ 100] Call dst:reg12, callee:reg13, this_value:Undefined, dup
+  [ 120] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8, reg9, reg10, reg11, reg12]
+  [ 158] End value:reg5
 
 
-alpha$29e24060 function-decl-source-order.js:5:20
+alpha$ae0829f8 function-decl-source-order.js:5:20
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(1)
 
 block0:
-  [   0] Return value:Int32(1)
+  [   0] Enter
+  [   8] Return value:Int32(1)
 
 
-beta$565e177b function-decl-source-order.js:7:19
+beta$d7c01003 function-decl-source-order.js:7:19
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(2)
 
 block0:
-  [   0] Return value:Int32(2)
+  [   0] Enter
+  [   8] Return value:Int32(2)
 
 
-gamma$03071905 function-decl-source-order.js:11:20
+gamma$81a5207d function-decl-source-order.js:11:20
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(3)
 
 block0:
-  [   0] Return value:Int32(3)
+  [   0] Enter
+  [   8] Return value:Int32(3)
 
 
-delta$3c1404ee function-decl-source-order.js:15:20
+delta$bd75fd76 function-decl-source-order.js:15:20
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(4)
 
 block0:
-  [   0] Return value:Int32(4)
+  [   0] Enter
+  [   8] Return value:Int32(4)
 
 
-dup$7c6f066b function-decl-source-order.js:13:18
+dup$f8491cd3 function-decl-source-order.js:13:18
   Registers: 5
   Blocks:    1
   Constants:
     [0] = String("second")
 
 block0:
-  [   0] Return value:String("second")
+  [   0] Enter
+  [   8] Return value:String("second")
 
 
 1 2 3 4 "second"

--- a/Tests/LibJS/Bytecode/expected/generator-yield-call.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-call.txt
@@ -1,4 +1,4 @@
-$21584cbd generator-yield-call.js:9:1
+$9ff65435 generator-yield-call.js:9:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -7,18 +7,19 @@ $21584cbd generator-yield-call.js:9:1
     [2] = Int32(2)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] NewObject dst:reg7
-  [  20] InitObjectLiteralProperty object:reg7, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  38] CacheObjectShape object:reg7
-  [  48] NewObject dst:reg8
-  [  58] InitObjectLiteralProperty object:reg8, `y`, src:Int32(2), shape_cache_index:1, property_slot:0
-  [  70] CacheObjectShape object:reg8
-  [  80] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7, reg8]
-  [  a8] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] NewObject dst:reg7
+  [  28] InitObjectLiteralProperty object:reg7, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  40] CacheObjectShape object:reg7
+  [  50] NewObject dst:reg8
+  [  60] InitObjectLiteralProperty object:reg8, `y`, src:Int32(2), shape_cache_index:1, property_slot:0
+  [  78] CacheObjectShape object:reg8
+  [  88] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7, reg8]
+  [  b0] End value:reg5
 
 
-f$8e86d913 generator-yield-call.js:6:5
+f$0d24e08b generator-yield-call.js:6:5
   Registers: 11
   Blocks:    12
   Constants:
@@ -27,45 +28,46 @@ f$8e86d913 generator-yield-call.js:6:5
     [2] = Int32(5)
 
 block0:
-  [   0] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  10] Mov dst:reg8, src:arg0
-  [  20] GetById dst:reg9, base:reg8, `x` (a.x)
-  [  38] Yield continuation_label:block2, value:reg9
+  [  18] Mov dst:reg8, src:arg0
+  [  28] GetById dst:reg9, base:reg8, `x` (a.x)
+  [  40] Yield continuation_label:block2, value:reg9
 
 block2:
-  [  48] Mov dst:reg5, src:reg0
-  [  58] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  68] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block3, false_target:block4
+  [  50] Mov dst:reg5, src:reg0
+  [  60] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [  70] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block3, false_target:block4
 
 block3:
-  [  80] Mov dst:reg9, src:arg1
-  [  90] GetById dst:reg8, base:reg9, `y` (b.y)
-  [  a8] Yield continuation_label:block7, value:reg8
+  [  88] Mov dst:reg9, src:arg1
+  [  98] GetById dst:reg8, base:reg9, `y` (b.y)
+  [  b0] Yield continuation_label:block7, value:reg8
 
 block4:
-  [  b8] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block5, false_target:block6
+  [  c0] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block5, false_target:block6
 
 block5:
-  [  d0] Throw src:reg7
+  [  d8] Throw src:reg7
 
 block6:
-  [  d8] Yield value:reg7
+  [  e0] Yield value:reg7
 
 block7:
-  [  e8] Mov dst:reg7, src:reg0
-  [  f8] GetCompletionFields type_dst:reg5, value_dst:reg6, completion:reg7
-  [ 108] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block8, false_target:block9
+  [  f0] Mov dst:reg7, src:reg0
+  [ 100] GetCompletionFields type_dst:reg5, value_dst:reg6, completion:reg7
+  [ 110] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block8, false_target:block9
 
 block8:
-  [ 120] Yield value:Undefined
+  [ 128] Yield value:Undefined
 
 block9:
-  [ 130] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:5, true_target:block10, false_target:block11
+  [ 138] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:5, true_target:block10, false_target:block11
 
 block10:
-  [ 148] Throw src:reg6
+  [ 150] Throw src:reg6
 
 block11:
-  [ 150] Yield value:reg6
+  [ 158] Yield value:reg6

--- a/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
@@ -1,16 +1,17 @@
-$30efac17 generator-yield-finally.js:11:1
+$ba9d77cf generator-yield-finally.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  38] End value:reg5
 
 
-f$6b17ea44 generator-yield-finally.js:4:5
+f$e9b5f1bc generator-yield-finally.js:4:5
   Registers: 13
   Blocks:    24
   Constants:
@@ -22,89 +23,90 @@ f$6b17ea44 generator-yield-finally.js:4:5
     [5] = Int32(3)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  18] Jump target:block4
+  [  20] Jump target:block4
 
 block2:
-  [  20] Catch dst:reg6
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Mov dst:reg5, src:Int32(1)
+  [  28] Catch dst:reg6
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Mov dst:reg5, src:Int32(1)
 
 block3:
-  [  40] Mov dst:reg10, src:reg1
-  [  50] Yield continuation_label:block15, value:Int32(3)
+  [  48] Mov dst:reg10, src:reg1
+  [  58] Yield continuation_label:block15, value:Int32(3)
 
 block4:
-  [  60] Yield continuation_label:block5, value:Int32(1)
+  [  68] Yield continuation_label:block5, value:Int32(1)
 
 block5:
-  [  70] Mov dst:reg7, src:reg0
-  [  80] GetCompletionFields type_dst:reg8, value_dst:reg9, completion:reg7
-  [  90] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:1, true_target:block6, false_target:block7
+  [  78] Mov dst:reg7, src:reg0
+  [  88] GetCompletionFields type_dst:reg8, value_dst:reg9, completion:reg7
+  [  98] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:1, true_target:block6, false_target:block7
 
 block6:
-  [  a8] Yield continuation_label:block10, value:Int32(2)
+  [  b0] Yield continuation_label:block10, value:Int32(2)
 
 block7:
-  [  b8] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:5, true_target:block8, false_target:block9
+  [  c0] JumpStrictlyEqualsRhsInt32 lhs:reg8, rhs:5, true_target:block8, false_target:block9
 
 block8:
-  [  d0] Throw src:reg9
+  [  d8] Throw src:reg9
 
 block9:
-  [  d8] Mov2 c0_dst:reg6, c0_src:reg9, c1_dst:reg5, c1_src:Int32(2)
-  [  f0] Jump target:block3
+  [  e0] Mov2 c0_dst:reg6, c0_src:reg9, c1_dst:reg5, c1_src:Int32(2)
+  [  f8] Jump target:block3
 
 block10:
-  [  f8] Mov dst:reg9, src:reg0
-  [ 108] GetCompletionFields type_dst:reg7, value_dst:reg8, completion:reg9
-  [ 118] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:1, true_target:block11, false_target:block12
+  [ 100] Mov dst:reg9, src:reg0
+  [ 110] GetCompletionFields type_dst:reg7, value_dst:reg8, completion:reg9
+  [ 120] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:1, true_target:block11, false_target:block12
 
 block11:
-  [ 130] Mov dst:reg5, src:Int32(0)
-  [ 140] Jump target:block3
+  [ 138] Mov dst:reg5, src:Int32(0)
+  [ 148] Jump target:block3
 
 block12:
-  [ 148] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:5, true_target:block13, false_target:block14
+  [ 150] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:5, true_target:block13, false_target:block14
 
 block13:
-  [ 160] Throw src:reg8
+  [ 168] Throw src:reg8
 
 block14:
-  [ 168] Mov2 c0_dst:reg6, c0_src:reg8, c1_dst:reg5, c1_src:Int32(2)
-  [ 180] Jump target:block3
+  [ 170] Mov2 c0_dst:reg6, c0_src:reg8, c1_dst:reg5, c1_src:Int32(2)
+  [ 188] Jump target:block3
 
 block15:
-  [ 188] Mov2 c0_dst:reg1, c0_src:reg10, c1_dst:reg8, c1_src:reg0
-  [ 1a0] GetCompletionFields type_dst:reg9, value_dst:reg7, completion:reg8
-  [ 1b0] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:1, true_target:block16, false_target:block17
+  [ 190] Mov2 c0_dst:reg1, c0_src:reg10, c1_dst:reg8, c1_src:reg0
+  [ 1a8] GetCompletionFields type_dst:reg9, value_dst:reg7, completion:reg8
+  [ 1b8] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:1, true_target:block16, false_target:block17
 
 block16:
-  [ 1c8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block20, false_target:block21
+  [ 1d0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block20, false_target:block21
 
 block17:
-  [ 1e0] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:5, true_target:block18, false_target:block19
+  [ 1e8] JumpStrictlyEqualsRhsInt32 lhs:reg9, rhs:5, true_target:block18, false_target:block19
 
 block18:
-  [ 1f8] Throw src:reg7
+  [ 200] Throw src:reg7
 
 block19:
-  [ 200] Yield value:reg7
+  [ 208] Yield value:reg7
 
 block20:
-  [ 210] Yield value:Undefined
+  [ 218] Yield value:Undefined
 
 block21:
-  [ 220] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block22, false_target:block23
+  [ 228] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block22, false_target:block23
 
 block22:
-  [ 238] Yield value:reg6
+  [ 240] Yield value:reg6
 
 block23:
-  [ 248] Throw src:reg6
+  [ 250] Throw src:reg6
 
 Exception handlers:
-  [  60 ..  188] => handler block2
+  [  68 ..  190] => handler block2

--- a/Tests/LibJS/Bytecode/expected/generator-yield-star.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-star.txt
@@ -1,17 +1,18 @@
-$ee59c992 generator-yield-star.js:6:1
+$6fbbc21a generator-yield-star.js:6:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] NewPrimitiveArray dst:reg7, elements:[1, 2]
-  [  30] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  58] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] NewPrimitiveArray dst:reg7, elements:[1, 2]
+  [  38] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  60] End value:reg5
 
 
-f$fd11892c generator-yield-star.js:4:5
+f$813772c4 generator-yield-star.js:4:5
   Registers: 21
   Blocks:    19
   Constants:
@@ -20,77 +21,78 @@ f$fd11892c generator-yield-star.js:4:5
     [2] = Int32(5)
 
 block0:
-  [   0] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  10] GetIterator dst_iterator_object:reg8, dst_iterator_next:reg9, dst_iterator_done:reg10, iterable:arg0
-  [  28] Mov2 c0_dst:reg6, c0_src:Int32(1), c1_dst:reg7, c1_src:Undefined
+  [  18] GetIterator dst_iterator_object:reg8, dst_iterator_next:reg9, dst_iterator_done:reg10, iterable:arg0
+  [  30] Mov2 c0_dst:reg6, c0_src:Int32(1), c1_dst:reg7, c1_src:Undefined
 
 block2:
-  [  40] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block5, false_target:block6
+  [  48] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block5, false_target:block6
 
 block3:
-  [  58] Mov dst:reg5, src:reg0
-  [  68] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  78] Jump target:block2
+  [  60] Mov dst:reg5, src:reg0
+  [  70] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [  80] Jump target:block2
 
 block4:
-  [  80] Yield value:Undefined
+  [  88] Yield value:Undefined
 
 block5:
-  [  90] Call dst:reg12, callee:reg9, this_value:reg8, arguments:[reg7]
-  [  b8] ThrowIfNotObject src:reg12
-  [  c0] GetById dst:reg13, base:reg12, `done`
-  [  d8] JumpIf condition:reg13, true_target:block7, false_target:block8
+  [  98] Call dst:reg12, callee:reg9, this_value:reg8, arguments:[reg7]
+  [  c0] ThrowIfNotObject src:reg12
+  [  c8] GetById dst:reg13, base:reg12, `done`
+  [  e0] JumpIf condition:reg13, true_target:block7, false_target:block8
 
 block6:
-  [  e8] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block9, false_target:block10
+  [  f0] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block9, false_target:block10
 
 block7:
-  [ 100] GetById dst:reg14, base:reg12, `value`
-  [ 118] Jump target:block4
+  [ 108] GetById dst:reg14, base:reg12, `value`
+  [ 120] Jump target:block4
 
 block8:
-  [ 120] YieldIteratorResult continuation_label:block3, value:reg12
+  [ 128] YieldIteratorResult continuation_label:block3, value:reg12
 
 block9:
-  [ 130] GetMethod dst:reg16, object:reg8, `throw`
-  [ 140] JumpUndefined condition:reg16, true_target:block12, false_target:block11
+  [ 138] GetMethod dst:reg16, object:reg8, `throw`
+  [ 148] JumpUndefined condition:reg16, true_target:block12, false_target:block11
 
 block10:
-  [ 150] GetMethod dst:reg18, object:reg8, `return`
-  [ 160] JumpUndefined condition:reg18, true_target:block15, false_target:block16
+  [ 158] GetMethod dst:reg18, object:reg8, `return`
+  [ 168] JumpUndefined condition:reg18, true_target:block15, false_target:block16
 
 block11:
-  [ 170] Call dst:reg12, callee:reg16, this_value:reg8, arguments:[reg7]
-  [ 198] ThrowIfNotObject src:reg12
-  [ 1a0] GetById dst:reg13, base:reg12, `done`
-  [ 1b8] JumpIf condition:reg13, true_target:block13, false_target:block14
+  [ 178] Call dst:reg12, callee:reg16, this_value:reg8, arguments:[reg7]
+  [ 1a0] ThrowIfNotObject src:reg12
+  [ 1a8] GetById dst:reg13, base:reg12, `done`
+  [ 1c0] JumpIf condition:reg13, true_target:block13, false_target:block14
 
 block12:
-  [ 1c8] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg13, completion_value:Undefined
-  [ 1e0] NewTypeError dst:reg17, yield* protocol violation: iterator must have a throw method
-  [ 1f0] Throw src:reg17
+  [ 1d0] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg13, completion_value:Undefined
+  [ 1e8] NewTypeError dst:reg17, yield* protocol violation: iterator must have a throw method
+  [ 1f8] Throw src:reg17
 
 block13:
-  [ 1f8] GetById dst:reg14, base:reg12, `value`
-  [ 210] Jump target:block4
+  [ 200] GetById dst:reg14, base:reg12, `value`
+  [ 218] Jump target:block4
 
 block14:
-  [ 218] YieldIteratorResult continuation_label:block3, value:reg12
+  [ 220] YieldIteratorResult continuation_label:block3, value:reg12
 
 block15:
-  [ 228] Yield value:reg7
+  [ 230] Yield value:reg7
 
 block16:
-  [ 238] Call dst:reg19, callee:reg18, this_value:reg8, arguments:[reg7]
-  [ 260] ThrowIfNotObject src:reg19
-  [ 268] GetById dst:reg13, base:reg19, `done`
-  [ 280] JumpFalse condition:reg13, target:block18
+  [ 240] Call dst:reg19, callee:reg18, this_value:reg8, arguments:[reg7]
+  [ 268] ThrowIfNotObject src:reg19
+  [ 270] GetById dst:reg13, base:reg19, `done`
+  [ 288] JumpFalse condition:reg13, target:block18
 
 block17:
-  [ 290] GetById dst:reg20, base:reg19, `value`
-  [ 2a8] Yield value:reg20
+  [ 298] GetById dst:reg20, base:reg19, `value`
+  [ 2b0] Yield value:reg20
 
 block18:
-  [ 2b8] YieldIteratorResult continuation_label:block3, value:reg19
+  [ 2c0] YieldIteratorResult continuation_label:block3, value:reg19

--- a/Tests/LibJS/Bytecode/expected/generator-yield.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield.txt
@@ -1,23 +1,24 @@
-$205805b7 generator-yield.js:11:1
+$aa05d16f generator-yield.js:11:1
   Registers: 9
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `multi_yield`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, multi_yield
-  [  30] SetGlobal `g`, src:reg5
-  [  40] GetGlobal dst:reg6, `g`
-  [  50] GetById dst:reg7, base:reg6, `next` (g.next)
-  [  68] Call dst:reg5, callee:reg7, this_value:reg6, g.next
-  [  88] GetGlobal dst:reg6, `g`
-  [  98] GetById dst:reg8, base:reg6, `next` (g.next)
-  [  b0] Call dst:reg7, callee:reg8, this_value:reg6, g.next
-  [  d0] End value:reg7
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `multi_yield`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, multi_yield
+  [  38] SetGlobal `g`, src:reg5
+  [  48] GetGlobal dst:reg6, `g`
+  [  58] GetById dst:reg7, base:reg6, `next` (g.next)
+  [  70] Call dst:reg5, callee:reg7, this_value:reg6, g.next
+  [  90] GetGlobal dst:reg6, `g`
+  [  a0] GetById dst:reg8, base:reg6, `next` (g.next)
+  [  b8] Call dst:reg7, callee:reg8, this_value:reg6, g.next
+  [  d8] End value:reg7
 
 
-multi_yield$7e2d183f generator-yield.js:7:5
+multi_yield$ff8f10c7 generator-yield.js:7:5
   Registers: 10
   Blocks:    12
   Constants:
@@ -27,41 +28,42 @@ multi_yield$7e2d183f generator-yield.js:7:5
     [3] = Int32(2)
 
 block0:
-  [   0] Yield continuation_label:block1, value:Undefined
+  [   0] Enter
+  [   8] Yield continuation_label:block1, value:Undefined
 
 block1:
-  [  10] Yield continuation_label:block2, value:Int32(1)
+  [  18] Yield continuation_label:block2, value:Int32(1)
 
 block2:
-  [  20] Mov dst:reg5, src:reg0
-  [  30] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  40] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block3, false_target:block4
+  [  28] Mov dst:reg5, src:reg0
+  [  38] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [  48] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:1, true_target:block3, false_target:block4
 
 block3:
-  [  58] Yield continuation_label:block7, value:Int32(2)
+  [  60] Yield continuation_label:block7, value:Int32(2)
 
 block4:
-  [  68] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block5, false_target:block6
+  [  70] JumpStrictlyEqualsRhsInt32 lhs:reg6, rhs:5, true_target:block5, false_target:block6
 
 block5:
-  [  80] Throw src:reg7
+  [  88] Throw src:reg7
 
 block6:
-  [  88] Yield value:reg7
+  [  90] Yield value:reg7
 
 block7:
-  [  98] Mov dst:reg7, src:reg0
-  [  a8] GetCompletionFields type_dst:reg5, value_dst:reg6, completion:reg7
-  [  b8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block8, false_target:block9
+  [  a0] Mov dst:reg7, src:reg0
+  [  b0] GetCompletionFields type_dst:reg5, value_dst:reg6, completion:reg7
+  [  c0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block8, false_target:block9
 
 block8:
-  [  d0] Yield value:Undefined
+  [  d8] Yield value:Undefined
 
 block9:
-  [  e0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:5, true_target:block10, false_target:block11
+  [  e8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:5, true_target:block10, false_target:block11
 
 block10:
-  [  f8] Throw src:reg6
+  [ 100] Throw src:reg6
 
 block11:
-  [ 100] Yield value:reg6
+  [ 108] Yield value:reg6

--- a/Tests/LibJS/Bytecode/expected/global-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/global-variables.txt
@@ -1,16 +1,17 @@
-$afbf6828 global-variables.js:4:1
+$2089ba50 global-variables.js:4:1
   Registers: 9
   Blocks:    1
   Constants:
     [0] = Int32(1)
 
 block0:
-  [   0] SetGlobal `x`, src:Int32(1)
-  [  10] GetGlobal dst:reg6, `console`
-  [  20] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg8, `x`
-  [  48] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  70] End value:reg5
+  [   0] Enter
+  [   8] SetGlobal `x`, src:Int32(1)
+  [  18] GetGlobal dst:reg6, `console`
+  [  28] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  40] GetGlobal dst:reg8, `x`
+  [  50] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  78] End value:reg5
 
 
 1

--- a/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
@@ -1,17 +1,18 @@
-$36778e37 if-else-register-lifetime.js:11:1
+$c02559ef if-else-register-lifetime.js:11:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `test`
-  [  10] NewPrimitiveArray dst:reg7, elements:[1]
-  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[reg7]
-  [  50] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `test`
+  [  18] NewPrimitiveArray dst:reg7, elements:[1]
+  [  30] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[reg7]
+  [  58] End value:reg5
 
 
-test$64e627fa if-else-register-lifetime.js:2:5
+test$e3842f72 if-else-register-lifetime.js:2:5
   Registers: 13
   Blocks:    12
   Locals:    a~0, i~1, j~2
@@ -24,53 +25,54 @@ test$64e627fa if-else-register-lifetime.js:2:5
     [5] = Int32(3)
 
 block0:
-  [   0] MovUndefined3 c0_dst:a~0, c1_dst:i~1, c2_dst:j~2
-  [  10] Mov2 c0_dst:a~0, c0_src:Int32(1), c1_dst:i~1, c1_src:Int32(0)
-  [  28] Jump target:block3
+  [   0] Enter
+  [   8] MovUndefined3 c0_dst:a~0, c1_dst:i~1, c2_dst:j~2
+  [  18] Mov2 c0_dst:a~0, c0_src:Int32(1), c1_dst:i~1, c1_src:Int32(0)
+  [  30] Jump target:block3
 
 block1:
-  [  30] Mov dst:j~2, src:Int32(0)
-  [  40] Jump target:block7
+  [  38] Mov dst:j~2, src:Int32(0)
+  [  48] Jump target:block7
 
 block2:
-  [  48] PostfixIncrement dst:reg5, src:i~1
+  [  50] PostfixIncrement dst:reg5, src:i~1
 
 block3:
-  [  58] JumpLessThanRhsInt32 lhs:i~1, rhs:10, true_target:block1, false_target:block4
+  [  60] JumpLessThanRhsInt32 lhs:i~1, rhs:10, true_target:block1, false_target:block4
 
 block4:
-  [  70] GetGlobal dst:reg7, `parseInt`
-  [  80] Mov dst:reg10, src:a~0
-  [  90] Call dst:reg5, callee:reg7, this_value:Undefined, parseInt, arguments:[reg10]
-  [  b8] Return value:reg5
+  [  78] GetGlobal dst:reg7, `parseInt`
+  [  88] Mov dst:reg10, src:a~0
+  [  98] Call dst:reg5, callee:reg7, this_value:Undefined, parseInt, arguments:[reg10]
+  [  c0] Return value:reg5
 
 block5:
-  [  c0] JumpLessThanRhsInt32 lhs:j~2, rhs:5, true_target:block9, false_target:block10
+  [  c8] JumpLessThanRhsInt32 lhs:j~2, rhs:5, true_target:block9, false_target:block10
 
 block6:
-  [  d8] PostfixIncrement dst:reg5, src:j~2
+  [  e0] PostfixIncrement dst:reg5, src:j~2
 
 block7:
-  [  e8] JumpLessThanRhsInt32 lhs:j~2, rhs:10, true_target:block5, false_target:block8
+  [  f0] JumpLessThanRhsInt32 lhs:j~2, rhs:10, true_target:block5, false_target:block8
 
 block8:
-  [ 100] Jump target:block2
+  [ 108] Jump target:block2
 
 block9:
-  [ 108] Mov3 c0_dst:reg6, c0_src:arg0, c1_dst:reg7, c1_src:j~2, c2_dst:reg8, c2_src:arg0
-  [ 128] Add dst:reg9, lhs:i~1, rhs:j~2
-  [ 138] GetByValue dst:reg10, base:reg8, property:reg9 (x[reg9])
-  [ 150] PutByValue base:reg6, property:reg7, src:reg10, kind:Normal (x[reg7])
-  [ 168] Jump target:block11
+  [ 110] Mov3 c0_dst:reg6, c0_src:arg0, c1_dst:reg7, c1_src:j~2, c2_dst:reg8, c2_src:arg0
+  [ 130] Add dst:reg9, lhs:i~1, rhs:j~2
+  [ 140] GetByValue dst:reg10, base:reg8, property:reg9 (x[reg9])
+  [ 158] PutByValue base:reg6, property:reg7, src:reg10, kind:Normal (x[reg7])
+  [ 170] Jump target:block11
 
 block10:
-  [ 170] Mov2 c0_dst:reg10, c0_src:arg0, c1_dst:reg6, c1_src:j~2
-  [ 188] GetGlobal dst:reg8, `parseInt`
-  [ 198] Mov dst:reg9, src:arg0
-  [ 1a8] SubRhsInt32 dst:reg11, lhs:j~2, rhs:3
-  [ 1b8] GetByValue dst:reg12, base:reg9, property:reg11 (x[reg11])
-  [ 1d0] Call dst:reg7, callee:reg8, this_value:Undefined, parseInt, arguments:[reg12, Int32(1)]
-  [ 1f8] PutByValue base:reg10, property:reg6, src:reg7, kind:Normal (x[reg6])
+  [ 178] Mov2 c0_dst:reg10, c0_src:arg0, c1_dst:reg6, c1_src:j~2
+  [ 190] GetGlobal dst:reg8, `parseInt`
+  [ 1a0] Mov dst:reg9, src:arg0
+  [ 1b0] SubRhsInt32 dst:reg11, lhs:j~2, rhs:3
+  [ 1c0] GetByValue dst:reg12, base:reg9, property:reg11 (x[reg11])
+  [ 1d8] Call dst:reg7, callee:reg8, this_value:Undefined, parseInt, arguments:[reg12, Int32(1)]
+  [ 200] PutByValue base:reg10, property:reg6, src:reg7, kind:Normal (x[reg6])
 
 block11:
-  [ 210] Jump target:block6
+  [ 218] Jump target:block6

--- a/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
+++ b/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
@@ -1,4 +1,4 @@
-$0c4fbf6d indexed-append-guards.js:16:1
+$8db1b7f5 indexed-append-guards.js:16:1
   Registers: 11
   Blocks:    7
   Constants:
@@ -14,68 +14,69 @@ $0c4fbf6d indexed-append-guards.js:16:1
     [9] = String("Array append mutated")
 
 block0:
-  [   0] GetGlobal dst:reg6, `Object`
-  [  10] GetById dst:reg7, base:reg6, `preventExtensions` (Object.preventExtensions)
-  [  28] NewObject dst:reg8
-  [  38] ToPrimitiveWithStringHint dst:Int32(0), value:Int32(0)
-  [  48] PutByValue base:reg8, property:Int32(0), src:Int32(1), kind:Own
-  [  60] Call dst:reg5, callee:reg7, this_value:reg6, Object.preventExtensions, arguments:[reg8]
-  [  88] DynamicInitializeLexicalBinding `object`, src:reg5
-  [  98] GetGlobal dst:reg7, `expect_type_error`
-  [  a8] NewFunction dst:reg6, shared_function_data_index:0
-  [  c0] Call dst:reg5, callee:reg7, this_value:Undefined, expect_type_error, arguments:[reg6]
-  [  e8] GetGlobal dst:reg7, `object`
-  [  f8] GetByValue dst:reg6, base:reg7, property:Int32(1) (object[Int32(1)])
-  [ 110] StrictlyInequals dst:reg7, lhs:reg6, rhs:Undefined
-  [ 120] MovSrcUndefined dst:reg6
-  [ 128] JumpFalse condition:reg7, target:block2
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `Object`
+  [  18] GetById dst:reg7, base:reg6, `preventExtensions` (Object.preventExtensions)
+  [  30] NewObject dst:reg8
+  [  40] ToPrimitiveWithStringHint dst:Int32(0), value:Int32(0)
+  [  50] PutByValue base:reg8, property:Int32(0), src:Int32(1), kind:Own
+  [  68] Call dst:reg5, callee:reg7, this_value:reg6, Object.preventExtensions, arguments:[reg8]
+  [  90] DynamicInitializeLexicalBinding `object`, src:reg5
+  [  a0] GetGlobal dst:reg7, `expect_type_error`
+  [  b0] NewFunction dst:reg6, shared_function_data_index:0
+  [  c8] Call dst:reg5, callee:reg7, this_value:Undefined, expect_type_error, arguments:[reg6]
+  [  f0] GetGlobal dst:reg7, `object`
+  [ 100] GetByValue dst:reg6, base:reg7, property:Int32(1) (object[Int32(1)])
+  [ 118] StrictlyInequals dst:reg7, lhs:reg6, rhs:Undefined
+  [ 128] MovSrcUndefined dst:reg6
+  [ 130] JumpFalse condition:reg7, target:block2
 
 block1:
-  [ 138] GetGlobal dst:reg9, `Error`
-  [ 148] CallConstruct dst:reg8, callee:reg9, Error, arguments:[String("Indexed object append mutated")]
-  [ 168] Throw src:reg8
+  [ 140] GetGlobal dst:reg9, `Error`
+  [ 150] CallConstruct dst:reg8, callee:reg9, Error, arguments:[String("Indexed object append mutated")]
+  [ 170] Throw src:reg8
 
 block2:
-  [ 170] NewPrimitiveArray dst:reg5, elements:[1, 2]
-  [ 190] DynamicInitializeLexicalBinding `array`, src:reg5
-  [ 1a0] GetGlobal dst:reg7, `Object`
-  [ 1b0] GetById dst:reg8, base:reg7, `defineProperty` (Object.defineProperty)
-  [ 1c8] GetGlobal dst:reg9, `array`
-  [ 1d8] NewObject dst:reg10
-  [ 1e8] InitObjectLiteralProperty object:reg10, `writable`, src:Bool(false), shape_cache_index:0, property_slot:0
-  [ 200] CacheObjectShape object:reg10
-  [ 210] Call dst:reg5, callee:reg8, this_value:reg7, Object.defineProperty, arguments:[reg9, String("length"), reg10]
-  [ 240] GetGlobal dst:reg8, `expect_type_error`
-  [ 250] NewFunction dst:reg7, shared_function_data_index:1
-  [ 268] Call dst:reg6, callee:reg8, this_value:Undefined, expect_type_error, arguments:[reg7]
-  [ 290] GetGlobal dst:reg5, `array`
-  [ 2a0] GetLength dst:reg8, base:reg5 (array.length)
-  [ 2b8] StrictlyInequalsRhsInt32 dst:reg5, lhs:reg8, rhs:2
-  [ 2c8] MovSrcUndefined dst:reg8
-  [ 2d0] JumpFalse condition:reg5, target:block4
+  [ 178] NewPrimitiveArray dst:reg5, elements:[1, 2]
+  [ 198] DynamicInitializeLexicalBinding `array`, src:reg5
+  [ 1a8] GetGlobal dst:reg7, `Object`
+  [ 1b8] GetById dst:reg8, base:reg7, `defineProperty` (Object.defineProperty)
+  [ 1d0] GetGlobal dst:reg9, `array`
+  [ 1e0] NewObject dst:reg10
+  [ 1f0] InitObjectLiteralProperty object:reg10, `writable`, src:Bool(false), shape_cache_index:0, property_slot:0
+  [ 208] CacheObjectShape object:reg10
+  [ 218] Call dst:reg5, callee:reg8, this_value:reg7, Object.defineProperty, arguments:[reg9, String("length"), reg10]
+  [ 248] GetGlobal dst:reg8, `expect_type_error`
+  [ 258] NewFunction dst:reg7, shared_function_data_index:1
+  [ 270] Call dst:reg6, callee:reg8, this_value:Undefined, expect_type_error, arguments:[reg7]
+  [ 298] GetGlobal dst:reg5, `array`
+  [ 2a8] GetLength dst:reg8, base:reg5 (array.length)
+  [ 2c0] StrictlyInequalsRhsInt32 dst:reg5, lhs:reg8, rhs:2
+  [ 2d0] MovSrcUndefined dst:reg8
+  [ 2d8] JumpFalse condition:reg5, target:block4
 
 block3:
-  [ 2e0] GetGlobal dst:reg10, `Error`
-  [ 2f0] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array length changed")]
-  [ 310] Throw src:reg7
+  [ 2e8] GetGlobal dst:reg10, `Error`
+  [ 2f8] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array length changed")]
+  [ 318] Throw src:reg7
 
 block4:
-  [ 318] GetGlobal dst:reg6, `array`
-  [ 328] GetByValue dst:reg5, base:reg6, property:Int32(2) (array[Int32(2)])
-  [ 340] StrictlyInequals dst:reg6, lhs:reg5, rhs:Undefined
-  [ 350] MovSrcUndefined dst:reg5
-  [ 358] JumpFalse condition:reg6, target:block6
+  [ 320] GetGlobal dst:reg6, `array`
+  [ 330] GetByValue dst:reg5, base:reg6, property:Int32(2) (array[Int32(2)])
+  [ 348] StrictlyInequals dst:reg6, lhs:reg5, rhs:Undefined
+  [ 358] MovSrcUndefined dst:reg5
+  [ 360] JumpFalse condition:reg6, target:block6
 
 block5:
-  [ 368] GetGlobal dst:reg10, `Error`
-  [ 378] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array append mutated")]
-  [ 398] Throw src:reg7
+  [ 370] GetGlobal dst:reg10, `Error`
+  [ 380] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array append mutated")]
+  [ 3a0] Throw src:reg7
 
 block6:
-  [ 3a0] End value:reg5
+  [ 3a8] End value:reg5
 
 
-expect_type_error$fc915998 indexed-append-guards.js:4:5
+expect_type_error$7df35220 indexed-append-guards.js:4:5
   Registers: 9
   Blocks:    8
   Locals:    error~0, did_throw~1
@@ -86,46 +87,47 @@ expect_type_error$fc915998 indexed-append-guards.js:4:5
     [3] = String("Expected TypeError")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:did_throw~1, src:Bool(false)
-  [  18] Jump target:block5
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:did_throw~1, src:Bool(false)
+  [  20] Jump target:block5
 
 block1:
-  [  20] Catch dst:reg5
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Mov dst:error~0, src:reg5
-  [  40] GetGlobal dst:reg7, `TypeError`
-  [  50] InstanceOf dst:reg8, lhs:error~0, rhs:reg7
-  [  60] Not dst:reg6, src:reg8
-  [  70] JumpFalse condition:reg6, target:block3
+  [  28] Catch dst:reg5
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Mov dst:error~0, src:reg5
+  [  48] GetGlobal dst:reg7, `TypeError`
+  [  58] InstanceOf dst:reg8, lhs:error~0, rhs:reg7
+  [  68] Not dst:reg6, src:reg8
+  [  78] JumpFalse condition:reg6, target:block3
 
 block2:
-  [  80] Throw src:error~0
+  [  88] Throw src:error~0
 
 block3:
-  [  88] Mov dst:did_throw~1, src:Bool(true)
+  [  90] Mov dst:did_throw~1, src:Bool(true)
 
 block4:
-  [  98] Not dst:reg5, src:did_throw~1
-  [  a8] JumpIf condition:reg5, true_target:block6, false_target:block7
+  [  a0] Not dst:reg5, src:did_throw~1
+  [  b0] JumpIf condition:reg5, true_target:block6, false_target:block7
 
 block5:
-  [  b8] Call dst:reg5, callee:arg0, this_value:Undefined, callback
-  [  d8] Jump target:block4
+  [  c0] Call dst:reg5, callee:arg0, this_value:Undefined, callback
+  [  e0] Jump target:block4
 
 block6:
-  [  e0] GetGlobal dst:reg8, `Error`
-  [  f0] CallConstruct dst:reg6, callee:reg8, Error, arguments:[String("Expected TypeError")]
-  [ 110] Throw src:reg6
+  [  e8] GetGlobal dst:reg8, `Error`
+  [  f8] CallConstruct dst:reg6, callee:reg8, Error, arguments:[String("Expected TypeError")]
+  [ 118] Throw src:reg6
 
 block7:
-  [ 118] End value:Undefined
+  [ 120] End value:Undefined
 
 Exception handlers:
-  [  b8 ..   e0] => handler block1
+  [  c0 ..   e8] => handler block1
 
 
-$ec717972 indexed-append-guards.js:18:5
+$6dd371fa indexed-append-guards.js:18:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -134,12 +136,13 @@ $ec717972 indexed-append-guards.js:18:5
     [2] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg5, `object`
-  [  10] PutByValue base:reg5, property:Int32(1), src:Int32(2), kind:Normal (object[Int32(1)])
-  [  28] End value:Undefined
+  [   0] Enter
+  [   8] GetGlobal dst:reg5, `object`
+  [  18] PutByValue base:reg5, property:Int32(1), src:Int32(2), kind:Normal (object[Int32(1)])
+  [  30] End value:Undefined
 
 
-$01eb2052 indexed-append-guards.js:26:5
+$7b0145aa indexed-append-guards.js:26:5
   Registers: 8
   Blocks:    1
   Constants:
@@ -147,8 +150,9 @@ $01eb2052 indexed-append-guards.js:26:5
     [1] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg5, `array`
-  [  10] GetGlobal dst:reg6, `array`
-  [  20] GetLength dst:reg7, base:reg6 (array.length)
-  [  38] PutByValue base:reg5, property:reg7, src:Int32(3), kind:Normal (array[reg7])
-  [  50] End value:Undefined
+  [   0] Enter
+  [   8] GetGlobal dst:reg5, `array`
+  [  18] GetGlobal dst:reg6, `array`
+  [  28] GetLength dst:reg7, base:reg6 (array.length)
+  [  40] PutByValue base:reg5, property:reg7, src:Int32(3), kind:Normal (array[reg7])
+  [  58] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/int32-binary-specializations.txt
+++ b/Tests/LibJS/Bytecode/expected/int32-binary-specializations.txt
@@ -1,4 +1,4 @@
-$646081a0 int32-binary-specializations.js:20:1
+$e5c27a28 int32-binary-specializations.js:20:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $646081a0 int32-binary-specializations.js:20:1
     [1] = Int32(8)
 
 block0:
-  [   0] GetGlobal dst:reg6, `int32_binary_specializations`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, int32_binary_specializations, arguments:[Int32(8)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `int32_binary_specializations`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, int32_binary_specializations, arguments:[Int32(8)]
+  [  40] End value:reg5
 
 
-int32_binary_specializations$e0948c88 int32-binary-specializations.js:2:5
+int32_binary_specializations$61f68510 int32-binary-specializations.js:2:5
   Registers: 20
   Blocks:    1
   Constants:
@@ -19,19 +20,20 @@ int32_binary_specializations$e0948c88 int32-binary-specializations.js:2:5
     [1] = Double(2.5)
 
 block0:
-  [   0] AddLhsInt32 dst:reg5, lhs:2, rhs:arg0
-  [  10] AddRhsInt32 dst:reg6, lhs:arg0, rhs:2
-  [  20] SubRhsInt32 dst:reg7, lhs:arg0, rhs:2
-  [  30] MulRhsInt32 dst:reg8, lhs:arg0, rhs:2
-  [  40] ExpRhsInt32 dst:reg9, lhs:arg0, rhs:2
-  [  50] DivRhsInt32 dst:reg10, lhs:arg0, rhs:2
-  [  60] BitwiseXorRhsInt32 dst:reg11, lhs:arg0, rhs:2
-  [  70] BitwiseAndRhsInt32 dst:reg12, lhs:arg0, rhs:2
-  [  80] BitwiseOrRhsInt32 dst:reg13, lhs:arg0, rhs:2
-  [  90] LeftShiftRhsInt32 dst:reg14, lhs:arg0, rhs:2
-  [  a0] RightShiftRhsInt32 dst:reg15, lhs:arg0, rhs:2
-  [  b0] UnsignedRightShiftRhsInt32 dst:reg16, lhs:arg0, rhs:2
-  [  c0] ModRhsInt32 dst:reg17, lhs:arg0, rhs:2
-  [  d0] Add dst:reg18, lhs:arg0, rhs:Double(2.5)
-  [  e0] NewArray dst:reg19, elements:[reg5, reg6, reg7, reg8, reg9, reg10, reg11, reg12, reg13, reg14, reg15, reg16, reg17, reg18]
-  [ 128] Return value:reg19
+  [   0] Enter
+  [   8] AddLhsInt32 dst:reg5, lhs:2, rhs:arg0
+  [  18] AddRhsInt32 dst:reg6, lhs:arg0, rhs:2
+  [  28] SubRhsInt32 dst:reg7, lhs:arg0, rhs:2
+  [  38] MulRhsInt32 dst:reg8, lhs:arg0, rhs:2
+  [  48] ExpRhsInt32 dst:reg9, lhs:arg0, rhs:2
+  [  58] DivRhsInt32 dst:reg10, lhs:arg0, rhs:2
+  [  68] BitwiseXorRhsInt32 dst:reg11, lhs:arg0, rhs:2
+  [  78] BitwiseAndRhsInt32 dst:reg12, lhs:arg0, rhs:2
+  [  88] BitwiseOrRhsInt32 dst:reg13, lhs:arg0, rhs:2
+  [  98] LeftShiftRhsInt32 dst:reg14, lhs:arg0, rhs:2
+  [  a8] RightShiftRhsInt32 dst:reg15, lhs:arg0, rhs:2
+  [  b8] UnsignedRightShiftRhsInt32 dst:reg16, lhs:arg0, rhs:2
+  [  c8] ModRhsInt32 dst:reg17, lhs:arg0, rhs:2
+  [  d8] Add dst:reg18, lhs:arg0, rhs:Double(2.5)
+  [  e8] NewArray dst:reg19, elements:[reg5, reg6, reg7, reg8, reg9, reg10, reg11, reg12, reg13, reg14, reg15, reg16, reg17, reg18]
+  [ 130] Return value:reg19

--- a/Tests/LibJS/Bytecode/expected/int32-comparison-specializations.txt
+++ b/Tests/LibJS/Bytecode/expected/int32-comparison-specializations.txt
@@ -1,4 +1,4 @@
-$08de21bf int32-comparison-specializations.js:35:1
+$6e98afa7 int32-comparison-specializations.js:35:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,33 +6,35 @@ $08de21bf int32-comparison-specializations.js:35:1
     [1] = Int32(1)
 
 block0:
-  [   0] GetGlobal dst:reg6, `comparison_results`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, comparison_results, arguments:[Int32(1)]
-  [  38] GetGlobal dst:reg7, `comparison_jumps`
-  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, comparison_jumps, arguments:[Int32(1)]
-  [  70] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `comparison_results`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, comparison_results, arguments:[Int32(1)]
+  [  40] GetGlobal dst:reg7, `comparison_jumps`
+  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, comparison_jumps, arguments:[Int32(1)]
+  [  78] End value:reg6
 
 
-comparison_results$cb56ba16 int32-comparison-specializations.js:2:5
+comparison_results$4f7ca3ae int32-comparison-specializations.js:2:5
   Registers: 14
   Blocks:    1
   Constants:
     [0] = Int32(2)
 
 block0:
-  [   0] LessThanRhsInt32 dst:reg5, lhs:arg0, rhs:2
-  [  10] LessThanEqualsRhsInt32 dst:reg6, lhs:arg0, rhs:2
-  [  20] GreaterThanRhsInt32 dst:reg7, lhs:arg0, rhs:2
-  [  30] GreaterThanEqualsRhsInt32 dst:reg8, lhs:arg0, rhs:2
-  [  40] StrictlyEqualsRhsInt32 dst:reg9, lhs:arg0, rhs:2
-  [  50] StrictlyInequalsRhsInt32 dst:reg10, lhs:arg0, rhs:2
-  [  60] LooselyEqualsRhsInt32 dst:reg11, lhs:arg0, rhs:2
-  [  70] LooselyInequalsRhsInt32 dst:reg12, lhs:arg0, rhs:2
-  [  80] NewArray dst:reg13, elements:[reg5, reg6, reg7, reg8, reg9, reg10, reg11, reg12]
-  [  b0] Return value:reg13
+  [   0] Enter
+  [   8] LessThanRhsInt32 dst:reg5, lhs:arg0, rhs:2
+  [  18] LessThanEqualsRhsInt32 dst:reg6, lhs:arg0, rhs:2
+  [  28] GreaterThanRhsInt32 dst:reg7, lhs:arg0, rhs:2
+  [  38] GreaterThanEqualsRhsInt32 dst:reg8, lhs:arg0, rhs:2
+  [  48] StrictlyEqualsRhsInt32 dst:reg9, lhs:arg0, rhs:2
+  [  58] StrictlyInequalsRhsInt32 dst:reg10, lhs:arg0, rhs:2
+  [  68] LooselyEqualsRhsInt32 dst:reg11, lhs:arg0, rhs:2
+  [  78] LooselyInequalsRhsInt32 dst:reg12, lhs:arg0, rhs:2
+  [  88] NewArray dst:reg13, elements:[reg5, reg6, reg7, reg8, reg9, reg10, reg11, reg12]
+  [  b8] Return value:reg13
 
 
-comparison_jumps$ed0f09b6 int32-comparison-specializations.js:15:5
+comparison_jumps$6bad112e int32-comparison-specializations.js:15:5
   Registers: 8
   Blocks:    17
   Locals:    result~0
@@ -48,69 +50,70 @@ comparison_jumps$ed0f09b6 int32-comparison-specializations.js:15:5
     [8] = Int32(128)
 
 block0:
-  [   0] Mov dst:result~0, src:Int32(0)
-  [  10] JumpLessThanRhsInt32 lhs:arg0, rhs:2, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] Mov dst:result~0, src:Int32(0)
+  [  18] JumpLessThanRhsInt32 lhs:arg0, rhs:2, true_target:block1, false_target:block2
 
 block1:
-  [  28] Mov dst:reg6, src:result~0
-  [  38] AddRhsInt32 dst:reg7, lhs:reg6, rhs:1
-  [  48] Mov dst:result~0, src:reg7
+  [  30] Mov dst:reg6, src:result~0
+  [  40] AddRhsInt32 dst:reg7, lhs:reg6, rhs:1
+  [  50] Mov dst:result~0, src:reg7
 
 block2:
-  [  58] JumpLessThanEqualsRhsInt32 lhs:arg0, rhs:2, true_target:block3, false_target:block4
+  [  60] JumpLessThanEqualsRhsInt32 lhs:arg0, rhs:2, true_target:block3, false_target:block4
 
 block3:
-  [  70] Mov dst:reg7, src:result~0
-  [  80] AddRhsInt32 dst:reg6, lhs:reg7, rhs:2
-  [  90] Mov dst:result~0, src:reg6
+  [  78] Mov dst:reg7, src:result~0
+  [  88] AddRhsInt32 dst:reg6, lhs:reg7, rhs:2
+  [  98] Mov dst:result~0, src:reg6
 
 block4:
-  [  a0] JumpGreaterThanRhsInt32 lhs:arg0, rhs:2, true_target:block5, false_target:block6
+  [  a8] JumpGreaterThanRhsInt32 lhs:arg0, rhs:2, true_target:block5, false_target:block6
 
 block5:
-  [  b8] Mov dst:reg6, src:result~0
-  [  c8] AddRhsInt32 dst:reg7, lhs:reg6, rhs:4
-  [  d8] Mov dst:result~0, src:reg7
+  [  c0] Mov dst:reg6, src:result~0
+  [  d0] AddRhsInt32 dst:reg7, lhs:reg6, rhs:4
+  [  e0] Mov dst:result~0, src:reg7
 
 block6:
-  [  e8] JumpGreaterThanEqualsRhsInt32 lhs:arg0, rhs:2, true_target:block7, false_target:block8
+  [  f0] JumpGreaterThanEqualsRhsInt32 lhs:arg0, rhs:2, true_target:block7, false_target:block8
 
 block7:
-  [ 100] Mov dst:reg7, src:result~0
-  [ 110] AddRhsInt32 dst:reg6, lhs:reg7, rhs:8
-  [ 120] Mov dst:result~0, src:reg6
+  [ 108] Mov dst:reg7, src:result~0
+  [ 118] AddRhsInt32 dst:reg6, lhs:reg7, rhs:8
+  [ 128] Mov dst:result~0, src:reg6
 
 block8:
-  [ 130] JumpStrictlyEqualsRhsInt32 lhs:arg0, rhs:2, true_target:block9, false_target:block10
+  [ 138] JumpStrictlyEqualsRhsInt32 lhs:arg0, rhs:2, true_target:block9, false_target:block10
 
 block9:
-  [ 148] Mov dst:reg6, src:result~0
-  [ 158] AddRhsInt32 dst:reg7, lhs:reg6, rhs:16
-  [ 168] Mov dst:result~0, src:reg7
+  [ 150] Mov dst:reg6, src:result~0
+  [ 160] AddRhsInt32 dst:reg7, lhs:reg6, rhs:16
+  [ 170] Mov dst:result~0, src:reg7
 
 block10:
-  [ 178] JumpStrictlyInequalsRhsInt32 lhs:arg0, rhs:2, true_target:block11, false_target:block12
+  [ 180] JumpStrictlyInequalsRhsInt32 lhs:arg0, rhs:2, true_target:block11, false_target:block12
 
 block11:
-  [ 190] Mov dst:reg7, src:result~0
-  [ 1a0] AddRhsInt32 dst:reg6, lhs:reg7, rhs:32
-  [ 1b0] Mov dst:result~0, src:reg6
+  [ 198] Mov dst:reg7, src:result~0
+  [ 1a8] AddRhsInt32 dst:reg6, lhs:reg7, rhs:32
+  [ 1b8] Mov dst:result~0, src:reg6
 
 block12:
-  [ 1c0] JumpLooselyEqualsRhsInt32 lhs:arg0, rhs:2, true_target:block13, false_target:block14
+  [ 1c8] JumpLooselyEqualsRhsInt32 lhs:arg0, rhs:2, true_target:block13, false_target:block14
 
 block13:
-  [ 1d8] Mov dst:reg6, src:result~0
-  [ 1e8] AddRhsInt32 dst:reg7, lhs:reg6, rhs:64
-  [ 1f8] Mov dst:result~0, src:reg7
+  [ 1e0] Mov dst:reg6, src:result~0
+  [ 1f0] AddRhsInt32 dst:reg7, lhs:reg6, rhs:64
+  [ 200] Mov dst:result~0, src:reg7
 
 block14:
-  [ 208] JumpLooselyInequalsRhsInt32 lhs:arg0, rhs:2, true_target:block15, false_target:block16
+  [ 210] JumpLooselyInequalsRhsInt32 lhs:arg0, rhs:2, true_target:block15, false_target:block16
 
 block15:
-  [ 220] Mov dst:reg7, src:result~0
-  [ 230] AddRhsInt32 dst:reg6, lhs:reg7, rhs:128
-  [ 240] Mov dst:result~0, src:reg6
+  [ 228] Mov dst:reg7, src:result~0
+  [ 238] AddRhsInt32 dst:reg6, lhs:reg7, rhs:128
+  [ 248] Mov dst:result~0, src:reg6
 
 block16:
-  [ 250] Return value:result~0
+  [ 258] Return value:result~0

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
@@ -1,48 +1,51 @@
-$b8c00624 invalid-lhs-assignment-no-dead-code.js:8:1
+$2c4e495c invalid-lhs-assignment-no-dead-code.js:8:1
   Registers: 10
   Blocks:    3
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Jump target:block2
 
 block1:
-  [  10] Catch dst:reg5
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] Mov2 c0_dst:reg6, c0_src:Undefined, c1_dst:reg7, c1_src:reg6
-  [  38] End value:reg6
+  [  18] Catch dst:reg5
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] Mov2 c0_dst:reg6, c0_src:Undefined, c1_dst:reg7, c1_src:reg6
+  [  40] End value:reg6
 
 block2:
-  [  40] MovSrcUndefined dst:reg5
-  [  48] GetGlobal dst:reg8, `f`
-  [  58] NewFunction dst:reg9, shared_function_data_index:0
-  [  70] Call dst:reg6, callee:reg8, this_value:Undefined, f, arguments:[reg9]
-  [  98] Mov2 c0_dst:reg5, c0_src:reg6, c1_dst:reg6, c1_src:reg5
-  [  b0] End value:reg6
+  [  48] MovSrcUndefined dst:reg5
+  [  50] GetGlobal dst:reg8, `f`
+  [  60] NewFunction dst:reg9, shared_function_data_index:0
+  [  78] Call dst:reg6, callee:reg8, this_value:Undefined, f, arguments:[reg9]
+  [  a0] Mov2 c0_dst:reg5, c0_src:reg6, c1_dst:reg6, c1_src:reg5
+  [  b8] End value:reg6
 
 Exception handlers:
-  [  40 ..   b8] => handler block1
+  [  48 ..   c0] => handler block1
 
 
-f$36958900 invalid-lhs-assignment-no-dead-code.js:5:6
+f$cb5318f8 invalid-lhs-assignment-no-dead-code.js:5:6
   Registers: 6
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Call dst:reg5, callee:arg0, this_value:Undefined, x
-  [  20] NewReferenceError dst:reg5, Invalid left-hand side in assignment
-  [  30] Throw src:reg5
+  [   0] Enter
+  [   8] Call dst:reg5, callee:arg0, this_value:Undefined, x
+  [  28] NewReferenceError dst:reg5, Invalid left-hand side in assignment
+  [  38] Throw src:reg5
 
 
-$ccf7ed9d
+$4e59e625
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
@@ -1,30 +1,31 @@
-$95b394cd invalid-lhs-forin-no-dead-code.js:6:6
+$00f604d5 invalid-lhs-forin-no-dead-code.js:6:6
   Registers: 11
   Blocks:    6
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] NewArray dst:reg5
-  [  10] JumpNullish condition:reg5, true_target:block3, false_target:block4
+  [   0] Enter
+  [   8] NewArray dst:reg5
+  [  18] JumpNullish condition:reg5, true_target:block3, false_target:block4
 
 block1:
-  [  20] End value:reg5
+  [  28] End value:reg5
 
 block2:
-  [  28] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg6
-  [  38] JumpIf condition:reg8, true_target:block1, false_target:block5
+  [  30] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg6
+  [  40] JumpIf condition:reg8, true_target:block1, false_target:block5
 
 block3:
-  [  48] End value:reg5
+  [  50] End value:reg5
 
 block4:
-  [  50] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
-  [  60] MovSrcUndefined dst:reg5
-  [  68] Jump target:block2
+  [  58] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
+  [  68] MovSrcUndefined dst:reg5
+  [  70] Jump target:block2
 
 block5:
-  [  70] GetGlobal dst:reg10, `f`
-  [  80] Call dst:reg9, callee:reg10, this_value:Undefined, f
-  [  a0] NewReferenceError dst:reg9, Invalid left-hand side in assignment
-  [  b0] Throw src:reg9
+  [  78] GetGlobal dst:reg10, `f`
+  [  88] Call dst:reg9, callee:reg10, this_value:Undefined, f
+  [  a8] NewReferenceError dst:reg9, Invalid left-hand side in assignment
+  [  b8] Throw src:reg9

--- a/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
+++ b/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
@@ -1,51 +1,52 @@
-$e76f7008 lexical-env-teardown.js:13:1
+$660d7780 lexical-env-teardown.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  30] GetGlobal dst:reg9, `withTeardown`
-  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, withTeardown
-  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  88] GetGlobal dst:reg6, `console`
-  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  b0] GetGlobal dst:reg10, `blockTeardown`
-  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, blockTeardown
-  [  e0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 108] GetGlobal dst:reg8, `console`
-  [ 118] GetById dst:reg6, base:reg8, `log` (console.log)
-  [ 130] GetGlobal dst:reg10, `forInTeardown`
-  [ 140] Call dst:reg9, callee:reg10, this_value:Undefined, forInTeardown
-  [ 160] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
-  [ 188] GetGlobal dst:reg6, `console`
-  [ 198] GetById dst:reg8, base:reg6, `log` (console.log)
-  [ 1b0] GetGlobal dst:reg10, `forOfTeardown`
-  [ 1c0] Call dst:reg9, callee:reg10, this_value:Undefined, forOfTeardown
-  [ 1e0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 208] GetGlobal dst:reg8, `console`
-  [ 218] GetById dst:reg6, base:reg8, `log` (console.log)
-  [ 230] GetGlobal dst:reg10, `catchTeardown`
-  [ 240] Call dst:reg9, callee:reg10, this_value:Undefined, catchTeardown
-  [ 260] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
-  [ 288] CreateLexicalEnvironment dst:reg7, parent:reg4, capacity:0, is_catch_environment:false
-  [ 2a0] CreateVariable `myName`, is_immutable:true, is_global:false, is_strict:false
-  [ 2b0] NewFunction dst:reg6, shared_function_data_index:0
-  [ 2c8] InitializeLexicalBinding `myName`, src:reg6
-  [ 2e0] SetLexicalEnvironment environment:reg4
-  [ 2e8] SetGlobal `namedFn`, src:reg6
-  [ 2f8] GetGlobal dst:reg7, `console`
-  [ 308] GetById dst:reg8, base:reg7, `log` (console.log)
-  [ 320] GetGlobal dst:reg10, `namedFn`
-  [ 330] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
-  [ 350] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 378] End value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] GetGlobal dst:reg6, `console`
+  [  20] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  38] GetGlobal dst:reg9, `withTeardown`
+  [  48] Call dst:reg8, callee:reg9, this_value:Undefined, withTeardown
+  [  68] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  90] GetGlobal dst:reg6, `console`
+  [  a0] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b8] GetGlobal dst:reg10, `blockTeardown`
+  [  c8] Call dst:reg9, callee:reg10, this_value:Undefined, blockTeardown
+  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 110] GetGlobal dst:reg8, `console`
+  [ 120] GetById dst:reg6, base:reg8, `log` (console.log)
+  [ 138] GetGlobal dst:reg10, `forInTeardown`
+  [ 148] Call dst:reg9, callee:reg10, this_value:Undefined, forInTeardown
+  [ 168] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 190] GetGlobal dst:reg6, `console`
+  [ 1a0] GetById dst:reg8, base:reg6, `log` (console.log)
+  [ 1b8] GetGlobal dst:reg10, `forOfTeardown`
+  [ 1c8] Call dst:reg9, callee:reg10, this_value:Undefined, forOfTeardown
+  [ 1e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 210] GetGlobal dst:reg8, `console`
+  [ 220] GetById dst:reg6, base:reg8, `log` (console.log)
+  [ 238] GetGlobal dst:reg10, `catchTeardown`
+  [ 248] Call dst:reg9, callee:reg10, this_value:Undefined, catchTeardown
+  [ 268] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 290] CreateLexicalEnvironment dst:reg7, parent:reg4, capacity:0, is_catch_environment:false
+  [ 2a8] CreateVariable `myName`, is_immutable:true, is_global:false, is_strict:false
+  [ 2b8] NewFunction dst:reg6, shared_function_data_index:0
+  [ 2d0] InitializeLexicalBinding `myName`, src:reg6
+  [ 2e8] SetLexicalEnvironment environment:reg4
+  [ 2f0] SetGlobal `namedFn`, src:reg6
+  [ 300] GetGlobal dst:reg7, `console`
+  [ 310] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 328] GetGlobal dst:reg10, `namedFn`
+  [ 338] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
+  [ 358] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [ 380] End value:reg6
 
 
-withTeardown$748dfcb5 lexical-env-teardown.js:7:5
+withTeardown$f8b3e64d lexical-env-teardown.js:7:5
   Registers: 10
   Blocks:    1
   Locals:    inner~0
@@ -55,23 +56,24 @@ withTeardown$748dfcb5 lexical-env-teardown.js:7:5
     [2] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
-  [  20] CreateVariable `outer`, is_immutable:false, is_global:false, is_strict:false
-  [  30] InitializeLexicalBinding `outer`, src:Int32(1)
-  [  48] NewObject dst:reg6
-  [  58] InitObjectLiteralProperty object:reg6, `x`, src:Int32(10), shape_cache_index:0, property_slot:0
-  [  70] CacheObjectShape object:reg6
-  [  80] EnterObjectEnvironment dst:reg7, object:reg6
-  [  90] DynamicGetBinding dst:reg8, `x`
-  [  a0] DynamicGetBinding dst:reg9, `outer`
-  [  b0] Add dst:inner~0, lhs:reg8, rhs:reg9
-  [  c0] SetLexicalEnvironment environment:reg5
-  [  c8] GetBinding dst:reg6, `outer`
-  [  e0] Return value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
+  [  28] CreateVariable `outer`, is_immutable:false, is_global:false, is_strict:false
+  [  38] InitializeLexicalBinding `outer`, src:Int32(1)
+  [  50] NewObject dst:reg6
+  [  60] InitObjectLiteralProperty object:reg6, `x`, src:Int32(10), shape_cache_index:0, property_slot:0
+  [  78] CacheObjectShape object:reg6
+  [  88] EnterObjectEnvironment dst:reg7, object:reg6
+  [  98] DynamicGetBinding dst:reg8, `x`
+  [  a8] DynamicGetBinding dst:reg9, `outer`
+  [  b8] Add dst:inner~0, lhs:reg8, rhs:reg9
+  [  c8] SetLexicalEnvironment environment:reg5
+  [  d0] GetBinding dst:reg6, `outer`
+  [  e8] Return value:reg6
 
 
-blockTeardown$b6f5c4f0 lexical-env-teardown.js:17:5
+blockTeardown$3857bd78 lexical-env-teardown.js:17:5
   Registers: 5
   Blocks:    1
   Locals:    inner~0, outer~1
@@ -80,11 +82,12 @@ blockTeardown$b6f5c4f0 lexical-env-teardown.js:17:5
     [1] = Int32(3)
 
 block0:
-  [   0] Mov2 c0_dst:outer~1, c0_src:Int32(2), c1_dst:inner~0, c1_src:Int32(3)
-  [  18] Return value:outer~1
+  [   0] Enter
+  [   8] Mov2 c0_dst:outer~1, c0_src:Int32(2), c1_dst:inner~0, c1_src:Int32(3)
+  [  20] Return value:outer~1
 
 
-forInTeardown$fde78f98 lexical-env-teardown.js:28:5
+forInTeardown$7c859710 lexical-env-teardown.js:28:5
   Registers: 8
   Blocks:    6
   Locals:    k~0, outer~1
@@ -94,33 +97,34 @@ forInTeardown$fde78f98 lexical-env-teardown.js:28:5
     [2] = Int32(2)
 
 block0:
-  [   0] Mov dst:outer~1, src:Int32(4)
-  [  10] NewObject dst:reg5
-  [  20] InitObjectLiteralProperty object:reg5, `a`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  38] InitObjectLiteralProperty object:reg5, `b`, src:Int32(2), shape_cache_index:0, property_slot:1
-  [  50] CacheObjectShape object:reg5
-  [  60] JumpNullish condition:reg5, true_target:block3, false_target:block4
+  [   0] Enter
+  [   8] Mov dst:outer~1, src:Int32(4)
+  [  18] NewObject dst:reg5
+  [  28] InitObjectLiteralProperty object:reg5, `a`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  40] InitObjectLiteralProperty object:reg5, `b`, src:Int32(2), shape_cache_index:0, property_slot:1
+  [  58] CacheObjectShape object:reg5
+  [  68] JumpNullish condition:reg5, true_target:block3, false_target:block4
 
 block1:
-  [  70] Return value:outer~1
+  [  78] Return value:outer~1
 
 block2:
-  [  78] ObjectPropertyIteratorNext dst_value:reg5, dst_done:reg7, iterator_object:reg6
-  [  88] JumpIf condition:reg7, true_target:block1, false_target:block5
+  [  80] ObjectPropertyIteratorNext dst_value:reg5, dst_done:reg7, iterator_object:reg6
+  [  90] JumpIf condition:reg7, true_target:block1, false_target:block5
 
 block3:
-  [  98] Return value:outer~1
+  [  a0] Return value:outer~1
 
 block4:
-  [  a0] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
-  [  b0] Jump target:block2
+  [  a8] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
+  [  b8] Jump target:block2
 
 block5:
-  [  b8] Mov dst:k~0, src:reg5
-  [  c8] Jump target:block2
+  [  c0] Mov dst:k~0, src:reg5
+  [  d0] Jump target:block2
 
 
-forOfTeardown$269c4d7f lexical-env-teardown.js:38:5
+forOfTeardown$94a2ae97 lexical-env-teardown.js:38:5
   Registers: 12
   Blocks:    9
   Locals:    v~0, outer~1
@@ -131,48 +135,49 @@ forOfTeardown$269c4d7f lexical-env-teardown.js:38:5
     [3] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:outer~1, src:Int32(5)
-  [  18] NewPrimitiveArray dst:reg5, elements:[10, 20]
-  [  38] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
-  [  50] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:outer~1, src:Int32(5)
+  [  20] NewPrimitiveArray dst:reg5, elements:[10, 20]
+  [  40] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
+  [  58] Jump target:block2
 
 block1:
-  [  58] Return value:outer~1
+  [  60] Return value:outer~1
 
 block2:
-  [  60] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
-  [  78] JumpIf condition:reg11, true_target:block1, false_target:block4
+  [  68] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
+  [  80] JumpIf condition:reg11, true_target:block1, false_target:block4
 
 block3:
-  [  88] Catch dst:reg9
-  [  90] SetLexicalEnvironment environment:reg4
-  [  98] Mov dst:reg5, src:Int32(1)
-  [  a8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block5, false_target:block6
+  [  90] Catch dst:reg9
+  [  98] SetLexicalEnvironment environment:reg4
+  [  a0] Mov dst:reg5, src:Int32(1)
+  [  b0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block5, false_target:block6
 
 block4:
-  [  c0] Mov dst:v~0, src:reg10
-  [  d0] Jump target:block2
+  [  c8] Mov dst:v~0, src:reg10
+  [  d8] Jump target:block2
 
 block5:
-  [  d8] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
-  [  f0] Throw src:reg9
+  [  e0] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
+  [  f8] Throw src:reg9
 
 block6:
-  [  f8] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
-  [ 110] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block7, false_target:block8
+  [ 100] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
+  [ 118] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block7, false_target:block8
 
 block7:
-  [ 128] Return value:reg9
+  [ 130] Return value:reg9
 
 block8:
-  [ 130] Throw src:reg9
+  [ 138] Throw src:reg9
 
 Exception handlers:
-  [  c0 ..   d8] => handler block3
+  [  c8 ..   e0] => handler block3
 
 
-catchTeardown$6b833e8d lexical-env-teardown.js:48:5
+catchTeardown$ea214605 lexical-env-teardown.js:48:5
   Registers: 7
   Blocks:    3
   Locals:    e~0, outer~1
@@ -182,32 +187,34 @@ catchTeardown$6b833e8d lexical-env-teardown.js:48:5
     [2] = String("test")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:outer~1, src:Int32(6)
-  [  18] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:outer~1, src:Int32(6)
+  [  20] Jump target:block2
 
 block1:
-  [  20] Catch dst:reg5
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Mov dst:e~0, src:reg5
-  [  40] Return value:outer~1
+  [  28] Catch dst:reg5
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Mov dst:e~0, src:reg5
+  [  48] Return value:outer~1
 
 block2:
-  [  48] GetGlobal dst:reg6, `Error`
-  [  58] CallConstruct dst:reg5, callee:reg6, Error, arguments:[String("test")]
-  [  78] Throw src:reg5
+  [  50] GetGlobal dst:reg6, `Error`
+  [  60] CallConstruct dst:reg5, callee:reg6, Error, arguments:[String("test")]
+  [  80] Throw src:reg5
 
 Exception handlers:
-  [  48 ..   80] => handler block1
+  [  50 ..   88] => handler block1
 
 
-myName$2e6467bf lexical-env-teardown.js:60:5
+myName$b54e4267 lexical-env-teardown.js:60:5
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] DynamicTypeofBinding dst:reg5, `myName`
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] DynamicTypeofBinding dst:reg5, `myName`
+  [  18] Return value:reg5
 
 
 1

--- a/Tests/LibJS/Bytecode/expected/local-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/local-source-order.txt
@@ -1,16 +1,17 @@
-$546ebce0 local-source-order.js:12:1
+$c7fd0018 local-source-order.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `source_order_locals`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, source_order_locals
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `source_order_locals`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, source_order_locals
+  [  38] End value:reg5
 
 
-source_order_locals$4b1aeb83 local-source-order.js:6:5
+source_order_locals$c9b8f2fb local-source-order.js:6:5
   Registers: 7
   Blocks:    1
   Locals:    zebra~0, yak~1, aardvark~2
@@ -20,7 +21,8 @@ source_order_locals$4b1aeb83 local-source-order.js:6:5
     [2] = Int32(3)
 
 block0:
-  [   0] Mov3 c0_dst:zebra~0, c0_src:Int32(1), c1_dst:yak~1, c1_src:Int32(2), c2_dst:aardvark~2, c2_src:Int32(3)
-  [  20] Add dst:reg5, lhs:zebra~0, rhs:yak~1
-  [  30] Add dst:reg6, lhs:reg5, rhs:aardvark~2
-  [  40] Return value:reg6
+  [   0] Enter
+  [   8] Mov3 c0_dst:zebra~0, c0_src:Int32(1), c1_dst:yak~1, c1_src:Int32(2), c2_dst:aardvark~2, c2_src:Int32(3)
+  [  28] Add dst:reg5, lhs:zebra~0, rhs:yak~1
+  [  38] Add dst:reg6, lhs:reg5, rhs:aardvark~2
+  [  48] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/local-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/local-variables.txt
@@ -1,20 +1,21 @@
-$dd76a6f8 local-variables.js:20:1
+$53c8db40 local-variables.js:20:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `simple_let`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, simple_let
-  [  30] GetGlobal dst:reg7, `simple_const`
-  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, simple_const
-  [  60] GetGlobal dst:reg7, `multiple_locals`
-  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, multiple_locals
-  [  90] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `simple_let`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, simple_let
+  [  38] GetGlobal dst:reg7, `simple_const`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, simple_const
+  [  68] GetGlobal dst:reg7, `multiple_locals`
+  [  78] Call dst:reg5, callee:reg7, this_value:Undefined, multiple_locals
+  [  98] End value:reg5
 
 
-simple_let$40478631 local-variables.js:5:5
+simple_let$bee58da9 local-variables.js:5:5
   Registers: 5
   Blocks:    1
   Locals:    x~0
@@ -22,11 +23,12 @@ simple_let$40478631 local-variables.js:5:5
     [0] = Int32(1)
 
 block0:
-  [   0] Mov dst:x~0, src:Int32(1)
-  [  10] Return value:x~0
+  [   0] Enter
+  [   8] Mov dst:x~0, src:Int32(1)
+  [  18] Return value:x~0
 
 
-simple_const$80d5d79e local-variables.js:10:5
+simple_const$f7280be6 local-variables.js:10:5
   Registers: 5
   Blocks:    1
   Locals:    y~0
@@ -34,11 +36,12 @@ simple_const$80d5d79e local-variables.js:10:5
     [0] = Int32(2)
 
 block0:
-  [   0] Mov dst:y~0, src:Int32(2)
-  [  10] Return value:y~0
+  [   0] Enter
+  [   8] Mov dst:y~0, src:Int32(2)
+  [  18] Return value:y~0
 
 
-multiple_locals$77559ec6 local-variables.js:15:5
+multiple_locals$f8b7974e local-variables.js:15:5
   Registers: 6
   Blocks:    1
   Locals:    a~0, b~1
@@ -47,6 +50,7 @@ multiple_locals$77559ec6 local-variables.js:15:5
     [1] = Int32(2)
 
 block0:
-  [   0] Mov2 c0_dst:a~0, c0_src:Int32(1), c1_dst:b~1, c1_src:Int32(2)
-  [  18] Add dst:reg5, lhs:a~0, rhs:b~1
-  [  28] Return value:reg5
+  [   0] Enter
+  [   8] Mov2 c0_dst:a~0, c0_src:Int32(1), c1_dst:b~1, c1_src:Int32(2)
+  [  20] Add dst:reg5, lhs:a~0, rhs:b~1
+  [  30] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/logical-assignment-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-assignment-register-order.txt
@@ -1,17 +1,18 @@
-$7fd192c8 logical-assignment-register-order.js:2:7
+$11cb31b0 logical-assignment-register-order.js:2:7
   Registers: 8
   Blocks:    3
 
 block0:
-  [   0] GetGlobal dst:reg5, `value`
-  [  10] JumpFalse condition:reg5, target:block2
+  [   0] Enter
+  [   8] GetGlobal dst:reg5, `value`
+  [  18] JumpFalse condition:reg5, target:block2
 
 block1:
-  [  20] NewFunction dst:reg6, shared_function_data_index:0 (value)
-  [  38] Mov dst:reg7, src:reg6
-  [  48] SetGlobal `value`, src:reg7
-  [  58] End value:reg7
+  [  28] NewFunction dst:reg6, shared_function_data_index:0 (value)
+  [  40] Mov dst:reg7, src:reg6
+  [  50] SetGlobal `value`, src:reg7
+  [  60] End value:reg7
 
 block2:
-  [  60] Mov dst:reg7, src:reg5
-  [  70] End value:reg7
+  [  68] Mov dst:reg7, src:reg5
+  [  78] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/logical-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-constant-folding.txt
@@ -1,4 +1,4 @@
-$e52776fd logical-constant-folding.js:1:1
+$8230da25 logical-constant-folding.js:1:1
   Registers: 6
   Blocks:    1
   Constants:
@@ -10,11 +10,12 @@ $e52776fd logical-constant-folding.js:1:1
     [5] = Bool(true)
 
 block0:
-  [   0] SetGlobal `a`, src:Int32(42)
-  [  10] SetGlobal `b`, src:Int32(42)
-  [  20] SetGlobal `c`, src:Int32(0)
-  [  30] SetGlobal `d`, src:Int32(42)
-  [  40] SetGlobal `e`, src:Bool(true)
-  [  50] SetGlobal `f`, src:Int32(42)
-  [  60] SetGlobal `g`, src:Bool(false)
-  [  70] End value:Undefined
+  [   0] Enter
+  [   8] SetGlobal `a`, src:Int32(42)
+  [  18] SetGlobal `b`, src:Int32(42)
+  [  28] SetGlobal `c`, src:Int32(0)
+  [  38] SetGlobal `d`, src:Int32(42)
+  [  48] SetGlobal `e`, src:Bool(true)
+  [  58] SetGlobal `f`, src:Int32(42)
+  [  68] SetGlobal `g`, src:Bool(false)
+  [  78] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/logical-or-in-if-condition.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-or-in-if-condition.txt
@@ -1,4 +1,4 @@
-$c7fd0018 logical-or-in-if-condition.js:12:1
+$469b0790 logical-or-in-if-condition.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,32 +6,36 @@ $c7fd0018 logical-or-in-if-condition.js:12:1
     [1] = Bool(false)
 
 block0:
-  [   0] GetGlobal dst:reg6, `blocked`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, blocked, arguments:[Bool(false)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `blocked`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, blocked, arguments:[Bool(false)]
+  [  40] End value:reg5
 
 
-blocked$f2600453 logical-or-in-if-condition.js:7:9
+blocked$70fe0bcb logical-or-in-if-condition.js:7:9
   Registers: 6
-  Blocks:    6
+  Blocks:    7
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Mov dst:reg5, src:arg0
-  [  10] JumpIf condition:arg0, true_target:block3, false_target:block2
+  [   0] Enter
 
 block1:
-  [  20] End value:Undefined
+  [   8] Mov dst:reg5, src:arg0
+  [  18] JumpIf condition:arg0, true_target:block4, false_target:block3
 
 block2:
-  [  28] Mov dst:reg5, src:arg0
+  [  28] End value:Undefined
 
 block3:
-  [  38] JumpFalse condition:reg5, target:block5
+  [  30] Mov dst:reg5, src:arg0
 
 block4:
-  [  48] Jump target:block0
+  [  40] JumpFalse condition:reg5, target:block6
 
 block5:
   [  50] Jump target:block1
+
+block6:
+  [  58] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/logical-or-preferred-dst.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-or-preferred-dst.txt
@@ -1,4 +1,4 @@
-$ba9d77cf logical-or-preferred-dst.js:11:1
+$393b7f47 logical-or-preferred-dst.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,33 +6,37 @@ $ba9d77cf logical-or-preferred-dst.js:11:1
     [1] = Bool(false)
 
 block0:
-  [   0] GetGlobal dst:reg6, `blocked`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, blocked, arguments:[Bool(false)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `blocked`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, blocked, arguments:[Bool(false)]
+  [  40] End value:reg5
 
 
-blocked$0b29b642 logical-or-preferred-dst.js:6:9
+blocked$89c7bdba logical-or-preferred-dst.js:6:9
   Registers: 6
-  Blocks:    6
+  Blocks:    7
   Constants:
     [0] = Int32(0)
     [1] = Undefined
 
 block0:
-  [   0] Mov dst:reg5, src:arg0
-  [  10] JumpIf condition:arg0, true_target:block3, false_target:block2
+  [   0] Enter
 
 block1:
-  [  20] End value:Undefined
+  [   8] Mov dst:reg5, src:arg0
+  [  18] JumpIf condition:arg0, true_target:block4, false_target:block3
 
 block2:
-  [  28] GreaterThanRhsInt32 dst:reg5, lhs:arg0, rhs:0
+  [  28] End value:Undefined
 
 block3:
-  [  38] JumpFalse condition:reg5, target:block5
+  [  30] GreaterThanRhsInt32 dst:reg5, lhs:arg0, rhs:0
 
 block4:
-  [  48] Jump target:block0
+  [  40] JumpFalse condition:reg5, target:block6
 
 block5:
   [  50] Jump target:block1
+
+block6:
+  [  58] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/mov-merging.txt
+++ b/Tests/LibJS/Bytecode/expected/mov-merging.txt
@@ -1,24 +1,25 @@
-$37aa5f7d mov-merging.js:14:1
+$b64866f5 mov-merging.js:14:1
   Registers: 11
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `twoLocals`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, twoLocals
-  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  80] GetGlobal dst:reg6, `console`
-  [  90] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  a8] GetGlobal dst:reg10, `threeLocals`
-  [  b8] Call dst:reg9, callee:reg10, this_value:Undefined, threeLocals
-  [  d8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 100] End value:reg7
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `twoLocals`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, twoLocals
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] GetGlobal dst:reg6, `console`
+  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b0] GetGlobal dst:reg10, `threeLocals`
+  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, threeLocals
+  [  e0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 108] End value:reg7
 
 
-twoLocals$848f6408 mov-merging.js:2:5
+twoLocals$032d6b80 mov-merging.js:2:5
   Registers: 6
   Blocks:    1
   Locals:    a~0, b~1
@@ -27,12 +28,13 @@ twoLocals$848f6408 mov-merging.js:2:5
     [1] = Int32(2)
 
 block0:
-  [   0] Mov2 c0_dst:a~0, c0_src:Int32(1), c1_dst:b~1, c1_src:Int32(2)
-  [  18] Add dst:reg5, lhs:a~0, rhs:b~1
-  [  28] Return value:reg5
+  [   0] Enter
+  [   8] Mov2 c0_dst:a~0, c0_src:Int32(1), c1_dst:b~1, c1_src:Int32(2)
+  [  20] Add dst:reg5, lhs:a~0, rhs:b~1
+  [  30] Return value:reg5
 
 
-threeLocals$f4c3fc48 mov-merging.js:8:5
+threeLocals$7625f4d0 mov-merging.js:8:5
   Registers: 7
   Blocks:    1
   Locals:    a~0, b~1, c~2
@@ -42,10 +44,11 @@ threeLocals$f4c3fc48 mov-merging.js:8:5
     [2] = Int32(3)
 
 block0:
-  [   0] Mov3 c0_dst:a~0, c0_src:Int32(1), c1_dst:b~1, c1_src:Int32(2), c2_dst:c~2, c2_src:Int32(3)
-  [  20] Add dst:reg5, lhs:a~0, rhs:b~1
-  [  30] Add dst:reg6, lhs:reg5, rhs:c~2
-  [  40] Return value:reg6
+  [   0] Enter
+  [   8] Mov3 c0_dst:a~0, c0_src:Int32(1), c1_dst:b~1, c1_src:Int32(2), c2_dst:c~2, c2_src:Int32(3)
+  [  28] Add dst:reg5, lhs:a~0, rhs:b~1
+  [  38] Add dst:reg6, lhs:reg5, rhs:c~2
+  [  48] Return value:reg6
 
 
 3

--- a/Tests/LibJS/Bytecode/expected/named-class-expression-no-lhs-name-leak.txt
+++ b/Tests/LibJS/Bytecode/expected/named-class-expression-no-lhs-name-leak.txt
@@ -1,4 +1,4 @@
-$bc604c32 named-class-expression-no-lhs-name-leak.js:1:1
+$ee43eb0f named-class-expression-no-lhs-name-leak.js:1:1
   Registers: 15
   Blocks:    18
   Constants:
@@ -8,75 +8,76 @@ $bc604c32 named-class-expression-no-lhs-name-leak.js:1:1
     [3] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewArray dst:reg5
-  [  18] Mov dst:reg6, src:Bool(false)
-  [  28] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
-  [  40] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewArray dst:reg5
+  [  20] Mov dst:reg6, src:Bool(false)
+  [  30] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
+  [  48] Jump target:block3
 
 block1:
-  [  48] Catch dst:reg11
-  [  50] SetLexicalEnvironment environment:reg4
-  [  58] Mov dst:reg10, src:Int32(1)
-  [  68] JumpIf condition:reg9, true_target:block13, false_target:block12
+  [  50] Catch dst:reg11
+  [  58] SetLexicalEnvironment environment:reg4
+  [  60] Mov dst:reg10, src:Int32(1)
+  [  70] JumpIf condition:reg9, true_target:block13, false_target:block12
 
 block2:
-  [  78] End value:Undefined
+  [  80] End value:Undefined
 
 block3:
-  [  80] Jump target:block5
+  [  88] Jump target:block5
 
 block4:
-  [  88] MovSrcUndefined dst:reg12
-  [  90] Jump target:block6
+  [  90] MovSrcUndefined dst:reg12
+  [  98] Jump target:block6
 
 block5:
-  [  98] IteratorNextUnpack dst_value:reg12, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
-  [  b0] JumpTrue condition:reg6, target:block4
+  [  a0] IteratorNextUnpack dst_value:reg12, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
+  [  b8] JumpTrue condition:reg6, target:block4
 
 block6:
-  [  c0] JumpUndefined condition:reg12, true_target:block7, false_target:block8
+  [  c8] JumpUndefined condition:reg12, true_target:block7, false_target:block8
 
 block7:
-  [  d0] CreateLexicalEnvironment dst:reg13, parent:reg4, capacity:0, is_catch_environment:false
-  [  e8] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:true
-  [  f8] SetLexicalEnvironment environment:reg4
-  [ 100] NewClass dst:reg14, class_environment:reg13, class_blueprint_index:0
-  [ 120] Mov dst:reg12, src:reg14
+  [  d8] CreateLexicalEnvironment dst:reg13, parent:reg4, capacity:0, is_catch_environment:false
+  [  f0] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:true
+  [ 100] SetLexicalEnvironment environment:reg4
+  [ 108] NewClass dst:reg14, class_environment:reg13, class_blueprint_index:0
+  [ 128] Mov dst:reg12, src:reg14
 
 block8:
-  [ 130] SetGlobal `C`, src:reg12
+  [ 138] SetGlobal `C`, src:reg12
 
 block9:
-  [ 140] JumpFalse condition:reg9, target:block11
+  [ 148] JumpFalse condition:reg9, target:block11
 
 block10:
-  [ 150] Jump target:block2
+  [ 158] Jump target:block2
 
 block11:
-  [ 158] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 170] Jump target:block10
+  [ 160] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 178] Jump target:block10
 
 block12:
-  [ 178] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block14, false_target:block15
+  [ 180] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:1, true_target:block14, false_target:block15
 
 block13:
-  [ 190] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block16, false_target:block17
+  [ 198] JumpStrictlyEqualsRhsInt32 lhs:reg10, rhs:2, true_target:block16, false_target:block17
 
 block14:
-  [ 1a8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
-  [ 1c0] Throw src:reg11
+  [ 1b0] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:reg11
+  [ 1c8] Throw src:reg11
 
 block15:
-  [ 1c8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 1e0] Jump target:block13
+  [ 1d0] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 1e8] Jump target:block13
 
 block16:
-  [ 1e8] Return value:reg11
+  [ 1f0] Return value:reg11
 
 block17:
-  [ 1f0] Throw src:reg11
+  [ 1f8] Throw src:reg11
 
 Exception handlers:
-  [  80 ..   98] => handler block1
-  [  c0 ..  140] => handler block1
+  [  88 ..   a0] => handler block1
+  [  c8 ..  148] => handler block1

--- a/Tests/LibJS/Bytecode/expected/named-function-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/named-function-expression.txt
@@ -1,15 +1,16 @@
-$615c3fdf named-function-expression.js:4:6
+$e2be3867 named-function-expression.js:4:6
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `Oops`, is_immutable:true, is_global:false, is_strict:false
-  [  30] NewFunction dst:reg6, shared_function_data_index:0
-  [  48] InitializeLexicalBinding `Oops`, src:reg6
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] SetGlobal `Oops`, src:reg6
-  [  78] GetGlobal dst:reg5, `Oops`
-  [  88] GetById dst:reg7, base:reg5, `x` (Oops.x)
-  [  a0] End value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `Oops`, is_immutable:true, is_global:false, is_strict:false
+  [  38] NewFunction dst:reg6, shared_function_data_index:0
+  [  50] InitializeLexicalBinding `Oops`, src:reg6
+  [  68] SetLexicalEnvironment environment:reg4
+  [  70] SetGlobal `Oops`, src:reg6
+  [  80] GetGlobal dst:reg5, `Oops`
+  [  90] GetById dst:reg7, base:reg5, `x` (Oops.x)
+  [  a8] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
@@ -1,4 +1,4 @@
-$72cc050b nested-for-loop-completion.js:4:1
+$f42dfd93 nested-for-loop-completion.js:4:1
   Registers: 9
   Blocks:    8
   Constants:
@@ -10,36 +10,37 @@ $72cc050b nested-for-loop-completion.js:4:1
     [5] = Int32(2)
 
 block0:
-  [   0] SetGlobal `n`, src:Int32(4)
-  [  10] MovSrcUndefined dst:reg5
-  [  18] Jump target:block3
+  [   0] Enter
+  [   8] SetGlobal `n`, src:Int32(4)
+  [  18] MovSrcUndefined dst:reg5
+  [  20] Jump target:block3
 
 block1:
-  [  20] SetGlobal `depth`, src:Int32(0)
-  [  30] MovSrcUndefined dst:reg6
-  [  38] Jump target:block6
+  [  28] SetGlobal `depth`, src:Int32(0)
+  [  38] MovSrcUndefined dst:reg6
+  [  40] Jump target:block6
 
 block2:
-  [  40] GetGlobal dst:reg7, `n`
-  [  50] AddRhsInt32 dst:reg6, lhs:reg7, rhs:1
-  [  60] SetGlobal `n`, src:reg6
+  [  48] GetGlobal dst:reg7, `n`
+  [  58] AddRhsInt32 dst:reg6, lhs:reg7, rhs:1
+  [  68] SetGlobal `n`, src:reg6
 
 block3:
-  [  70] GetGlobal dst:reg6, `n`
-  [  80] JumpLessThanEqualsRhsInt32 lhs:reg6, rhs:7, true_target:block1, false_target:block4
+  [  78] GetGlobal dst:reg6, `n`
+  [  88] JumpLessThanEqualsRhsInt32 lhs:reg6, rhs:7, true_target:block1, false_target:block4
 
 block4:
-  [  98] End value:reg5
+  [  a0] End value:reg5
 
 block5:
-  [  a0] GetGlobal dst:reg8, `depth`
-  [  b0] AddRhsInt32 dst:reg7, lhs:reg8, rhs:2
-  [  c0] SetGlobal `depth`, src:reg7
+  [  a8] GetGlobal dst:reg8, `depth`
+  [  b8] AddRhsInt32 dst:reg7, lhs:reg8, rhs:2
+  [  c8] SetGlobal `depth`, src:reg7
 
 block6:
-  [  d0] GetGlobal dst:reg7, `depth`
-  [  e0] JumpLessThanEqualsRhsInt32 lhs:reg7, rhs:0, true_target:block5, false_target:block7
+  [  d8] GetGlobal dst:reg7, `depth`
+  [  e8] JumpLessThanEqualsRhsInt32 lhs:reg7, rhs:0, true_target:block5, false_target:block7
 
 block7:
-  [  f8] Mov dst:reg5, src:reg6
-  [ 108] Jump target:block2
+  [ 100] Mov dst:reg5, src:reg6
+  [ 110] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
@@ -1,4 +1,4 @@
-$01294703 nested-function-decl-source-order.js:15:1
+$7fc74e7b nested-function-decl-source-order.js:15:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -6,17 +6,18 @@ $01294703 nested-function-decl-source-order.js:15:1
     [1] = String(",")
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg10, `outer`
-  [  38] Call dst:reg9, callee:reg10, this_value:Undefined, outer
-  [  58] GetById dst:reg10, base:reg9, `join`
-  [  70] Call dst:reg8, callee:reg10, this_value:reg9, <object>.join, arguments:[String(",")]
-  [  98] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  c0] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg10, `outer`
+  [  40] Call dst:reg9, callee:reg10, this_value:Undefined, outer
+  [  60] GetById dst:reg10, base:reg9, `join`
+  [  78] Call dst:reg8, callee:reg10, this_value:reg9, <object>.join, arguments:[String(",")]
+  [  a0] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  c8] End value:reg5
 
 
-outer$8801e542 nested-function-decl-source-order.js:12:5
+outer$03dbfbaa nested-function-decl-source-order.js:12:5
   Registers: 11
   Blocks:    1
   Locals:    alpha~0, beta~1, dup~2, gamma~3, delta~4
@@ -24,70 +25,76 @@ outer$8801e542 nested-function-decl-source-order.js:12:5
     [0] = Undefined
 
 block0:
-  [   0] MovUndefined3 c0_dst:alpha~0, c1_dst:beta~1, c2_dst:dup~2
-  [  10] MovUndefined2 c0_dst:gamma~3, c1_dst:delta~4
-  [  20] NewFunction dst:alpha~0, shared_function_data_index:0
-  [  38] NewFunction dst:beta~1, shared_function_data_index:1
-  [  50] NewFunction dst:gamma~3, shared_function_data_index:2
-  [  68] NewFunction dst:dup~2, shared_function_data_index:3
-  [  80] NewFunction dst:delta~4, shared_function_data_index:4
-  [  98] Call dst:reg5, callee:alpha~0, this_value:Undefined, alpha
-  [  b8] Call dst:reg6, callee:beta~1, this_value:Undefined, beta
-  [  d8] Call dst:reg7, callee:gamma~3, this_value:Undefined, gamma
-  [  f8] Call dst:reg8, callee:delta~4, this_value:Undefined, delta
-  [ 118] Call dst:reg9, callee:dup~2, this_value:Undefined, dup
-  [ 138] NewArray dst:reg10, elements:[reg5, reg6, reg7, reg8, reg9]
-  [ 160] Return value:reg10
+  [   0] Enter
+  [   8] MovUndefined3 c0_dst:alpha~0, c1_dst:beta~1, c2_dst:dup~2
+  [  18] MovUndefined2 c0_dst:gamma~3, c1_dst:delta~4
+  [  28] NewFunction dst:alpha~0, shared_function_data_index:0
+  [  40] NewFunction dst:beta~1, shared_function_data_index:1
+  [  58] NewFunction dst:gamma~3, shared_function_data_index:2
+  [  70] NewFunction dst:dup~2, shared_function_data_index:3
+  [  88] NewFunction dst:delta~4, shared_function_data_index:4
+  [  a0] Call dst:reg5, callee:alpha~0, this_value:Undefined, alpha
+  [  c0] Call dst:reg6, callee:beta~1, this_value:Undefined, beta
+  [  e0] Call dst:reg7, callee:gamma~3, this_value:Undefined, gamma
+  [ 100] Call dst:reg8, callee:delta~4, this_value:Undefined, delta
+  [ 120] Call dst:reg9, callee:dup~2, this_value:Undefined, dup
+  [ 140] NewArray dst:reg10, elements:[reg5, reg6, reg7, reg8, reg9]
+  [ 168] Return value:reg10
 
 
-alpha$ddf1e99f nested-function-decl-source-order.js:6:24
+alpha$5f53e227 nested-function-decl-source-order.js:6:24
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(1)
 
 block0:
-  [   0] Return value:Int32(1)
+  [   0] Enter
+  [   8] Return value:Int32(1)
 
 
-beta$cbe393ff nested-function-decl-source-order.js:7:23
+beta$4d458c87 nested-function-decl-source-order.js:7:23
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(2)
 
 block0:
-  [   0] Return value:Int32(2)
+  [   0] Enter
+  [   8] Return value:Int32(2)
 
 
-gamma$4c5374eb nested-function-decl-source-order.js:9:24
+gamma$c82d8b53 nested-function-decl-source-order.js:9:24
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(3)
 
 block0:
-  [   0] Return value:Int32(3)
+  [   0] Enter
+  [   8] Return value:Int32(3)
 
 
-delta$fd075126 nested-function-decl-source-order.js:11:24
+delta$812d3abe nested-function-decl-source-order.js:11:24
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(4)
 
 block0:
-  [   0] Return value:Int32(4)
+  [   0] Enter
+  [   8] Return value:Int32(4)
 
 
-dup$5f4e2278 nested-function-decl-source-order.js:10:22
+dup$db2838e0 nested-function-decl-source-order.js:10:22
   Registers: 5
   Blocks:    1
   Constants:
     [0] = String("second")
 
 block0:
-  [   0] Return value:String("second")
+  [   0] Enter
+  [   8] Return value:String("second")
 
 
 "1,2,3,4,second"

--- a/Tests/LibJS/Bytecode/expected/nested-member-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-member-base-identifier.txt
@@ -1,4 +1,4 @@
-$1bd06a9d nested-member-base-identifier.js:9:1
+$9a6e7215 nested-member-base-identifier.js:9:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,16 +6,17 @@ $1bd06a9d nested-member-base-identifier.js:9:1
     [1] = Int32(1)
 
 block0:
-  [   0] GetGlobal dst:reg6, `assign_nested`
-  [  10] NewObject dst:reg7
-  [  20] InitObjectLiteralProperty object:reg7, `shader`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  38] CacheObjectShape object:reg7
-  [  48] NewArray dst:reg8, elements:[reg7]
-  [  60] Call dst:reg5, callee:reg6, this_value:Undefined, assign_nested, arguments:[reg8, Int32(1)]
-  [  88] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `assign_nested`
+  [  18] NewObject dst:reg7
+  [  28] InitObjectLiteralProperty object:reg7, `shader`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  40] CacheObjectShape object:reg7
+  [  50] NewArray dst:reg8, elements:[reg7]
+  [  68] Call dst:reg5, callee:reg6, this_value:Undefined, assign_nested, arguments:[reg8, Int32(1)]
+  [  90] End value:reg5
 
 
-assign_nested$93cc3898 nested-member-base-identifier.js:6:8
+assign_nested$126a4010 nested-member-base-identifier.js:6:8
   Registers: 8
   Blocks:    1
   Constants:
@@ -24,8 +25,9 @@ assign_nested$93cc3898 nested-member-base-identifier.js:6:8
     [2] = Undefined
 
 block0:
-  [   0] Mov dst:reg5, src:arg0
-  [  10] SubRhsInt32 dst:reg6, lhs:arg1, rhs:1
-  [  20] GetByValue dst:reg7, base:reg5, property:reg6 (arr[reg6])
-  [  38] PutById base:reg7, `shader`, src:Int32(0), kind:Normal (arr.shader)
-  [  58] End value:Undefined
+  [   0] Enter
+  [   8] Mov dst:reg5, src:arg0
+  [  18] SubRhsInt32 dst:reg6, lhs:arg1, rhs:1
+  [  28] GetByValue dst:reg7, base:reg5, property:reg6 (arr[reg6])
+  [  40] PutById base:reg7, `shader`, src:Int32(0), kind:Normal (arr.shader)
+  [  60] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
@@ -1,16 +1,17 @@
-$fb879d42 nested-try-finally-continue.js:14:1
+$853568fa nested-try-finally-continue.js:14:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `nestedTryFinallyContinue`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, nestedTryFinallyContinue
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `nestedTryFinallyContinue`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, nestedTryFinallyContinue
+  [  38] End value:reg5
 
 
-nestedTryFinallyContinue$498e9e46 nested-try-finally-continue.js:2:5
+nestedTryFinallyContinue$c82ca5be nested-try-finally-continue.js:2:5
   Registers: 13
   Blocks:    24
   Locals:    i~0
@@ -24,100 +25,101 @@ nestedTryFinallyContinue$498e9e46 nested-try-finally-continue.js:2:5
     [6] = String("outer")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:i~0, src:Int32(0)
-  [  18] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:i~0, src:Int32(0)
+  [  20] Jump target:block3
 
 block1:
-  [  20] Jump target:block7
+  [  28] Jump target:block7
 
 block2:
-  [  28] PostfixIncrement dst:reg5, src:i~0
+  [  30] PostfixIncrement dst:reg5, src:i~0
 
 block3:
-  [  38] JumpLessThanRhsInt32 lhs:i~0, rhs:3, true_target:block1, false_target:block4
+  [  40] JumpLessThanRhsInt32 lhs:i~0, rhs:3, true_target:block1, false_target:block4
 
 block4:
-  [  50] End value:Undefined
+  [  58] End value:Undefined
 
 block5:
-  [  58] Catch dst:reg6
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] Mov dst:reg5, src:Int32(1)
+  [  60] Catch dst:reg6
+  [  68] SetLexicalEnvironment environment:reg4
+  [  70] Mov dst:reg5, src:Int32(1)
 
 block6:
-  [  78] GetGlobal dst:reg8, `console`
-  [  88] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  a0] Mov dst:reg11, src:i~0
-  [  b0] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer"), reg11]
-  [  d8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block19, false_target:block20
+  [  80] GetGlobal dst:reg8, `console`
+  [  90] GetById dst:reg9, base:reg8, `log` (console.log)
+  [  a8] Mov dst:reg11, src:i~0
+  [  b8] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer"), reg11]
+  [  e0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block19, false_target:block20
 
 block7:
-  [  f0] Jump target:block10
+  [  f8] Jump target:block10
 
 block8:
-  [  f8] Catch dst:reg8
-  [ 100] SetLexicalEnvironment environment:reg4
-  [ 108] Mov dst:reg7, src:Int32(1)
+  [ 100] Catch dst:reg8
+  [ 108] SetLexicalEnvironment environment:reg4
+  [ 110] Mov dst:reg7, src:Int32(1)
 
 block9:
-  [ 118] GetGlobal dst:reg10, `console`
-  [ 128] GetById dst:reg11, base:reg10, `log` (console.log)
-  [ 140] Mov dst:reg12, src:i~0
-  [ 150] Call dst:reg9, callee:reg11, this_value:reg10, console.log, arguments:[String("inner"), reg12]
-  [ 178] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:0, true_target:block14, false_target:block15
+  [ 120] GetGlobal dst:reg10, `console`
+  [ 130] GetById dst:reg11, base:reg10, `log` (console.log)
+  [ 148] Mov dst:reg12, src:i~0
+  [ 158] Call dst:reg9, callee:reg11, this_value:reg10, console.log, arguments:[String("inner"), reg12]
+  [ 180] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:0, true_target:block14, false_target:block15
 
 block10:
-  [ 190] JumpStrictlyEqualsRhsInt32 lhs:i~0, rhs:1, true_target:block11, false_target:block12
+  [ 198] JumpStrictlyEqualsRhsInt32 lhs:i~0, rhs:1, true_target:block11, false_target:block12
 
 block11:
-  [ 1a8] Mov dst:reg7, src:Int32(3)
-  [ 1b8] Jump target:block9
+  [ 1b0] Mov dst:reg7, src:Int32(3)
+  [ 1c0] Jump target:block9
 
 block12:
-  [ 1c0] Mov dst:reg7, src:Int32(0)
-  [ 1d0] Jump target:block9
+  [ 1c8] Mov dst:reg7, src:Int32(0)
+  [ 1d8] Jump target:block9
 
 block13:
-  [ 1d8] Mov dst:reg5, src:Int32(3)
-  [ 1e8] Jump target:block6
+  [ 1e0] Mov dst:reg5, src:Int32(3)
+  [ 1f0] Jump target:block6
 
 block14:
-  [ 1f0] Mov dst:reg5, src:Int32(0)
-  [ 200] Jump target:block6
+  [ 1f8] Mov dst:reg5, src:Int32(0)
+  [ 208] Jump target:block6
 
 block15:
-  [ 208] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:3, true_target:block13, false_target:block16
+  [ 210] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:3, true_target:block13, false_target:block16
 
 block16:
-  [ 220] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:2, true_target:block17, false_target:block18
+  [ 228] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:2, true_target:block17, false_target:block18
 
 block17:
-  [ 238] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg6, c1_src:reg8
-  [ 250] Jump target:block6
+  [ 240] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg6, c1_src:reg8
+  [ 258] Jump target:block6
 
 block18:
-  [ 258] Throw src:reg8
+  [ 260] Throw src:reg8
 
 block19:
-  [ 260] Jump target:block2
+  [ 268] Jump target:block2
 
 block20:
-  [ 268] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block2, false_target:block21
+  [ 270] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block2, false_target:block21
 
 block21:
-  [ 280] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block22, false_target:block23
+  [ 288] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block22, false_target:block23
 
 block22:
-  [ 298] Return value:reg6
+  [ 2a0] Return value:reg6
 
 block23:
-  [ 2a0] Throw src:reg6
+  [ 2a8] Throw src:reg6
 
 Exception handlers:
-  [  f0 ..  190] => handler block5
-  [ 190 ..  1f0] => handler block8
-  [ 1f0 ..  260] => handler block5
+  [  f8 ..  198] => handler block5
+  [ 198 ..  1f8] => handler block8
+  [ 1f8 ..  268] => handler block5
 
 
 "inner" 0

--- a/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
@@ -1,4 +1,4 @@
-$745d24d5 numeric-class-field-name.js:1:1
+$f5bf1d5d numeric-class-field-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,36 +6,39 @@ $745d24d5 numeric-class-field-name.js:1:1
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:Int32(42)]
-  [  60] DynamicInitializeLexicalBinding `C`, src:reg6
-  [  70] GetGlobal dst:reg5, `C`
-  [  80] CallConstruct dst:reg6, callee:reg5, C
-  [  98] GetByValue dst:reg5, base:reg6, property:Int32(42)
-  [  b0] GetById dst:reg6, base:reg5, `name` ([42].name)
-  [  c8] End value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:Int32(42)]
+  [  68] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  78] GetGlobal dst:reg5, `C`
+  [  88] CallConstruct dst:reg6, callee:reg5, C
+  [  a0] GetByValue dst:reg5, base:reg6, property:Int32(42)
+  [  b8] GetById dst:reg6, base:reg5, `name` ([42].name)
+  [  d0] End value:reg6
 
 
-C$e7b179de
+C$638b9046
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-field$b1dc4a8f numeric-class-field-name.js:2:10
+field$307a5207 numeric-class-field-name.js:2:10
   Registers: 7
   Blocks:    1
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] SetLexicalEnvironment environment:reg4
-  [  28] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (42)
-  [  48] Return value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] SetLexicalEnvironment environment:reg4
+  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (42)
+  [  50] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/numeric-getter-no-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-getter-no-lhs-name.txt
@@ -1,26 +1,28 @@
-$87b8bc45 numeric-getter-no-lhs-name.js:1:1
+$091ab4cd numeric-getter-no-lhs-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Int32(0)
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] ToPrimitiveWithStringHint dst:Int32(0), value:Int32(0)
-  [  20] NewFunction dst:reg6, shared_function_data_index:0, home_object:reg5
-  [  38] SetFunctionName function:reg6, name:Int32(0)
-  [  48] PutByValue base:reg5, property:Int32(0), src:reg6, kind:Getter
-  [  60] SetGlobal `obj`, src:reg5
-  [  70] GetGlobal dst:reg5, `obj`
-  [  80] GetByValue dst:reg6, base:reg5, property:Int32(0) (obj[Int32(0)])
-  [  98] End value:reg6
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] ToPrimitiveWithStringHint dst:Int32(0), value:Int32(0)
+  [  28] NewFunction dst:reg6, shared_function_data_index:0, home_object:reg5
+  [  40] SetFunctionName function:reg6, name:Int32(0)
+  [  50] PutByValue base:reg5, property:Int32(0), src:reg6, kind:Getter
+  [  68] SetGlobal `obj`, src:reg5
+  [  78] GetGlobal dst:reg5, `obj`
+  [  88] GetByValue dst:reg6, base:reg5, property:Int32(0) (obj[Int32(0)])
+  [  a0] End value:reg6
 
 
-get 0$4c2eeb71 numeric-getter-no-lhs-name.js:3:9
+get 0$d054d509 numeric-getter-no-lhs-name.js:3:9
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(42)
 
 block0:
-  [   0] Return value:Int32(42)
+  [   0] Enter
+  [   8] Return value:Int32(42)

--- a/Tests/LibJS/Bytecode/expected/numeric-index-object-literal.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-index-object-literal.txt
@@ -1,16 +1,17 @@
-$bacf2c68 numeric-index-object-literal.js:4:1
+$2b997e90 numeric-index-object-literal.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `test`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `test`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  38] End value:reg5
 
 
-test$7e9a426c numeric-index-object-literal.js:2:5
+test$fd3849e4 numeric-index-object-literal.js:2:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -22,11 +23,12 @@ test$7e9a426c numeric-index-object-literal.js:2:5
     [5] = Int32(3)
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] ToPrimitiveWithStringHint dst:Int32(100), value:Int32(100)
-  [  20] PutByValue base:reg5, property:Int32(100), src:Int32(1), kind:Own
-  [  38] ToPrimitiveWithStringHint dst:Int32(200), value:Int32(200)
-  [  48] PutByValue base:reg5, property:Int32(200), src:Int32(2), kind:Own
-  [  60] ToPrimitiveWithStringHint dst:Int32(300), value:Int32(300)
-  [  70] PutByValue base:reg5, property:Int32(300), src:Int32(3), kind:Own
-  [  88] Return value:reg5
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] ToPrimitiveWithStringHint dst:Int32(100), value:Int32(100)
+  [  28] PutByValue base:reg5, property:Int32(100), src:Int32(1), kind:Own
+  [  40] ToPrimitiveWithStringHint dst:Int32(200), value:Int32(200)
+  [  50] PutByValue base:reg5, property:Int32(200), src:Int32(2), kind:Own
+  [  68] ToPrimitiveWithStringHint dst:Int32(300), value:Int32(300)
+  [  78] PutByValue base:reg5, property:Int32(300), src:Int32(3), kind:Own
+  [  90] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/numeric-property-key.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-property-key.txt
@@ -1,4 +1,4 @@
-$28d58d80 numeric-property-key.js:4:1
+$aa378608 numeric-property-key.js:4:1
   Registers: 6
   Blocks:    1
   Constants:
@@ -7,8 +7,9 @@ $28d58d80 numeric-property-key.js:4:1
     [2] = Undefined
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] ToPrimitiveWithStringHint dst:Int32(20), value:Int32(20)
-  [  20] PutByValue base:reg5, property:Int32(20), src:Int32(3), kind:Own
-  [  38] SetGlobal `obj`, src:reg5
-  [  48] End value:Undefined
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] ToPrimitiveWithStringHint dst:Int32(20), value:Int32(20)
+  [  28] PutByValue base:reg5, property:Int32(20), src:Int32(3), kind:Own
+  [  40] SetGlobal `obj`, src:reg5
+  [  50] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/object-rest-computed-key.txt
+++ b/Tests/LibJS/Bytecode/expected/object-rest-computed-key.txt
@@ -1,4 +1,4 @@
-$fe0af08d object-rest-computed-key.js:1:1
+$79e506f5 object-rest-computed-key.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -8,16 +8,17 @@ $fe0af08d object-rest-computed-key.js:1:1
     [3] = Undefined
 
 block0:
-  [   0] SetGlobal `a`, src:String("foo")
-  [  10] NewObject dst:reg5
-  [  20] InitObjectLiteralProperty object:reg5, `foo`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  38] InitObjectLiteralProperty object:reg5, `bar`, src:Int32(2), shape_cache_index:0, property_slot:1
-  [  50] CacheObjectShape object:reg5
-  [  60] ThrowIfNullish src:reg5
-  [  68] GetGlobal dst:reg7, `a`
-  [  78] ToPrimitiveWithStringHint dst:reg7, value:reg7
-  [  88] GetByValue dst:reg6, base:reg5, property:reg7
-  [  a0] SetGlobal `b`, src:reg6
-  [  b0] CopyObjectExcludingProperties dst:reg6, from_object:reg5, excluded_names:[reg7]
-  [  d0] SetGlobal `rest`, src:reg6
-  [  e0] End value:Undefined
+  [   0] Enter
+  [   8] SetGlobal `a`, src:String("foo")
+  [  18] NewObject dst:reg5
+  [  28] InitObjectLiteralProperty object:reg5, `foo`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  40] InitObjectLiteralProperty object:reg5, `bar`, src:Int32(2), shape_cache_index:0, property_slot:1
+  [  58] CacheObjectShape object:reg5
+  [  68] ThrowIfNullish src:reg5
+  [  70] GetGlobal dst:reg7, `a`
+  [  80] ToPrimitiveWithStringHint dst:reg7, value:reg7
+  [  90] GetByValue dst:reg6, base:reg5, property:reg7
+  [  a8] SetGlobal `b`, src:reg6
+  [  b8] CopyObjectExcludingProperties dst:reg6, from_object:reg5, excluded_names:[reg7]
+  [  d8] SetGlobal `rest`, src:reg6
+  [  e8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/optional-chain-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/optional-chain-base-identifier.txt
@@ -1,4 +1,4 @@
-$abc8a5d2 optional-chain-base-identifier.js:1:1
+$32b2807a optional-chain-base-identifier.js:1:1
   Registers: 9
   Blocks:    3
   Constants:
@@ -6,24 +6,25 @@ $abc8a5d2 optional-chain-base-identifier.js:1:1
     [1] = Undefined
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] NewObject dst:reg6
-  [  20] InitObjectLiteralProperty object:reg6, `b`, src:Int32(44), shape_cache_index:1, property_slot:0
-  [  38] CacheObjectShape object:reg6
-  [  48] InitObjectLiteralProperty object:reg5, `a`, src:reg6, shape_cache_index:0, property_slot:0
-  [  60] CacheObjectShape object:reg5
-  [  70] SetGlobal `obj`, src:reg5
-  [  80] MovSrcUndefined dst:reg5
-  [  88] GetGlobal dst:reg7, `obj`
-  [  98] GetById dst:reg8, base:reg7, `a` (obj.a)
-  [  b0] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg6, c1_src:reg8
-  [  c8] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] NewObject dst:reg6
+  [  28] InitObjectLiteralProperty object:reg6, `b`, src:Int32(44), shape_cache_index:1, property_slot:0
+  [  40] CacheObjectShape object:reg6
+  [  50] InitObjectLiteralProperty object:reg5, `a`, src:reg6, shape_cache_index:0, property_slot:0
+  [  68] CacheObjectShape object:reg5
+  [  78] SetGlobal `obj`, src:reg5
+  [  88] MovSrcUndefined dst:reg5
+  [  90] GetGlobal dst:reg7, `obj`
+  [  a0] GetById dst:reg8, base:reg7, `a` (obj.a)
+  [  b8] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg6, c1_src:reg8
+  [  d0] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  d8] MovSrcUndefined dst:reg6
-  [  e0] End value:reg6
+  [  e0] MovSrcUndefined dst:reg6
+  [  e8] End value:reg6
 
 block2:
-  [  e8] Mov dst:reg5, src:reg6
-  [  f8] GetById dst:reg6, base:reg6, `b`
-  [ 110] End value:reg6
+  [  f0] Mov dst:reg5, src:reg6
+  [ 100] GetById dst:reg6, base:reg6, `b`
+  [ 118] End value:reg6

--- a/Tests/LibJS/Bytecode/expected/optional-chain.txt
+++ b/Tests/LibJS/Bytecode/expected/optional-chain.txt
@@ -1,4 +1,4 @@
-$78a7573a optional-chain.js:25:1
+$f1bd7c92 optional-chain.js:25:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,90 +6,94 @@ $78a7573a optional-chain.js:25:1
     [1] = Null
 
 block0:
-  [   0] GetGlobal dst:reg6, `member`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, member, arguments:[Null]
-  [  38] GetGlobal dst:reg7, `nested_member`
-  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, nested_member, arguments:[Null]
-  [  70] GetGlobal dst:reg7, `call_no_args`
-  [  80] Call dst:reg5, callee:reg7, this_value:Undefined, call_no_args, arguments:[Null]
-  [  a8] GetGlobal dst:reg7, `call_with_args`
-  [  b8] Call dst:reg6, callee:reg7, this_value:Undefined, call_with_args, arguments:[Null]
-  [  e0] GetGlobal dst:reg7, `computed`
-  [  f0] Call dst:reg5, callee:reg7, this_value:Undefined, computed, arguments:[Null]
-  [ 118] GetGlobal dst:reg7, `member_then_call`
-  [ 128] Call dst:reg6, callee:reg7, this_value:Undefined, member_then_call, arguments:[Null]
-  [ 150] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `member`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, member, arguments:[Null]
+  [  40] GetGlobal dst:reg7, `nested_member`
+  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, nested_member, arguments:[Null]
+  [  78] GetGlobal dst:reg7, `call_no_args`
+  [  88] Call dst:reg5, callee:reg7, this_value:Undefined, call_no_args, arguments:[Null]
+  [  b0] GetGlobal dst:reg7, `call_with_args`
+  [  c0] Call dst:reg6, callee:reg7, this_value:Undefined, call_with_args, arguments:[Null]
+  [  e8] GetGlobal dst:reg7, `computed`
+  [  f8] Call dst:reg5, callee:reg7, this_value:Undefined, computed, arguments:[Null]
+  [ 120] GetGlobal dst:reg7, `member_then_call`
+  [ 130] Call dst:reg6, callee:reg7, this_value:Undefined, member_then_call, arguments:[Null]
+  [ 158] End value:reg6
 
 
-member$b2c55037 optional-chain.js:7:5
+member$36eb39cf optional-chain.js:7:5
   Registers: 7
   Blocks:    3
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
-  [  18] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
+  [  20] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  28] MovSrcUndefined dst:reg6
-  [  30] Return value:reg6
+  [  30] MovSrcUndefined dst:reg6
+  [  38] Return value:reg6
 
 block2:
-  [  38] Mov dst:reg5, src:reg6
-  [  48] GetById dst:reg6, base:reg6, `x`
-  [  60] Return value:reg6
+  [  40] Mov dst:reg5, src:reg6
+  [  50] GetById dst:reg6, base:reg6, `x`
+  [  68] Return value:reg6
 
 
-nested_member$046f1110 optional-chain.js:10:5
+nested_member$85d10998 optional-chain.js:10:5
   Registers: 7
   Blocks:    4
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
-  [  18] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
+  [  20] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  28] MovSrcUndefined dst:reg6
-  [  30] Return value:reg6
+  [  30] MovSrcUndefined dst:reg6
+  [  38] Return value:reg6
 
 block2:
-  [  38] Mov dst:reg5, src:reg6
-  [  48] GetById dst:reg6, base:reg6, `x`
-  [  60] JumpNullish condition:reg6, true_target:block1, false_target:block3
+  [  40] Mov dst:reg5, src:reg6
+  [  50] GetById dst:reg6, base:reg6, `x`
+  [  68] JumpNullish condition:reg6, true_target:block1, false_target:block3
 
 block3:
-  [  70] Mov dst:reg5, src:reg6
-  [  80] GetById dst:reg6, base:reg6, `y`
-  [  98] Return value:reg6
+  [  78] Mov dst:reg5, src:reg6
+  [  88] GetById dst:reg6, base:reg6, `y`
+  [  a0] Return value:reg6
 
 
-call_no_args$6ddca629 optional-chain.js:13:5
+call_no_args$ef3e9eb1 optional-chain.js:13:5
   Registers: 8
   Blocks:    3
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
-  [  18] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
+  [  20] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  28] MovSrcUndefined dst:reg6
-  [  30] Return value:reg6
+  [  30] MovSrcUndefined dst:reg6
+  [  38] Return value:reg6
 
 block2:
-  [  38] Mov dst:reg5, src:reg6
-  [  48] GetById dst:reg6, base:reg6, `foo`
-  [  60] NewArray dst:reg7
-  [  70] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-  [  88] MovSrcUndefined dst:reg5
-  [  90] Return value:reg6
+  [  40] Mov dst:reg5, src:reg6
+  [  50] GetById dst:reg6, base:reg6, `foo`
+  [  68] NewArray dst:reg7
+  [  78] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+  [  90] MovSrcUndefined dst:reg5
+  [  98] Return value:reg6
 
 
-call_with_args$ba85f82f optional-chain.js:16:5
+call_with_args$36600e97 optional-chain.js:16:5
   Registers: 11
   Blocks:    3
   Constants:
@@ -99,24 +103,25 @@ call_with_args$ba85f82f optional-chain.js:16:5
     [3] = Int32(3)
 
 block0:
-  [   0] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
-  [  18] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
+  [  20] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  28] MovSrcUndefined dst:reg6
-  [  30] Return value:reg6
+  [  30] MovSrcUndefined dst:reg6
+  [  38] Return value:reg6
 
 block2:
-  [  38] Mov dst:reg5, src:reg6
-  [  48] GetById dst:reg6, base:reg6, `foo`
-  [  60] Mov3 c0_dst:reg8, c0_src:Int32(1), c1_dst:reg9, c1_src:Int32(2), c2_dst:reg10, c2_src:Int32(3)
-  [  80] NewArray dst:reg7, elements:[reg8, reg9, reg10]
-  [  a0] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-  [  b8] MovSrcUndefined dst:reg5
-  [  c0] Return value:reg6
+  [  40] Mov dst:reg5, src:reg6
+  [  50] GetById dst:reg6, base:reg6, `foo`
+  [  68] Mov3 c0_dst:reg8, c0_src:Int32(1), c1_dst:reg9, c1_src:Int32(2), c2_dst:reg10, c2_src:Int32(3)
+  [  88] NewArray dst:reg7, elements:[reg8, reg9, reg10]
+  [  a8] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+  [  c0] MovSrcUndefined dst:reg5
+  [  c8] Return value:reg6
 
 
-computed$1ad267c2 optional-chain.js:19:5
+computed$9ef8515a optional-chain.js:19:5
   Registers: 7
   Blocks:    3
   Constants:
@@ -124,39 +129,41 @@ computed$1ad267c2 optional-chain.js:19:5
     [1] = String("hello")
 
 block0:
-  [   0] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
-  [  18] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
+  [  20] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  28] MovSrcUndefined dst:reg6
-  [  30] Return value:reg6
+  [  30] MovSrcUndefined dst:reg6
+  [  38] Return value:reg6
 
 block2:
-  [  38] Mov dst:reg5, src:reg6
-  [  48] GetById dst:reg6, base:reg6, `hello`
-  [  60] Return value:reg6
+  [  40] Mov dst:reg5, src:reg6
+  [  50] GetById dst:reg6, base:reg6, `hello`
+  [  68] Return value:reg6
 
 
-member_then_call$b33c44d3 optional-chain.js:22:5
+member_then_call$349e3d5b optional-chain.js:22:5
   Registers: 8
   Blocks:    3
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
-  [  18] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] Mov2 c0_dst:reg5, c0_src:Undefined, c1_dst:reg6, c1_src:arg0
+  [  20] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  28] MovSrcUndefined dst:reg6
-  [  30] Return value:reg6
+  [  30] MovSrcUndefined dst:reg6
+  [  38] Return value:reg6
 
 block2:
-  [  38] Mov dst:reg5, src:reg6
-  [  48] GetById dst:reg6, base:reg6, `x`
-  [  60] Mov dst:reg5, src:reg6
-  [  70] GetById dst:reg6, base:reg6, `foo`
-  [  88] NewArray dst:reg7
-  [  98] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-  [  b0] MovSrcUndefined dst:reg5
-  [  b8] Return value:reg6
+  [  40] Mov dst:reg5, src:reg6
+  [  50] GetById dst:reg6, base:reg6, `x`
+  [  68] Mov dst:reg5, src:reg6
+  [  78] GetById dst:reg6, base:reg6, `foo`
+  [  90] NewArray dst:reg7
+  [  a0] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+  [  b8] MovSrcUndefined dst:reg5
+  [  c0] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
+++ b/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
@@ -1,4 +1,4 @@
-$516a2e0b parameter-createvariable-order.js:7:1
+$cd444473 parameter-createvariable-order.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -8,12 +8,13 @@ $516a2e0b parameter-createvariable-order.js:7:1
     [3] = Int32(3)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1), Int32(2), Int32(3)]
-  [  40] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1), Int32(2), Int32(3)]
+  [  48] End value:reg5
 
 
-f$0ae4b9bc parameter-createvariable-order.js:2:5
+f$8982c134 parameter-createvariable-order.js:2:5
   Registers: 6
   Blocks:    1
   Locals:    inner~0
@@ -21,27 +22,29 @@ f$0ae4b9bc parameter-createvariable-order.js:2:5
     [0] = Undefined
 
 block0:
-  [   0] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
-  [  10] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
-  [  20] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
-  [  30] InitializeLexicalBinding `a`, src:arg0
-  [  48] InitializeLexicalBinding `b`, src:arg1
-  [  60] InitializeLexicalBinding `c`, src:arg2
-  [  78] MovSrcUndefined dst:inner~0
-  [  80] NewFunction dst:reg5, shared_function_data_index:0 (inner)
-  [  98] Mov dst:inner~0, src:reg5
-  [  a8] Call dst:reg5, callee:inner~0, this_value:Undefined, inner
-  [  c8] Return value:reg5
+  [   0] Enter
+  [   8] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
+  [  18] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
+  [  28] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
+  [  38] InitializeLexicalBinding `a`, src:arg0
+  [  50] InitializeLexicalBinding `b`, src:arg1
+  [  68] InitializeLexicalBinding `c`, src:arg2
+  [  80] MovSrcUndefined dst:inner~0
+  [  88] NewFunction dst:reg5, shared_function_data_index:0 (inner)
+  [  a0] Mov dst:inner~0, src:reg5
+  [  b0] Call dst:reg5, callee:inner~0, this_value:Undefined, inner
+  [  d0] Return value:reg5
 
 
-inner$2575e5f9 parameter-createvariable-order.js:3:9
+inner$a14ffc61 parameter-createvariable-order.js:3:9
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `a`
-  [  10] DynamicGetBinding dst:reg6, `b`
-  [  20] Add dst:reg7, lhs:reg5, rhs:reg6
-  [  30] DynamicGetBinding dst:reg5, `c`
-  [  40] Add dst:reg6, lhs:reg7, rhs:reg5
-  [  50] Return value:reg6
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `a`
+  [  18] DynamicGetBinding dst:reg6, `b`
+  [  28] Add dst:reg7, lhs:reg5, rhs:reg6
+  [  38] DynamicGetBinding dst:reg5, `c`
+  [  48] Add dst:reg6, lhs:reg7, rhs:reg5
+  [  58] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
@@ -1,4 +1,4 @@
-$79e506f5 postfix-increment-private-member.js:1:1
+$fb46ff7d postfix-increment-private-member.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,41 +6,44 @@ $79e506f5 postfix-increment-private-member.js:1:1
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
-  [  30] CreatePrivateEnvironment
-  [  38] AddPrivateName `#c`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("nextId")]
-  [  70] LeavePrivateEnvironment
-  [  78] DynamicInitializeLexicalBinding `C`, src:reg6
-  [  88] GetGlobal dst:reg7, `C`
-  [  98] CallConstruct dst:reg5, callee:reg7, C
-  [  b0] GetById dst:reg7, base:reg5, `nextId`
-  [  c8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.nextId
-  [  e8] End value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
+  [  38] CreatePrivateEnvironment
+  [  40] AddPrivateName `#c`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("nextId")]
+  [  78] LeavePrivateEnvironment
+  [  80] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  90] GetGlobal dst:reg7, `C`
+  [  a0] CallConstruct dst:reg5, callee:reg7, C
+  [  b8] GetById dst:reg7, base:reg5, `nextId`
+  [  d0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.nextId
+  [  f0] End value:reg6
 
 
-C$e7b179de
+C$638b9046
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-nextId$ab917a32 postfix-increment-private-member.js:4:9
+nextId$2a2f81aa postfix-increment-private-member.js:4:9
   Registers: 7
   Blocks:    1
   Constants:
     [0] = String("id-")
 
 block0:
-  [   0] GetPrivateById dst:reg5, base:this, `#c`
-  [  10] PostfixIncrement dst:reg6, src:reg5
-  [  20] PutPrivateById base:this, `#c`, src:reg5
-  [  30] Add dst:reg5, lhs:String("id-"), rhs:reg6
-  [  40] Return value:reg5
+  [   0] Enter
+  [   8] GetPrivateById dst:reg5, base:this, `#c`
+  [  18] PostfixIncrement dst:reg6, src:reg5
+  [  28] PutPrivateById base:this, `#c`, src:reg5
+  [  38] Add dst:reg5, lhs:String("id-"), rhs:reg6
+  [  48] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/postfix-update-in-logical-and.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-update-in-logical-and.txt
@@ -1,4 +1,4 @@
-$2b997e90 postfix-update-in-logical-and.js:4:1
+$acfb7718 postfix-update-in-logical-and.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,25 +6,27 @@ $2b997e90 postfix-update-in-logical-and.js:4:1
     [1] = Int32(5)
 
 block0:
-  [   0] GetGlobal dst:reg6, `postfixInLogicalAnd`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, postfixInLogicalAnd, arguments:[Int32(5)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `postfixInLogicalAnd`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, postfixInLogicalAnd, arguments:[Int32(5)]
+  [  40] End value:reg5
 
 
-postfixInLogicalAnd$ff9880b2 postfix-update-in-logical-and.js:2:5
+postfixInLogicalAnd$80fa793a postfix-update-in-logical-and.js:2:5
   Registers: 8
   Blocks:    3
   Constants:
     [0] = Int32(0)
 
 block0:
-  [   0] GreaterThanRhsInt32 dst:reg5, lhs:arg0, rhs:0
-  [  10] Mov dst:reg6, src:reg5
-  [  20] JumpFalse condition:reg5, target:block2
+  [   0] Enter
+  [   8] GreaterThanRhsInt32 dst:reg5, lhs:arg0, rhs:0
+  [  18] Mov dst:reg6, src:reg5
+  [  28] JumpFalse condition:reg5, target:block2
 
 block1:
-  [  30] PostfixDecrement dst:reg7, src:arg0
-  [  40] Mov2 c0_dst:arg0, c0_src:arg0, c1_dst:reg6, c1_src:reg7
+  [  38] PostfixDecrement dst:reg7, src:arg0
+  [  48] Mov2 c0_dst:arg0, c0_src:arg0, c1_dst:reg6, c1_src:reg7
 
 block2:
-  [  58] Return value:reg6
+  [  60] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/private-identifier-access-patterns.txt
+++ b/Tests/LibJS/Bytecode/expected/private-identifier-access-patterns.txt
@@ -1,4 +1,4 @@
-$7f6ce915 private-identifier-access-patterns.js:1:1
+$00cee19d private-identifier-access-patterns.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,13 +6,14 @@ $7f6ce915 private-identifier-access-patterns.js:1:1
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
-  [  30] CreatePrivateEnvironment
-  [  38] AddPrivateName `#x`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
-  [  70] LeavePrivateEnvironment
-  [  78] DynamicInitializeLexicalBinding `C`, src:reg6
-  [  88] End value:Undefined
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
+  [  38] CreatePrivateEnvironment
+  [  40] AddPrivateName `#x`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
+  [  78] LeavePrivateEnvironment
+  [  80] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  90] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
@@ -1,4 +1,4 @@
-$79e506f5 private-logical-assignment-register-order.js:1:1
+$fb46ff7d private-logical-assignment-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,33 +6,35 @@ $79e506f5 private-logical-assignment-register-order.js:1:1
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
-  [  30] CreatePrivateEnvironment
-  [  38] AddPrivateName `#x`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("f")]
-  [  70] LeavePrivateEnvironment
-  [  78] DynamicInitializeLexicalBinding `C`, src:reg6
-  [  88] GetGlobal dst:reg7, `C`
-  [  98] CallConstruct dst:reg5, callee:reg7, C
-  [  b0] GetById dst:reg7, base:reg5, `f`
-  [  c8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.f
-  [  e8] End value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
+  [  38] CreatePrivateEnvironment
+  [  40] AddPrivateName `#x`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("f")]
+  [  78] LeavePrivateEnvironment
+  [  80] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  90] GetGlobal dst:reg7, `C`
+  [  a0] CallConstruct dst:reg5, callee:reg7, C
+  [  b8] GetById dst:reg7, base:reg5, `f`
+  [  d0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.f
+  [  f0] End value:reg6
 
 
-C$e7b179de
+C$638b9046
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-f$2cb7734b private-logical-assignment-register-order.js:3:19
+f$ab557ac3 private-logical-assignment-register-order.js:3:19
   Registers: 7
   Blocks:    4
   Constants:
@@ -40,16 +42,17 @@ f$2cb7734b private-logical-assignment-register-order.js:3:19
     [1] = Undefined
 
 block0:
-  [   0] GetPrivateById dst:reg5, base:this, `#x`
-  [  10] JumpFalse condition:reg5, target:block2
+  [   0] Enter
+  [   8] GetPrivateById dst:reg5, base:this, `#x`
+  [  18] JumpFalse condition:reg5, target:block2
 
 block1:
-  [  20] Mov dst:reg6, src:Int32(1)
-  [  30] PutPrivateById base:this, `#x`, src:reg6
-  [  40] Jump target:block3
+  [  28] Mov dst:reg6, src:Int32(1)
+  [  38] PutPrivateById base:this, `#x`, src:reg6
+  [  48] Jump target:block3
 
 block2:
-  [  48] Mov dst:reg6, src:reg5
+  [  50] Mov dst:reg6, src:reg5
 
 block3:
-  [  58] End value:Undefined
+  [  60] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
+++ b/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
@@ -1,4 +1,4 @@
-$79e506f5 private-method-call-description.js:1:1
+$fb46ff7d private-method-call-description.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,47 +6,51 @@ $79e506f5 private-method-call-description.js:1:1
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
-  [  30] CreatePrivateEnvironment
-  [  38] AddPrivateName `#m`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("call")]
-  [  70] LeavePrivateEnvironment
-  [  78] DynamicInitializeLexicalBinding `C`, src:reg6
-  [  88] GetGlobal dst:reg7, `C`
-  [  98] CallConstruct dst:reg5, callee:reg7, C
-  [  b0] GetById dst:reg7, base:reg5, `call`
-  [  c8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.call
-  [  e8] End value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
+  [  38] CreatePrivateEnvironment
+  [  40] AddPrivateName `#m`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("call")]
+  [  78] LeavePrivateEnvironment
+  [  80] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  90] GetGlobal dst:reg7, `C`
+  [  a0] CallConstruct dst:reg5, callee:reg7, C
+  [  b8] GetById dst:reg7, base:reg5, `call`
+  [  d0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.call
+  [  f0] End value:reg6
 
 
-C$e7b179de
+C$638b9046
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-call$c4371728 private-method-call-description.js:6:9
+call$4b20f1d0 private-method-call-description.js:6:9
   Registers: 7
   Blocks:    1
 
 block0:
-  [   0] GetPrivateById dst:reg6, base:this, `#m`
-  [  10] Call dst:reg5, callee:reg6, this_value:this, this.#m
-  [  30] Return value:reg5
+  [   0] Enter
+  [   8] GetPrivateById dst:reg6, base:this, `#m`
+  [  18] Call dst:reg5, callee:reg6, this_value:this, this.#m
+  [  38] Return value:reg5
 
 
-#m$a16f05d1 private-method-call-description.js:3:9
+#m$2594ef69 private-method-call-description.js:3:9
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(42)
 
 block0:
-  [   0] Return value:Int32(42)
+  [   0] Enter
+  [   8] Return value:Int32(42)

--- a/Tests/LibJS/Bytecode/expected/regex-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/regex-literals.txt
@@ -1,4 +1,4 @@
-$a246183e regex-literals.js:2:1
+$1e202ea6 regex-literals.js:2:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,25 +7,27 @@ $a246183e regex-literals.js:2:1
     [2] = String("abc123")
 
 block0:
-  [   0] NewRegExp dst:reg5, foo, 
-  [  18] DynamicInitializeLexicalBinding `a`, src:reg5
-  [  28] NewRegExp dst:reg5, bar, gi
-  [  40] DynamicInitializeLexicalBinding `b`, src:reg5
-  [  50] NewRegExp dst:reg5, baz, i
-  [  68] AddLhsInt32 dst:reg6, lhs:1, rhs:reg5
-  [  78] DynamicInitializeLexicalBinding `c`, src:reg6
-  [  88] GetGlobal dst:reg5, `matchDigits`
-  [  98] Call dst:reg6, callee:reg5, this_value:Undefined, matchDigits, arguments:[String("abc123")]
-  [  c0] End value:reg6
+  [   0] Enter
+  [   8] NewRegExp dst:reg5, foo, 
+  [  20] DynamicInitializeLexicalBinding `a`, src:reg5
+  [  30] NewRegExp dst:reg5, bar, gi
+  [  48] DynamicInitializeLexicalBinding `b`, src:reg5
+  [  58] NewRegExp dst:reg5, baz, i
+  [  70] AddLhsInt32 dst:reg6, lhs:1, rhs:reg5
+  [  80] DynamicInitializeLexicalBinding `c`, src:reg6
+  [  90] GetGlobal dst:reg5, `matchDigits`
+  [  a0] Call dst:reg6, callee:reg5, this_value:Undefined, matchDigits, arguments:[String("abc123")]
+  [  c8] End value:reg6
 
 
-matchDigits$cfe7cda7 regex-literals.js:8:5
+matchDigits$5149c62f regex-literals.js:8:5
   Registers: 9
   Blocks:    1
 
 block0:
-  [   0] NewRegExp dst:reg6, \d+, g
-  [  18] GetById dst:reg7, base:reg6, `test`
-  [  30] Mov dst:reg8, src:arg0
-  [  40] Call dst:reg5, callee:reg7, this_value:reg6, <object>.test, arguments:[reg8]
-  [  68] Return value:reg5
+  [   0] Enter
+  [   8] NewRegExp dst:reg6, \d+, g
+  [  20] GetById dst:reg7, base:reg6, `test`
+  [  38] Mov dst:reg8, src:arg0
+  [  48] Call dst:reg5, callee:reg7, this_value:reg6, <object>.test, arguments:[reg8]
+  [  70] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/resolve-this-caching.txt
+++ b/Tests/LibJS/Bytecode/expected/resolve-this-caching.txt
@@ -1,34 +1,37 @@
-$bacf2c68 resolve-this-caching.js:4:1
+$2b997e90 resolve-this-caching.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `foo`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `foo`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo
+  [  38] End value:reg5
 
 
-foo$1d0ffb84 resolve-this-caching.js:2:5
+foo$9e71f40c resolve-this-caching.js:2:5
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] NewFunction dst:reg6, shared_function_data_index:0
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined
-  [  38] Return value:reg5
+  [   0] Enter
+  [   8] NewFunction dst:reg6, shared_function_data_index:0
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined
+  [  40] Return value:reg5
 
 
-$93a5ab2a resolve-this-caching.js:2:13
+$1243b2a2 resolve-this-caching.js:2:13
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] GetById dst:reg5, base:this, `x` (this.x)
-  [  20] GetById dst:reg6, base:this, `y` (this.y)
-  [  38] Add dst:reg7, lhs:reg5, rhs:reg6
-  [  48] Return value:reg7
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] GetById dst:reg5, base:this, `x` (this.x)
+  [  28] GetById dst:reg6, base:this, `y` (this.y)
+  [  40] Add dst:reg7, lhs:reg5, rhs:reg6
+  [  50] Return value:reg7

--- a/Tests/LibJS/Bytecode/expected/right-shift-by-zero.txt
+++ b/Tests/LibJS/Bytecode/expected/right-shift-by-zero.txt
@@ -1,4 +1,4 @@
-$12cfcca1 right-shift-by-zero.js:5:1
+$9431c529 right-shift-by-zero.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,17 +6,19 @@ $12cfcca1 right-shift-by-zero.js:5:1
     [1] = Double(1.5)
 
 block0:
-  [   0] GetGlobal dst:reg6, `foo`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[Double(1.5)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `foo`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[Double(1.5)]
+  [  40] End value:reg5
 
 
-foo$962620dc right-shift-by-zero.js:2:5
+foo$17881964 right-shift-by-zero.js:2:5
   Registers: 6
   Blocks:    1
   Constants:
     [0] = Int32(0)
 
 block0:
-  [   0] ToInt32 dst:reg5, value:arg0
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] ToInt32 dst:reg5, value:arg0
+  [  18] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
+++ b/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
@@ -1,19 +1,20 @@
-$3c59d5bd sequential-try-blocks.js:17:1
+$bdbbce45 sequential-try-blocks.js:17:1
   Registers: 10
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `sequentialTryCatch`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, sequentialTryCatch
-  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  80] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `sequentialTryCatch`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, sequentialTryCatch
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] End value:reg5
 
 
-sequentialTryCatch$0a8456ee sequential-try-blocks.js:2:5
+sequentialTryCatch$89225e66 sequential-try-blocks.js:2:5
   Registers: 8
   Blocks:    5
   Locals:    e~0, e~1, result~2
@@ -27,41 +28,42 @@ sequentialTryCatch$0a8456ee sequential-try-blocks.js:2:5
     [6] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:result~2, src:String("")
-  [  18] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:result~2, src:String("")
+  [  20] Jump target:block2
 
 block1:
-  [  20] Catch dst:reg5
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Mov2 c0_dst:e~0, c0_src:reg5, c1_dst:reg6, c1_src:result~2
-  [  48] Add dst:reg7, lhs:reg6, rhs:String("b")
-  [  58] Mov dst:result~2, src:reg7
-  [  68] Jump target:block4
+  [  28] Catch dst:reg5
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Mov2 c0_dst:e~0, c0_src:reg5, c1_dst:reg6, c1_src:result~2
+  [  50] Add dst:reg7, lhs:reg6, rhs:String("b")
+  [  60] Mov dst:result~2, src:reg7
+  [  70] Jump target:block4
 
 block2:
-  [  70] Mov dst:reg5, src:result~2
-  [  80] Add dst:reg7, lhs:reg5, rhs:String("a")
-  [  90] Mov dst:result~2, src:reg7
-  [  a0] Throw src:Int32(1)
+  [  78] Mov dst:reg5, src:result~2
+  [  88] Add dst:reg7, lhs:reg5, rhs:String("a")
+  [  98] Mov dst:result~2, src:reg7
+  [  a8] Throw src:Int32(1)
 
 block3:
-  [  a8] Catch dst:reg7
-  [  b0] SetLexicalEnvironment environment:reg4
-  [  b8] Mov2 c0_dst:e~1, c0_src:reg7, c1_dst:reg5, c1_src:result~2
-  [  d0] Add dst:reg6, lhs:reg5, rhs:String("d")
-  [  e0] Mov dst:result~2, src:reg6
-  [  f0] Return value:result~2
+  [  b0] Catch dst:reg7
+  [  b8] SetLexicalEnvironment environment:reg4
+  [  c0] Mov2 c0_dst:e~1, c0_src:reg7, c1_dst:reg5, c1_src:result~2
+  [  d8] Add dst:reg6, lhs:reg5, rhs:String("d")
+  [  e8] Mov dst:result~2, src:reg6
+  [  f8] Return value:result~2
 
 block4:
-  [  f8] Mov dst:reg7, src:result~2
-  [ 108] Add dst:reg6, lhs:reg7, rhs:String("c")
-  [ 118] Mov dst:result~2, src:reg6
-  [ 128] Throw src:Int32(2)
+  [ 100] Mov dst:reg7, src:result~2
+  [ 110] Add dst:reg6, lhs:reg7, rhs:String("c")
+  [ 120] Mov dst:result~2, src:reg6
+  [ 130] Throw src:Int32(2)
 
 Exception handlers:
-  [  70 ..   a8] => handler block1
-  [  f8 ..  130] => handler block3
+  [  78 ..   b0] => handler block1
+  [ 100 ..  138] => handler block3
 
 
 "abcd"

--- a/Tests/LibJS/Bytecode/expected/string-from-char-code-builtin.txt
+++ b/Tests/LibJS/Bytecode/expected/string-from-char-code-builtin.txt
@@ -1,4 +1,4 @@
-$7ba8b0ff string-from-char-code-builtin.js:3:1
+$02928ba7 string-from-char-code-builtin.js:3:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,10 +6,11 @@ $7ba8b0ff string-from-char-code-builtin.js:3:1
     [1] = Int32(66)
 
 block0:
-  [   0] GetGlobal dst:reg6, `String`
-  [  10] GetById dst:reg7, base:reg6, `fromCharCode` (String.fromCharCode)
-  [  28] CallBuiltinStringFromCharCode dst:reg5, callee:reg7, this_value:reg6, argument:Int32(65), String.fromCharCode
-  [  40] GetGlobal dst:reg6, `String`
-  [  50] GetById dst:reg8, base:reg6, `fromCharCode` (String.fromCharCode)
-  [  68] Call dst:reg7, callee:reg8, this_value:reg6, String.fromCharCode, arguments:[Int32(65), Int32(66)]
-  [  90] End value:reg7
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `String`
+  [  18] GetById dst:reg7, base:reg6, `fromCharCode` (String.fromCharCode)
+  [  30] CallBuiltinStringFromCharCode dst:reg5, callee:reg7, this_value:reg6, argument:Int32(65), String.fromCharCode
+  [  48] GetGlobal dst:reg6, `String`
+  [  58] GetById dst:reg8, base:reg6, `fromCharCode` (String.fromCharCode)
+  [  70] Call dst:reg7, callee:reg8, this_value:reg6, String.fromCharCode, arguments:[Int32(65), Int32(66)]
+  [  98] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/string-prototype-char-at-builtin.txt
+++ b/Tests/LibJS/Bytecode/expected/string-prototype-char-at-builtin.txt
@@ -1,4 +1,4 @@
-$23ab7524 string-prototype-char-at-builtin.js:4:13
+$811a2fdc string-prototype-char-at-builtin.js:4:13
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,8 +7,9 @@ $23ab7524 string-prototype-char-at-builtin.js:4:13
     [2] = String("charAt")
 
 block0:
-  [   0] GetById dst:reg6, base:String("abc"), `charAt` ('abc'.charAt)
-  [  18] CallBuiltinStringPrototypeCharAt dst:reg5, callee:reg6, this_value:String("abc"), argument:Int32(1), 'abc'.charAt
-  [  30] GetById dst:reg7, base:String("abc"), `charAt`
-  [  48] Call dst:reg6, callee:reg7, this_value:String("abc"), 'abc'['charAt'], arguments:[Int32(1)]
-  [  70] End value:reg6
+  [   0] Enter
+  [   8] GetById dst:reg6, base:String("abc"), `charAt` ('abc'.charAt)
+  [  20] CallBuiltinStringPrototypeCharAt dst:reg5, callee:reg6, this_value:String("abc"), argument:Int32(1), 'abc'.charAt
+  [  38] GetById dst:reg7, base:String("abc"), `charAt`
+  [  50] Call dst:reg6, callee:reg7, this_value:String("abc"), 'abc'['charAt'], arguments:[Int32(1)]
+  [  78] End value:reg6

--- a/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
@@ -1,32 +1,34 @@
-$091ab4cd super-call-spread-register-order.js:1:1
+$84f4cb35 super-call-spread-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
-  [  30] GetGlobal dst:reg6, `Object`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
-  [  68] DynamicInitializeLexicalBinding `C`, src:reg7
-  [  78] GetGlobal dst:reg5, `C`
-  [  88] CallConstruct dst:reg7, callee:reg5, C
-  [  a0] End value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
+  [  38] GetGlobal dst:reg6, `Object`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
+  [  70] DynamicInitializeLexicalBinding `C`, src:reg7
+  [  80] GetGlobal dst:reg5, `C`
+  [  90] CallConstruct dst:reg7, callee:reg5, C
+  [  a8] End value:reg7
 
 
-C$be5ab2d3 super-call-spread-register-order.js:3:14
+C$3cf8ba4b super-call-spread-register-order.js:3:14
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] CreateRestParams dst:arg0, rest_index:0
-  [  10] GetSuperConstructor dst:reg5
-  [  18] NewArray dst:reg6
-  [  28] ArrayAppend dst:reg6, src:arg0, is_spread:true
-  [  38] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:false
-  [  50] End value:Undefined
+  [   0] Enter
+  [   8] CreateRestParams dst:arg0, rest_index:0
+  [  18] GetSuperConstructor dst:reg5
+  [  20] NewArray dst:reg6
+  [  30] ArrayAppend dst:reg6, src:arg0, is_spread:true
+  [  40] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:false
+  [  58] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
@@ -1,4 +1,4 @@
-$a37cd2a2 super-computed-eval-order.js:1:1
+$1f56e90a super-computed-eval-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,56 +6,60 @@ $a37cd2a2 super-computed-eval-order.js:1:1
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
-  [  58] DynamicInitializeLexicalBinding `Base`, src:reg6
-  [  68] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
-  [  80] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:true
-  [  90] GetGlobal dst:reg5, `Base`
-  [  a0] SetLexicalEnvironment environment:reg4
-  [  a8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("test")]
-  [  d0] DynamicInitializeLexicalBinding `Derived`, src:reg7
-  [  e0] GetGlobal dst:reg5, `Derived`
-  [  f0] CallConstruct dst:reg6, callee:reg5, Derived
-  [ 108] GetById dst:reg5, base:reg6, `test`
-  [ 120] Call dst:reg7, callee:reg5, this_value:reg6, <object>.test
-  [ 140] End value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
+  [  60] DynamicInitializeLexicalBinding `Base`, src:reg6
+  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  88] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:true
+  [  98] GetGlobal dst:reg5, `Base`
+  [  a8] SetLexicalEnvironment environment:reg4
+  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("test")]
+  [  d8] DynamicInitializeLexicalBinding `Derived`, src:reg7
+  [  e8] GetGlobal dst:reg5, `Derived`
+  [  f8] CallConstruct dst:reg6, callee:reg5, Derived
+  [ 110] GetById dst:reg5, base:reg6, `test`
+  [ 128] Call dst:reg7, callee:reg5, this_value:reg6, <object>.test
+  [ 148] End value:reg7
 
 
-Derived$704ace62 super-computed-eval-order.js:4:14
+Derived$eee8d5da super-computed-eval-order.js:4:14
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetSuperConstructor dst:reg5
-  [   8] NewArray dst:reg6
-  [  18] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:false
-  [  30] End value:Undefined
+  [   0] Enter
+  [   8] GetSuperConstructor dst:reg5
+  [  10] NewArray dst:reg6
+  [  20] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:false
+  [  38] End value:Undefined
 
 
-Base$a461b108
+Base$25c3a990
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-test$37ca7115 super-computed-eval-order.js:7:9
+test$b92c699d super-computed-eval-order.js:7:9
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Int32(0)
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg5
-  [  10] GetByValueWithThis dst:reg6, base:reg5, property:Int32(0), this_value:this
-  [  28] Return value:reg6
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg5
+  [  18] GetByValueWithThis dst:reg6, base:reg5, property:Int32(0), this_value:this
+  [  30] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
@@ -1,23 +1,24 @@
-$091ab4cd super-computed-string-to-id.js:1:1
+$84f4cb35 super-computed-string-to-id.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
-  [  30] GetGlobal dst:reg6, `Object`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
-  [  68] DynamicInitializeLexicalBinding `C`, src:reg7
-  [  78] GetGlobal dst:reg5, `C`
-  [  88] CallConstruct dst:reg7, callee:reg5, C
-  [  a0] End value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
+  [  38] GetGlobal dst:reg6, `Object`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
+  [  70] DynamicInitializeLexicalBinding `C`, src:reg7
+  [  80] GetGlobal dst:reg5, `C`
+  [  90] CallConstruct dst:reg7, callee:reg5, C
+  [  a8] End value:reg7
 
 
-C$bb96c1c3 super-computed-string-to-id.js:3:14
+C$3a34c93b super-computed-string-to-id.js:3:14
   Registers: 8
   Blocks:    1
   Constants:
@@ -26,10 +27,11 @@ C$bb96c1c3 super-computed-string-to-id.js:3:14
     [2] = Undefined
 
 block0:
-  [   0] GetSuperConstructor dst:reg5
-  [   8] NewArray dst:reg6
-  [  18] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:false
-  [  30] ResolveThisBinding
-  [  38] ResolveSuperBase dst:reg7
-  [  40] PutByIdWithThis base:reg7, this_value:this, `foo`, src:Int32(1), kind:Normal
-  [  60] End value:Undefined
+  [   0] Enter
+  [   8] GetSuperConstructor dst:reg5
+  [  10] NewArray dst:reg6
+  [  20] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:false
+  [  38] ResolveThisBinding
+  [  40] ResolveSuperBase dst:reg7
+  [  48] PutByIdWithThis base:reg7, this_value:this, `foo`, src:Int32(1), kind:Normal
+  [  68] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
+++ b/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
@@ -1,4 +1,4 @@
-$2a66ad4a super-constructor-call.js:1:1
+$abc8a5d2 super-constructor-call.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,42 +6,45 @@ $2a66ad4a super-constructor-call.js:1:1
     [1] = Int32(1)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
-  [  58] DynamicInitializeLexicalBinding `Base`, src:reg6
-  [  68] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
-  [  80] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:true
-  [  90] GetGlobal dst:reg5, `Base`
-  [  a0] SetLexicalEnvironment environment:reg4
-  [  a8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1
-  [  c8] DynamicInitializeLexicalBinding `Derived`, src:reg7
-  [  d8] GetGlobal dst:reg6, `Derived`
-  [  e8] CallConstruct dst:reg7, callee:reg6, Derived, arguments:[Int32(1)]
-  [ 108] End value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
+  [  60] DynamicInitializeLexicalBinding `Base`, src:reg6
+  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  88] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:true
+  [  98] GetGlobal dst:reg5, `Base`
+  [  a8] SetLexicalEnvironment environment:reg4
+  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1
+  [  d0] DynamicInitializeLexicalBinding `Derived`, src:reg7
+  [  e0] GetGlobal dst:reg6, `Derived`
+  [  f0] CallConstruct dst:reg7, callee:reg6, Derived, arguments:[Int32(1)]
+  [ 110] End value:reg7
 
 
-Derived$ec24e4ca super-constructor-call.js:4:14
+Derived$6ac2ec42 super-constructor-call.js:4:14
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetSuperConstructor dst:reg5
-  [   8] Mov dst:reg7, src:arg0
-  [  18] NewArray dst:reg6, elements:[reg7]
-  [  30] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:false
-  [  48] End value:Undefined
+  [   0] Enter
+  [   8] GetSuperConstructor dst:reg5
+  [  10] Mov dst:reg7, src:arg0
+  [  20] NewArray dst:reg6, elements:[reg7]
+  [  38] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:false
+  [  50] End value:Undefined
 
 
-Base$a461b108
+Base$25c3a990
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
@@ -1,4 +1,4 @@
-$460e17ea super-evaluation-order.js:1:1
+$c7701072 super-evaluation-order.js:1:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -8,56 +8,59 @@ $460e17ea super-evaluation-order.js:1:1
     [3] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
-  [  30] GetGlobal dst:reg6, `Object`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("read"), element_keys:String("write"), element_keys:String("update")]
-  [  78] DynamicInitializeLexicalBinding `A`, src:reg7
-  [  88] GetGlobal dst:reg6, `A`
-  [  98] CallConstruct dst:reg5, callee:reg6, A
-  [  b0] GetById dst:reg6, base:reg5, `read`
-  [  c8] Call dst:reg7, callee:reg6, this_value:reg5, <object>.read
-  [  e8] GetGlobal dst:reg8, `A`
-  [  f8] CallConstruct dst:reg5, callee:reg8, A
-  [ 110] GetById dst:reg8, base:reg5, `write`
-  [ 128] Call dst:reg6, callee:reg8, this_value:reg5, <object>.write
-  [ 148] GetGlobal dst:reg5, `A`
-  [ 158] CallConstruct dst:reg8, callee:reg5, A
-  [ 170] GetById dst:reg5, base:reg8, `update`
-  [ 188] Call dst:reg7, callee:reg5, this_value:reg8, <object>.update
-  [ 1a8] End value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
+  [  38] GetGlobal dst:reg6, `Object`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("read"), element_keys:String("write"), element_keys:String("update")]
+  [  80] DynamicInitializeLexicalBinding `A`, src:reg7
+  [  90] GetGlobal dst:reg6, `A`
+  [  a0] CallConstruct dst:reg5, callee:reg6, A
+  [  b8] GetById dst:reg6, base:reg5, `read`
+  [  d0] Call dst:reg7, callee:reg6, this_value:reg5, <object>.read
+  [  f0] GetGlobal dst:reg8, `A`
+  [ 100] CallConstruct dst:reg5, callee:reg8, A
+  [ 118] GetById dst:reg8, base:reg5, `write`
+  [ 130] Call dst:reg6, callee:reg8, this_value:reg5, <object>.write
+  [ 150] GetGlobal dst:reg5, `A`
+  [ 160] CallConstruct dst:reg8, callee:reg5, A
+  [ 178] GetById dst:reg5, base:reg8, `update`
+  [ 190] Call dst:reg7, callee:reg5, this_value:reg8, <object>.update
+  [ 1b0] End value:reg7
 
 
-A$3a3ed48c super-evaluation-order.js:1:1
+A$9ff96274 super-evaluation-order.js:1:1
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
-  [  10] CreateRestParams dst:arg0, rest_index:0
-  [  20] InitializeLexicalBinding `args`, src:arg0
-  [  38] GetSuperConstructor dst:reg5
-  [  40] GetBinding dst:reg6, `args`
-  [  58] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:true
-  [  70] Return value:reg7
+  [   0] Enter
+  [   8] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
+  [  18] CreateRestParams dst:arg0, rest_index:0
+  [  28] InitializeLexicalBinding `args`, src:arg0
+  [  40] GetSuperConstructor dst:reg5
+  [  48] GetBinding dst:reg6, `args`
+  [  60] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:true
+  [  78] Return value:reg7
 
 
-read$5dc3ca35 super-evaluation-order.js:3:9
+read$df25c2bd super-evaluation-order.js:3:9
   Registers: 7
   Blocks:    1
   Constants:
     [0] = String("x")
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg5
-  [  10] GetByIdWithThis dst:reg6, base:reg5, `x`, this_value:this
-  [  28] Return value:reg6
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg5
+  [  18] GetByIdWithThis dst:reg6, base:reg5, `x`, this_value:this
+  [  30] Return value:reg6
 
 
-write$7ede70d2 super-evaluation-order.js:6:20
+write$03045a6a super-evaluation-order.js:6:20
   Registers: 6
   Blocks:    1
   Constants:
@@ -66,22 +69,24 @@ write$7ede70d2 super-evaluation-order.js:6:20
     [2] = Undefined
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg5
-  [  10] PutByIdWithThis base:reg5, this_value:this, `x`, src:Int32(42), kind:Normal
-  [  30] End value:Undefined
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg5
+  [  18] PutByIdWithThis base:reg5, this_value:this, `x`, src:Int32(42), kind:Normal
+  [  38] End value:Undefined
 
 
-update$85af5ccd super-evaluation-order.js:9:16
+update$044d6445 super-evaluation-order.js:9:16
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg5
-  [  10] GetByIdWithThis dst:reg6, base:reg5, `x`, this_value:this
-  [  28] PostfixIncrement dst:reg7, src:reg6
-  [  38] PutByIdWithThis base:reg5, this_value:this, `x`, src:reg6, kind:Normal
-  [  58] End value:Undefined
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg5
+  [  18] GetByIdWithThis dst:reg6, base:reg5, `x`, this_value:this
+  [  30] PostfixIncrement dst:reg7, src:reg6
+  [  40] PutByIdWithThis base:reg5, this_value:this, `x`, src:reg6, kind:Normal
+  [  60] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
@@ -1,22 +1,23 @@
-$00cee19d super-for-of-resolve-order.js:1:1
+$87b8bc45 super-for-of-resolve-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
-  [  58] DynamicInitializeLexicalBinding `C`, src:reg6
-  [  68] GetGlobal dst:reg5, `C`
-  [  78] CallConstruct dst:reg6, callee:reg5, C
-  [  90] End value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
+  [  60] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  70] GetGlobal dst:reg5, `C`
+  [  80] CallConstruct dst:reg6, callee:reg5, C
+  [  98] End value:reg6
 
 
-C$9d8b2466 super-for-of-resolve-order.js:3:28
+C$21b10dfe super-for-of-resolve-order.js:3:28
   Registers: 13
   Blocks:    9
   Constants:
@@ -26,43 +27,44 @@ C$9d8b2466 super-for-of-resolve-order.js:3:28
     [3] = Int32(2)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewPrimitiveArray dst:reg5, elements:[1, 2]
-  [  28] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
-  [  40] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewPrimitiveArray dst:reg5, elements:[1, 2]
+  [  30] GetIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg5
+  [  48] Jump target:block2
 
 block1:
-  [  48] End value:Undefined
+  [  50] End value:Undefined
 
 block2:
-  [  50] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
-  [  68] JumpIf condition:reg11, true_target:block1, false_target:block4
+  [  58] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
+  [  70] JumpIf condition:reg11, true_target:block1, false_target:block4
 
 block3:
-  [  78] Catch dst:reg9
-  [  80] SetLexicalEnvironment environment:reg4
-  [  88] Mov dst:reg5, src:Int32(1)
-  [  98] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block5, false_target:block6
+  [  80] Catch dst:reg9
+  [  88] SetLexicalEnvironment environment:reg4
+  [  90] Mov dst:reg5, src:Int32(1)
+  [  a0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:1, true_target:block5, false_target:block6
 
 block4:
-  [  b0] ResolveThisBinding
-  [  b8] ResolveSuperBase dst:reg12
-  [  c0] PutByIdWithThis base:reg12, this_value:this, `prop`, src:reg10, kind:Normal
-  [  e0] Jump target:block2
+  [  b8] ResolveThisBinding
+  [  c0] ResolveSuperBase dst:reg12
+  [  c8] PutByIdWithThis base:reg12, this_value:this, `prop`, src:reg10, kind:Normal
+  [  e8] Jump target:block2
 
 block5:
-  [  e8] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
-  [ 100] Throw src:reg9
+  [  f0] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
+  [ 108] Throw src:reg9
 
 block6:
-  [ 108] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
-  [ 120] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block7, false_target:block8
+  [ 110] IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
+  [ 128] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block7, false_target:block8
 
 block7:
-  [ 138] Return value:reg9
+  [ 140] Return value:reg9
 
 block8:
-  [ 140] Throw src:reg9
+  [ 148] Throw src:reg9
 
 Exception handlers:
-  [  b0 ..   e8] => handler block3
+  [  b8 ..   f0] => handler block3

--- a/Tests/LibJS/Bytecode/expected/super-length-access.txt
+++ b/Tests/LibJS/Bytecode/expected/super-length-access.txt
@@ -1,4 +1,4 @@
-$dc8f51ec super-length-access.js:3:1
+$5df14a74 super-length-access.js:3:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,65 +7,70 @@ $dc8f51ec super-length-access.js:3:1
     [2] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("length")]
-  [  60] DynamicInitializeLexicalBinding `A`, src:reg6
-  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
-  [  88] CreateVariable `B`, is_immutable:true, is_global:false, is_strict:true
-  [  98] GetGlobal dst:reg5, `A`
-  [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("m")]
-  [  d8] DynamicInitializeLexicalBinding `B`, src:reg7
-  [  e8] GetGlobal dst:reg5, `B`
-  [  f8] CallConstruct dst:reg6, callee:reg5, B
-  [ 110] GetById dst:reg5, base:reg6, `m`
-  [ 128] Call dst:reg7, callee:reg5, this_value:reg6, <object>.m
-  [ 148] End value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("length")]
+  [  68] DynamicInitializeLexicalBinding `A`, src:reg6
+  [  78] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  90] CreateVariable `B`, is_immutable:true, is_global:false, is_strict:true
+  [  a0] GetGlobal dst:reg5, `A`
+  [  b0] SetLexicalEnvironment environment:reg4
+  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("m")]
+  [  e0] DynamicInitializeLexicalBinding `B`, src:reg7
+  [  f0] GetGlobal dst:reg5, `B`
+  [ 100] CallConstruct dst:reg6, callee:reg5, B
+  [ 118] GetById dst:reg5, base:reg6, `m`
+  [ 130] Call dst:reg7, callee:reg5, this_value:reg6, <object>.m
+  [ 150] End value:reg7
 
 
-B$ce9c9421 super-length-access.js:7:1
+B$73f1ca79 super-length-access.js:7:1
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
-  [  10] CreateRestParams dst:arg0, rest_index:0
-  [  20] InitializeLexicalBinding `args`, src:arg0
-  [  38] GetSuperConstructor dst:reg5
-  [  40] GetBinding dst:reg6, `args`
-  [  58] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:true
-  [  70] Return value:reg7
+  [   0] Enter
+  [   8] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
+  [  18] CreateRestParams dst:arg0, rest_index:0
+  [  28] InitializeLexicalBinding `args`, src:arg0
+  [  40] GetSuperConstructor dst:reg5
+  [  48] GetBinding dst:reg6, `args`
+  [  60] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:true
+  [  78] Return value:reg7
 
 
-A$ef0589ec
+A$70678274
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-m$6cadcac8 super-length-access.js:9:9
+m$eb4bd240 super-length-access.js:9:9
   Registers: 7
   Blocks:    1
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg5
-  [  10] GetLengthWithThis dst:reg6, base:reg5, this_value:this
-  [  28] Return value:reg6
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg5
+  [  18] GetLengthWithThis dst:reg6, base:reg5, this_value:this
+  [  30] Return value:reg6
 
 
-get length$e8de8dcf super-length-access.js:4:20
+get length$64b8a437 super-length-access.js:4:20
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Int32(42)
 
 block0:
-  [   0] Return value:Int32(42)
+  [   0] Enter
+  [   8] Return value:Int32(42)

--- a/Tests/LibJS/Bytecode/expected/super-method-call-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-method-call-order.txt
@@ -1,77 +1,82 @@
-$6ce1f287 super-method-call-order.js:1:1
+$f3cbcd2f super-method-call-order.js:1:1
   Registers: 9
   Blocks:    1
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] NewFunction dst:reg6, shared_function_data_index:0 (m), home_object:reg5
-  [  28] InitObjectLiteralProperty object:reg5, `m`, src:reg6, shape_cache_index:0, property_slot:0
-  [  40] CacheObjectShape object:reg5
-  [  50] SetGlobal `proto`, src:reg5
-  [  60] NewObject dst:reg5
-  [  70] GetGlobal dst:reg6, `proto`
-  [  80] PutById base:reg5, `__proto__`, src:reg6, kind:Prototype
-  [  a0] NewFunction dst:reg6, shared_function_data_index:1 (test), home_object:reg5
-  [  b8] PutById base:reg5, `test`, src:reg6, kind:Own
-  [  d8] NewFunction dst:reg6, shared_function_data_index:2 (get x), home_object:reg5
-  [  f0] PutById base:reg5, `x`, src:reg6, kind:Getter
-  [ 110] NewFunction dst:reg6, shared_function_data_index:3 (test2), home_object:reg5
-  [ 128] PutById base:reg5, `test2`, src:reg6, kind:Own
-  [ 148] SetGlobal `obj`, src:reg5
-  [ 158] GetGlobal dst:reg6, `obj`
-  [ 168] GetById dst:reg7, base:reg6, `test` (obj.test)
-  [ 180] Call dst:reg5, callee:reg7, this_value:reg6, obj.test
-  [ 1a0] GetGlobal dst:reg7, `obj`
-  [ 1b0] GetById dst:reg6, base:reg7, `x` (obj.x)
-  [ 1c8] GetGlobal dst:reg7, `obj`
-  [ 1d8] GetById dst:reg8, base:reg7, `test2` (obj.test2)
-  [ 1f0] Call dst:reg5, callee:reg8, this_value:reg7, obj.test2
-  [ 210] End value:reg5
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] NewFunction dst:reg6, shared_function_data_index:0 (m), home_object:reg5
+  [  30] InitObjectLiteralProperty object:reg5, `m`, src:reg6, shape_cache_index:0, property_slot:0
+  [  48] CacheObjectShape object:reg5
+  [  58] SetGlobal `proto`, src:reg5
+  [  68] NewObject dst:reg5
+  [  78] GetGlobal dst:reg6, `proto`
+  [  88] PutById base:reg5, `__proto__`, src:reg6, kind:Prototype
+  [  a8] NewFunction dst:reg6, shared_function_data_index:1 (test), home_object:reg5
+  [  c0] PutById base:reg5, `test`, src:reg6, kind:Own
+  [  e0] NewFunction dst:reg6, shared_function_data_index:2 (get x), home_object:reg5
+  [  f8] PutById base:reg5, `x`, src:reg6, kind:Getter
+  [ 118] NewFunction dst:reg6, shared_function_data_index:3 (test2), home_object:reg5
+  [ 130] PutById base:reg5, `test2`, src:reg6, kind:Own
+  [ 150] SetGlobal `obj`, src:reg5
+  [ 160] GetGlobal dst:reg6, `obj`
+  [ 170] GetById dst:reg7, base:reg6, `test` (obj.test)
+  [ 188] Call dst:reg5, callee:reg7, this_value:reg6, obj.test
+  [ 1a8] GetGlobal dst:reg7, `obj`
+  [ 1b8] GetById dst:reg6, base:reg7, `x` (obj.x)
+  [ 1d0] GetGlobal dst:reg7, `obj`
+  [ 1e0] GetById dst:reg8, base:reg7, `test2` (obj.test2)
+  [ 1f8] Call dst:reg5, callee:reg8, this_value:reg7, obj.test2
+  [ 218] End value:reg5
 
 
-test$ef7af7d7 super-method-call-order.js:5:9
+test$70dcf05f super-method-call-order.js:5:9
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg6
-  [  10] GetByIdWithThis dst:reg7, base:reg6, `m`, this_value:this
-  [  28] Call dst:reg5, callee:reg7, this_value:this, <object>.m
-  [  48] Return value:reg5
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg6
+  [  18] GetByIdWithThis dst:reg7, base:reg6, `m`, this_value:this
+  [  30] Call dst:reg5, callee:reg7, this_value:this, <object>.m
+  [  50] Return value:reg5
 
 
-m$685877e0
+m$ec7e6178
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-get x$18e950ea super-method-call-order.js:8:9
+get x$97875862 super-method-call-order.js:8:9
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg6
-  [  10] GetByIdWithThis dst:reg7, base:reg6, `m`, this_value:this
-  [  28] Call dst:reg5, callee:reg7, this_value:this, <object>.m
-  [  48] Return value:reg5
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg6
+  [  18] GetByIdWithThis dst:reg7, base:reg6, `m`, this_value:this
+  [  30] Call dst:reg5, callee:reg7, this_value:this, <object>.m
+  [  50] Return value:reg5
 
 
-test2$dbcdbeb3 super-method-call-order.js:11:9
+test2$5d2fb73b super-method-call-order.js:11:9
   Registers: 8
   Blocks:    1
   Constants:
     [0] = String("m")
 
 block0:
-  [   0] ResolveThisBinding
-  [   8] ResolveSuperBase dst:reg6
-  [  10] GetByIdWithThis dst:reg7, base:reg6, `m`, this_value:this
-  [  28] Call dst:reg5, callee:reg7, this_value:this, <object>['m']
-  [  48] Return value:reg5
+  [   0] Enter
+  [   8] ResolveThisBinding
+  [  10] ResolveSuperBase dst:reg6
+  [  18] GetByIdWithThis dst:reg7, base:reg6, `m`, this_value:this
+  [  30] Call dst:reg5, callee:reg7, this_value:this, <object>['m']
+  [  50] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
+++ b/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
@@ -1,4 +1,4 @@
-$1f56e90a super-optional-call-this.js:1:1
+$a0b8e192 super-optional-call-this.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,79 +6,84 @@ $1f56e90a super-optional-call-this.js:1:1
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:true
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
-  [  60] DynamicInitializeLexicalBinding `Base`, src:reg6
-  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
-  [  88] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:true
-  [  98] GetGlobal dst:reg5, `Base`
-  [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("method")]
-  [  d8] DynamicInitializeLexicalBinding `Foo`, src:reg7
-  [  e8] GetGlobal dst:reg5, `Foo`
-  [  f8] CallConstruct dst:reg6, callee:reg5, Foo
-  [ 110] GetById dst:reg5, base:reg6, `method`
-  [ 128] Call dst:reg7, callee:reg5, this_value:reg6, <object>.method
-  [ 148] End value:reg7
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:true
+  [  38] SetLexicalEnvironment environment:reg4
+  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
+  [  68] DynamicInitializeLexicalBinding `Base`, src:reg6
+  [  78] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  90] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:true
+  [  a0] GetGlobal dst:reg5, `Base`
+  [  b0] SetLexicalEnvironment environment:reg4
+  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("method")]
+  [  e0] DynamicInitializeLexicalBinding `Foo`, src:reg7
+  [  f0] GetGlobal dst:reg5, `Foo`
+  [ 100] CallConstruct dst:reg6, callee:reg5, Foo
+  [ 118] GetById dst:reg5, base:reg6, `method`
+  [ 130] Call dst:reg7, callee:reg5, this_value:reg6, <object>.method
+  [ 150] End value:reg7
 
 
-Foo$fbafd3fe super-optional-call-this.js:4:1
+Foo$9e411946 super-optional-call-this.js:4:1
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
-  [  10] CreateRestParams dst:arg0, rest_index:0
-  [  20] InitializeLexicalBinding `args`, src:arg0
-  [  38] GetSuperConstructor dst:reg5
-  [  40] GetBinding dst:reg6, `args`
-  [  58] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:true
-  [  70] Return value:reg7
+  [   0] Enter
+  [   8] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
+  [  18] CreateRestParams dst:arg0, rest_index:0
+  [  28] InitializeLexicalBinding `args`, src:arg0
+  [  40] GetSuperConstructor dst:reg5
+  [  48] GetBinding dst:reg6, `args`
+  [  60] SuperCallWithArgumentArray dst:reg7, super_constructor:reg5, arguments:reg6, is_synthetic:true
+  [  78] Return value:reg7
 
 
-Base$a461b108
+Base$25c3a990
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined
 
 
-method$a9e5e24d super-optional-call-this.js:6:9
+method$2883e9c5 super-optional-call-this.js:6:9
   Registers: 9
   Blocks:    3
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] MovSrcUndefined dst:reg5
-  [   8] ResolveThisBinding
-  [  10] ResolveSuperBase dst:reg7
-  [  18] GetByIdWithThis dst:reg8, base:reg7, `method`, this_value:this
-  [  30] Mov2 c0_dst:reg5, c0_src:this, c1_dst:reg6, c1_src:reg8
-  [  48] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] MovSrcUndefined dst:reg5
+  [  10] ResolveThisBinding
+  [  18] ResolveSuperBase dst:reg7
+  [  20] GetByIdWithThis dst:reg8, base:reg7, `method`, this_value:this
+  [  38] Mov2 c0_dst:reg5, c0_src:this, c1_dst:reg6, c1_src:reg8
+  [  50] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  58] MovSrcUndefined dst:reg6
-  [  60] Return value:reg6
+  [  60] MovSrcUndefined dst:reg6
+  [  68] Return value:reg6
 
 block2:
-  [  68] NewArray dst:reg7
-  [  78] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-  [  90] MovSrcUndefined dst:reg5
-  [  98] Return value:reg6
+  [  70] NewArray dst:reg7
+  [  80] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+  [  98] MovSrcUndefined dst:reg5
+  [  a0] Return value:reg6
 
 
-method$6c22ae6a
+method$ed84a6f2
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
@@ -1,4 +1,4 @@
-$48d208fa switch-completion-value.js:1:1
+$ca340182 switch-completion-value.js:1:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -8,25 +8,26 @@ $48d208fa switch-completion-value.js:1:1
     [3] = String("switch(1) { case 1: 'matched'; break; default: 'default'; }")
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `eval`
-  [  38] CallDirectEval dst:reg8, callee:reg9, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'hello'; let x = 1; }")]
-  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  88] GetGlobal dst:reg6, `console`
-  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  b0] GetGlobal dst:reg10, `eval`
-  [  c0] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'first'; 'second'; }")]
-  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 110] GetGlobal dst:reg8, `console`
-  [ 120] GetById dst:reg6, base:reg8, `log` (console.log)
-  [ 138] GetGlobal dst:reg10, `eval`
-  [ 148] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'matched'; break; default: 'default'; }")]
-  [ 170] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
-  [ 198] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `eval`
+  [  40] CallDirectEval dst:reg8, callee:reg9, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'hello'; let x = 1; }")]
+  [  68] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  90] GetGlobal dst:reg6, `console`
+  [  a0] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b8] GetGlobal dst:reg10, `eval`
+  [  c8] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'first'; 'second'; }")]
+  [  f0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 118] GetGlobal dst:reg8, `console`
+  [ 128] GetById dst:reg6, base:reg8, `log` (console.log)
+  [ 140] GetGlobal dst:reg10, `eval`
+  [ 150] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'matched'; break; default: 'default'; }")]
+  [ 178] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 1a0] End value:reg5
 
 
-eval$e6bbe983 line 1, column 1
+eval$6559f0fb line 1, column 1
   Registers: 7
   Blocks:    3
   Locals:    x~0
@@ -36,18 +37,19 @@ eval$e6bbe983 line 1, column 1
     [2] = String("hello")
 
 block0:
-  [   0] MovSrcUndefined dst:reg5
-  [   8] JumpStrictlyEqualsRhsInt32 lhs:Int32(1), rhs:1, true_target:block2, false_target:block1
+  [   0] Enter
+  [   8] MovSrcUndefined dst:reg5
+  [  10] JumpStrictlyEqualsRhsInt32 lhs:Int32(1), rhs:1, true_target:block2, false_target:block1
 
 block1:
-  [  20] End value:reg5
+  [  28] End value:reg5
 
 block2:
-  [  28] Mov2 c0_dst:reg5, c0_src:String("hello"), c1_dst:x~0, c1_src:Int32(1)
-  [  40] End value:reg5
+  [  30] Mov2 c0_dst:reg5, c0_src:String("hello"), c1_dst:x~0, c1_src:Int32(1)
+  [  48] End value:reg5
 
 
-eval$e6bbe983 line 1, column 1
+eval$6559f0fb line 1, column 1
   Registers: 7
   Blocks:    3
   Constants:
@@ -57,18 +59,19 @@ eval$e6bbe983 line 1, column 1
     [3] = String("second")
 
 block0:
-  [   0] MovSrcUndefined dst:reg5
-  [   8] JumpStrictlyEqualsRhsInt32 lhs:Int32(1), rhs:1, true_target:block2, false_target:block1
+  [   0] Enter
+  [   8] MovSrcUndefined dst:reg5
+  [  10] JumpStrictlyEqualsRhsInt32 lhs:Int32(1), rhs:1, true_target:block2, false_target:block1
 
 block1:
-  [  20] End value:reg5
+  [  28] End value:reg5
 
 block2:
-  [  28] Mov2 c0_dst:reg5, c0_src:String("first"), c1_dst:reg5, c1_src:String("second")
-  [  40] End value:reg5
+  [  30] Mov2 c0_dst:reg5, c0_src:String("first"), c1_dst:reg5, c1_src:String("second")
+  [  48] End value:reg5
 
 
-eval$e3f7f873 line 1, column 1
+eval$6da5c42b line 1, column 1
   Registers: 7
   Blocks:    4
   Constants:
@@ -78,19 +81,20 @@ eval$e3f7f873 line 1, column 1
     [3] = String("default")
 
 block0:
-  [   0] MovSrcUndefined dst:reg5
-  [   8] JumpStrictlyEqualsRhsInt32 lhs:Int32(1), rhs:1, true_target:block2, false_target:block1
+  [   0] Enter
+  [   8] MovSrcUndefined dst:reg5
+  [  10] JumpStrictlyEqualsRhsInt32 lhs:Int32(1), rhs:1, true_target:block2, false_target:block1
 
 block1:
-  [  20] Jump target:block3
+  [  28] Jump target:block3
 
 block2:
-  [  28] Mov dst:reg5, src:String("matched")
-  [  38] End value:reg5
+  [  30] Mov dst:reg5, src:String("matched")
+  [  40] End value:reg5
 
 block3:
-  [  40] Mov dst:reg5, src:String("default")
-  [  50] End value:reg5
+  [  48] Mov dst:reg5, src:String("default")
+  [  58] End value:reg5
 
 
 "hello"

--- a/Tests/LibJS/Bytecode/expected/switch-local-only-let.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-local-only-let.txt
@@ -1,4 +1,4 @@
-$3e1caa20 switch-local-only-let.js:15:1
+$bcbab198 switch-local-only-let.js:15:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -8,25 +8,26 @@ $3e1caa20 switch-local-only-let.js:15:1
     [3] = Int32(3)
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `switchLocalOnly`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, switchLocalOnly, arguments:[Int32(1)]
-  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  88] GetGlobal dst:reg6, `console`
-  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  b0] GetGlobal dst:reg10, `switchLocalOnly`
-  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(2)]
-  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 110] GetGlobal dst:reg8, `console`
-  [ 120] GetById dst:reg6, base:reg8, `log` (console.log)
-  [ 138] GetGlobal dst:reg10, `switchLocalOnly`
-  [ 148] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(3)]
-  [ 170] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
-  [ 198] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `switchLocalOnly`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, switchLocalOnly, arguments:[Int32(1)]
+  [  68] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  90] GetGlobal dst:reg6, `console`
+  [  a0] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b8] GetGlobal dst:reg10, `switchLocalOnly`
+  [  c8] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(2)]
+  [  f0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 118] GetGlobal dst:reg8, `console`
+  [ 128] GetById dst:reg6, base:reg8, `log` (console.log)
+  [ 140] GetGlobal dst:reg10, `switchLocalOnly`
+  [ 150] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(3)]
+  [ 178] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 1a0] End value:reg5
 
 
-switchLocalOnly$fc47fb27 switch-local-only-let.js:4:5
+switchLocalOnly$6a4e5c3f switch-local-only-let.js:4:5
   Registers: 6
   Blocks:    7
   Locals:    a~0, b~1
@@ -39,27 +40,28 @@ switchLocalOnly$fc47fb27 switch-local-only-let.js:4:5
     [5] = Undefined
 
 block0:
-  [   0] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
+  [   0] Enter
+  [   8] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
 
 block1:
-  [  18] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
+  [  20] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
 
 block2:
-  [  30] Return value:Int32(0)
+  [  38] Return value:Int32(0)
 
 block3:
-  [  38] Mov dst:a~0, src:Int32(10)
-  [  48] Return value:a~0
+  [  40] Mov dst:a~0, src:Int32(10)
+  [  50] Return value:a~0
 
 block4:
-  [  50] Mov dst:b~1, src:Int32(20)
-  [  60] Return value:b~1
+  [  58] Mov dst:b~1, src:Int32(20)
+  [  68] Return value:b~1
 
 block5:
-  [  68] Return value:Int32(0)
+  [  70] Return value:Int32(0)
 
 block6:
-  [  70] End value:Undefined
+  [  78] End value:Undefined
 
 
 10

--- a/Tests/LibJS/Bytecode/expected/switch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-scoping.txt
@@ -1,4 +1,4 @@
-$9e4f55e8 switch-scoping.js:15:1
+$27fd21a0 switch-scoping.js:15:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -7,20 +7,21 @@ $9e4f55e8 switch-scoping.js:15:1
     [2] = Int32(2)
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `switchWithBlockDecl`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(1)]
-  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  88] GetGlobal dst:reg6, `console`
-  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  b0] GetGlobal dst:reg10, `switchWithBlockDecl`
-  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(2)]
-  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 110] End value:reg7
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `switchWithBlockDecl`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(1)]
+  [  68] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  90] GetGlobal dst:reg6, `console`
+  [  a0] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b8] GetGlobal dst:reg10, `switchWithBlockDecl`
+  [  c8] Call dst:reg9, callee:reg10, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(2)]
+  [  f0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 118] End value:reg7
 
 
-switchWithBlockDecl$4f465f02 switch-scoping.js:2:5
+switchWithBlockDecl$ba88cf0a switch-scoping.js:2:5
   Registers: 7
   Blocks:    6
   Locals:    result~0
@@ -32,52 +33,55 @@ switchWithBlockDecl$4f465f02 switch-scoping.js:2:5
     [4] = String("two")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] MovSrcUndefined dst:result~0
-  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  28] CreateMutableBinding environment:reg5, `a`, can_be_deleted:false
-  [  38] CreateMutableBinding environment:reg5, `b`, can_be_deleted:false
-  [  48] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] MovSrcUndefined dst:result~0
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  30] CreateMutableBinding environment:reg5, `a`, can_be_deleted:false
+  [  40] CreateMutableBinding environment:reg5, `b`, can_be_deleted:false
+  [  50] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
 
 block1:
-  [  60] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
+  [  68] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
 
 block2:
-  [  78] Jump target:block5
+  [  80] Jump target:block5
 
 block3:
-  [  80] InitializeLexicalBinding `a`, src:String("one")
-  [  98] NewFunction dst:reg6, shared_function_data_index:0 (result)
-  [  b0] Mov dst:result~0, src:reg6
-  [  c0] Jump target:block5
+  [  88] InitializeLexicalBinding `a`, src:String("one")
+  [  a0] NewFunction dst:reg6, shared_function_data_index:0 (result)
+  [  b8] Mov dst:result~0, src:reg6
+  [  c8] Jump target:block5
 
 block4:
-  [  c8] InitializeLexicalBinding `b`, src:String("two")
-  [  e0] NewFunction dst:reg6, shared_function_data_index:1 (result)
-  [  f8] Mov dst:result~0, src:reg6
+  [  d0] InitializeLexicalBinding `b`, src:String("two")
+  [  e8] NewFunction dst:reg6, shared_function_data_index:1 (result)
+  [ 100] Mov dst:result~0, src:reg6
 
 block5:
-  [ 108] SetLexicalEnvironment environment:reg4
-  [ 110] Call dst:reg5, callee:result~0, this_value:Undefined, result
-  [ 130] Return value:reg5
+  [ 110] SetLexicalEnvironment environment:reg4
+  [ 118] Call dst:reg5, callee:result~0, this_value:Undefined, result
+  [ 138] Return value:reg5
 
 
-result$bf9aaf34 switch-scoping.js:6:22
+result$38b0d48c switch-scoping.js:6:22
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `a`
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `a`
+  [  18] Return value:reg5
 
 
-result$8921e678 switch-scoping.js:10:22
+result$ff741ac0 switch-scoping.js:10:22
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] DynamicGetBinding dst:reg5, `b`
-  [  10] Return value:reg5
+  [   0] Enter
+  [   8] DynamicGetBinding dst:reg5, `b`
+  [  18] Return value:reg5
 
 
 "one"

--- a/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
@@ -1,4 +1,4 @@
-$c7fd0018 switch-with-block-scope-return.js:12:1
+$469b0790 switch-with-block-scope-return.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,12 +6,13 @@ $c7fd0018 switch-with-block-scope-return.js:12:1
     [1] = Int32(1)
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  38] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  40] End value:reg5
 
 
-f$83fadf14 switch-with-block-scope-return.js:2:5
+f$25d82f37 switch-with-block-scope-return.js:2:5
   Registers: 8
   Blocks:    7
   Constants:
@@ -23,32 +24,33 @@ f$83fadf14 switch-with-block-scope-return.js:2:5
     [5] = String("other")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateImmutableBinding environment:reg5, `y`, strict_binding:true
-  [  30] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateImmutableBinding environment:reg5, `y`, strict_binding:true
+  [  38] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
 
 block1:
-  [  48] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
+  [  50] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
 
 block2:
-  [  60] Jump target:block5
+  [  68] Jump target:block5
 
 block3:
-  [  68] SetLexicalEnvironment environment:reg4
-  [  70] Return value:String("one")
+  [  70] SetLexicalEnvironment environment:reg4
+  [  78] Return value:String("one")
 
 block4:
-  [  78] InitializeLexicalBinding `y`, src:String("two")
-  [  90] NewFunction dst:reg7, shared_function_data_index:0
-  [  a8] Call dst:reg6, callee:reg7, this_value:Undefined
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] Return value:reg6
+  [  80] InitializeLexicalBinding `y`, src:String("two")
+  [  98] NewFunction dst:reg7, shared_function_data_index:0
+  [  b0] Call dst:reg6, callee:reg7, this_value:Undefined
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] Return value:reg6
 
 block5:
-  [  d8] SetLexicalEnvironment environment:reg4
-  [  e0] Return value:String("other")
+  [  e0] SetLexicalEnvironment environment:reg4
+  [  e8] Return value:String("other")
 
 block6:
-  [  e8] SetLexicalEnvironment environment:reg4
-  [  f0] End value:Undefined
+  [  f0] SetLexicalEnvironment environment:reg4
+  [  f8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/tagged-template-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-base-identifier.txt
@@ -1,25 +1,27 @@
-$f5bf1d5d tagged-template-base-identifier.js:1:1
+$7ca8f805 tagged-template-base-identifier.js:1:1
   Registers: 9
   Blocks:    1
   Constants:
     [0] = String("")
 
 block0:
-  [   0] NewObject dst:reg5
-  [  10] NewFunction dst:reg6, shared_function_data_index:0 (f)
-  [  28] InitObjectLiteralProperty object:reg5, `f`, src:reg6, shape_cache_index:0, property_slot:0
-  [  40] CacheObjectShape object:reg5
-  [  50] SetGlobal `obj`, src:reg5
-  [  60] GetGlobal dst:reg5, `obj`
-  [  70] GetById dst:reg6, base:reg5, `f` (obj.f)
-  [  88] GetTemplateObject dst:reg7, strings:[String(""), String("")]
-  [  a8] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
-  [  d0] End value:reg8
+  [   0] Enter
+  [   8] NewObject dst:reg5
+  [  18] NewFunction dst:reg6, shared_function_data_index:0 (f)
+  [  30] InitObjectLiteralProperty object:reg5, `f`, src:reg6, shape_cache_index:0, property_slot:0
+  [  48] CacheObjectShape object:reg5
+  [  58] SetGlobal `obj`, src:reg5
+  [  68] GetGlobal dst:reg5, `obj`
+  [  78] GetById dst:reg6, base:reg5, `f` (obj.f)
+  [  90] GetTemplateObject dst:reg7, strings:[String(""), String("")]
+  [  b0] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
+  [  d8] End value:reg8
 
 
-f$eef94cf9 tagged-template-base-identifier.js:3:9
+f$705b4581 tagged-template-base-identifier.js:3:9
   Registers: 5
   Blocks:    1
 
 block0:
-  [   0] Return value:this
+  [   0] Enter
+  [   8] Return value:this

--- a/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
@@ -1,4 +1,4 @@
-$f74c5409 tagged-template-if-register-order.js:2:1
+$73266a71 tagged-template-if-register-order.js:2:1
   Registers: 11
   Blocks:    3
   Constants:
@@ -8,24 +8,25 @@ $f74c5409 tagged-template-if-register-order.js:2:1
     [3] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg5, `String`
-  [  10] GetById dst:reg6, base:reg5, `raw` (String.raw)
-  [  28] GetTemplateObject dst:reg7, strings:[String("hello"), String("hello")]
-  [  48] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
-  [  70] DynamicInitializeLexicalBinding `x`, src:reg8
-  [  80] DynamicInitializeLexicalBinding `y`, src:Null
-  [  90] GetGlobal dst:reg8, `x`
-  [  a0] StrictlyEquals dst:reg6, lhs:reg8, rhs:String("hello")
-  [  b0] MovSrcUndefined dst:reg8
-  [  b8] JumpFalse condition:reg6, target:block2
+  [   0] Enter
+  [   8] GetGlobal dst:reg5, `String`
+  [  18] GetById dst:reg6, base:reg5, `raw` (String.raw)
+  [  30] GetTemplateObject dst:reg7, strings:[String("hello"), String("hello")]
+  [  50] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
+  [  78] DynamicInitializeLexicalBinding `x`, src:reg8
+  [  88] DynamicInitializeLexicalBinding `y`, src:Null
+  [  98] GetGlobal dst:reg8, `x`
+  [  a8] StrictlyEquals dst:reg6, lhs:reg8, rhs:String("hello")
+  [  b8] MovSrcUndefined dst:reg8
+  [  c0] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  c8] ResolveBinding dst:reg7, `y`
-  [  d8] GetGlobal dst:reg9, `x`
-  [  e8] GetById dst:reg10, base:reg9, `toUpperCase` (x.toUpperCase)
-  [ 100] Call dst:reg5, callee:reg10, this_value:reg9, x.toUpperCase
-  [ 120] SetResolvedBinding environment:reg7, `y`, src:reg5
-  [ 130] Mov dst:reg8, src:reg5
+  [  d0] ResolveBinding dst:reg7, `y`
+  [  e0] GetGlobal dst:reg9, `x`
+  [  f0] GetById dst:reg10, base:reg9, `toUpperCase` (x.toUpperCase)
+  [ 108] Call dst:reg5, callee:reg10, this_value:reg9, x.toUpperCase
+  [ 128] SetResolvedBinding environment:reg7, `y`, src:reg5
+  [ 138] Mov dst:reg8, src:reg5
 
 block2:
-  [ 140] End value:reg8
+  [ 148] End value:reg8

--- a/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
@@ -1,44 +1,46 @@
-$474fd25c this-base-identifier.js:16:1
+$fc88b9ef this-base-identifier.js:16:1
   Registers: 10
   Blocks:    3
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] GetGlobal dst:reg6, `get_from_this`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, get_from_this
-  [  38] GetGlobal dst:reg7, `set_on_this`
-  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, set_on_this
-  [  68] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] GetGlobal dst:reg6, `get_from_this`
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, get_from_this
+  [  40] GetGlobal dst:reg7, `set_on_this`
+  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, set_on_this
+  [  70] Jump target:block2
 
 block1:
-  [  70] Catch dst:reg5
-  [  78] SetLexicalEnvironment environment:reg4
-  [  80] Mov2 c0_dst:reg7, c0_src:Undefined, c1_dst:reg8, c1_src:reg7
-  [  98] End value:reg7
+  [  78] Catch dst:reg5
+  [  80] SetLexicalEnvironment environment:reg4
+  [  88] Mov2 c0_dst:reg7, c0_src:Undefined, c1_dst:reg8, c1_src:reg7
+  [  a0] End value:reg7
 
 block2:
-  [  a0] MovSrcUndefined dst:reg5
-  [  a8] GetGlobal dst:reg9, `chained_this_access`
-  [  b8] Call dst:reg7, callee:reg9, this_value:Undefined, chained_this_access
-  [  d8] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg7, c1_src:reg5
-  [  f0] End value:reg7
+  [  a8] MovSrcUndefined dst:reg5
+  [  b0] GetGlobal dst:reg9, `chained_this_access`
+  [  c0] Call dst:reg7, callee:reg9, this_value:Undefined, chained_this_access
+  [  e0] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg7, c1_src:reg5
+  [  f8] End value:reg7
 
 Exception handlers:
-  [  a0 ..   f8] => handler block1
+  [  a8 ..  100] => handler block1
 
 
-get_from_this$fcaf59fb this-base-identifier.js:5:5
+get_from_this$7b4d6173 this-base-identifier.js:5:5
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] GetById dst:reg5, base:this, `foo` (this.foo)
-  [  18] Return value:reg5
+  [   0] Enter
+  [   8] GetById dst:reg5, base:this, `foo` (this.foo)
+  [  20] Return value:reg5
 
 
-set_on_this$997a7c27 this-base-identifier.js:9:14
+set_on_this$1818839f this-base-identifier.js:9:14
   Registers: 5
   Blocks:    1
   Constants:
@@ -46,15 +48,17 @@ set_on_this$997a7c27 this-base-identifier.js:9:14
     [1] = Undefined
 
 block0:
-  [   0] PutById base:this, `bar`, src:Int32(1), kind:Normal (this.bar)
-  [  20] End value:Undefined
+  [   0] Enter
+  [   8] PutById base:this, `bar`, src:Int32(1), kind:Normal (this.bar)
+  [  28] End value:Undefined
 
 
-chained_this_access$39eea63b this-base-identifier.js:13:5
+chained_this_access$cbe84523 this-base-identifier.js:13:5
   Registers: 7
   Blocks:    1
 
 block0:
-  [   0] GetById dst:reg5, base:this, `a` (this.a)
-  [  18] GetById dst:reg6, base:reg5, `b` (this.a.b)
-  [  30] Return value:reg6
+  [   0] Enter
+  [   8] GetById dst:reg5, base:this, `a` (this.a)
+  [  20] GetById dst:reg6, base:reg5, `b` (this.a.b)
+  [  38] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/try-catch-completion-ordering.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-completion-ordering.txt
@@ -1,4 +1,4 @@
-$e7eb680d try-catch-completion-ordering.js:1:1
+$63c57e75 try-catch-completion-ordering.js:1:1
   Registers: 8
   Blocks:    3
   Locals:    e~0
@@ -8,19 +8,20 @@ $e7eb680d try-catch-completion-ordering.js:1:1
     [2] = Null
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Jump target:block2
 
 block1:
-  [  10] Catch dst:reg5
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] Mov3 c0_dst:e~0, c0_src:reg5, c1_dst:reg6, c1_src:Undefined, c2_dst:reg6, c2_src:Int32(42)
-  [  40] Mov dst:reg7, src:reg6
-  [  50] End value:reg7
+  [  18] Catch dst:reg5
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] Mov3 c0_dst:e~0, c0_src:reg5, c1_dst:reg6, c1_src:Undefined, c2_dst:reg6, c2_src:Int32(42)
+  [  48] Mov dst:reg7, src:reg6
+  [  58] End value:reg7
 
 block2:
-  [  58] MovSrcUndefined dst:reg5
-  [  60] Throw src:Null
+  [  60] MovSrcUndefined dst:reg5
+  [  68] Throw src:Null
 
 Exception handlers:
-  [  58 ..   68] => handler block1
+  [  60 ..   70] => handler block1

--- a/Tests/LibJS/Bytecode/expected/try-catch-finally-register.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-finally-register.txt
@@ -1,4 +1,4 @@
-$abc8a5d2 try-catch-finally-register.js:1:1
+$32b2807a try-catch-finally-register.js:1:1
   Registers: 10
   Blocks:    9
   Locals:    e~0
@@ -10,42 +10,43 @@ $abc8a5d2 try-catch-finally-register.js:1:1
     [4] = Int32(3)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Jump target:block4
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Jump target:block4
 
 block1:
-  [  10] Catch dst:reg6
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] Mov dst:reg5, src:Int32(1)
+  [  18] Catch dst:reg6
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] Mov dst:reg5, src:Int32(1)
 
 block2:
-  [  30] Mov2 c0_dst:reg9, c0_src:Undefined, c1_dst:reg9, c1_src:Int32(3)
-  [  48] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block5, false_target:block6
+  [  38] Mov2 c0_dst:reg9, c0_src:Undefined, c1_dst:reg9, c1_src:Int32(3)
+  [  50] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block5, false_target:block6
 
 block3:
-  [  60] Catch dst:reg7
-  [  68] SetLexicalEnvironment environment:reg4
-  [  70] Mov3 c0_dst:e~0, c0_src:reg7, c1_dst:reg8, c1_src:Undefined, c2_dst:reg8, c2_src:Int32(2)
-  [  90] Mov2 c0_dst:reg9, c0_src:reg8, c1_dst:reg5, c1_src:Int32(0)
-  [  a8] Jump target:block2
+  [  68] Catch dst:reg7
+  [  70] SetLexicalEnvironment environment:reg4
+  [  78] Mov3 c0_dst:e~0, c0_src:reg7, c1_dst:reg8, c1_src:Undefined, c2_dst:reg8, c2_src:Int32(2)
+  [  98] Mov2 c0_dst:reg9, c0_src:reg8, c1_dst:reg5, c1_src:Int32(0)
+  [  b0] Jump target:block2
 
 block4:
-  [  b0] Mov3 c0_dst:reg7, c0_src:Undefined, c1_dst:reg7, c1_src:Int32(1), c2_dst:reg8, c2_src:reg7
-  [  d0] Mov dst:reg5, src:Int32(0)
-  [  e0] Jump target:block2
+  [  b8] Mov3 c0_dst:reg7, c0_src:Undefined, c1_dst:reg7, c1_src:Int32(1), c2_dst:reg8, c2_src:reg7
+  [  d8] Mov dst:reg5, src:Int32(0)
+  [  e8] Jump target:block2
 
 block5:
-  [  e8] End value:reg8
+  [  f0] End value:reg8
 
 block6:
-  [  f0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block7, false_target:block8
+  [  f8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block7, false_target:block8
 
 block7:
-  [ 108] Return value:reg6
+  [ 110] Return value:reg6
 
 block8:
-  [ 110] Throw src:reg6
+  [ 118] Throw src:reg6
 
 Exception handlers:
-  [  60 ..   b0] => handler block1
-  [  b0 ..   e8] => handler block3
+  [  68 ..   b8] => handler block1
+  [  b8 ..   f0] => handler block3

--- a/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
@@ -1,18 +1,19 @@
-$3ec36167 try-catch-scoping.js:11:1
+$bd6168df try-catch-scoping.js:11:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `tryCatchWithBlocks`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, tryCatchWithBlocks
-  [  30] GetGlobal dst:reg7, `tryCatchFinallyWithBlocks`
-  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, tryCatchFinallyWithBlocks
-  [  60] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `tryCatchWithBlocks`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, tryCatchWithBlocks
+  [  38] GetGlobal dst:reg7, `tryCatchFinallyWithBlocks`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, tryCatchFinallyWithBlocks
+  [  68] End value:reg6
 
 
-tryCatchWithBlocks$04cb6df0 try-catch-scoping.js:2:5
+tryCatchWithBlocks$7de19348 try-catch-scoping.js:2:5
   Registers: 11
   Blocks:    3
   Locals:    y~0, z~1, e~2, x~3
@@ -23,30 +24,31 @@ tryCatchWithBlocks$04cb6df0 try-catch-scoping.js:2:5
     [3] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:x~3, src:Int32(1)
-  [  18] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:x~3, src:Int32(1)
+  [  20] Jump target:block2
 
 block1:
-  [  20] Catch dst:reg5
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Mov2 c0_dst:e~2, c0_src:reg5, c1_dst:z~1, c1_src:Int32(3)
-  [  48] GetGlobal dst:reg7, `console`
-  [  58] GetById dst:reg8, base:reg7, `log` (console.log)
-  [  70] Add dst:reg9, lhs:x~3, rhs:e~2
-  [  80] Add dst:reg10, lhs:reg9, rhs:z~1
-  [  90] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg10]
-  [  b8] End value:Undefined
+  [  28] Catch dst:reg5
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Mov2 c0_dst:e~2, c0_src:reg5, c1_dst:z~1, c1_src:Int32(3)
+  [  50] GetGlobal dst:reg7, `console`
+  [  60] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  78] Add dst:reg9, lhs:x~3, rhs:e~2
+  [  88] Add dst:reg10, lhs:reg9, rhs:z~1
+  [  98] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg10]
+  [  c0] End value:Undefined
 
 block2:
-  [  c0] Mov dst:y~0, src:Int32(2)
-  [  d0] Throw src:y~0
+  [  c8] Mov dst:y~0, src:Int32(2)
+  [  d8] Throw src:y~0
 
 Exception handlers:
-  [  c0 ..   d8] => handler block1
+  [  c8 ..   e0] => handler block1
 
 
-tryCatchFinallyWithBlocks$ae3c37ba try-catch-scoping.js:14:5
+tryCatchFinallyWithBlocks$2cda3f32 try-catch-scoping.js:14:5
   Registers: 12
   Blocks:    9
   Locals:    y~0, e~1, z~2, x~3
@@ -58,53 +60,54 @@ tryCatchFinallyWithBlocks$ae3c37ba try-catch-scoping.js:14:5
     [4] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:x~3, src:Int32(1)
-  [  18] Jump target:block4
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:x~3, src:Int32(1)
+  [  20] Jump target:block4
 
 block1:
-  [  20] Catch dst:reg6
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Mov dst:reg5, src:Int32(1)
+  [  28] Catch dst:reg6
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Mov dst:reg5, src:Int32(1)
 
 block2:
-  [  40] Mov dst:z~2, src:Int32(3)
-  [  50] GetGlobal dst:reg8, `console`
-  [  60] GetById dst:reg10, base:reg8, `log` (console.log)
-  [  78] Mov dst:reg9, src:z~2
-  [  88] Call dst:reg7, callee:reg10, this_value:reg8, console.log, arguments:[reg9]
-  [  b0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block5, false_target:block6
+  [  48] Mov dst:z~2, src:Int32(3)
+  [  58] GetGlobal dst:reg8, `console`
+  [  68] GetById dst:reg10, base:reg8, `log` (console.log)
+  [  80] Mov dst:reg9, src:z~2
+  [  90] Call dst:reg7, callee:reg10, this_value:reg8, console.log, arguments:[reg9]
+  [  b8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block5, false_target:block6
 
 block3:
-  [  c8] Catch dst:reg7
-  [  d0] SetLexicalEnvironment environment:reg4
-  [  d8] Mov dst:e~1, src:reg7
-  [  e8] GetGlobal dst:reg9, `console`
-  [  f8] GetById dst:reg10, base:reg9, `log` (console.log)
-  [ 110] Mov dst:reg11, src:e~1
-  [ 120] Call dst:reg8, callee:reg10, this_value:reg9, console.log, arguments:[reg11]
-  [ 148] Mov dst:reg5, src:Int32(0)
-  [ 158] Jump target:block2
+  [  d0] Catch dst:reg7
+  [  d8] SetLexicalEnvironment environment:reg4
+  [  e0] Mov dst:e~1, src:reg7
+  [  f0] GetGlobal dst:reg9, `console`
+  [ 100] GetById dst:reg10, base:reg9, `log` (console.log)
+  [ 118] Mov dst:reg11, src:e~1
+  [ 128] Call dst:reg8, callee:reg10, this_value:reg9, console.log, arguments:[reg11]
+  [ 150] Mov dst:reg5, src:Int32(0)
+  [ 160] Jump target:block2
 
 block4:
-  [ 160] Mov dst:y~0, src:Int32(2)
-  [ 170] Throw src:y~0
+  [ 168] Mov dst:y~0, src:Int32(2)
+  [ 178] Throw src:y~0
 
 block5:
-  [ 178] End value:Undefined
+  [ 180] End value:Undefined
 
 block6:
-  [ 180] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block7, false_target:block8
+  [ 188] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block7, false_target:block8
 
 block7:
-  [ 198] Return value:reg6
+  [ 1a0] Return value:reg6
 
 block8:
-  [ 1a0] Throw src:reg6
+  [ 1a8] Throw src:reg6
 
 Exception handlers:
-  [  c8 ..  160] => handler block1
-  [ 160 ..  178] => handler block3
+  [  d0 ..  168] => handler block1
+  [ 168 ..  180] => handler block3
 
 
 6

--- a/Tests/LibJS/Bytecode/expected/try-catch-terminated.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-terminated.txt
@@ -1,16 +1,17 @@
-$546ebce0 try-catch-terminated.js:12:1
+$c7fd0018 try-catch-terminated.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `try_return`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, try_return
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `try_return`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, try_return
+  [  38] End value:reg5
 
 
-try_return$6825fe97 try-catch-terminated.js:5:5
+try_return$e987f71f try-catch-terminated.js:5:5
   Registers: 6
   Blocks:    3
   Locals:    e~0
@@ -18,17 +19,18 @@ try_return$6825fe97 try-catch-terminated.js:5:5
     [0] = Int32(1)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Jump target:block2
 
 block1:
-  [  10] Catch dst:reg5
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] Mov dst:e~0, src:reg5
-  [  30] Return value:e~0
+  [  18] Catch dst:reg5
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] Mov dst:e~0, src:reg5
+  [  38] Return value:e~0
 
 block2:
-  [  38] Throw src:Int32(1)
+  [  40] Throw src:Int32(1)
 
 Exception handlers:
-  [  38 ..   40] => handler block1
+  [  40 ..   48] => handler block1

--- a/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
@@ -1,24 +1,25 @@
-$f9fa6696 try-finally-continue.js:13:1
+$78986e0e try-finally-continue.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `console`
-  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  28] GetGlobal dst:reg9, `continueThroughFinally`
-  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, continueThroughFinally
-  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  80] GetGlobal dst:reg6, `console`
-  [  90] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  a8] GetGlobal dst:reg10, `breakThroughFinally`
-  [  b8] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughFinally
-  [  d8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 100] End value:reg7
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `continueThroughFinally`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, continueThroughFinally
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] GetGlobal dst:reg6, `console`
+  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b0] GetGlobal dst:reg10, `breakThroughFinally`
+  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughFinally
+  [  e0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 108] End value:reg7
 
 
-continueThroughFinally$49ed363e try-finally-continue.js:2:5
+continueThroughFinally$c88b3db6 try-finally-continue.js:2:5
   Registers: 9
   Blocks:    15
   Locals:    i~0, result~1
@@ -31,66 +32,67 @@ continueThroughFinally$49ed363e try-finally-continue.js:2:5
     [5] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov2 c0_dst:result~1, c0_src:Int32(0), c1_dst:i~0, c1_src:Int32(0)
-  [  20] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov2 c0_dst:result~1, c0_src:Int32(0), c1_dst:i~0, c1_src:Int32(0)
+  [  28] Jump target:block3
 
 block1:
-  [  28] Jump target:block7
+  [  30] Jump target:block7
 
 block2:
-  [  30] PostfixIncrement dst:reg5, src:i~0
+  [  38] PostfixIncrement dst:reg5, src:i~0
 
 block3:
-  [  40] JumpLessThanRhsInt32 lhs:i~0, rhs:3, true_target:block1, false_target:block4
+  [  48] JumpLessThanRhsInt32 lhs:i~0, rhs:3, true_target:block1, false_target:block4
 
 block4:
-  [  58] Return value:result~1
+  [  60] Return value:result~1
 
 block5:
-  [  60] Catch dst:reg6
-  [  68] SetLexicalEnvironment environment:reg4
-  [  70] Mov dst:reg5, src:Int32(1)
+  [  68] Catch dst:reg6
+  [  70] SetLexicalEnvironment environment:reg4
+  [  78] Mov dst:reg5, src:Int32(1)
 
 block6:
-  [  80] Mov dst:reg8, src:result~1
-  [  90] AddRhsInt32 dst:reg7, lhs:reg8, rhs:10
-  [  a0] Mov dst:result~1, src:reg7
-  [  b0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block10, false_target:block11
+  [  88] Mov dst:reg8, src:result~1
+  [  98] AddRhsInt32 dst:reg7, lhs:reg8, rhs:10
+  [  a8] Mov dst:result~1, src:reg7
+  [  b8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block10, false_target:block11
 
 block7:
-  [  c8] JumpStrictlyEqualsRhsInt32 lhs:i~0, rhs:1, true_target:block8, false_target:block9
+  [  d0] JumpStrictlyEqualsRhsInt32 lhs:i~0, rhs:1, true_target:block8, false_target:block9
 
 block8:
-  [  e0] Mov dst:reg5, src:Int32(3)
-  [  f0] Jump target:block6
+  [  e8] Mov dst:reg5, src:Int32(3)
+  [  f8] Jump target:block6
 
 block9:
-  [  f8] Mov dst:reg7, src:result~1
-  [ 108] Add dst:reg8, lhs:reg7, rhs:i~0
-  [ 118] Mov2 c0_dst:result~1, c0_src:reg8, c1_dst:reg5, c1_src:Int32(0)
-  [ 130] Jump target:block6
+  [ 100] Mov dst:reg7, src:result~1
+  [ 110] Add dst:reg8, lhs:reg7, rhs:i~0
+  [ 120] Mov2 c0_dst:result~1, c0_src:reg8, c1_dst:reg5, c1_src:Int32(0)
+  [ 138] Jump target:block6
 
 block10:
-  [ 138] Jump target:block2
+  [ 140] Jump target:block2
 
 block11:
-  [ 140] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block2, false_target:block12
+  [ 148] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block2, false_target:block12
 
 block12:
-  [ 158] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block13, false_target:block14
+  [ 160] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block13, false_target:block14
 
 block13:
-  [ 170] Return value:reg6
+  [ 178] Return value:reg6
 
 block14:
-  [ 178] Throw src:reg6
+  [ 180] Throw src:reg6
 
 Exception handlers:
-  [  c8 ..  138] => handler block5
+  [  d0 ..  140] => handler block5
 
 
-breakThroughFinally$d975d962 try-finally-continue.js:16:5
+breakThroughFinally$5813e0da try-finally-continue.js:16:5
   Registers: 9
   Blocks:    15
   Locals:    i~0, result~1
@@ -104,63 +106,64 @@ breakThroughFinally$d975d962 try-finally-continue.js:16:5
     [6] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov2 c0_dst:result~1, c0_src:Int32(0), c1_dst:i~0, c1_src:Int32(0)
-  [  20] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov2 c0_dst:result~1, c0_src:Int32(0), c1_dst:i~0, c1_src:Int32(0)
+  [  28] Jump target:block3
 
 block1:
-  [  28] Jump target:block7
+  [  30] Jump target:block7
 
 block2:
-  [  30] PostfixIncrement dst:reg5, src:i~0
+  [  38] PostfixIncrement dst:reg5, src:i~0
 
 block3:
-  [  40] JumpLessThanRhsInt32 lhs:i~0, rhs:10, true_target:block1, false_target:block4
+  [  48] JumpLessThanRhsInt32 lhs:i~0, rhs:10, true_target:block1, false_target:block4
 
 block4:
-  [  58] Return value:result~1
+  [  60] Return value:result~1
 
 block5:
-  [  60] Catch dst:reg6
-  [  68] SetLexicalEnvironment environment:reg4
-  [  70] Mov dst:reg5, src:Int32(1)
+  [  68] Catch dst:reg6
+  [  70] SetLexicalEnvironment environment:reg4
+  [  78] Mov dst:reg5, src:Int32(1)
 
 block6:
-  [  80] Mov dst:reg8, src:result~1
-  [  90] AddRhsInt32 dst:reg7, lhs:reg8, rhs:100
-  [  a0] Mov dst:result~1, src:reg7
-  [  b0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block10, false_target:block11
+  [  88] Mov dst:reg8, src:result~1
+  [  98] AddRhsInt32 dst:reg7, lhs:reg8, rhs:100
+  [  a8] Mov dst:result~1, src:reg7
+  [  b8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block10, false_target:block11
 
 block7:
-  [  c8] JumpStrictlyEqualsRhsInt32 lhs:i~0, rhs:2, true_target:block8, false_target:block9
+  [  d0] JumpStrictlyEqualsRhsInt32 lhs:i~0, rhs:2, true_target:block8, false_target:block9
 
 block8:
-  [  e0] Mov dst:reg5, src:Int32(3)
-  [  f0] Jump target:block6
+  [  e8] Mov dst:reg5, src:Int32(3)
+  [  f8] Jump target:block6
 
 block9:
-  [  f8] Mov dst:reg7, src:result~1
-  [ 108] Add dst:reg8, lhs:reg7, rhs:i~0
-  [ 118] Mov2 c0_dst:result~1, c0_src:reg8, c1_dst:reg5, c1_src:Int32(0)
-  [ 130] Jump target:block6
+  [ 100] Mov dst:reg7, src:result~1
+  [ 110] Add dst:reg8, lhs:reg7, rhs:i~0
+  [ 120] Mov2 c0_dst:result~1, c0_src:reg8, c1_dst:reg5, c1_src:Int32(0)
+  [ 138] Jump target:block6
 
 block10:
-  [ 138] Jump target:block2
+  [ 140] Jump target:block2
 
 block11:
-  [ 140] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block4, false_target:block12
+  [ 148] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block4, false_target:block12
 
 block12:
-  [ 158] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block13, false_target:block14
+  [ 160] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block13, false_target:block14
 
 block13:
-  [ 170] Return value:reg6
+  [ 178] Return value:reg6
 
 block14:
-  [ 178] Throw src:reg6
+  [ 180] Throw src:reg6
 
 Exception handlers:
-  [  c8 ..  138] => handler block5
+  [  d0 ..  140] => handler block5
 
 
 32

--- a/Tests/LibJS/Bytecode/expected/try-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally.txt
@@ -1,20 +1,21 @@
-$b3382404 try-finally.js:8:1
+$3ce5efbc try-finally.js:8:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `basicTryFinally`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, basicTryFinally
-  [  30] GetGlobal dst:reg7, `breakThroughFinally`
-  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, breakThroughFinally
-  [  60] GetGlobal dst:reg7, `nestedTryFinallyWithBreak`
-  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, nestedTryFinallyWithBreak
-  [  90] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `basicTryFinally`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, basicTryFinally
+  [  38] GetGlobal dst:reg7, `breakThroughFinally`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, breakThroughFinally
+  [  68] GetGlobal dst:reg7, `nestedTryFinallyWithBreak`
+  [  78] Call dst:reg5, callee:reg7, this_value:Undefined, nestedTryFinallyWithBreak
+  [  98] End value:reg5
 
 
-basicTryFinally$2acf4276 try-finally.js:2:5
+basicTryFinally$a96d49ee try-finally.js:2:5
   Registers: 10
   Blocks:    8
   Constants:
@@ -25,41 +26,42 @@ basicTryFinally$2acf4276 try-finally.js:2:5
     [4] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Jump target:block3
 
 block1:
-  [  10] Catch dst:reg6
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] Mov dst:reg5, src:Int32(1)
+  [  18] Catch dst:reg6
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] Mov dst:reg5, src:Int32(1)
 
 block2:
-  [  30] GetGlobal dst:reg8, `console`
-  [  40] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  58] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("finally")]
-  [  80] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block4, false_target:block5
+  [  38] GetGlobal dst:reg8, `console`
+  [  48] GetById dst:reg9, base:reg8, `log` (console.log)
+  [  60] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("finally")]
+  [  88] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block4, false_target:block5
 
 block3:
-  [  98] Mov2 c0_dst:reg6, c0_src:Int32(1), c1_dst:reg5, c1_src:Int32(2)
-  [  b0] Jump target:block2
+  [  a0] Mov2 c0_dst:reg6, c0_src:Int32(1), c1_dst:reg5, c1_src:Int32(2)
+  [  b8] Jump target:block2
 
 block4:
-  [  b8] End value:Undefined
+  [  c0] End value:Undefined
 
 block5:
-  [  c0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block6, false_target:block7
+  [  c8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block6, false_target:block7
 
 block6:
-  [  d8] Return value:reg6
+  [  e0] Return value:reg6
 
 block7:
-  [  e0] Throw src:reg6
+  [  e8] Throw src:reg6
 
 Exception handlers:
-  [  98 ..   b8] => handler block1
+  [  a0 ..   c0] => handler block1
 
 
-breakThroughFinally$874a42d1 try-finally.js:11:5
+breakThroughFinally$08ac3b59 try-finally.js:11:5
   Registers: 11
   Blocks:    15
   Locals:    i~0
@@ -73,65 +75,66 @@ breakThroughFinally$874a42d1 try-finally.js:11:5
     [6] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:i~0, src:Int32(0)
-  [  18] Jump target:block3
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:i~0, src:Int32(0)
+  [  20] Jump target:block3
 
 block1:
-  [  20] Jump target:block7
+  [  28] Jump target:block7
 
 block2:
-  [  28] PostfixIncrement dst:reg5, src:i~0
+  [  30] PostfixIncrement dst:reg5, src:i~0
 
 block3:
-  [  38] JumpLessThanRhsInt32 lhs:i~0, rhs:10, true_target:block1, false_target:block4
+  [  40] JumpLessThanRhsInt32 lhs:i~0, rhs:10, true_target:block1, false_target:block4
 
 block4:
-  [  50] End value:Undefined
+  [  58] End value:Undefined
 
 block5:
-  [  58] Catch dst:reg6
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] Mov dst:reg5, src:Int32(1)
+  [  60] Catch dst:reg6
+  [  68] SetLexicalEnvironment environment:reg4
+  [  70] Mov dst:reg5, src:Int32(1)
 
 block6:
-  [  78] GetGlobal dst:reg8, `console`
-  [  88] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  a0] Mov dst:reg10, src:i~0
-  [  b0] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[reg10]
-  [  d8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block10, false_target:block11
+  [  80] GetGlobal dst:reg8, `console`
+  [  90] GetById dst:reg9, base:reg8, `log` (console.log)
+  [  a8] Mov dst:reg10, src:i~0
+  [  b8] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[reg10]
+  [  e0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block10, false_target:block11
 
 block7:
-  [  f0] JumpStrictlyEqualsRhsInt32 lhs:i~0, rhs:5, true_target:block8, false_target:block9
+  [  f8] JumpStrictlyEqualsRhsInt32 lhs:i~0, rhs:5, true_target:block8, false_target:block9
 
 block8:
-  [ 108] Mov dst:reg5, src:Int32(3)
-  [ 118] Jump target:block6
+  [ 110] Mov dst:reg5, src:Int32(3)
+  [ 120] Jump target:block6
 
 block9:
-  [ 120] Mov dst:reg5, src:Int32(0)
-  [ 130] Jump target:block6
+  [ 128] Mov dst:reg5, src:Int32(0)
+  [ 138] Jump target:block6
 
 block10:
-  [ 138] Jump target:block2
+  [ 140] Jump target:block2
 
 block11:
-  [ 140] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block4, false_target:block12
+  [ 148] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block4, false_target:block12
 
 block12:
-  [ 158] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block13, false_target:block14
+  [ 160] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block13, false_target:block14
 
 block13:
-  [ 170] Return value:reg6
+  [ 178] Return value:reg6
 
 block14:
-  [ 178] Throw src:reg6
+  [ 180] Throw src:reg6
 
 Exception handlers:
-  [  f0 ..  138] => handler block5
+  [  f8 ..  140] => handler block5
 
 
-nestedTryFinallyWithBreak$ac0322db try-finally.js:22:12
+nestedTryFinallyWithBreak$2d651b63 try-finally.js:22:12
   Registers: 12
   Blocks:    21
   Locals:    i~0
@@ -145,88 +148,89 @@ nestedTryFinallyWithBreak$ac0322db try-finally.js:22:12
     [6] = String("outer")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Mov dst:i~0, src:Int32(0)
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Mov dst:i~0, src:Int32(0)
 
 block1:
-  [  18] Jump target:block6
+  [  20] Jump target:block6
 
 block2:
-  [  20] PostfixIncrement dst:reg5, src:i~0
-  [  30] Jump target:block1
+  [  28] PostfixIncrement dst:reg5, src:i~0
+  [  38] Jump target:block1
 
 block3:
-  [  38] End value:Undefined
+  [  40] End value:Undefined
 
 block4:
-  [  40] Catch dst:reg6
-  [  48] SetLexicalEnvironment environment:reg4
-  [  50] Mov dst:reg5, src:Int32(1)
+  [  48] Catch dst:reg6
+  [  50] SetLexicalEnvironment environment:reg4
+  [  58] Mov dst:reg5, src:Int32(1)
 
 block5:
-  [  60] GetGlobal dst:reg8, `console`
-  [  70] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  88] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer")]
-  [  b0] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block16, false_target:block17
+  [  68] GetGlobal dst:reg8, `console`
+  [  78] GetById dst:reg9, base:reg8, `log` (console.log)
+  [  90] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer")]
+  [  b8] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:0, true_target:block16, false_target:block17
 
 block6:
-  [  c8] Jump target:block9
+  [  d0] Jump target:block9
 
 block7:
-  [  d0] Catch dst:reg8
-  [  d8] SetLexicalEnvironment environment:reg4
-  [  e0] Mov dst:reg7, src:Int32(1)
+  [  d8] Catch dst:reg8
+  [  e0] SetLexicalEnvironment environment:reg4
+  [  e8] Mov dst:reg7, src:Int32(1)
 
 block8:
-  [  f0] GetGlobal dst:reg10, `console`
-  [ 100] GetById dst:reg11, base:reg10, `log` (console.log)
-  [ 118] Call dst:reg9, callee:reg11, this_value:reg10, console.log, arguments:[String("inner")]
-  [ 140] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:0, true_target:block11, false_target:block12
+  [  f8] GetGlobal dst:reg10, `console`
+  [ 108] GetById dst:reg11, base:reg10, `log` (console.log)
+  [ 120] Call dst:reg9, callee:reg11, this_value:reg10, console.log, arguments:[String("inner")]
+  [ 148] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:0, true_target:block11, false_target:block12
 
 block9:
-  [ 158] Mov dst:reg7, src:Int32(3)
-  [ 168] Jump target:block8
+  [ 160] Mov dst:reg7, src:Int32(3)
+  [ 170] Jump target:block8
 
 block10:
-  [ 170] Mov dst:reg5, src:Int32(3)
-  [ 180] Jump target:block5
+  [ 178] Mov dst:reg5, src:Int32(3)
+  [ 188] Jump target:block5
 
 block11:
-  [ 188] Mov dst:reg5, src:Int32(0)
-  [ 198] Jump target:block5
+  [ 190] Mov dst:reg5, src:Int32(0)
+  [ 1a0] Jump target:block5
 
 block12:
-  [ 1a0] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:3, true_target:block10, false_target:block13
+  [ 1a8] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:3, true_target:block10, false_target:block13
 
 block13:
-  [ 1b8] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:2, true_target:block14, false_target:block15
+  [ 1c0] JumpStrictlyEqualsRhsInt32 lhs:reg7, rhs:2, true_target:block14, false_target:block15
 
 block14:
-  [ 1d0] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg6, c1_src:reg8
-  [ 1e8] Jump target:block5
+  [ 1d8] Mov2 c0_dst:reg5, c0_src:reg7, c1_dst:reg6, c1_src:reg8
+  [ 1f0] Jump target:block5
 
 block15:
-  [ 1f0] Throw src:reg8
+  [ 1f8] Throw src:reg8
 
 block16:
-  [ 1f8] Jump target:block2
+  [ 200] Jump target:block2
 
 block17:
-  [ 200] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block3, false_target:block18
+  [ 208] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:3, true_target:block3, false_target:block18
 
 block18:
-  [ 218] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block19, false_target:block20
+  [ 220] JumpStrictlyEqualsRhsInt32 lhs:reg5, rhs:2, true_target:block19, false_target:block20
 
 block19:
-  [ 230] Return value:reg6
+  [ 238] Return value:reg6
 
 block20:
-  [ 238] Throw src:reg6
+  [ 240] Throw src:reg6
 
 Exception handlers:
-  [  c8 ..  158] => handler block4
-  [ 158 ..  188] => handler block7
-  [ 188 ..  1f8] => handler block4
+  [  d0 ..  160] => handler block4
+  [ 160 ..  190] => handler block7
+  [ 190 ..  200] => handler block4
 
 
 "finally"

--- a/Tests/LibJS/Bytecode/expected/update-member-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/update-member-expression.txt
@@ -1,40 +1,43 @@
-$1ffda051 update-member-expression.js:13:1
+$a9ab6c09 update-member-expression.js:13:1
   Registers: 9
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `postfix_increment`
-  [  10] NewObject dst:reg7
-  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, postfix_increment, arguments:[reg7]
-  [  48] GetGlobal dst:reg7, `prefix_decrement`
-  [  58] NewObject dst:reg8
-  [  68] Call dst:reg6, callee:reg7, this_value:Undefined, prefix_decrement, arguments:[reg8]
-  [  90] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `postfix_increment`
+  [  18] NewObject dst:reg7
+  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, postfix_increment, arguments:[reg7]
+  [  50] GetGlobal dst:reg7, `prefix_decrement`
+  [  60] NewObject dst:reg8
+  [  70] Call dst:reg6, callee:reg7, this_value:Undefined, prefix_decrement, arguments:[reg8]
+  [  98] End value:reg6
 
 
-postfix_increment$4c3d5f7c update-member-expression.js:6:14
+postfix_increment$cadb66f4 update-member-expression.js:6:14
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetById dst:reg5, base:arg0, `count` (obj.count)
-  [  18] PostfixIncrement dst:reg6, src:reg5
-  [  28] PutById base:arg0, `count`, src:reg5, kind:Normal
-  [  48] End value:Undefined
+  [   0] Enter
+  [   8] GetById dst:reg5, base:arg0, `count` (obj.count)
+  [  20] PostfixIncrement dst:reg6, src:reg5
+  [  30] PutById base:arg0, `count`, src:reg5, kind:Normal
+  [  50] End value:Undefined
 
 
-prefix_decrement$f7e6cd12 update-member-expression.js:10:5
+prefix_decrement$7684d48a update-member-expression.js:10:5
   Registers: 6
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetById dst:reg5, base:arg0, `count` (obj.count)
-  [  18] Decrement dst:reg5
-  [  20] PutById base:arg0, `count`, src:reg5, kind:Normal
-  [  40] End value:Undefined
+  [   0] Enter
+  [   8] GetById dst:reg5, base:arg0, `count` (obj.count)
+  [  20] Decrement dst:reg5
+  [  28] PutById base:arg0, `count`, src:reg5, kind:Normal
+  [  48] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/using-declaration-non-local-env.txt
+++ b/Tests/LibJS/Bytecode/expected/using-declaration-non-local-env.txt
@@ -1,4 +1,4 @@
-$091ab4cd using-declaration-non-local-env.js:1:1
+$84f4cb35 using-declaration-non-local-env.js:1:1
   Registers: 9
   Blocks:    3
   Locals:    e~0
@@ -6,42 +6,44 @@ $091ab4cd using-declaration-non-local-env.js:1:1
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] Jump target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] Jump target:block2
 
 block1:
-  [  10] Catch dst:reg5
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] Mov3 c0_dst:e~0, c0_src:reg5, c1_dst:reg6, c1_src:Undefined, c2_dst:reg7, c2_src:reg6
-  [  40] End value:reg6
+  [  18] Catch dst:reg5
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] Mov3 c0_dst:e~0, c0_src:reg5, c1_dst:reg6, c1_src:Undefined, c2_dst:reg7, c2_src:reg6
+  [  48] End value:reg6
 
 block2:
-  [  48] MovSrcUndefined dst:reg5
-  [  50] NewFunction dst:reg8, shared_function_data_index:0
-  [  68] Call dst:reg6, callee:reg8, this_value:Undefined
-  [  88] Mov2 c0_dst:reg5, c0_src:reg6, c1_dst:reg6, c1_src:reg5
-  [  a0] End value:reg6
+  [  50] MovSrcUndefined dst:reg5
+  [  58] NewFunction dst:reg8, shared_function_data_index:0
+  [  70] Call dst:reg6, callee:reg8, this_value:Undefined
+  [  90] Mov2 c0_dst:reg5, c0_src:reg6, c1_dst:reg6, c1_src:reg5
+  [  a8] End value:reg6
 
 Exception handlers:
-  [  48 ..   a8] => handler block1
+  [  50 ..   b0] => handler block1
 
 
-$66e73949 using-declaration-non-local-env.js:1:21
+$dd396d91 using-declaration-non-local-env.js:1:21
   Registers: 8
   Blocks:    2
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateImmutableBinding environment:reg5, `x`, strict_binding:true
-  [  30] NewTypeError dst:reg6, TODO: UsingDeclaration
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] Throw src:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateImmutableBinding environment:reg5, `x`, strict_binding:true
+  [  38] NewTypeError dst:reg6, TODO: UsingDeclaration
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] Throw src:reg6
 
 block1:
-  [  50] NewFunction dst:reg7, shared_function_data_index:0
-  [  68] Call dst:reg6, callee:reg7, this_value:Undefined
-  [  88] SetLexicalEnvironment environment:reg4
-  [  90] End value:Undefined
+  [  58] NewFunction dst:reg7, shared_function_data_index:0
+  [  70] Call dst:reg6, callee:reg7, this_value:Undefined
+  [  90] SetLexicalEnvironment environment:reg4
+  [  98] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/var-binding-access.txt
+++ b/Tests/LibJS/Bytecode/expected/var-binding-access.txt
@@ -1,18 +1,19 @@
-$9d7300ea var-binding-access.js:22:1
+$1ed4f972 var-binding-access.js:22:1
   Registers: 8
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `var_access`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, var_access
-  [  30] GetGlobal dst:reg7, `let_access`
-  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, let_access
-  [  60] End value:reg6
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `var_access`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, var_access
+  [  38] GetGlobal dst:reg7, `let_access`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, let_access
+  [  68] End value:reg6
 
 
-var_access$52e19afb var-binding-access.js:5:5
+var_access$e4db39e3 var-binding-access.js:5:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -20,25 +21,27 @@ var_access$52e19afb var-binding-access.js:5:5
     [1] = Int32(1)
 
 block0:
-  [   0] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  10] InitializeVariableBinding `x`, src:Undefined
-  [  28] SetLexicalBinding `x`, src:Int32(1)
-  [  40] NewFunction dst:reg5, shared_function_data_index:0
-  [  58] GetInitializedBinding dst:reg5, `x`
-  [  70] Return value:reg5
+  [   0] Enter
+  [   8] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  18] InitializeVariableBinding `x`, src:Undefined
+  [  30] SetLexicalBinding `x`, src:Int32(1)
+  [  48] NewFunction dst:reg5, shared_function_data_index:0
+  [  60] GetInitializedBinding dst:reg5, `x`
+  [  78] Return value:reg5
 
 
-let_access$6d3f61f0 var-binding-access.js:14:5
+let_access$eea15a78 var-binding-access.js:14:5
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Int32(1)
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
-  [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  30] InitializeLexicalBinding `x`, src:Int32(1)
-  [  48] NewFunction dst:reg6, shared_function_data_index:0
-  [  60] GetBinding dst:reg6, `x`
-  [  78] Return value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
+  [  28] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  38] InitializeLexicalBinding `x`, src:Int32(1)
+  [  50] NewFunction dst:reg6, shared_function_data_index:0
+  [  68] GetBinding dst:reg6, `x`
+  [  80] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
@@ -1,16 +1,17 @@
-$a2057a79 var-env-capacity-with-param-expressions.js:5:1
+$12cfcca1 var-env-capacity-with-param-expressions.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  38] End value:reg5
 
 
-f$1e18fac6 var-env-capacity-with-param-expressions.js:3:9
+f$9f7af34e var-env-capacity-with-param-expressions.js:3:9
   Registers: 10
   Blocks:    3
   Constants:
@@ -19,38 +20,40 @@ f$1e18fac6 var-env-capacity-with-param-expressions.js:3:9
     [2] = String("")
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  30] CreateArguments is_immutable:false
-  [  40] JumpUndefined condition:arg0, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  28] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  38] CreateArguments is_immutable:false
+  [  48] JumpUndefined condition:arg0, true_target:block1, false_target:block2
 
 block1:
-  [  50] Mov dst:arg0, src:Int32(1)
+  [  58] Mov dst:arg0, src:Int32(1)
 
 block2:
-  [  60] InitializeLexicalBinding `x`, src:arg0
-  [  78] CreateVariableEnvironment capacity:3
-  [  80] GetLexicalEnvironment dst:reg6
-  [  88] MovSrcUndefined dst:reg7
-  [  90] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
-  [  a0] InitializeVariableBinding `a`, src:reg7
-  [  b8] MovSrcUndefined dst:reg7
-  [  c0] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
-  [  d0] InitializeVariableBinding `b`, src:reg7
-  [  e8] MovSrcUndefined dst:reg7
-  [  f0] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
-  [ 100] InitializeVariableBinding `c`, src:reg7
-  [ 118] DynamicGetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `eval`
-  [ 130] CallDirectEval dst:reg7, callee:reg8, this_value:reg9, eval, arguments:[String("")]
-  [ 158] End value:Undefined
+  [  68] InitializeLexicalBinding `x`, src:arg0
+  [  80] CreateVariableEnvironment capacity:3
+  [  88] GetLexicalEnvironment dst:reg6
+  [  90] MovSrcUndefined dst:reg7
+  [  98] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
+  [  a8] InitializeVariableBinding `a`, src:reg7
+  [  c0] MovSrcUndefined dst:reg7
+  [  c8] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
+  [  d8] InitializeVariableBinding `b`, src:reg7
+  [  f0] MovSrcUndefined dst:reg7
+  [  f8] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
+  [ 108] InitializeVariableBinding `c`, src:reg7
+  [ 120] DynamicGetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `eval`
+  [ 138] CallDirectEval dst:reg7, callee:reg8, this_value:reg9, eval, arguments:[String("")]
+  [ 160] End value:Undefined
 
 
-eval$b72141f3
+eval$3b472b8b
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] End value:Undefined
+  [   0] Enter
+  [   8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/var-hoisting-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/var-hoisting-tdz.txt
@@ -1,16 +1,17 @@
-$89d6cbb5 var-hoisting-tdz.js:9:1
+$fd650eed var-hoisting-tdz.js:9:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `isect`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, isect
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `isect`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, isect
+  [  38] End value:reg5
 
 
-isect$63c4d7d5 var-hoisting-tdz.js:5:5
+isect$e526d05d var-hoisting-tdz.js:5:5
   Registers: 6
   Blocks:    7
   Locals:    i~0
@@ -20,24 +21,25 @@ isect$63c4d7d5 var-hoisting-tdz.js:5:5
     [2] = Int32(3)
 
 block0:
-  [   0] Mov2 c0_dst:i~0, c0_src:Undefined, c1_dst:i~0, c1_src:Int32(0)
-  [  18] Jump target:block2
+  [   0] Enter
+  [   8] Mov2 c0_dst:i~0, c0_src:Undefined, c1_dst:i~0, c1_src:Int32(0)
+  [  20] Jump target:block2
 
 block1:
-  [  20] PostfixIncrement dst:reg5, src:i~0
+  [  28] PostfixIncrement dst:reg5, src:i~0
 
 block2:
-  [  30] JumpLessThanRhsInt32 lhs:i~0, rhs:3, true_target:block1, false_target:block3
+  [  38] JumpLessThanRhsInt32 lhs:i~0, rhs:3, true_target:block1, false_target:block3
 
 block3:
-  [  48] Mov dst:i~0, src:Int32(0)
-  [  58] Jump target:block5
+  [  50] Mov dst:i~0, src:Int32(0)
+  [  60] Jump target:block5
 
 block4:
-  [  60] PostfixIncrement dst:reg5, src:i~0
+  [  68] PostfixIncrement dst:reg5, src:i~0
 
 block5:
-  [  70] JumpLessThanRhsInt32 lhs:i~0, rhs:3, true_target:block4, false_target:block6
+  [  78] JumpLessThanRhsInt32 lhs:i~0, rhs:3, true_target:block4, false_target:block6
 
 block6:
-  [  88] End value:Undefined
+  [  90] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/var-init-in-param-body-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/var-init-in-param-body-scope.txt
@@ -1,16 +1,17 @@
-$bacf2c68 var-init-in-param-body-scope.js:4:1
+$2b997e90 var-init-in-param-body-scope.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `f`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `f`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  38] End value:reg5
 
 
-f$6f9adbc3
+f$ee38e33b
   Registers: 6
   Blocks:    3
   Locals:    x~0
@@ -20,11 +21,12 @@ f$6f9adbc3
     [2] = String("inside")
 
 block0:
-  [   0] JumpUndefined condition:arg0, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] JumpUndefined condition:arg0, true_target:block1, false_target:block2
 
 block1:
-  [  10] Mov dst:arg0, src:Int32(1)
+  [  18] Mov dst:arg0, src:Int32(1)
 
 block2:
-  [  20] Mov3 c0_dst:reg5, c0_src:Undefined, c1_dst:x~0, c1_src:reg5, c2_dst:x~0, c2_src:String("inside")
-  [  40] End value:Undefined
+  [  28] Mov3 c0_dst:reg5, c0_src:Undefined, c1_dst:x~0, c1_src:reg5, c2_dst:x~0, c2_src:String("inside")
+  [  48] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
+++ b/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
@@ -1,4 +1,4 @@
-$542e1f1b var-shadow-in-default-param.js:7:1
+$db17f9c3 var-shadow-in-default-param.js:7:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,15 +6,16 @@ $542e1f1b var-shadow-in-default-param.js:7:1
     [1] = Undefined
 
 block0:
-  [   0] SetGlobal `shadow`, src:String("outer")
-  [  10] GetGlobal dst:reg6, `shadow_in_default`
-  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, shadow_in_default
-  [  40] GetGlobal dst:reg7, `no_conflict`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, no_conflict
-  [  70] End value:reg6
+  [   0] Enter
+  [   8] SetGlobal `shadow`, src:String("outer")
+  [  18] GetGlobal dst:reg6, `shadow_in_default`
+  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, shadow_in_default
+  [  48] GetGlobal dst:reg7, `no_conflict`
+  [  58] Call dst:reg6, callee:reg7, this_value:Undefined, no_conflict
+  [  78] End value:reg6
 
 
-shadow_in_default$b0bb3597 var-shadow-in-default-param.js:8:32
+shadow_in_default$321d2e1f var-shadow-in-default-param.js:8:32
   Registers: 7
   Blocks:    3
   Constants:
@@ -22,23 +23,24 @@ shadow_in_default$b0bb3597 var-shadow-in-default-param.js:8:32
     [1] = String("inner")
 
 block0:
-  [   0] JumpUndefined condition:arg0, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] JumpUndefined condition:arg0, true_target:block1, false_target:block2
 
 block1:
-  [  10] DynamicGetInitializedBinding dst:reg5, `shadow`
-  [  20] Mov dst:arg0, src:reg5
+  [  18] DynamicGetInitializedBinding dst:reg5, `shadow`
+  [  28] Mov dst:arg0, src:reg5
 
 block2:
-  [  30] CreateVariableEnvironment capacity:1
-  [  38] GetLexicalEnvironment dst:reg5
-  [  40] MovSrcUndefined dst:reg6
-  [  48] CreateVariable `shadow`, is_immutable:false, is_global:false, is_strict:false
-  [  58] InitializeVariableBinding `shadow`, src:reg6
-  [  70] SetLexicalBinding `shadow`, src:String("inner")
-  [  88] Return value:arg0
+  [  38] CreateVariableEnvironment capacity:1
+  [  40] GetLexicalEnvironment dst:reg5
+  [  48] MovSrcUndefined dst:reg6
+  [  50] CreateVariable `shadow`, is_immutable:false, is_global:false, is_strict:false
+  [  60] InitializeVariableBinding `shadow`, src:reg6
+  [  78] SetLexicalBinding `shadow`, src:String("inner")
+  [  90] Return value:arg0
 
 
-no_conflict$f0c5f291 var-shadow-in-default-param.js:17:5
+no_conflict$74ebdc29 var-shadow-in-default-param.js:17:5
   Registers: 6
   Blocks:    3
   Locals:    y~0
@@ -48,11 +50,12 @@ no_conflict$f0c5f291 var-shadow-in-default-param.js:17:5
     [2] = Int32(2)
 
 block0:
-  [   0] JumpUndefined condition:arg0, true_target:block1, false_target:block2
+  [   0] Enter
+  [   8] JumpUndefined condition:arg0, true_target:block1, false_target:block2
 
 block1:
-  [  10] Mov dst:arg0, src:Int32(1)
+  [  18] Mov dst:arg0, src:Int32(1)
 
 block2:
-  [  20] Mov3 c0_dst:reg5, c0_src:Undefined, c1_dst:y~0, c1_src:reg5, c2_dst:y~0, c2_src:Int32(2)
-  [  40] Return value:y~0
+  [  28] Mov3 c0_dst:reg5, c0_src:Undefined, c1_dst:y~0, c1_src:reg5, c2_dst:y~0, c2_src:Int32(2)
+  [  48] Return value:y~0

--- a/Tests/LibJS/Bytecode/expected/with-return.txt
+++ b/Tests/LibJS/Bytecode/expected/with-return.txt
@@ -1,4 +1,4 @@
-$54c92246 with-return.js:10:1
+$b237dcfe with-return.js:10:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,23 +6,25 @@ $54c92246 with-return.js:10:1
     [1] = Int32(42)
 
 block0:
-  [   0] GetGlobal dst:reg6, `with_return`
-  [  10] NewObject dst:reg7
-  [  20] InitObjectLiteralProperty object:reg7, `x`, src:Int32(42), shape_cache_index:0, property_slot:0
-  [  38] CacheObjectShape object:reg7
-  [  48] Call dst:reg5, callee:reg6, this_value:Undefined, with_return, arguments:[reg7]
-  [  70] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `with_return`
+  [  18] NewObject dst:reg7
+  [  28] InitObjectLiteralProperty object:reg7, `x`, src:Int32(42), shape_cache_index:0, property_slot:0
+  [  40] CacheObjectShape object:reg7
+  [  50] Call dst:reg5, callee:reg6, this_value:Undefined, with_return, arguments:[reg7]
+  [  78] End value:reg5
 
 
-with_return$57f2e7e2 with-return.js:5:5
+with_return$d690ef5a with-return.js:5:5
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] EnterObjectEnvironment dst:reg5, object:arg0
-  [  18] DynamicGetBinding dst:reg6, `x`
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] Return value:reg6
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] EnterObjectEnvironment dst:reg5, object:arg0
+  [  20] DynamicGetBinding dst:reg6, `x`
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/with-statement.txt
+++ b/Tests/LibJS/Bytecode/expected/with-statement.txt
@@ -1,16 +1,17 @@
-$491e5adb with-statement.js:7:1
+$d0083583 with-statement.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] GetGlobal dst:reg6, `withBlock`
-  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, withBlock
-  [  30] End value:reg5
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `withBlock`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, withBlock
+  [  38] End value:reg5
 
 
-withBlock$1119afe3 with-statement.js:2:15
+withBlock$927ba86b with-statement.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    obj~0
@@ -19,17 +20,18 @@ withBlock$1119afe3 with-statement.js:2:15
     [1] = Undefined
 
 block0:
-  [   0] GetLexicalEnvironment dst:reg4
-  [   8] NewObject dst:obj~0
-  [  18] InitObjectLiteralProperty object:obj~0, `x`, src:Int32(42), shape_cache_index:0, property_slot:0
-  [  30] CacheObjectShape object:obj~0
-  [  40] EnterObjectEnvironment dst:reg5, object:obj~0
-  [  50] DynamicGetBinding dst:reg7, `console`
-  [  60] GetById dst:reg8, base:reg7, `log` (console.log)
-  [  78] DynamicGetBinding dst:reg9, `x`
-  [  88] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [  b0] SetLexicalEnvironment environment:reg4
-  [  b8] End value:Undefined
+  [   0] Enter
+  [   8] GetLexicalEnvironment dst:reg4
+  [  10] NewObject dst:obj~0
+  [  20] InitObjectLiteralProperty object:obj~0, `x`, src:Int32(42), shape_cache_index:0, property_slot:0
+  [  38] CacheObjectShape object:obj~0
+  [  48] EnterObjectEnvironment dst:reg5, object:obj~0
+  [  58] DynamicGetBinding dst:reg7, `console`
+  [  68] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  80] DynamicGetBinding dst:reg9, `x`
+  [  90] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [  b8] SetLexicalEnvironment environment:reg4
+  [  c0] End value:Undefined
 
 
 42

--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -1,6 +1,7 @@
 ladybird_test(test-value-js.cpp LibJS LIBS LibJS LibUnicode)
 ladybird_test(test-primitive-string.cpp LibJS LIBS LibJS LibGC)
 ladybird_test(test-bytecode-cache.cpp LibJS LIBS LibCrypto LibFileSystem LibGC LibJS)
+ladybird_test(test-slow-path-result.cpp LibJS LIBS LibJS)
 ladybird_test(test-debugger.cpp LibJS LIBS LibGC LibJS)
 ladybird_test(test-native-function-table.cpp LibJS LIBS LibGC LibJS)
 ladybird_test(test-type-error-realm.cpp LibJS LIBS LibGC LibJS)

--- a/Tests/LibJS/Runtime/function-frame-entry.js
+++ b/Tests/LibJS/Runtime/function-frame-entry.js
@@ -1,0 +1,54 @@
+test("function entry initializes reused locals and constants", () => {
+    function callee(initialize) {
+        if (!initialize) return local;
+        let local = "initialized";
+        return [local, 12345678901234567890n, 1.25];
+    }
+
+    for (let iteration = 0; iteration < 3; ++iteration) {
+        expect(callee(true)).toEqual(["initialized", 12345678901234567890n, 1.25]);
+        let threw = false;
+        try {
+            callee(false);
+        } catch (error) {
+            threw = true;
+            expect(error).toBeInstanceOf(ReferenceError);
+        }
+        expect(threw).toBeTrue();
+        expect(callee.call(null, true)).toEqual(["initialized", 12345678901234567890n, 1.25]);
+        expect(() => callee.apply(null, [false])).toThrow(ReferenceError);
+    }
+});
+
+test("function entry preserves the receiver and argument slots", () => {
+    function callee(first, second = 42) {
+        return [this, first, second, arguments.length];
+    }
+    const receiver = {};
+    const argument = {};
+    const bound = callee.bind(receiver, argument);
+    for (let iteration = 0; iteration < 3; ++iteration) {
+        expect(callee.call(receiver, argument)).toEqual([receiver, argument, 42, 1]);
+        expect(Reflect.apply(callee, receiver, [argument, 7])).toEqual([receiver, argument, 7, 2]);
+        expect(bound()).toEqual([receiver, argument, 42, 1]);
+    }
+});
+
+test("generator resumption preserves initialized locals and constants", () => {
+    function* callee(argument) {
+        let local = argument;
+        yield local;
+        local += 1.25;
+        yield local;
+        gc();
+        return [local, 12345678901234567890n];
+    }
+    const first = callee(10);
+    const second = callee(20);
+    expect(first.next()).toEqual({ value: 10, done: false });
+    expect(second.next()).toEqual({ value: 20, done: false });
+    expect(first.next()).toEqual({ value: 11.25, done: false });
+    expect(second.next()).toEqual({ value: 21.25, done: false });
+    expect(first.next()).toEqual({ value: [11.25, 12345678901234567890n], done: true });
+    expect(second.next()).toEqual({ value: [21.25, 12345678901234567890n], done: true });
+});

--- a/Tests/LibJS/Runtime/ordinary-constructor-frames.js
+++ b/Tests/LibJS/Runtime/ordinary-constructor-frames.js
@@ -1,0 +1,58 @@
+test("ordinary constructors preserve returns, new.target, and exceptions", () => {
+    function Assign(a, b) {
+        this.total = a + b;
+        this.target = new.target;
+        gc();
+    }
+    function Primitive(value) {
+        return value;
+    }
+    function Replacement(value) {
+        gc();
+        return value;
+    }
+    function CaptureTarget() {
+        return () => new.target;
+    }
+    function Throwing(value) {
+        throw value;
+    }
+    function Prototype() {}
+    class Derived extends Assign {}
+    const Bound = Assign.bind(null, 10);
+    const replacement = { replacement: true };
+
+    for (let iteration = 0; iteration < 3; ++iteration) {
+        const object = new Assign(3, 4);
+        expect(object.total).toBe(7);
+        expect(object.target).toBe(Assign);
+        expect(object).toBeInstanceOf(Assign);
+
+        for (const value of [undefined, null, false, 17, "text", 12n, Symbol()])
+            expect(new Primitive(value)).toBeInstanceOf(Primitive);
+
+        expect(new Replacement(replacement)).toBe(replacement);
+        expect(new CaptureTarget()()).toBe(CaptureTarget);
+
+        const derived = new Derived(4, 5);
+        expect(derived.total).toBe(9);
+        expect(derived.target).toBe(Derived);
+        expect(derived).toBeInstanceOf(Derived);
+
+        const bound = new Bound(5);
+        expect(bound.total).toBe(15);
+        expect(bound.target).toBe(Assign);
+
+        const reflected = Reflect.construct(Assign, [6, 7], Derived);
+        expect(reflected.total).toBe(13);
+        expect(reflected.target).toBe(Derived);
+        expect(reflected).toBeInstanceOf(Derived);
+
+        expect(() => new Throwing(replacement)).toThrow(replacement);
+
+        new Prototype();
+        Prototype.prototype = null;
+        expect(Object.getPrototypeOf(new Prototype())).toBe(Object.prototype);
+        Prototype.prototype = {};
+    }
+});

--- a/Tests/LibJS/Runtime/regress/global-cache-shadowing.js
+++ b/Tests/LibJS/Runtime/regress/global-cache-shadowing.js
@@ -1,0 +1,16 @@
+test("global identifier cache is invalidated after lexical shadowing", () => {
+    evaluateSource(`
+        globalThis.globalCacheShadowValue = 40;
+        function updateGlobalCacheShadowValue() {
+            return globalCacheShadowValue += 1;
+        }
+    `);
+
+    expect(evaluateSource("updateGlobalCacheShadowValue();")).toBe(41);
+    expect(evaluateSource("updateGlobalCacheShadowValue();")).toBe(42);
+
+    evaluateSource("let globalCacheShadowValue = 100;");
+    expect(evaluateSource("updateGlobalCacheShadowValue();")).toBe(101);
+    expect(evaluateSource("updateGlobalCacheShadowValue();")).toBe(102);
+    expect(globalThis.globalCacheShadowValue).toBe(42);
+});

--- a/Tests/LibJS/Runtime/slow-path-values.js
+++ b/Tests/LibJS/Runtime/slow-path-values.js
@@ -1,0 +1,117 @@
+test("slow paths return values without overwriting destinations on exceptions", () => {
+    const number = { valueOf: () => 7 };
+    expect(number + 3).toBe(10);
+    expect(number * 3).toBe(21);
+    expect(number < 8).toBeTrue();
+    expect(number | 8).toBe(15);
+
+    const thrown = {};
+    let destination = 42;
+    try {
+        destination =
+            {
+                valueOf() {
+                    throw thrown;
+                },
+            } + 1;
+    } catch (error) {
+        expect(error).toBe(thrown);
+    }
+    expect(destination).toBe(42);
+});
+
+test("postfix slow paths return both the old and updated values", () => {
+    let value = { valueOf: () => 12345678901234567890n };
+    expect(value++).toBe(12345678901234567890n);
+    expect(value).toBe(12345678901234567891n);
+    expect(value--).toBe(12345678901234567891n);
+    expect(value).toBe(12345678901234567890n);
+    value = value++;
+    expect(value).toBe(12345678901234567890n);
+});
+
+test("cache-only helpers distinguish returned values from cache misses", () => {
+    function read(object) {
+        return object.value;
+    }
+    let getterCalls = 0;
+    const cases = [
+        [{ a: 1, value: false }, false],
+        [{ b: 1, value: 0 }, 0],
+        [{ c: 1, value: "" }, ""],
+        [{ d: 1, value: undefined }, undefined],
+        [{ e: 1, value: null }, null],
+        [{ missing: 1 }, undefined],
+        [
+            {
+                get value() {
+                    ++getterCalls;
+                    return "getter";
+                },
+            },
+            "getter",
+        ],
+    ];
+    for (let iteration = 0; iteration < 10; ++iteration)
+        for (const [object, expected] of cases) expect(read(object)).toBe(expected);
+    expect(getterCalls).toBe(10);
+});
+
+test("variable-length slow-path inputs survive nested calls and collection", () => {
+    const call = new Function("callee", "value", `return callee(${Array(600).fill("value").join(",")})`);
+    const value = {};
+    function callee() {
+        gc();
+        expect(arguments.length).toBe(600);
+        for (const argument of arguments) expect(argument).toBe(value);
+        return value;
+    }
+    const bound = callee.bind(null);
+    for (let iteration = 0; iteration < 3; ++iteration) expect(call(bound, value)).toBe(value);
+
+    const throwing = function () {
+        throw value;
+    }.bind(null);
+    expect(() => call(throwing, value)).toThrow(value);
+    expect(call(bound, value)).toBe(value);
+});
+
+test("iterator slow paths preserve done state when extracting a value throws", () => {
+    const thrown = {};
+    let closed = false;
+    const iterable = {
+        [Symbol.iterator]() {
+            return {
+                next() {
+                    return {
+                        done: false,
+                        get value() {
+                            throw thrown;
+                        },
+                    };
+                },
+                return() {
+                    closed = true;
+                    return {};
+                },
+            };
+        },
+    };
+    expect(() => {
+        const [value] = iterable;
+    }).toThrow(thrown);
+    expect(closed).toBeFalse();
+});
+
+test("exhausted iterator outputs remain safe across collection", () => {
+    function* values() {
+        yield 42;
+    }
+    const iterator = values();
+    for (let iteration = 0; iteration < 3; ++iteration) {
+        const [first, second = "default"] = iterator;
+        gc();
+        expect(first).toBe(iteration === 0 ? 42 : undefined);
+        expect(second).toBe("default");
+    }
+});

--- a/Tests/LibJS/test-debugger.cpp
+++ b/Tests/LibJS/test-debugger.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Bytecode/Op.h>
 #include <LibJS/Debugger.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -27,7 +28,7 @@ TEST_CASE(debugger_statement_pauses_execution)
     vm->debugger()->set_pause_callback([&](JS::Debugger::PauseInfo const& pause_info) {
         did_pause = true;
         EXPECT_EQ(pause_info.reason, JS::Debugger::PauseReason::DebuggerStatement);
-        EXPECT_EQ(pause_info.bytecode_offset, 0u);
+        EXPECT_EQ(pause_info.bytecode_offset, sizeof(JS::Bytecode::Op::Enter));
         VERIFY(pause_info.source_range.has_value());
         EXPECT_EQ(pause_info.source_range->filename(), "debugger.js"_utf16);
         EXPECT_EQ(pause_info.source_range->start.line, 1u);
@@ -601,6 +602,31 @@ TEST_CASE(pause_on_next_bytecode_execution_is_one_shot)
     result = vm->run(*script_or_error.value());
     EXPECT(!result.is_error());
     EXPECT_EQ(pause_count, 1u);
+}
+
+TEST_CASE(pause_on_empty_script_waits_for_frame_initialization)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto script_or_error = JS::Script::parse(""sv, realm, "empty.js"sv);
+    VERIFY(!script_or_error.is_error());
+
+    vm->enable_debugging();
+    vm->debugger()->request_pause_on_next_bytecode_execution();
+
+    bool did_pause = false;
+    vm->debugger()->set_pause_callback([&](JS::Debugger::PauseInfo const& pause_info) {
+        did_pause = true;
+        EXPECT(vm->running_execution_context().frame_initialized);
+        EXPECT_EQ(pause_info.bytecode_offset, sizeof(JS::Bytecode::Op::Enter));
+        vm->debugger()->continue_execution();
+    });
+
+    auto result = vm->run(*script_or_error.value());
+    EXPECT(!result.is_error());
+    EXPECT(did_pause);
 }
 
 TEST_CASE(pause_on_next_bytecode_execution_waits_for_a_callback)

--- a/Tests/LibJS/test-slow-path-result.cpp
+++ b/Tests/LibJS/test-slow-path-result.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Interpreter/SlowPathResult.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(encodes_same_frame_continuations)
+{
+    constexpr u32 next_pc = 42;
+    constexpr auto result = JS::continue_after_slow_path(next_pc);
+
+    EXPECT_EQ(static_cast<u32>(result), next_pc);
+    EXPECT_EQ(static_cast<u64>(result) >> JS::slow_path_continuation_bit, 1u);
+}


### PR DESCRIPTION
Move operand reads and writes into the interpreter, passing values explicitly to C++ helpers and returning their outputs to the caller. This removes `VM::get()` and `VM::set()` and keeps helpers independent of operand-slot storage.

Add an `Enter` bytecode instruction for clearing registers and locals and copying executable constants, giving callers freedom to decide how to handle frame initialization.

Also use linked frames for ordinary constructors, simplify helper continuations and cold-path layout, and fix stale global caches after lexical shadowing.