### PR TITLE
Carry backdrop filters on the box's visual context effect

### DIFF
--- a/Libraries/LibGfx/CornerRadii.h
+++ b/Libraries/LibGfx/CornerRadii.h
@@ -26,6 +26,8 @@ struct CornerRadius {
     {
         return horizontal_radius > 0 && vertical_radius > 0;
     }
+
+    bool operator==(CornerRadius const&) const = default;
 };
 
 struct CornerRadii {
@@ -38,6 +40,8 @@ struct CornerRadii {
     {
         return top_left || top_right || bottom_right || bottom_left;
     }
+
+    bool operator==(CornerRadii const&) const = default;
 
     void adjust_corners_for_spread_distance(int spread_distance);
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -257,9 +257,9 @@ bool AccumulatedVisualContextTree::effect_is_isolated_by_layer(EffectNodeIndex e
     return Layout::RustFFI::visual_context_tree_effect_is_isolated_by_layer(m_rust_tree, effect);
 }
 
-bool AccumulatedVisualContextTree::has_unisolated_blending_effect() const
+bool AccumulatedVisualContextTree::has_unisolated_destination_reading_effect() const
 {
-    return Layout::RustFFI::visual_context_tree_has_unisolated_blending_effect(m_rust_tree);
+    return Layout::RustFFI::visual_context_tree_has_unisolated_destination_reading_effect(m_rust_tree);
 }
 
 void AccumulatedVisualContextTree::for_each_effects_filter_bytes(Function<void(ReadonlyBytes)> const& visit) const

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -95,7 +95,7 @@ public:
     WEB_API Gfx::FloatMatrix4x4 accumulated_matrix(SpatialNodeIndex, ScrollStateSnapshot const&, IncludeVisualViewportTransform) const;
 
     WEB_API bool effect_is_isolated_by_layer(EffectNodeIndex) const;
-    WEB_API bool has_unisolated_blending_effect() const;
+    WEB_API bool has_unisolated_destination_reading_effect() const;
     WEB_API void for_each_effects_filter_bytes(Function<void(ReadonlyBytes)> const&) const;
 
 private:

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -37,7 +37,7 @@ namespace Web::Painting {
     V(StrokePath, stroke_path)                                                         \
     V(DrawEllipse, draw_ellipse)                                                       \
     V(DrawLine, draw_line)                                                             \
-    V(ApplyBackdropFilter, apply_backdrop_filter)                                      \
+    V(BackdropFilterRegion, backdrop_filter_region)                                    \
     V(DrawRect, draw_rect)                                                             \
     V(PaintNestedDisplayList, paint_nested_display_list)                               \
     V(DrawIsolatedDisplayList, draw_isolated_display_list)                             \

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -47,7 +47,15 @@ struct DisplayListPlayerSkia::LayerImageFilterCache {
         ByteBuffer filter_bytes;
         sk_sp<SkImageFilter> image_filter;
     };
+    struct BackdropEntry {
+        ByteBuffer filter_bytes;
+        Gfx::IntRect region;
+        Gfx::CornerRadii corner_radii;
+        bool limited_to_region { false };
+        sk_sp<SkImageFilter> image_filter;
+    };
     HashMap<u64, HashMap<u32, Entry>> entries_by_tree_structural_epoch_and_effect;
+    HashMap<u64, HashMap<u32, BackdropEntry>> backdrop_entries_by_tree_structural_epoch_and_effect;
     u64 tree_structural_epoch { 0 };
 };
 
@@ -78,6 +86,7 @@ void DisplayListPlayerSkia::execute(
     TemporaryChange composited_context_resolver_change { m_composited_context_resolver, composited_context_resolver };
     if (m_layer_image_filter_cache->tree_structural_epoch != visual_context_tree.structural_epoch()) {
         m_layer_image_filter_cache->entries_by_tree_structural_epoch_and_effect.clear();
+        m_layer_image_filter_cache->backdrop_entries_by_tree_structural_epoch_and_effect.clear();
         m_layer_image_filter_cache->tree_structural_epoch = visual_context_tree.structural_epoch();
     }
     DisplayListPlayer::execute(
@@ -1009,21 +1018,9 @@ void DisplayListPlayerSkia::play_command(DrawLine const& command)
     canvas.drawLine(from, to, paint);
 }
 
-void DisplayListPlayerSkia::play_command(ApplyBackdropFilter const& command)
+// The backdrop filter is applied by the layer of the effect the command records under.
+void DisplayListPlayerSkia::play_command(BackdropFilterRegion const&)
 {
-    auto& canvas = surface().canvas();
-
-    canvas.save();
-    clip_to_rounded_rect(canvas, command.backdrop_region, command.corner_radii, SkClipOp::kIntersect);
-    ScopeGuard guard = [&] { canvas.restore(); };
-
-    if (command.has_backdrop_filter) {
-        auto image_filter = Gfx::to_skia_image_filter(inline_data(command.backdrop_filter_data), [&](u64 image_id) -> Gfx::DecodedImageFrame const& {
-            return resource_storage().image_frame(ImageFrameResourceId { image_id });
-        });
-        canvas.saveLayer(SkCanvas::SaveLayerRec(nullptr, nullptr, image_filter.get(), 0));
-        canvas.restore();
-    }
 }
 
 void DisplayListPlayerSkia::play_command(DrawRect const& command)
@@ -1273,21 +1270,84 @@ void DisplayListPlayerSkia::push_clip_path(Gfx::Path const& path, Gfx::WindingRu
     clip_path(path, winding_rule, true);
 }
 
+// https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty
+// Skia reads a layer's backdrop from the layer's parent, so the filtered backdrop has to become the
+// layer's initial content here, where the layer is opened. The canvas clip is not narrowed to the
+// backdrop region, since that would clip the box's overflowing content along with it.
 void DisplayListPlayerSkia::push_layer(ReplayLayer const& layer)
 {
     auto& canvas = surface().canvas();
     SkPaint paint;
+    bool paint_has_effects = false;
 
-    if (layer.opacity < 1.0f)
+    if (layer.opacity < 1.0f) {
         paint.setAlphaf(layer.opacity);
+        paint_has_effects = true;
+    }
 
-    if (layer.blend_mode != Gfx::CompositingAndBlendingOperator::Normal)
+    if (layer.blend_mode != Gfx::CompositingAndBlendingOperator::Normal) {
         paint.setBlender(Gfx::to_skia_blender(layer.blend_mode));
+        paint_has_effects = true;
+    }
 
-    if (layer.filter_bytes_size)
+    if (layer.filter_bytes_size) {
         paint.setImageFilter(layer_image_filter(layer));
+        paint_has_effects = true;
+    }
 
-    canvas.saveLayer(nullptr, &paint);
+    if (!layer.backdrop_filter_bytes_size) {
+        canvas.saveLayer(nullptr, &paint);
+        return;
+    }
+
+    if (!paint_has_effects) {
+        // Source-over is associative, so compositing the filtered backdrop in place and painting the
+        // content over it gives the same pixels without a layer the size of the clip. The plain save
+        // balances the pop that closes the layer.
+        canvas.save();
+        clip_to_rounded_rect(canvas, layer.backdrop_region, layer.backdrop_corner_radii, SkClipOp::kIntersect);
+        canvas.saveLayer(SkCanvas::SaveLayerRec(nullptr, nullptr, backdrop_image_filter(layer, false).get(), 0));
+        canvas.restore();
+        canvas.restore();
+        canvas.save();
+        return;
+    }
+
+    canvas.saveLayer(SkCanvas::SaveLayerRec(nullptr, &paint, backdrop_image_filter(layer, true).get(), 0));
+}
+
+// With `limited_to_region`, the filtered backdrop is cropped to the rounded region inside the filter
+// graph, which also bounds what the filter reads.
+sk_sp<SkImageFilter> DisplayListPlayerSkia::backdrop_image_filter(ReplayLayer const& layer, bool limited_to_region)
+{
+    ReadonlyBytes filter_bytes { layer.backdrop_filter_bytes, layer.backdrop_filter_bytes_size };
+    auto& entries_by_effect = m_layer_image_filter_cache->backdrop_entries_by_tree_structural_epoch_and_effect.ensure(active_visual_context_tree().structural_epoch());
+    if (auto cached = entries_by_effect.get(layer.effect.value());
+        cached.has_value()
+        && cached->filter_bytes.bytes() == filter_bytes
+        && cached->region == layer.backdrop_region
+        && cached->corner_radii == layer.backdrop_corner_radii
+        && cached->limited_to_region == limited_to_region)
+        return cached->image_filter;
+
+    auto image_filter = Gfx::to_skia_image_filter(filter_bytes, [&](u64 image_id) -> Gfx::DecodedImageFrame const& {
+        return resource_storage().image_frame(ImageFrameResourceId { image_id });
+    });
+    if (limited_to_region) {
+        auto region = to_skia_rect(layer.backdrop_region);
+        image_filter = SkImageFilters::Crop(region, SkTileMode::kDecal, move(image_filter));
+        if (layer.backdrop_corner_radii.has_any_radius()) {
+            SkPictureRecorder recorder;
+            auto* picture_canvas = recorder.beginRecording(region);
+            SkPaint mask_paint;
+            mask_paint.setAntiAlias(true);
+            mask_paint.setColor(SK_ColorWHITE);
+            picture_canvas->drawRRect(to_skia_rrect(layer.backdrop_region, layer.backdrop_corner_radii), mask_paint);
+            image_filter = SkImageFilters::Blend(SkBlendMode::kDstIn, move(image_filter), SkImageFilters::Picture(recorder.finishRecordingAsPicture()));
+        }
+    }
+    entries_by_effect.set(layer.effect.value(), LayerImageFilterCache::BackdropEntry { MUST(ByteBuffer::copy(filter_bytes)), layer.backdrop_region, layer.backdrop_corner_radii, limited_to_region, image_filter });
+    return image_filter;
 }
 
 sk_sp<SkImageFilter> DisplayListPlayerSkia::layer_image_filter(ReplayLayer const& layer)

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -70,6 +70,7 @@ private:
 
     SkPaint paint_style_to_skia_paint(DisplayListPaintStyle const&, Gfx::FloatRect const& bounding_rect);
     sk_sp<SkImageFilter> layer_image_filter(ReplayLayer const&);
+    sk_sp<SkImageFilter> backdrop_image_filter(ReplayLayer const&, bool limited_to_region);
     Gfx::Path path_from_data(DisplayListDataSpan) const;
     ReadonlySpan<Color> gradient_colors(DisplayListGradientColorStops) const;
     ReadonlySpan<float> gradient_positions(DisplayListGradientColorStops) const;

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -546,8 +546,9 @@ bool DisplayListResourceStorage::should_cache_nested_display_list_raster(Display
 }
 
 // Determines whether reusing a rasterization of the display list can produce different pixels than replaying it
-// in place on every frame. That is the case when a destination-reading operation (a non-normal blend mode or a
-// backdrop filter) can see canvas content painted before the display list began, or when the list draws live
+// in place on every frame. That is the case when a destination-reading operation (a non-normal blend mode on a
+// command or a visual context effect, or a backdrop filter carried by a visual context effect) can see canvas
+// content painted before the display list began, or when the list draws live
 // content that changes underneath its immutable command stream (video frames are updated in place under a stable
 // resource id, canvas surfaces and composited child contexts are resolved at replay time). Destination-reading
 // operations enclosed in a save layer recorded within the list only ever read within-list content, so they do
@@ -564,7 +565,7 @@ bool DisplayListResourceStorage::nested_display_list_requires_direct_replay(Disp
     auto const& list_resource = display_list_resource(id);
 
     auto const& visual_context_tree = list_resource.visual_context_tree;
-    bool requires_direct_replay = visual_context_tree.has_unisolated_blending_effect();
+    bool requires_direct_replay = visual_context_tree.has_unisolated_destination_reading_effect();
 
     auto recurse_into_nested_display_list = [&](DisplayListResourceId nested_display_list_id) {
         if (visited_display_lists.set(nested_display_list_id.value()) != HashSetResult::InsertedNewEntry)
@@ -578,10 +579,7 @@ bool DisplayListResourceStorage::nested_display_list_requires_direct_replay(Disp
             return;
         visit_display_list_command(header.command_type, payload, [&](auto const& command) {
             using Command = RemoveCVReference<decltype(command)>;
-            if constexpr (IsSame<Command, ApplyBackdropFilter>) {
-                if (command.has_backdrop_filter && !visual_context_tree.effect_is_isolated_by_layer(header.context.effect))
-                    requires_direct_replay = true;
-            } else if constexpr (IsSame<Command, DrawVideoFrame> || IsSame<Command, DrawCanvas> || IsSame<Command, DrawCompositedContext>) {
+            if constexpr (IsSame<Command, DrawVideoFrame> || IsSame<Command, DrawCanvas> || IsSame<Command, DrawCompositedContext>) {
                 requires_direct_replay = true;
             } else if constexpr (IsSame<Command, PaintNestedDisplayList>) {
                 // NB: A nested list's live content matters at any depth, and its unisolated destination reads
@@ -613,12 +611,6 @@ bool DisplayListResourceStorage::nested_display_list_requires_direct_replay(Disp
     return requires_direct_replay;
 }
 
-static ReadonlyBytes inline_data(ReadonlyBytes payload, DisplayListDataSpan span)
-{
-    VERIFY(static_cast<size_t>(span.offset) + span.size <= payload.size());
-    return payload.slice(span.offset, span.size);
-}
-
 void DisplayListResourceStorage::collect_referenced_resources(
     ReadonlyBytes command_bytes,
     DisplayListResourceSet& referenced_resources) const
@@ -639,20 +631,6 @@ void DisplayListResourceStorage::collect_referenced_resources(
                 if (command.paint_kind == decltype(command.paint_kind)::PaintStyle
                     && command.paint_style.paint_style_type == DisplayListPaintStyleType::Pattern)
                     add_display_list_resource(command.paint_style.pattern_tile_display_list_id);
-            }
-            if constexpr (requires { command.backdrop_filter_data; }) {
-                if (command.has_backdrop_filter) {
-                    Gfx::for_each_filter_image_frame_id(inline_data(payload, command.backdrop_filter_data), [&](u64 image_id) {
-                        referenced_resources.image_frames.set(ImageFrameResourceId { image_id }, AK::HashSetExistingEntryBehavior::Keep);
-                    });
-                }
-            }
-            if constexpr (requires { command.filter_data; }) {
-                if (command.has_filter) {
-                    Gfx::for_each_filter_image_frame_id(inline_data(payload, command.filter_data), [&](u64 image_id) {
-                        referenced_resources.image_frames.set(ImageFrameResourceId { image_id }, AK::HashSetExistingEntryBehavior::Keep);
-                    });
-                }
             }
             if constexpr (requires { command.display_list_id; }) {
                 add_display_list_resource(command.display_list_id);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -1093,11 +1093,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 write_image_paint_facts(*paint, context, facts);
             return facts;
         },
-        .resolve_svg_filter = [](void* context_pointer, void* layout_node_shell, void const* url_value, void* sink) -> Layout::RustFFI::FfiResolvedSvgFilter {
-            auto& context = *static_cast<PaintHostContext*>(context_pointer);
-            auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
-            return push_svg_filter_reference(url_value, layout_node, &context.resource_storage, sink);
-        },
         .svg_image_facts = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiSvgImageFacts {
             auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
             auto const* row = committed_row(layout_node);

--- a/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
@@ -315,8 +315,7 @@ fn transform_value_is_invertible(property: u16, values: ComputedValuesView<'_>) 
 fn accumulated_visual_context_property_always_requires_repaint(property: u16) -> bool {
     matches!(
         property,
-        property_id::BACKDROP_FILTER
-            | property_id::BACKGROUND_ATTACHMENT
+        property_id::BACKGROUND_ATTACHMENT
             | property_id::BACKGROUND_IMAGE
             | property_id::BORDER_BOTTOM_LEFT_RADIUS
             | property_id::BORDER_BOTTOM_RIGHT_RADIUS
@@ -498,6 +497,7 @@ fn property_invalidation(property: u16, old: ComputedValuesView<'_>, new: Comput
                 | property_id::SCALE
                 | property_id::OPACITY
                 | property_id::FILTER
+                | property_id::BACKDROP_FILTER
                 | property_id::MIX_BLEND_MODE
                 | property_id::PERSPECTIVE
         ) && value_creates_stacking_context(property, old)

--- a/Libraries/LibWeb/Rust/src/painting/display_list/commands.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/commands.rs
@@ -33,7 +33,7 @@ pub enum DisplayListCommandType {
     StrokePath,
     DrawEllipse,
     DrawLine,
-    ApplyBackdropFilter,
+    BackdropFilterRegion,
     DrawRect,
     PaintNestedDisplayList,
     DrawIsolatedDisplayList,
@@ -94,7 +94,7 @@ impl DisplayListCommandType {
             Self::StrokePath => "StrokePath",
             Self::DrawEllipse => "DrawEllipse",
             Self::DrawLine => "DrawLine",
-            Self::ApplyBackdropFilter => "ApplyBackdropFilter",
+            Self::BackdropFilterRegion => "BackdropFilterRegion",
             Self::DrawRect => "DrawRect",
             Self::PaintNestedDisplayList => "PaintNestedDisplayList",
             Self::DrawIsolatedDisplayList => "DrawIsolatedDisplayList",
@@ -184,6 +184,10 @@ pub struct ReplayLayer {
     pub blend_mode: CompositingAndBlendingOperator,
     pub filter_bytes: *const u8,
     pub filter_bytes_size: usize,
+    pub backdrop_filter_bytes: *const u8,
+    pub backdrop_filter_bytes_size: usize,
+    pub backdrop_region: IntRect,
+    pub backdrop_corner_radii: CornerRadii,
     pub effect: EffectNodeIndex,
 }
 
@@ -1190,25 +1194,19 @@ impl DisplayListCommand for DrawLine {
     }
 }
 
+// The backdrop filter is applied by the effect the box records under. This command holds the box's
+// place in paint order, so the effect is entered there even when the box paints nothing else.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C)]
-pub struct ApplyBackdropFilter {
-    pub backdrop_region: IntRect,
-    pub corner_radii: CornerRadii,
-    pub has_backdrop_filter: bool,
-    pub backdrop_filter_data: DisplayListDataSpan,
+pub struct BackdropFilterRegion {
+    pub rect: IntRect,
 }
-ffi_bytes_fields!(ApplyBackdropFilter {
-    backdrop_region,
-    corner_radii,
-    has_backdrop_filter,
-    backdrop_filter_data
-});
+ffi_bytes_fields!(BackdropFilterRegion { rect });
 
-impl DisplayListCommand for ApplyBackdropFilter {
-    const COMMAND_TYPE: DisplayListCommandType = DisplayListCommandType::ApplyBackdropFilter;
+impl DisplayListCommand for BackdropFilterRegion {
+    const COMMAND_TYPE: DisplayListCommandType = DisplayListCommandType::BackdropFilterRegion;
     fn bounding_rect(&self) -> Option<IntRect> {
-        Some(self.backdrop_region)
+        Some(self.rect)
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
@@ -234,7 +234,10 @@ fn effect_data_is_equal(a: &EffectNodeData, b: &EffectNodeData) -> bool {
     match (a, b) {
         (EffectNodeData::BackgroundColorAnimation, EffectNodeData::BackgroundColorAnimation) => true,
         (EffectNodeData::Effects(data), EffectNodeData::Effects(other)) => {
-            data.opacity == other.opacity && data.blend_mode == other.blend_mode && data.filter == other.filter
+            data.opacity == other.opacity
+                && data.blend_mode == other.blend_mode
+                && data.filter == other.filter
+                && data.backdrop_filter == other.backdrop_filter
         }
         // Mask content is per-recording and invisible here, so mask chains always damage.
         (EffectNodeData::Mask(_), EffectNodeData::Mask(_)) => false,
@@ -697,14 +700,14 @@ mod tests {
     use crate::layout::node_data::NodeSlotId;
     use crate::painting::display_list::builder::HEADER_SIZE;
     use crate::painting::display_list::commands::{
-        CanvasId, CompositorMainThreadWheelEventRegion, DisplayListCommand, DisplayListGlyph, DrawCanvas, FillRect,
-        FontResourceId, ImageFrameResourceId, InlineClipKind,
+        BackdropFilterRegion, CanvasId, CompositorMainThreadWheelEventRegion, DisplayListCommand, DisplayListGlyph,
+        DrawCanvas, FillRect, FontResourceId, ImageFrameResourceId, InlineClipKind,
     };
     use crate::painting::display_list::ffi_bytes::FfiBytes;
     use crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT;
     use crate::painting::visual_context::{
-        ClipData, ClipMode, ClipNodeData, ClipNodeIndex, EffectNodeData, EffectNodeIndex, EffectsData, MaskData,
-        MaskLayerOrigin, ScrollData, SpatialData, TransformData, TransformDataRole,
+        BackdropFilterData, ClipData, ClipMode, ClipNodeData, ClipNodeIndex, EffectNodeData, EffectNodeIndex,
+        EffectsData, MaskData, MaskLayerOrigin, ScrollData, SpatialData, TransformData, TransformDataRole,
     };
     use libgfx_rust::filter::Filter;
     use libgfx_rust::{
@@ -866,6 +869,7 @@ mod tests {
             opacity: 1.0,
             blend_mode: CompositingAndBlendingOperator::Normal,
             filter: Some(Rc::new(filter)),
+            backdrop_filter: None,
         })
     }
 
@@ -1218,6 +1222,56 @@ mod tests {
         );
     }
 
+    fn backdrop_effects(filter: Vec<u8>, region: IntRect) -> EffectNodeData {
+        EffectNodeData::Effects(EffectsData {
+            opacity: 1.0,
+            blend_mode: CompositingAndBlendingOperator::Normal,
+            filter: None,
+            backdrop_filter: Some(BackdropFilterData {
+                filter: Rc::new(filter),
+                region,
+                corner_radii: CornerRadii::default(),
+            }),
+        })
+    }
+
+    // A backdrop filter's output is limited to its region, which the region command records, so a
+    // changed backdrop filter damages that region even when it widens the filter's extent.
+    #[test]
+    fn changed_backdrop_filter_damages_its_region() {
+        let region = IntRect::new(10, 10, 20, 20);
+        let mut old_tree = identity_tree();
+        let old_context = effect_context(&mut old_tree, backdrop_effects(blur_filter(1.0), region));
+        let mut new_tree = identity_tree();
+        let new_context = effect_context(&mut new_tree, backdrop_effects(blur_filter(10.0), region));
+        let mut unchanged_tree = identity_tree();
+        let unchanged_context = effect_context(&mut unchanged_tree, backdrop_effects(blur_filter(1.0), region));
+        let marker = BackdropFilterRegion { rect: region };
+        let old_display_list = command_bytes(
+            &marker,
+            Some(region),
+            context_in(VISUAL_VIEWPORT_NODE_INDEX, old_context),
+        );
+        let new_display_list = command_bytes(
+            &marker,
+            Some(region),
+            context_in(VISUAL_VIEWPORT_NODE_INDEX, new_context),
+        );
+        let unchanged_display_list = command_bytes(
+            &marker,
+            Some(region),
+            context_in(VISUAL_VIEWPORT_NODE_INDEX, unchanged_context),
+        );
+        assert_eq!(
+            damage(&old_display_list, &old_tree, &new_display_list, &new_tree),
+            Some(IntRect::new(9, 9, 22, 22))
+        );
+        assert_eq!(
+            damage(&old_display_list, &old_tree, &unchanged_display_list, &unchanged_tree),
+            Some(IntRect::default())
+        );
+    }
+
     #[test]
     fn mask_visual_context_damages_affected_commands() {
         let mut old_tree = identity_tree();
@@ -1314,6 +1368,7 @@ mod tests {
                 opacity: 0.5,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
+                backdrop_filter: None,
             }),
         );
         let new_command_spatial = new_tree.append_spatial(

--- a/Libraries/LibWeb/Rust/src/painting/display_list/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/dump.rs
@@ -462,9 +462,9 @@ fn dump_command(output: &mut String, command_type: DisplayListCommandType, paylo
                 write_field(output, "alternate_color", command.alternate_color);
             }
         }
-        DisplayListCommandType::ApplyBackdropFilter => {
-            let command = read_command::<ApplyBackdropFilter>(payload);
-            write_field(output, "backdrop_region", command.backdrop_region);
+        DisplayListCommandType::BackdropFilterRegion => {
+            let command = read_command::<BackdropFilterRegion>(payload);
+            write_field(output, "rect", command.rect);
         }
         DisplayListCommandType::DrawRect => {
             let command = read_command::<DrawRect>(payload);

--- a/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
@@ -957,19 +957,11 @@ impl DisplayListRecorder {
         self.append_command(&command, payload.inline_data());
     }
 
-    pub fn apply_backdrop_filter(&mut self, backdrop_region: IntRect, corner_radii: CornerRadii, filter_bytes: &[u8]) {
-        if backdrop_region.is_empty() {
+    pub fn backdrop_filter_region(&mut self, rect: IntRect) {
+        if rect.is_empty() {
             return;
         }
-        let mut payload = CommandPayloadBuilder::new::<ApplyBackdropFilter>(&self.builder);
-        let filter_data = payload.append_data(filter_bytes, std::mem::align_of::<u32>());
-        let command = ApplyBackdropFilter {
-            backdrop_region,
-            corner_radii,
-            has_backdrop_filter: true,
-            backdrop_filter_data: filter_data,
-        };
-        self.append_command(&command, payload.inline_data());
+        self.append_command(&BackdropFilterRegion { rect }, &[]);
     }
 
     pub fn paint_outer_box_shadow(&mut self, mut shadow: PaintOuterBoxShadow, force_dark_role: ForceDarkRole) {

--- a/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
@@ -14,7 +14,7 @@ use crate::painting::visual_context::{
     resolve_leaf_to_context_matrices, should_cull_back_face,
 };
 use libgfx_rust::path::OwnedPath;
-use libgfx_rust::{FloatMatrix4x4, FloatPoint, FloatVector3, IntRect, WindingRule, translation_matrix};
+use libgfx_rust::{CornerRadii, FloatMatrix4x4, FloatPoint, FloatVector3, IntRect, WindingRule, translation_matrix};
 use std::cell::RefCell;
 
 pub trait ReplayPainter {
@@ -131,11 +131,25 @@ fn replay_layer_of(effects: &crate::painting::visual_context::EffectsData, effec
         Some(bytes) => (bytes.as_ptr(), bytes.len()),
         None => (std::ptr::null(), 0),
     };
+    let (backdrop_filter_bytes, backdrop_filter_bytes_size, backdrop_region, backdrop_corner_radii) =
+        match &effects.backdrop_filter {
+            Some(backdrop) => (
+                backdrop.filter.as_ptr(),
+                backdrop.filter.len(),
+                backdrop.region,
+                backdrop.corner_radii,
+            ),
+            None => (std::ptr::null(), 0, IntRect::default(), CornerRadii::default()),
+        };
     ReplayLayer {
         opacity: effects.opacity,
         blend_mode: effects.blend_mode,
         filter_bytes,
         filter_bytes_size,
+        backdrop_filter_bytes,
+        backdrop_filter_bytes_size,
+        backdrop_region,
+        backdrop_corner_radii,
         effect,
     }
 }
@@ -573,8 +587,8 @@ mod tests {
     use crate::painting::display_list::commands::ContextRef;
     use crate::painting::display_list::commands::VISUAL_VIEWPORT_NODE_INDEX;
     use crate::painting::visual_context::{
-        BackfaceVisibilityData, ClipData, ClipMode, EffectsData, MaskData, MaskLayerOrigin, SpatialData, TransformData,
-        TransformDataRole,
+        BackdropFilterData, BackfaceVisibilityData, ClipData, ClipMode, EffectsData, MaskData, MaskLayerOrigin,
+        SpatialData, TransformData, TransformDataRole,
     };
     use libgfx_rust::{
         CompositingAndBlendingOperator, CornerRadii, FloatRect, MaskKind, scale_matrix, translation_matrix,
@@ -776,6 +790,7 @@ mod tests {
             opacity,
             blend_mode: CompositingAndBlendingOperator::Normal,
             filter: None,
+            backdrop_filter: None,
         })
     }
 
@@ -1228,6 +1243,38 @@ mod tests {
                 PainterEvent::SetMatrix(base),
             ]
         );
+    }
+
+    #[test]
+    fn a_layer_carries_its_backdrop_filter() {
+        let filter = std::rc::Rc::new(vec![1, 2, 3]);
+        let region = IntRect::new(1, 2, 30, 40);
+        let radii = CornerRadii::uniform(5);
+        let with_backdrop = EffectsData {
+            opacity: 0.5,
+            blend_mode: CompositingAndBlendingOperator::Normal,
+            filter: None,
+            backdrop_filter: Some(BackdropFilterData {
+                filter: filter.clone(),
+                region,
+                corner_radii: radii,
+            }),
+        };
+        let layer = replay_layer_of(&with_backdrop, EffectNodeIndex(3));
+        assert_eq!(layer.opacity, 0.5);
+        assert_eq!(layer.backdrop_filter_bytes, filter.as_ptr());
+        assert_eq!(layer.backdrop_filter_bytes_size, 3);
+        assert_eq!(layer.backdrop_region, region);
+        assert_eq!(layer.backdrop_corner_radii, radii);
+        assert_eq!(layer.effect, EffectNodeIndex(3));
+
+        let EffectNodeData::Effects(without_backdrop) = effects(0.5) else {
+            unreachable!()
+        };
+        let layer = replay_layer_of(&without_backdrop, EffectNodeIndex(4));
+        assert!(layer.backdrop_filter_bytes.is_null());
+        assert_eq!(layer.backdrop_filter_bytes_size, 0);
+        assert_eq!(layer.backdrop_region, IntRect::default());
     }
 
     // A background-color animation marker is an effect without canvas state: entering or leaving

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -3409,14 +3409,14 @@ pub unsafe extern "C" fn visual_context_tree_mark_spatial_subtrees(
 ///
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_has_unisolated_blending_effect(tree: *const c_void) -> bool {
-    unsafe { tree_from_handle(tree) }.has_unisolated_blending_effect()
+pub unsafe extern "C" fn visual_context_tree_has_unisolated_destination_reading_effect(tree: *const c_void) -> bool {
+    unsafe { tree_from_handle(tree) }.has_unisolated_destination_reading_effect()
 }
 
 /// # Safety
 ///
 /// `tree` must be a live retained tree handle; `visit` is called synchronously with `context` for every
-/// effect node that carries a filter.
+/// filter and backdrop filter an effect node carries.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_for_each_effects_filter_bytes(
     tree: *const c_void,
@@ -3425,9 +3425,11 @@ pub unsafe extern "C" fn visual_context_tree_for_each_effects_filter_bytes(
 ) {
     let tree = unsafe { tree_from_handle(tree) };
     for node in &tree.effect_nodes {
-        if let crate::painting::visual_context::EffectNodeData::Effects(effects) = &node.data
-            && let Some(filter_bytes) = &effects.filter
-        {
+        let crate::painting::visual_context::EffectNodeData::Effects(effects) = &node.data else {
+            continue;
+        };
+        let backdrop_filter_bytes = effects.backdrop_filter.as_ref().map(|backdrop| &backdrop.filter);
+        for filter_bytes in effects.filter.iter().chain(backdrop_filter_bytes) {
             // SAFETY: The C++ visitor reads the bytes synchronously.
             unsafe { visit(context, filter_bytes.as_ptr(), filter_bytes.len()) };
         }
@@ -3648,6 +3650,7 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_effects(
             opacity,
             blend_mode,
             filter: None,
+            backdrop_filter: None,
         }),
         EffectNodeIndex(parent_effect),
         SpatialNodeIndex(spatial),

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -4,12 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::css::computed_value_types::ComputedStyleValueHandle;
 use crate::layout::used_values;
 use crate::painting::display_list::builder::RecordedDisplayList;
 use crate::painting::display_list::commands::{DisplayListCommandRun, DisplayListResourceId, EffectNodeIndex};
 use crate::painting::display_list::commands::{OptionalAffineTransform, OptionalColor};
-use crate::painting::host::visual_context::{FfiResolvedSvgFilter, ResolvedSvgFilter};
 use libgfx_rust::{AffineTransform, Color, FloatMatrix4x4, FloatRect, FloatSize, IntRect, InterpolationColorSpace};
 use std::ffi::c_void;
 
@@ -455,8 +453,6 @@ pub struct FfiPaintHostCallbacks {
     pub replaced_paint_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiReplacedPaintFacts,
     pub replaced_image_paint:
         unsafe extern "C" fn(*mut c_void, *mut c_void, FloatRect, FloatSize) -> FfiImagePaintFacts,
-    pub resolve_svg_filter:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *const c_void, *mut c_void) -> FfiResolvedSvgFilter,
     pub svg_image_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgImageFacts,
     pub svg_paint_style: unsafe extern "C" fn(
         *mut c_void,
@@ -580,24 +576,6 @@ impl FfiPaintHostCallbacks {
     ) -> FfiImagePaintFacts {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe { (self.replaced_image_paint)(self.context, layout_node_shell, dest, accumulated_scale) }
-    }
-    pub(crate) fn resolve_svg_filter(
-        &self,
-        layout_node_shell: *mut c_void,
-        url_value: &ComputedStyleValueHandle,
-        device_pixels_per_css_pixel: f64,
-    ) -> ResolvedSvgFilter {
-        // SAFETY: The C++ host answers synchronously from a live layout node shell and only pushes
-        // into the builder whose pointer it receives.
-        unsafe {
-            ResolvedSvgFilter::from_host(
-                self.resolve_svg_filter,
-                self.context,
-                layout_node_shell,
-                url_value,
-                device_pixels_per_css_pixel,
-            )
-        }
     }
     pub(crate) fn svg_image_facts(&self, layout_node_shell: *mut c_void) -> FfiSvgImageFacts {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
@@ -247,42 +247,11 @@ pub(crate) fn paint_backdrop_filter<O: Observer>(
     if !facts.has_backdrop_filter {
         return;
     }
-    let backdrop_region =
-        recorder
-            .converter
-            .rounded_device_rect(crate::painting::paintable_geometry::absolute_border_box_rect(
-                recorder.layout_arena,
-                paintable,
-            ));
-    let border_radii = recorder.border_radii(paintable);
-    let filter_bytes = recorder.layout_arena.node_style_if_live(paintable).and_then(|style| {
-        let backdrop_filter = &style.effects().backdrop_filter;
-        if crate::painting::filter_bytes::contains_url(backdrop_filter) {
-            let layout_node_shell = recorder.layout_node_shell(paintable);
-            let resolved_svg_filter =
-                crate::painting::filter_bytes::resolve_svg_filter_references(backdrop_filter, |url_value| {
-                    recorder.paint_host.resolve_svg_filter(
-                        layout_node_shell,
-                        url_value,
-                        recorder.inputs.device_pixels_per_css_pixel,
-                    )
-                });
-            crate::painting::filter_bytes::serialize_filter_with_resolved_svg(
-                backdrop_filter,
-                resolved_svg_filter,
-                recorder.inputs.device_pixels_per_css_pixel,
-            )
-        } else {
-            crate::painting::filter_bytes::serialize_non_url_filter(
-                backdrop_filter,
-                recorder.inputs.device_pixels_per_css_pixel,
-            )
-        }
-    });
-    if let Some(filter_bytes) = filter_bytes {
-        let corner_radii = border_radii.as_corners(&recorder.converter);
-        recorder
-            .recorder
-            .apply_backdrop_filter(backdrop_region, corner_radii, &filter_bytes);
-    }
+    let region = recorder
+        .converter
+        .rounded_device_rect(crate::painting::paintable_geometry::absolute_border_box_rect(
+            recorder.layout_arena,
+            paintable,
+        ));
+    recorder.recorder.backdrop_filter_region(region);
 }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
@@ -385,7 +385,8 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead>(
 
     let transform_data = facts.transform;
 
-    if facts.effects.is_some() {
+    let effects_layer_is_inside_transform_and_clips = facts.effects_layer_is_inside_transform_and_clips();
+    if facts.effects.is_some() && !effects_layer_is_inside_transform_and_clips {
         append_shared_effect!(EffectNodeData::Effects(facts.effects_data().unwrap()));
     }
 
@@ -506,6 +507,13 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead>(
 
     if facts.clip_path.is_some() {
         append_clip_to_own_and_positioned_descendant_contexts!(ClipNodeData::Path(facts.clip_path_data().unwrap()));
+    }
+
+    // A backdrop filter is limited to the box's rounded border box in the box's own space, and a clip
+    // path clips the filtered backdrop along with the content, so its layer sits under the transform
+    // and clip nodes rather than above them.
+    if effects_layer_is_inside_transform_and_clips {
+        append_shared_effect!(EffectNodeData::Effects(facts.effects_data().unwrap()));
     }
 
     if !facts.mask_layers.is_empty() {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -80,7 +80,14 @@ impl BoxFacts {
             opacity: effects.opacity,
             blend_mode: effects.blend_mode,
             filter: effects.filter.clone(),
+            backdrop_filter: effects.backdrop_filter.clone(),
         })
+    }
+
+    pub(crate) fn effects_layer_is_inside_transform_and_clips(&self) -> bool {
+        self.effects
+            .as_ref()
+            .is_some_and(|effects| effects.backdrop_filter.is_some())
     }
 
     pub(crate) fn gather(

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
@@ -205,6 +205,17 @@ impl VisualContextTree {
                         text.push(' ');
                     }
                     text.push_str("filter");
+                    has_content = true;
+                }
+                if let Some(backdrop_filter) = &effects.backdrop_filter {
+                    if has_content {
+                        text.push(' ');
+                    }
+                    let _ = write!(
+                        text,
+                        "backdrop-filter=[{}]",
+                        format_int_rect_components(backdrop_filter.region)
+                    );
                 }
                 text.push(']');
             }
@@ -551,6 +562,7 @@ mod node_dump_tests {
                 opacity: 1.0,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
+                backdrop_filter: None,
             }),
             EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
@@ -561,6 +573,7 @@ mod node_dump_tests {
                 opacity: 0.5,
                 blend_mode: CompositingAndBlendingOperator::Multiply,
                 filter: Some(std::rc::Rc::new(vec![1, 2, 3])),
+                backdrop_filter: None,
             }),
             EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
@@ -668,6 +681,7 @@ mod section_dump_tests {
                 opacity: 0.5,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
+                backdrop_filter: None,
             }),
             EffectNodeIndex::NONE,
             scroll_node,

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -253,7 +253,8 @@ pub(crate) fn box_owns_geometry_dependent_nodes(
             EffectNodeData::BackgroundColorAnimation => false,
             EffectNodeData::Mask(_) => true,
             EffectNodeData::Effects(effects) => {
-                effects.filter.is_some() && effects_filter_is_resolved_by_the_host_against_geometry
+                effects.backdrop_filter.is_some()
+                    || (effects.filter.is_some() && effects_filter_is_resolved_by_the_host_against_geometry)
             }
             EffectNodeData::Dead => false,
         }
@@ -714,6 +715,7 @@ mod tests {
             opacity: 0.5,
             blend_mode: CompositingAndBlendingOperator::Normal,
             filter: None,
+            backdrop_filter: None,
         })
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -88,11 +88,21 @@ pub struct ClipPathData {
     pub fill_rule: WindingRule,
 }
 
+// The filtered backdrop, limited to the box's rounded border box, is the initial content of the box's
+// layer, so the layer's opacity, blend mode and filter apply to it along with the box's content.
+#[derive(Clone, PartialEq)]
+pub struct BackdropFilterData {
+    pub filter: Rc<Vec<u8>>,
+    pub region: IntRect,
+    pub corner_radii: CornerRadii,
+}
+
 #[derive(Clone)]
 pub struct EffectsData {
     pub opacity: f32,
     pub blend_mode: CompositingAndBlendingOperator,
     pub filter: Option<std::rc::Rc<Vec<u8>>>,
+    pub backdrop_filter: Option<BackdropFilterData>,
 }
 
 impl EffectNodeData {
@@ -101,6 +111,7 @@ impl EffectNodeData {
             opacity: 1.0,
             blend_mode,
             filter: None,
+            backdrop_filter: None,
         })
     }
 }
@@ -117,7 +128,10 @@ impl ClipNodeData {
 
 impl EffectsData {
     pub fn needs_layer(&self) -> bool {
-        self.opacity < 1.0 || self.blend_mode != CompositingAndBlendingOperator::Normal || self.filter.is_some()
+        self.opacity < 1.0
+            || self.blend_mode != CompositingAndBlendingOperator::Normal
+            || self.filter.is_some()
+            || self.backdrop_filter.is_some()
     }
 }
 
@@ -1565,6 +1579,7 @@ mod tests {
             opacity: 1.0,
             blend_mode: CompositingAndBlendingOperator::Normal,
             filter: None,
+            backdrop_filter: None,
         })
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
@@ -35,7 +35,8 @@ impl<Arena: PaintableRowsRead> NestedBuilder<'_, Arena> {
     fn build_subtree(&mut self, slot: NodeSlotId, inherited_state: ContextRef, include_element_transform: bool) {
         let facts = BoxFacts::gather(self.layout_arena, self.callbacks, slot, self.pixel_ratio, false);
         let mut own_state = inherited_state;
-        if let Some(effects) = facts.effects_data() {
+        let effects_layer_is_inside_transform = facts.effects_layer_is_inside_transform_and_clips();
+        if !effects_layer_is_inside_transform && let Some(effects) = facts.effects_data() {
             own_state = self
                 .tree
                 .append_effect_node_under(own_state, EffectNodeData::Effects(effects));
@@ -45,6 +46,12 @@ impl<Arena: PaintableRowsRead> NestedBuilder<'_, Arena> {
             own_state = self
                 .tree
                 .append_spatial_under(own_state, SpatialData::Transform(transform));
+        }
+
+        if effects_layer_is_inside_transform && let Some(effects) = facts.effects_data() {
+            own_state = self
+                .tree
+                .append_effect_node_under(own_state, EffectNodeData::Effects(effects));
         }
 
         for mask_layer in facts

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
@@ -558,9 +558,12 @@ pub(crate) fn compute_effects_data(
         crate::painting::filter_bytes::serialize_non_url_filter(&effects_values.filter, device_pixels_per_css_pixel)
             .map(std::rc::Rc::new)
     };
+    let backdrop_filter =
+        compute_backdrop_filter_data(layout_arena, callbacks, slot, style, device_pixels_per_css_pixel);
     let needs_compositor_effects_layer = layout_arena
         .node_has_compositor_animation_frame(slot, crate::layout::node_data::CompositorAnimationFrameKind::Opacity);
     if filter.is_none()
+        && backdrop_filter.is_none()
         && effects_values.opacity == 1.0
         && effects_values.mix_blend_mode == mix_blend_mode::NORMAL
         && !needs_compositor_effects_layer
@@ -571,12 +574,48 @@ pub(crate) fn compute_effects_data(
         opacity: effects_values.opacity,
         blend_mode: mix_blend_mode_to_compositing_and_blending_operator(effects_values.mix_blend_mode),
         filter,
+        backdrop_filter,
     };
-    let needs_layer = effects.opacity < 1.0
-        || effects.blend_mode != CompositingAndBlendingOperator::Normal
-        || effects.filter.is_some()
-        || needs_compositor_effects_layer;
+    let needs_layer = effects.needs_layer() || needs_compositor_effects_layer;
     needs_layer.then_some(effects)
+}
+
+// https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty
+fn compute_backdrop_filter_data(
+    layout_arena: &impl PaintableRowsRead,
+    callbacks: &FfiVisualContextHostCallbacks,
+    slot: NodeSlotId,
+    style: ComputedValuesView<'_>,
+    device_pixels_per_css_pixel: f64,
+) -> Option<super::BackdropFilterData> {
+    let backdrop_filter = &style.effects().backdrop_filter;
+    if backdrop_filter.operations.length == 0 {
+        return None;
+    }
+    let converter = DevicePixelConverter::new(device_pixels_per_css_pixel);
+    let region = converter.rounded_device_rect(paintable_geometry::absolute_border_box_rect(layout_arena, slot));
+    if region.is_empty() {
+        return None;
+    }
+    let filter = if crate::painting::filter_bytes::contains_url(backdrop_filter) {
+        let layout_node_shell = layout_arena.shell_if_live(slot);
+        let resolved_svg_filter =
+            crate::painting::filter_bytes::resolve_svg_filter_references(backdrop_filter, |url_value| {
+                callbacks.resolve_svg_filter(layout_node_shell, url_value, device_pixels_per_css_pixel)
+            });
+        crate::painting::filter_bytes::serialize_filter_with_resolved_svg(
+            backdrop_filter,
+            resolved_svg_filter,
+            device_pixels_per_css_pixel,
+        )
+    } else {
+        crate::painting::filter_bytes::serialize_non_url_filter(backdrop_filter, device_pixels_per_css_pixel)
+    }?;
+    Some(super::BackdropFilterData {
+        filter: std::rc::Rc::new(filter),
+        region,
+        corner_radii: border_radii_data(style, layout_arena, slot).as_corners(&converter),
+    })
 }
 
 fn any_background_layer_has_an_image_with_attachment(style: ComputedValuesView<'_>, wanted_attachment: u16) -> bool {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
@@ -670,10 +670,14 @@ impl VisualContextTree {
         false
     }
 
-    pub fn has_unisolated_blending_effect(&self) -> bool {
+    // A blend mode or a backdrop filter reads what the canvas holds outside the effect's own layer.
+    pub fn has_unisolated_destination_reading_effect(&self) -> bool {
         self.effect_nodes.iter().any(|node| {
-            matches!(&node.data, EffectNodeData::Effects(effects) if effects.blend_mode != CompositingAndBlendingOperator::Normal)
-                && !self.effect_is_isolated_by_layer(node.parent)
+            matches!(
+                &node.data,
+                EffectNodeData::Effects(effects)
+                    if effects.blend_mode != CompositingAndBlendingOperator::Normal || effects.backdrop_filter.is_some()
+            ) && !self.effect_is_isolated_by_layer(node.parent)
         })
     }
 }
@@ -881,6 +885,7 @@ mod tests {
             opacity,
             blend_mode,
             filter: None,
+            backdrop_filter: None,
         })
     }
 
@@ -984,9 +989,9 @@ mod tests {
     }
 
     #[test]
-    fn a_blending_context_counts_as_unisolated_only_without_a_layer_ancestor() {
+    fn a_destination_reading_effect_counts_as_unisolated_only_without_a_layer_ancestor() {
         let mut tree = identity_tree();
-        assert!(!tree.has_unisolated_blending_effect());
+        assert!(!tree.has_unisolated_destination_reading_effect());
         let opacity_effect = tree.append_effect(
             effects(0.5, CompositingAndBlendingOperator::Normal),
             EffectNodeIndex::NONE,
@@ -999,14 +1004,49 @@ mod tests {
             VISUAL_VIEWPORT_NODE_INDEX,
             ClipNodeIndex::NONE,
         );
-        assert!(!tree.has_unisolated_blending_effect());
+        assert!(!tree.has_unisolated_destination_reading_effect());
         tree.append_effect(
             effects(1.0, CompositingAndBlendingOperator::Multiply),
             EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
             ClipNodeIndex::NONE,
         );
-        assert!(tree.has_unisolated_blending_effect());
+        assert!(tree.has_unisolated_destination_reading_effect());
+
+        // A backdrop filter reads outside its own layer, so only an enclosing layer isolates it.
+        let backdrop_effects = || {
+            EffectNodeData::Effects(EffectsData {
+                opacity: 1.0,
+                blend_mode: CompositingAndBlendingOperator::Normal,
+                filter: None,
+                backdrop_filter: Some(crate::painting::visual_context::BackdropFilterData {
+                    filter: std::rc::Rc::new(vec![1]),
+                    region: IntRect::new(0, 0, 10, 10),
+                    corner_radii: libgfx_rust::CornerRadii::default(),
+                }),
+            })
+        };
+        let mut tree = identity_tree();
+        let opacity_effect = tree.append_effect(
+            effects(0.5, CompositingAndBlendingOperator::Normal),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        tree.append_effect(
+            backdrop_effects(),
+            opacity_effect,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        assert!(!tree.has_unisolated_destination_reading_effect());
+        tree.append_effect(
+            backdrop_effects(),
+            EffectNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            ClipNodeIndex::NONE,
+        );
+        assert!(tree.has_unisolated_destination_reading_effect());
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/reconcile.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/reconcile.rs
@@ -608,6 +608,7 @@ mod tests {
                 opacity: 0.7,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
+                backdrop_filter: None,
             }),
             ROOT_ISOLATION_EFFECT,
             BOX_A_SPATIAL,

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
@@ -5,10 +5,10 @@
  */
 
 use super::{
-    AnchorScrollShift, BackfaceVisibilityData, ClipData, ClipMode, ClipNode, ClipNodeData, ClipNodeIndex, ClipPathData,
-    EffectNode, EffectNodeData, EffectNodeIndex, EffectsData, MaskData, MaskLayerOrigin, PerspectiveData, ScrollData,
-    SpatialData, SpatialNode, SpatialNodeIndex, StickyData, TransformData, TransformDataRole,
-    VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree, scroll_state::NO_SCROLL_STATE_SLOT,
+    AnchorScrollShift, BackdropFilterData, BackfaceVisibilityData, ClipData, ClipMode, ClipNode, ClipNodeData,
+    ClipNodeIndex, ClipPathData, EffectNode, EffectNodeData, EffectNodeIndex, EffectsData, MaskData, MaskLayerOrigin,
+    PerspectiveData, ScrollData, SpatialData, SpatialNode, SpatialNodeIndex, StickyData, TransformData,
+    TransformDataRole, VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree, scroll_state::NO_SCROLL_STATE_SLOT,
 };
 use crate::layout::node_data::NodeSlotId;
 use libgfx_rust::path::OwnedPath;
@@ -427,6 +427,12 @@ fn write_effect_data(writer: &mut TreeByteWriter, data: &EffectNodeData) {
             writer.i32(effects.blend_mode as i32);
             writer.bool(effects.filter.is_some());
             writer.length_prefixed_bytes(effects.filter.as_deref().map_or(&[], Vec::as_slice));
+            writer.bool(effects.backdrop_filter.is_some());
+            if let Some(backdrop_filter) = &effects.backdrop_filter {
+                writer.int_rect(backdrop_filter.region);
+                writer.corner_radii(backdrop_filter.corner_radii);
+                writer.length_prefixed_bytes(&backdrop_filter.filter);
+            }
         }
         EffectNodeData::Mask(mask) => {
             writer.u8(EFFECT_KIND_MASK);
@@ -446,10 +452,20 @@ fn read_effect_data(reader: &mut TreeByteReader<'_>) -> Option<EffectNodeData> {
             let blend_mode = reader.compositing_and_blending_operator()?;
             let has_filter = reader.bool()?;
             let filter_bytes = reader.length_prefixed_bytes()?;
+            let backdrop_filter = if reader.bool()? {
+                Some(BackdropFilterData {
+                    region: reader.int_rect()?,
+                    corner_radii: reader.corner_radii()?,
+                    filter: Rc::new(reader.length_prefixed_bytes()?.to_vec()),
+                })
+            } else {
+                None
+            };
             EffectNodeData::Effects(EffectsData {
                 opacity,
                 blend_mode,
                 filter: has_filter.then(|| Rc::new(filter_bytes.to_vec())),
+                backdrop_filter,
             })
         }
         EFFECT_KIND_MASK => EffectNodeData::Mask(MaskData {
@@ -814,6 +830,7 @@ mod tests {
                 opacity: 1.0,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
+                backdrop_filter: None,
             }),
             EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
@@ -824,6 +841,17 @@ mod tests {
                 opacity: 0.25,
                 blend_mode: CompositingAndBlendingOperator::PlusLighter,
                 filter: Some(Rc::new(vec![1, 2, 3, 4])),
+                backdrop_filter: Some(BackdropFilterData {
+                    filter: Rc::new(vec![5, 6, 7]),
+                    region: IntRect::new(9, 10, 11, 12),
+                    corner_radii: CornerRadii {
+                        top_left: CornerRadius {
+                            horizontal_radius: 1,
+                            vertical_radius: 2,
+                        },
+                        ..CornerRadii::default()
+                    },
+                }),
             }),
             root_effect,
             scroll_node,
@@ -878,7 +906,10 @@ mod tests {
     fn effect_data_matches(a: &EffectNodeData, b: &EffectNodeData) -> bool {
         match (a, b) {
             (EffectNodeData::Effects(a), EffectNodeData::Effects(b)) => {
-                a.opacity == b.opacity && a.blend_mode == b.blend_mode && a.filter == b.filter
+                a.opacity == b.opacity
+                    && a.blend_mode == b.blend_mode
+                    && a.filter == b.filter
+                    && a.backdrop_filter == b.backdrop_filter
             }
             (EffectNodeData::Mask(a), EffectNodeData::Mask(b)) => a == b,
             (EffectNodeData::BackgroundColorAnimation, EffectNodeData::BackgroundColorAnimation) => true,
@@ -937,6 +968,7 @@ mod tests {
                 opacity: 0.5,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
+                backdrop_filter: None,
             }),
             EffectNodeIndex::NONE,
             scroll_node,
@@ -1027,6 +1059,7 @@ mod tests {
                 opacity: 1.0,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
+                backdrop_filter: None,
             })
         };
         let rect = || ClipNodeData::rect_clip(FloatRect::new(0.0, 0.0, 1.0, 1.0));
@@ -1177,6 +1210,7 @@ mod tests {
                 opacity: 1.0,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
+                backdrop_filter: None,
             }),
             EffectNodeIndex::NONE,
             VISUAL_VIEWPORT_NODE_INDEX,
@@ -1187,6 +1221,7 @@ mod tests {
                 opacity: 0.5,
                 blend_mode: CompositingAndBlendingOperator::Normal,
                 filter: None,
+                backdrop_filter: None,
             }),
             EffectNodeIndex(0),
             SpatialNodeIndex(2),

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/shape.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/shape.rs
@@ -174,6 +174,7 @@ pub(crate) fn effect_payloads_are_equal(a: &EffectNodeData, b: &EffectNodeData) 
             a.opacity == b.opacity
                 && a.blend_mode == b.blend_mode
                 && effects_filters_are_equal(a.filter.as_ref(), b.filter.as_ref())
+                && a.backdrop_filter == b.backdrop_filter
         }
         (EffectNodeData::Mask(a), EffectNodeData::Mask(b)) => a == b,
         (EffectNodeData::BackgroundColorAnimation, EffectNodeData::BackgroundColorAnimation) => true,

--- a/Tests/LibWeb/Ref/expected/visual-context/backdrop-filter-inside-opacity-ref.html
+++ b/Tests/LibWeb/Ref/expected/visual-context/backdrop-filter-inside-opacity-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.backdrop {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 300px;
+    height: 200px;
+    background: rgb(0, 255, 0);
+}
+.filtered {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background: rgb(255, 0, 255);
+    opacity: 0.5;
+}
+</style>
+<div class="backdrop"></div>
+<div class="filtered"></div>

--- a/Tests/LibWeb/Ref/expected/visual-context/backdrop-filter-inverted-backdrop-ref.html
+++ b/Tests/LibWeb/Ref/expected/visual-context/backdrop-filter-inverted-backdrop-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.backdrop {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 300px;
+    height: 200px;
+    background: rgb(0, 255, 0);
+}
+.filtered {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background: rgb(255, 0, 255);
+}
+</style>
+<div class="backdrop"></div>
+<div class="filtered"></div>

--- a/Tests/LibWeb/Ref/expected/visual-context/backdrop-filter-transformed-rounded-region-ref.html
+++ b/Tests/LibWeb/Ref/expected/visual-context/backdrop-filter-transformed-rounded-region-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.backdrop {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 300px;
+    height: 200px;
+    background: rgb(0, 255, 0);
+}
+.filtered {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 50px;
+    height: 50px;
+    border-radius: 10px;
+    transform: scale(2);
+    background: rgb(255, 0, 255);
+    opacity: 0.5;
+}
+</style>
+<div class="backdrop"></div>
+<div class="filtered"></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-basic-opacity-2-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-basic-opacity-2-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter: Basic operation of filter with opacity</title>
+<link rel="author" href="mailto:masonf@chromium.org">
+
+
+
+<div>
+  <p>Expected: Just a single grey box.</p>
+</div>
+<div class="colorbox"></div>
+
+
+<style>
+.colorbox {
+    position: absolute;
+    background: #808080;
+    width: 100px;
+    height: 100px;
+    left: 10px;
+    top: 100px;
+}
+</style>
+

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-paint-order-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-paint-order-ref.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter: Only filter objects painted before</title>
+<link rel="author" href="mailto:masonf@chromium.org">
+
+
+
+<div>
+  <p>Expected: A pure white box with a blue border, surrounded by green.<br>
+  No green should be observed within the white box.<br>
+  No dark/black should be observed within the white box either.</p>
+</div>
+
+<div class="filterbox"></div>
+<div class="greenbox top"></div>
+<div class="greenbox right"></div>
+<div class="greenbox bottom"></div>
+<style>
+.filterbox {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  top: 150px;
+  left: 0px;
+  border: 1px solid blue;
+
+
+}
+.greenbox {
+  position:absolute;
+  width: 150px;
+  height: 50px;
+  background: green;
+}
+.top {
+  top:100px;
+  left: 10px;
+}
+.right {
+  top:130px;
+  left: 102px;
+  width: 58px;
+  height: 150px;
+}
+.bottom {
+  top:252px;
+  left: 10px;
+}
+</style>
+

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-plus-opacity-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-plus-opacity-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter: Correctly apply backdrop-filter with opacity</title>
+<link rel="author" href="mailto:masonf@chromium.org">
+
+
+
+<p>Expected: A green box.</p>
+
+<div class="greenbox"></div>
+
+
+<style>
+.greenbox {
+  position: absolute;
+  background: green;
+  width: 100px;
+  height: 100px;
+  top: 100px;
+  left: 60px;
+}
+</style>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-with-mix-blend-mode-same-element-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-with-mix-blend-mode-same-element-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter with mix-blend-mode reference</title>
+<style>
+  .backdrop {
+    width: 100px;
+    height: 100px;
+    background: black;
+  }
+</style>
+
+<div class="backdrop"></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-zero-size-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/filter-effects/backdrop-filter-zero-size-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter: Zero-size div with backdrop filter shouldn't filter anything</title>
+<link rel="author" href="mailto:masonf@chromium.org">
+
+
+
+<p>Expected: A single green box.</p>
+<div></div>
+
+
+
+
+<style>
+div {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background: green;
+    left: 10px;
+    top: 100px;
+}
+</style>

--- a/Tests/LibWeb/Ref/input/visual-context/backdrop-filter-inside-filter-layer.html
+++ b/Tests/LibWeb/Ref/input/visual-context/backdrop-filter-inside-filter-layer.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/visual-context/backdrop-filter-inverted-backdrop-ref.html">
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.backdrop {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 300px;
+    height: 200px;
+    background: rgb(0, 255, 0);
+}
+.filtered {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    backdrop-filter: invert(1);
+    filter: grayscale(0);
+}
+</style>
+<!-- The box's own filter layer is opened with the filtered backdrop as its initial content; the backdrop
+     filter must not read the box's own, still empty, layer. -->
+<div class="backdrop"></div>
+<div class="filtered"></div>

--- a/Tests/LibWeb/Ref/input/visual-context/backdrop-filter-inside-mask.html
+++ b/Tests/LibWeb/Ref/input/visual-context/backdrop-filter-inside-mask.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/visual-context/backdrop-filter-inverted-backdrop-ref.html">
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.backdrop {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 300px;
+    height: 200px;
+    background: rgb(0, 255, 0);
+}
+.filtered {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    backdrop-filter: invert(1);
+    mask-image: linear-gradient(black, black);
+}
+</style>
+<!-- The box's mask layer nests inside the layer that holds the filtered backdrop; the backdrop filter must
+     not read the box's own, still empty, layers. -->
+<div class="backdrop"></div>
+<div class="filtered"></div>

--- a/Tests/LibWeb/Ref/input/visual-context/backdrop-filter-inside-opacity.html
+++ b/Tests/LibWeb/Ref/input/visual-context/backdrop-filter-inside-opacity.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/visual-context/backdrop-filter-inside-opacity-ref.html">
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.backdrop {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 300px;
+    height: 200px;
+    background: rgb(0, 255, 0);
+}
+.filtered {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    backdrop-filter: invert(1);
+    opacity: 0.5;
+}
+</style>
+<!-- The box's opacity applies to the filtered backdrop: the inverted green is composited at half
+     opacity over the green it was read from, which the reference paints directly. -->
+<div class="backdrop"></div>
+<div class="filtered"></div>

--- a/Tests/LibWeb/Ref/input/visual-context/backdrop-filter-transformed-rounded-region.html
+++ b/Tests/LibWeb/Ref/input/visual-context/backdrop-filter-transformed-rounded-region.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/visual-context/backdrop-filter-transformed-rounded-region-ref.html">
+<meta name="fuzzy" content="maxDifference=0-8;totalPixels=0-40">
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.backdrop {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 300px;
+    height: 200px;
+    background: rgb(0, 255, 0);
+}
+.filtered {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 50px;
+    height: 50px;
+    border-radius: 10px;
+    transform: scale(2);
+    backdrop-filter: invert(1);
+    opacity: 0.5;
+}
+</style>
+<!-- The filtered backdrop is limited to the box's rounded border box in the box's own transformed space,
+     so the corners are rounded by 20 device pixels and the rest of the box's layer stays empty. Only the
+     anti-aliased edge of the rounded region may differ from the reference (two pixels here). -->
+<div class="backdrop"></div>
+<div class="filtered"></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-basic-opacity-2.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-basic-opacity-2.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter: Basic operation of filter with opacity</title>
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
+<link rel="match"  href="../../../../expected/wpt-import/css/filter-effects/backdrop-filter-basic-opacity-2-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-10000">
+
+<div>
+  <p>Expected: Just a single grey box.</p>
+</div>
+<div class="box colorbox"></div>
+<div class="box filterbox"></div>
+
+<style>
+.box {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    left: 10px;
+    top: 100px;
+}
+.colorbox {
+    background: green;
+}
+.filterbox {
+    backdrop-filter: invert(1);
+    opacity: 0.5;
+    /* An invert backdrop-filter with opacity 0.5 should always give a grey
+       result. It will always mix the background color with its inverse, in
+       equal proportion.*/
+}
+</style>
+

--- a/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-paint-order.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-paint-order.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter: Only filter objects painted before</title>
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
+<link rel="match"  href="../../../../expected/wpt-import/css/filter-effects/backdrop-filter-paint-order-ref.html">
+
+<div>
+  <p>Expected: A pure white box with a blue border, surrounded by green.<br>
+  No green should be observed within the white box.<br>
+  No dark/black should be observed within the white box either.</p>
+</div>
+
+<div class="filterbox"></div>
+<div class="greenbox top"></div>
+<div class="greenbox right"></div>
+<div class="greenbox bottom"></div>
+<style>
+.filterbox {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  top: 150px;
+  left: 0px;
+  border: 1px solid blue;
+  backdrop-filter: blur(20px);
+}
+.greenbox {
+  position:absolute;
+  width: 150px;
+  height: 50px;
+  background: green;
+}
+.top {
+  top:100px;
+  left: 10px;
+}
+.right {
+  top:130px;
+  left: 102px;
+  width: 58px;
+  height: 150px;
+}
+.bottom {
+  top:252px;
+  left: 10px;
+}
+</style>
+

--- a/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-plus-opacity.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-plus-opacity.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter: Correctly apply backdrop-filter with opacity</title>
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
+<link rel="match"  href="../../../../expected/wpt-import/css/filter-effects/backdrop-filter-plus-opacity-ref.html">
+
+<p>Expected: A green box.</p>
+
+<div class="greenbox"></div>
+<div class="filter"></div>
+
+<style>
+.greenbox {
+  position: absolute;
+  background: green;
+  width: 100px;
+  height: 100px;
+  top: 100px;
+  left: 60px;
+}
+.filter {
+  position: absolute;
+  width: 200px;
+  height: 200px;
+  top: 50px;
+  left: 10px;
+  backdrop-filter: invert(1);
+  opacity: 0;
+}
+</style>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-with-mix-blend-mode-same-element.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-with-mix-blend-mode-same-element.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter should not be ignored when mix-blend-mode is set</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
+<link rel="match" href="../../../../expected/wpt-import/css/filter-effects/backdrop-filter-with-mix-blend-mode-same-element-ref.html">
+<style>
+  .backdrop {
+    width: 100px;
+    height: 100px;
+    background: white;
+  }
+  .box {
+    width: 100px;
+    height: 100px;
+    backdrop-filter: invert(1);
+    mix-blend-mode: darken;
+  }
+</style>
+
+<!--
+  Test: backdrop-filter must apply even when mix-blend-mode is set on
+  the same element.
+
+  backdrop-filter:invert(1) on white = black.
+  mix-blend-mode: since this element has no content or background,
+  the blend mode has no effect.
+
+  Expected: a 100x100 black box.
+-->
+<div class="backdrop">
+  <div class="box"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-zero-size.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/backdrop-filter-zero-size.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter: Zero-size div with backdrop filter shouldn't filter anything</title>
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
+<link rel="match"  href="../../../../expected/wpt-import/css/filter-effects/backdrop-filter-zero-size-ref.html">
+
+<p>Expected: A single green box.</p>
+<div class="colorbox"></div>
+<div class="filterparent">
+    <div class="filterchild"></div>
+</div>
+
+<style>
+div {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+}
+.colorbox {
+    background: green;
+    left: 10px;
+    top: 100px;
+}
+.filterparent {
+    width: 0px;
+    height: 0px;
+    left: 50px;
+    top: 150px;
+    backdrop-filter: invert(1);
+    background: lime;
+}
+.filterchild {
+    top: 100px;
+    background: #FFFFFF00;
+}
+</style>

--- a/Tests/LibWeb/Text/expected/display_list/backdrop-filter-effect-node.txt
+++ b/Tests/LibWeb/Text/expected/display_list/backdrop-filter-effect-node.txt
@@ -1,0 +1,19 @@
+AccumulatedVisualContext Tree:
+  spatial:
+    [s0] transform=[1,0,0,1,0,0] origin=(0,0) (Viewport<#document>)
+      [s1] scroll (Viewport<#document>)
+        [s2] transform=[1,0,0,1,5,5] origin=(70,70) (BlockContainer<DIV>#transformed)
+        [s3] transform=[1,0,0,1,5,5] origin=(250,70) (BlockContainer<DIV>#plain)
+  clips:
+    [c0 in s2] clip_path=[bounds: 20,20 100x100, path: M20 20L70 20L70 120L20 120L20 20Z] (BlockContainer<DIV>#transformed)
+  effects:
+    [e0 in s0] effects=[]
+      [e1 in s2 out=c0] effects=[opacity=0.5 backdrop-filter=[20,20 100x100]] (BlockContainer<DIV>#transformed)
+      [e2 in s1] effects=[opacity=0.5] (BlockContainer<DIV>#plain)
+      [e3 in s1] effects=[backdrop-filter=[400,20 50x50]] (BlockContainer<DIV>#empty)
+
+DisplayList:
+BackdropFilterRegion@s2/c0/e1 rect=[20,20 100x100]
+FillRect@s3/e2 rect=[200,20 100x100] color=rgb(0, 128, 0)
+BackdropFilterRegion@s1/e3 rect=[400,20 50x50]
+

--- a/Tests/LibWeb/Text/expected/display_list/inline-backdrop-filter.txt
+++ b/Tests/LibWeb/Text/expected/display_list/inline-backdrop-filter.txt
@@ -1,1 +1,3 @@
-backdrop commands: 1
+backdrop region commands: 1
+backdrop filter effects: 1
+      [e1 in s1] effects=[backdrop-filter=[rect]] (InlineNode<SPAN>#wrap)

--- a/Tests/LibWeb/Text/expected/visual-context/backdrop-filter-value-update-keeps-tree.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/backdrop-filter-value-update-keeps-tree.txt
@@ -1,0 +1,6 @@
+needs display list record: false
+full builds: 0
+incremental updates: 1
+live nodes unchanged: true
+capacity unchanged: true
+epoch unchanged: true

--- a/Tests/LibWeb/Text/input/display_list/backdrop-filter-effect-node.html
+++ b/Tests/LibWeb/Text/input/display_list/backdrop-filter-effect-node.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+    #transformed {
+        position: absolute;
+        left: 20px;
+        top: 20px;
+        width: 100px;
+        height: 100px;
+        border-radius: 10px;
+        transform: translate(5px, 5px);
+        clip-path: inset(0 50px 0 0);
+        opacity: 0.5;
+        backdrop-filter: invert(1);
+    }
+    #plain {
+        position: absolute;
+        left: 200px;
+        top: 20px;
+        width: 100px;
+        height: 100px;
+        transform: translate(5px, 5px);
+        opacity: 0.5;
+        background: rgb(0, 128, 0);
+    }
+    #empty {
+        position: absolute;
+        left: 400px;
+        top: 20px;
+        width: 50px;
+        height: 50px;
+        backdrop-filter: blur(2px);
+    }
+</style>
+<!-- The layer that carries a backdrop filter is entered in the box's own transformed space and inside
+     its clip path; a layer without one stays in the parent space, outside the box's transform. An empty
+     box with a backdrop filter still records a region so the layer is entered in paint order. -->
+<div id="transformed"></div>
+<div id="plain"></div>
+<div id="empty"></div>
+<script>
+    test(() => {
+        println(internals.dumpDisplayList());
+    });
+</script>

--- a/Tests/LibWeb/Text/input/display_list/inline-backdrop-filter.html
+++ b/Tests/LibWeb/Text/input/display_list/inline-backdrop-filter.html
@@ -8,7 +8,12 @@
 <div>before <span id="wrap">filtered</span> after</div>
 <script>
     test(() => {
-        const lines = internals.dumpDisplayList().split("\n").filter(line => line.toLowerCase().includes("backdrop"));
-        println(`backdrop commands: ${lines.length}`);
+        const lines = internals.dumpDisplayList().split("\n");
+        const regionCommands = lines.filter(line => line.startsWith("BackdropFilterRegion"));
+        const backdropEffects = lines.filter(line => line.includes("backdrop-filter="));
+        println(`backdrop region commands: ${regionCommands.length}`);
+        println(`backdrop filter effects: ${backdropEffects.length}`);
+        for (const line of backdropEffects)
+            println(line.replace(/\[[-\d]+,[-\d]+ \d+x\d+\]/g, "[rect]"));
     });
 </script>

--- a/Tests/LibWeb/Text/input/visual-context/backdrop-filter-value-update-keeps-tree.html
+++ b/Tests/LibWeb/Text/input/visual-context/backdrop-filter-value-update-keeps-tree.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<!-- Changing one backdrop filter for another patches the box's effect in place: the recorded display list
+     only marks the region and needs no new recording. -->
+<div id="box" style="width: 100px; height: 100px; backdrop-filter: invert(1)"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const box = document.getElementById("box");
+        settle();
+        const liveNodes = internals.visualContextTreeNodeCount();
+        const capacity = internals.visualContextTreeNodeCapacity();
+        const epoch = internals.visualContextTreeStructuralEpoch();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const incrementalUpdates = internals.accumulatedVisualContextIncrementalUpdateCount();
+
+        box.style.backdropFilter = "invert(0.5)";
+        settle();
+        const needsDisplayListRecord = internals.needsDisplayListRecord;
+
+        const lines = [
+            `needs display list record: ${needsDisplayListRecord}`,
+            `full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`,
+            `incremental updates: ${internals.accumulatedVisualContextIncrementalUpdateCount() - incrementalUpdates}`,
+            `live nodes unchanged: ${internals.visualContextTreeNodeCount() === liveNodes}`,
+            `capacity unchanged: ${internals.visualContextTreeNodeCapacity() === capacity}`,
+            `epoch unchanged: ${internals.visualContextTreeStructuralEpoch() === epoch}`,
+        ];
+        for (const line of lines)
+            println(line);
+    });
+</script>


### PR DESCRIPTION
A backdrop filter was the one layer-like effect still recorded as a
display list command, ApplyBackdropFilter, played under the box's own
context: inside the box's opacity/blend/filter layer and mask layer.
Skia reads a layer's backdrop from its immediate parent, so inside the
box's still empty layer the filter read nothing, and a box combining
backdrop-filter with opacity, filter or mask-image showed no filtered
backdrop at all.

The spec composes the filtered backdrop, limited to the box's rounded
border box, as the initial content of the box's own image and applies
the box's opacity, filter, blend mode and clips to the combination. In
Skia that is one saveLayer with a backdrop filter and the effects paint,
so the backdrop filter now lives on the box's Effects node:

- EffectsData carries the serialized filter, the device border box and
  its corner radii; the node is appended after the box's transform and
  clips, so the layer is entered in the box's own space (the rounded
  crop and the filter follow the transform) and inside a clip-path.
- push_layer opens the layer with the backdrop filter cropped to the
  rounded region inside the filter graph; narrowing the canvas clip
  would clip the box's overflowing content along with it. Without other
  effects on the layer it keeps the old cheap form of compositing the
  filtered backdrop in place, since source-over is associative.
- The tape keeps a payload-free BackdropFilterRegion command so the
  effect is entered at the box's place in paint order even when the box
  paints nothing else, and so damage covers the region.
- Changing one backdrop filter for another is a value-only visual
  context update with no new recording, like filter and opacity.
- The isolation query behind cached nested display lists covers both
  destination-reading effects, and the recorder no longer needs the
  paint host's SVG filter resolution callback.

Masks nested inside the box's layer still do not mask the filtered
backdrop; that needs the mask folded into the same layer.