### PR TITLE
LibWeb: Improve media scrubbing UX and fix some controls bugs

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -441,6 +441,7 @@ GC::Ref<TimeRanges> HTMLMediaElement::seekable() const
 {
     // The seekable attribute must return a new static normalized TimeRanges object that represents the ranges of the media resource, if any, that the
     // user agent is able to seek to, at the time the attribute is evaluated.
+    // FIXME: Implement the seekable steps from the Media Source Extensions spec to handle unbounded resources.
     auto time_ranges = TimeRanges::create();
     time_ranges->add_range(0, m_duration);
     return time_ranges;

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/NumberFormat.h>
+#include <AK/Utf16StringBuilder.h>
 #include <LibGC/Heap.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibWeb/CSS/CSSStyleProperties.h>
@@ -234,9 +235,7 @@ void MediaControls::set_up_event_listeners()
     }
 
     // Timeline scrubbing
-    static constexpr auto compute_timeline_progress = [](UIEvents::MouseEvent const& event, DOM::Element& timeline_element, double duration) -> Optional<double> {
-        if (isnan(duration) || duration == 0.0)
-            return {};
+    static constexpr auto compute_timeline_progress = [](UIEvents::MouseEvent const& event, DOM::Element& timeline_element) -> double {
         auto rect = timeline_element.get_bounding_client_rect();
         return clamp((event.client_x() - rect.left().to_double()) / rect.width().to_double(), 0.0, 1.0);
     };
@@ -245,10 +244,11 @@ void MediaControls::set_up_event_listeners()
         VERIFY(m_media_element);
         VERIFY(m_dom->timeline_element);
 
-        auto duration = m_media_element->duration();
-        auto progress = compute_timeline_progress(event, *m_dom->timeline_element, duration);
-        if (!progress.has_value())
+        auto range = timeline_range();
+        if (!range.has_value())
             return false;
+
+        auto progress = compute_timeline_progress(event, *m_dom->timeline_element);
 
         m_scrubbing_timeline = Scrubbing::WhilePaused;
         if (!m_media_element->paused()) {
@@ -256,10 +256,10 @@ void MediaControls::set_up_event_listeners()
             m_scrubbing_timeline = Scrubbing::WhilePlaying;
         }
 
-        m_pending_scrub_seek_time = *progress * duration;
+        m_pending_scrub_seek_time = range->time_at(progress);
         submit_pending_scrub_seek();
-        set_timeline_progress(*progress);
-        set_timestamp(*progress * duration, duration);
+        set_timeline_progress(progress);
+        set_timestamp(range->time_at(progress), m_media_element->duration());
 
         auto& realm = HTML::relevant_realm(*m_media_element);
         auto& window = relevant_window(realm.global_object());
@@ -268,14 +268,15 @@ void MediaControls::set_up_event_listeners()
             VERIFY(m_media_element);
             VERIFY(m_dom->timeline_element);
 
-            auto duration = m_media_element->duration();
-            auto progress = compute_timeline_progress(event, *m_dom->timeline_element, duration);
-            if (!progress.has_value())
+            auto range = timeline_range();
+            if (!range.has_value())
                 return false;
 
-            seek_while_scrubbing(*progress * duration);
-            set_timeline_progress(*progress);
-            set_timestamp(*progress * duration, duration);
+            auto progress = compute_timeline_progress(event, *m_dom->timeline_element);
+
+            seek_while_scrubbing(range->time_at(progress));
+            set_timeline_progress(progress);
+            set_timestamp(range->time_at(progress), m_media_element->duration());
             return true;
         });
 
@@ -288,10 +289,8 @@ void MediaControls::set_up_event_listeners()
             m_pending_scrub_seek_time.clear();
             m_scrub_seek_preemption_timer.clear();
 
-            auto duration = m_media_element->duration();
-            auto progress = compute_timeline_progress(event, *m_dom->timeline_element, duration);
-            if (progress.has_value())
-                set_current_time(*progress * duration);
+            if (auto range = timeline_range(); range.has_value())
+                set_current_time(range->time_at(compute_timeline_progress(event, *m_dom->timeline_element)));
 
             if (was_playing) {
                 if (m_media_element->ended()) {
@@ -425,9 +424,13 @@ void MediaControls::set_up_event_listeners()
         case UIEvents::KeyCode::Key_Home:
             set_current_time(0);
             break;
-        case UIEvents::KeyCode::Key_End:
-            set_current_time(m_media_element->duration());
+        case UIEvents::KeyCode::Key_End: {
+            auto range = timeline_range();
+            if (!range.has_value())
+                return false;
+            set_current_time(range->end);
             break;
+        }
         case UIEvents::KeyCode::Key_Right:
             set_current_time(m_media_element->current_time() + arrow_time_step);
             break;
@@ -546,23 +549,39 @@ static Utf16String format_percent(double value)
     return Utf16String::formatted("{}%", value * 100);
 }
 
+Optional<MediaControls::TimelineRange> MediaControls::timeline_range() const
+{
+    VERIFY(m_media_element);
+
+    auto seekable = m_media_element->seekable();
+    if (seekable->length() == 0)
+        return {};
+
+    auto index = seekable->length() - 1;
+    TimelineRange range { MUST(seekable->start(index)), MUST(seekable->end(index)) };
+
+    if (!isfinite(range.start) || !isfinite(range.end) || range.span() <= 0.0)
+        return {};
+    return range;
+}
+
 void MediaControls::update_timeline()
 {
     VERIFY(m_media_element);
     VERIFY(m_dom->timeline_track);
     VERIFY(m_dom->timeline_fill);
 
-    auto duration = m_media_element->duration();
+    auto range = timeline_range();
     if (m_scrubbing_timeline == Scrubbing::No) {
         double progress = 0.0;
-        if (!isnan(duration) && duration > 0.0)
-            progress = m_media_element->current_time() / duration;
+        if (range.has_value())
+            progress = clamp(range->progress_at(m_media_element->current_time()), 0.0, 1.0);
         set_timeline_progress(progress);
     }
 
     auto buffered = m_media_element->buffered();
     auto range_count = buffered->length();
-    if (isnan(duration) || duration <= 0.0)
+    if (!range.has_value())
         range_count = 0;
 
     while (m_buffered_ranges.size() > range_count) {
@@ -572,25 +591,25 @@ void MediaControls::update_timeline()
     }
 
     while (m_buffered_ranges.size() < range_count) {
-        auto range = MUST(DOM::create_element(m_media_element->document(), HTML::TagNames::div, Namespace::HTML));
-        MUST(range->class_list()->toggle("timeline-buffered"_utf16, true));
-        MUST(range->style()->set_property(CSS::PropertyID::Display, "block"_utf16));
-        m_dom->timeline_track->insert_before(range, nullptr);
-        m_buffered_ranges.empend(*range);
+        auto element = MUST(DOM::create_element(m_media_element->document(), HTML::TagNames::div, Namespace::HTML));
+        MUST(element->class_list()->toggle("timeline-buffered"_utf16, true));
+        MUST(element->style()->set_property(CSS::PropertyID::Display, "block"_utf16));
+        m_dom->timeline_track->insert_before(element, nullptr);
+        m_buffered_ranges.empend(*element);
     }
 
     for (size_t i = 0; i < range_count; i++) {
-        auto& range = m_buffered_ranges[i];
+        auto& buffered_range = m_buffered_ranges[i];
         auto range_start = MUST(buffered->start(i));
         auto range_duration = MUST(buffered->end(i)) - range_start;
-        auto left = range_start / duration;
-        auto width = range_duration / duration;
-        if (left == range.left && width == range.width)
+        auto left = range->progress_at(range_start);
+        auto width = range_duration / range->span();
+        if (left == buffered_range.left && width == buffered_range.width)
             continue;
-        range.left = left;
-        range.width = width;
+        buffered_range.left = left;
+        buffered_range.width = width;
 
-        auto style = range.element->style();
+        auto style = buffered_range.element->style();
         auto left_text = format_percent(left);
         auto width_text = format_percent(width);
         MUST(style->set_property(CSS::PropertyID::Left, left_text.utf16_view()));
@@ -640,14 +659,22 @@ void MediaControls::set_timestamp(double time, double duration)
     VERIFY(m_dom->timestamp_element);
 
     auto rounded_time = round_to<i64>(time);
-    auto rounded_duration = isnan(duration) ? 0 : round_to<i64>(duration);
+
+    Optional<i64> rounded_duration;
+    if (!isinf(duration))
+        rounded_duration = isnan(duration) ? 0 : round_to<i64>(duration);
 
     if (rounded_time == m_last_timestamp_time && rounded_duration == m_last_timestamp_duration)
         return;
     m_last_timestamp_time = rounded_time;
     m_last_timestamp_duration = rounded_duration;
 
-    MUST(m_dom->timestamp_element->set_text_content(Utf16String::formatted("{} / {}", human_readable_digital_time(rounded_time), human_readable_digital_time(rounded_duration))));
+    auto timestamp_builder = Utf16StringBuilder();
+    timestamp_builder.appendff("{}", human_readable_digital_time(rounded_time));
+    if (rounded_duration.has_value())
+        timestamp_builder.appendff(" / {}", human_readable_digital_time(*rounded_duration));
+
+    MUST(m_dom->timestamp_element->set_text_content(timestamp_builder.to_string()));
 }
 
 void MediaControls::update_volume_and_mute_indicator()

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -443,6 +443,9 @@ void MediaControls::set_up_event_listeners()
         case UIEvents::KeyCode::Key_M:
             toggle_mute();
             break;
+        case UIEvents::KeyCode::Key_F:
+            toggle_fullscreen();
+            break;
         default:
             return false;
         }

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -459,11 +459,6 @@ void MediaControls::set_up_event_listeners()
     request_timeline_update();
 }
 
-void MediaControls::play()
-{
-    m_media_element->play_from_user_interaction();
-}
-
 void MediaControls::toggle_playback()
 {
     if (m_scrubbing_timeline != Scrubbing::No)

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -196,7 +196,11 @@ void MediaControls::set_up_event_listeners()
         update_volume_and_mute_indicator();
         return true;
     });
-    add_event_listener(realm, media_element, HTML::EventNames::addtrack, [this] {
+    add_event_listener(realm, *media_element.audio_tracks(), HTML::EventNames::addtrack, [this] {
+        update_volume_and_mute_indicator();
+        return true;
+    });
+    add_event_listener(realm, *media_element.audio_tracks(), HTML::EventNames::removetrack, [this] {
         update_volume_and_mute_indicator();
         return true;
     });
@@ -204,6 +208,7 @@ void MediaControls::set_up_event_listeners()
         update_placeholder_visibility();
         update_timeline();
         update_timestamp();
+        update_volume_and_mute_indicator();
         return true;
     });
 

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -169,6 +169,8 @@ void MediaControls::set_up_event_listeners()
     });
     add_event_listener(realm, media_element, HTML::EventNames::seeked, [this] {
         update_placeholder_visibility();
+        if (m_scrubbing_timeline != Scrubbing::No)
+            submit_pending_scrub_seek();
         return true;
     });
     add_event_listener(realm, media_element, HTML::EventNames::timeupdate, [this] {
@@ -249,7 +251,8 @@ void MediaControls::set_up_event_listeners()
             m_scrubbing_timeline = Scrubbing::WhilePlaying;
         }
 
-        set_current_time(*progress * duration);
+        m_pending_scrub_seek_time = *progress * duration;
+        submit_pending_scrub_seek();
         set_timeline_progress(*progress);
         set_timestamp(*progress * duration, duration);
 
@@ -265,7 +268,7 @@ void MediaControls::set_up_event_listeners()
             if (!progress.has_value())
                 return false;
 
-            set_current_time(*progress * duration);
+            seek_while_scrubbing(*progress * duration);
             set_timeline_progress(*progress);
             set_timestamp(*progress * duration, duration);
             return true;
@@ -277,6 +280,8 @@ void MediaControls::set_up_event_listeners()
 
             auto was_playing = m_scrubbing_timeline == Scrubbing::WhilePlaying;
             m_scrubbing_timeline = Scrubbing::No;
+            m_pending_scrub_seek_time.clear();
+            m_scrub_seek_preemption_timer.clear();
 
             auto duration = m_media_element->duration();
             auto progress = compute_timeline_progress(event, *m_dom->timeline_element, duration);
@@ -465,6 +470,33 @@ void MediaControls::set_current_time(double time)
     update_timeline();
     update_timestamp();
     show_controls();
+}
+
+void MediaControls::seek_while_scrubbing(double time)
+{
+    m_pending_scrub_seek_time = time;
+    if (m_media_element->seeking())
+        return;
+    submit_pending_scrub_seek();
+}
+
+void MediaControls::submit_pending_scrub_seek()
+{
+    if (!m_pending_scrub_seek_time.has_value())
+        return;
+    auto time = m_pending_scrub_seek_time.release_value();
+
+    if (!m_scrub_seek_preemption_timer) {
+        constexpr int scrub_seek_preemption_timeout_ms = 500;
+        m_scrub_seek_preemption_timer = Core::Timer::create_single_shot(scrub_seek_preemption_timeout_ms, [this] {
+            submit_pending_scrub_seek();
+        });
+        m_scrub_seek_preemption_timer->start();
+    } else {
+        m_scrub_seek_preemption_timer->restart();
+    }
+
+    set_current_time(time);
 }
 
 void MediaControls::set_volume(double volume)

--- a/Libraries/LibWeb/HTML/MediaControls.css
+++ b/Libraries/LibWeb/HTML/MediaControls.css
@@ -7,6 +7,7 @@
     --panel-color: rgb(38, 38, 38);
 
     overflow: hidden;
+    text-align: left;
 }
 
 .container.video {
@@ -52,7 +53,6 @@
     margin: -5px 0;
     cursor: pointer;
     flex-shrink: 0;
-    text-align: left;
 }
 
 .timeline-track {

--- a/Libraries/LibWeb/HTML/MediaControls.h
+++ b/Libraries/LibWeb/HTML/MediaControls.h
@@ -51,6 +51,8 @@ private:
     void play();
     void toggle_playback();
     void set_current_time(double);
+    void seek_while_scrubbing(double);
+    void submit_pending_scrub_seek();
     void set_volume(double);
     void toggle_mute();
     void toggle_fullscreen();
@@ -88,6 +90,8 @@ private:
         WhilePlaying,
     };
     Scrubbing m_scrubbing_timeline { Scrubbing::No };
+    Optional<double> m_pending_scrub_seek_time;
+    RefPtr<Core::Timer> m_scrub_seek_preemption_timer;
     bool m_scrubbing_volume { false };
     bool m_hovering_controls { false };
 

--- a/Libraries/LibWeb/HTML/MediaControls.h
+++ b/Libraries/LibWeb/HTML/MediaControls.h
@@ -48,7 +48,6 @@ private:
     void remove_event_listeners();
     void set_up_event_listeners();
 
-    void play();
     void toggle_playback();
     void set_current_time(double);
     void seek_while_scrubbing(double);

--- a/Libraries/LibWeb/HTML/MediaControls.h
+++ b/Libraries/LibWeb/HTML/MediaControls.h
@@ -57,6 +57,16 @@ private:
     void toggle_mute();
     void toggle_fullscreen();
 
+    struct TimelineRange {
+        double start { 0 };
+        double end { 0 };
+
+        double span() const { return end - start; }
+        double time_at(double progress) const { return start + (progress * span()); }
+        double progress_at(double time) const { return (time - start) / span(); }
+    };
+    Optional<TimelineRange> timeline_range() const;
+
     void update_play_pause_icon();
     void update_timeline();
     void set_timeline_progress(double);
@@ -108,7 +118,7 @@ private:
 
     double m_last_timeline_progress { 0.0 };
     i64 m_last_timestamp_time { -1 };
-    i64 m_last_timestamp_duration { -1 };
+    Optional<i64> m_last_timestamp_duration;
 
     struct BufferedRange {
         GC::Weak<DOM::Element> element;

--- a/Libraries/LibWeb/HTML/MediaControls.html
+++ b/Libraries/LibWeb/HTML/MediaControls.html
@@ -20,7 +20,7 @@
                     <path class="pause-path" d="M14 5h4v14h-4Zm-4 0H6v14h4z"/>
                 </svg>
             </button>
-            <span data-name="timestamp-element" class="timestamp">0:00 / 0:00</span>
+            <span data-name="timestamp-element" class="timestamp"></span>
             <button data-name="mute-button" class="control-button mute-button">
                 <svg class="icon" viewBox="0 0 24 24">
                     <defs><clipPath id="muted-clip">

--- a/Libraries/LibWeb/HTML/MediaControls.html
+++ b/Libraries/LibWeb/HTML/MediaControls.html
@@ -37,12 +37,12 @@
                     <div data-name="volume-fill" class="volume-fill"></div>
                 </div>
             </div>
-            <div data-name="fullscreen-button" data-option="video" class="control-button fullscreen-button">
+            <button data-name="fullscreen-button" data-option="video" class="control-button fullscreen-button">
                 <svg data-name="fullscreen-icon" class="icon fullscreen-icon" viewBox="0 0 24 24">
                     <path class="fullscreen-maximize-path" d="M3 3h6v2H5v4H3Zm12 0h6v6h-2V5h-4Zm6 12v6h-6v-2h4v-4ZM3 15v6h6v-2H5v-4Z"/>
                     <path class="fullscreen-minimize-path" d="M9 3v6H3V7h4V3Zm6 0v6h6V7h-4V3ZM3 15h6v6H7v-4H3Zm12 0v6h2v-4h4v-2Z"/>
                 </svg>
-            </div>
+            </button>
         </div>
     </div>
 </div>

--- a/Tests/LibWeb/Layout/expected/video-controls-default-object-size.txt
+++ b/Tests/LibWeb/Layout/expected/video-controls-default-object-size.txt
@@ -33,7 +33,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                     SVGGeometryBox <path.speaker> at [4,4] [0+0+0 8 0+0+0] [0+0+0 16 0+0+0] children: not-inline
                       SVGClipBox <clipPath#muted-clip> at [0,0] [0+0+0 24 0+0+0] [0+0+0 24 0+0+0] children: not-inline
                         SVGGeometryBox <path> at [0,0] [0+0+0 24 0+0+0] [0+0+0 24 0+0+0] children: not-inline
-                Box <div.control-button.fullscreen-button> at [276,127] flex-container(row) flex-item [0+0+0 24 0+0+0] [0+0+0 24 0+0+0] [FFC] children: not-inline
+                Box <button.control-button.fullscreen-button> at [276,127] flex-container(row) flex-item [0+0+0 24 0+0+0] [0+0+0 24 0+0+0] [FFC] children: not-inline
                   SVGSVGBox <svg.icon.fullscreen-icon> at [276,127] flex-item [0+0+0 24 0+0+0] [0+0+0 24 0+0+0] viewport-transform=[1 0 0 1 0 0] [SVG] children: not-inline
                     SVGGeometryBox <path.fullscreen-maximize-path> at [3,3] [0+0+0 18 0+0+0] [0+0+0 18 0+0+0] children: not-inline
       TextNode <#text> (not painted)

--- a/Tests/LibWeb/Text/expected/HTML/media-controls-fill-alignment.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-controls-fill-alignment.txt
@@ -1,0 +1,4 @@
+timeline fill is narrower than its track: true
+timeline fill starts at track start: true
+volume fill is narrower than its track: true
+volume fill starts at track start: false

--- a/Tests/LibWeb/Text/expected/HTML/media-controls-fill-alignment.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-controls-fill-alignment.txt
@@ -1,4 +1,4 @@
 timeline fill is narrower than its track: true
 timeline fill starts at track start: true
 volume fill is narrower than its track: true
-volume fill starts at track start: false
+volume fill starts at track start: true

--- a/Tests/LibWeb/Text/expected/HTML/media-controls-unbounded-duration.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-controls-unbounded-duration.txt
@@ -1,0 +1,4 @@
+bounded timestamp: "00:00 / 00:30"
+unbounded timestamp: "00:00"
+current time after scrubbing an unbounded timeline: 0
+current time after End on an unbounded resource: 0

--- a/Tests/LibWeb/Text/expected/HTML/media-controls-volume-state-after-emptied.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-controls-volume-state-after-emptied.txt
@@ -1,0 +1,3 @@
+no source: muted: true, icon: high, area hidden: true, fill width: 0px
+loaded:    muted: false, icon: high, area hidden: false, fill width: 100%
+emptied:   muted: true, icon: high, area hidden: true, fill width: 0px

--- a/Tests/LibWeb/Text/input/HTML/media-controls-fill-alignment.html
+++ b/Tests/LibWeb/Text/input/HTML/media-controls-fill-alignment.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<center>
+    <audio id="audio" controls></audio>
+</center>
+<script>
+    const audio = document.getElementById("audio");
+
+    promiseTest(async () => {
+        audio.src = "../../../Assets/test-webm-audio.ogg";
+        await new Promise(resolve => audio.addEventListener("loadedmetadata", resolve, { once: true }));
+
+        // Give both fills a width that is neither zero nor the full track, so that a centered fill is displaced.
+        audio.currentTime = audio.duration / 2;
+        await new Promise(resolve => audio.addEventListener("seeked", resolve, { once: true }));
+
+        audio.volume = 0.5;
+        await new Promise(resolve => audio.addEventListener("volumechange", resolve, { once: true }));
+
+        const shadowRoot = internals.getShadowRoot(audio);
+        for (const name of ["timeline", "volume"]) {
+            const trackRect = shadowRoot.querySelector(`.${name}`).getBoundingClientRect();
+            const fillRect = shadowRoot.querySelector(`.${name}-fill`).getBoundingClientRect();
+            println(`${name} fill is narrower than its track: ${fillRect.width > 0 && fillRect.width < trackRect.width}`);
+            println(`${name} fill starts at track start: ${fillRect.left === trackRect.left}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/media-controls-unbounded-duration.html
+++ b/Tests/LibWeb/Text/input/HTML/media-controls-unbounded-duration.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<video id="video" controls></video>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const video = document.getElementById("video");
+        const shadowRoot = internals.getShadowRoot(video);
+        const timestamp = shadowRoot.querySelector(".timestamp");
+        const timeline = shadowRoot.querySelector(".timeline");
+
+        const mediaSource = new MediaSource();
+        video.src = URL.createObjectURL(mediaSource);
+        await new Promise(resolve => mediaSource.addEventListener("sourceopen", resolve, { once: true }));
+
+        async function setDuration(duration) {
+            mediaSource.duration = duration;
+            await new Promise(resolve => video.addEventListener("durationchange", resolve, { once: true }));
+        }
+
+        await setDuration(30);
+        println(`bounded timestamp: "${timestamp.textContent}"`);
+
+        await setDuration(Infinity);
+        println(`unbounded timestamp: "${timestamp.textContent}"`);
+
+        const timelineRect = timeline.getBoundingClientRect();
+        timeline.dispatchEvent(new MouseEvent("mousedown", {
+            clientX: timelineRect.left + timelineRect.width / 2,
+            bubbles: true,
+        }));
+        println(`current time after scrubbing an unbounded timeline: ${video.currentTime}`);
+
+        // 0x23 is the End key.
+        video.dispatchEvent(new KeyboardEvent("keydown", { keyCode: 0x23, bubbles: true }));
+        println(`current time after End on an unbounded resource: ${video.currentTime}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/media-controls-volume-state-after-emptied.html
+++ b/Tests/LibWeb/Text/input/HTML/media-controls-volume-state-after-emptied.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<audio id="audio" controls></audio>
+<script>
+    function describeVolumeControls(shadowRoot) {
+        const muteButton = shadowRoot.querySelector(".mute-button");
+        const volumeArea = shadowRoot.querySelector(".volume-area");
+        const volumeFill = shadowRoot.querySelector(".volume-fill");
+        const iconState = ["low", "high"].find(name => muteButton.classList.contains(name)) ?? "empty";
+
+        return `muted: ${muteButton.classList.contains("muted")}, icon: ${iconState}, `
+            + `area hidden: ${volumeArea.classList.contains("hidden")}, fill width: ${volumeFill.style.width}`;
+    }
+
+    promiseTest(async () => {
+        const audio = document.getElementById("audio");
+        const shadowRoot = internals.getShadowRoot(audio);
+
+        println(`no source: ${describeVolumeControls(shadowRoot)}`);
+
+        audio.src = "../../../Assets/test-webm-audio.ogg";
+        await new Promise(resolve => audio.addEventListener("loadedmetadata", resolve, { once: true }));
+        println(`loaded:    ${describeVolumeControls(shadowRoot)}`);
+
+        audio.removeAttribute("src");
+        audio.load();
+        await new Promise(resolve => audio.addEventListener("emptied", resolve, { once: true }));
+        println(`emptied:   ${describeVolumeControls(shadowRoot)}`);
+    });
+</script>


### PR DESCRIPTION
The main improvement here is to give scrubbing seeks a window to complete, allowing us to display a frame more often. This matches what QuickTime Player does, and makes seeking feel much more responsive despite the fact that latency to the current cursor position may suffer if the seeks lag.

The bugs fixes included alongside this are very minor, but thought I'd fix them while I had them on my stack. See individual commits.