### PR TITLE
LibWeb: Improve typing, selection, and caret behavior

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -909,7 +909,7 @@ AnimationUpdateContext::~AnimationUpdateContext()
             target->document().style_computer().style_engine().record_element_style_input_change(target->style_node_id());
 
         if (!element.pseudo_element().has_value() && invalidation.inherited_style_changed())
-            invalidation |= target->recompute_pseudo_element_styles_after_animation_update({});
+            invalidation |= target->recompute_pseudo_element_styles();
 
         // An animated value can be inherited through shadow and slot boundaries. Publish the exact
         // flat-tree descendants as one feedback batch; the ordinary transaction owns their style

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -637,7 +637,7 @@ static void ensure_pseudo_element_style_for_cssom(DOM::AbstractElement abstract_
     if (!is_synthetic_pseudo_element(*pseudo_element))
         return;
     if (*pseudo_element != PseudoElement::Backdrop
-        && (*pseudo_element != PseudoElement::Selection || abstract_element.document().selection_styles_are_observable())
+        && *pseudo_element != PseudoElement::Selection
         && abstract_element.computed_style())
         return;
 

--- a/Libraries/LibWeb/CSS/StyleInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.h
@@ -91,6 +91,8 @@ struct RequiredInvalidationAfterStyleChange {
     // A property controlling decorations originated by this box changed. Descendant boxes paint
     // the propagated decorations from these values, so their cached paint commands are stale.
     bool repaint_propagated_text_decorations : 1 { false };
+    // Selection highlights are painted by text descendants, even when the element has no box.
+    bool repaint_selection : 1 { false };
     // A non-inherited property changed without any other invalidation, which happens when a running
     // animation covers the property. Descendants that explicitly inherit non-inherited properties
     // still observe the change.
@@ -113,6 +115,7 @@ struct RequiredInvalidationAfterStyleChange {
         m_inherited_style_groups_changed |= other.m_inherited_style_groups_changed;
         changes_containing_block_establishment |= other.changes_containing_block_establishment;
         repaint_propagated_text_decorations |= other.repaint_propagated_text_decorations;
+        repaint_selection |= other.repaint_selection;
         non_inherited_property_inheritance_sources_changed |= other.non_inherited_property_inheritance_sources_changed;
     }
 
@@ -125,6 +128,7 @@ struct RequiredInvalidationAfterStyleChange {
             && !recompute_descendant_styles
             && !inherited_style_changed()
             && !changes_containing_block_establishment
+            && !repaint_selection
             && !repaint_propagated_text_decorations
             && !non_inherited_property_inheritance_sources_changed;
     }

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -1275,6 +1275,13 @@ namespace Web::DOM {
 
 void Document::update_selection_style_observability()
 {
+    // NB: Editing commands temporarily select content to restore its formatting. Style reads
+    //     during the action must not activate selection styles throughout the document for these
+    //     intermediate ranges. Observe the final selection after the action, including in input
+    //     event handlers. Explicit ::selection queries can still compute their style on demand.
+    if (m_running_editing_command_action)
+        return;
+
     auto selection = get_selection();
     bool observable = selection && !selection->is_collapsed();
     if (auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(focused_area().ptr()))

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/PseudoElement.h>
+#include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLSlotElement.h>
@@ -714,6 +715,13 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
                 element->invalidate_descendant_styles_depending_on_style_container_query();
             }
 
+            // NB: Making deferred pseudo-element styles observable changes only their inputs.
+            //     The originating element's cascade and computed style remain valid.
+            if (!needs_regular_style_recompute && !needs_inherited_style_recompute && !needs_full_custom_property_recompute
+                && (reaction.reaction & StyleEngine::PseudoInputsMayHaveChanged) && element->has_style()) {
+                invalidation |= element->recompute_pseudo_element_styles();
+            }
+
             auto const* current_inherited_box_values = element->style_group<ComputedValues::InheritedBoxValues>();
             if (previous_visibility.has_value() && current_inherited_box_values
                 && *previous_visibility != static_cast<Visibility>(current_inherited_box_values->visibility)) {
@@ -1283,26 +1291,43 @@ void Document::update_selection_style_observability()
         return;
 
     auto selection = get_selection();
+    auto* text_control = as_if<HTML::FormAssociatedTextControlElement>(focused_area().ptr());
     bool observable = selection && !selection->is_collapsed();
-    if (auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(focused_area().ptr()))
-        observable |= text_control->selection_start() != text_control->selection_end();
-    if (observable == m_selection_styles_are_observable)
+    bool text_control_selection_is_observable = text_control && text_control->selection_start() != text_control->selection_end();
+    observable |= text_control_selection_is_observable;
+    if (observable == m_selection_styles_are_observable && !m_needs_selection_style_update)
         return;
+    m_needs_selection_style_update = false;
     m_selection_styles_are_observable = observable;
     style_computer().style_engine().set_pseudo_element_style_deferred(to_underlying(CSS::PseudoElement::Selection), !observable);
     if (!observable)
         return;
-    for_each_shadow_including_inclusive_descendant([&](Node& node) {
-        auto* element = as_if<Element>(node);
-        if (!element)
-            return TraversalDecision::Continue;
-        auto style = element->computed_style();
-        if (style) {
+
+    auto record_element = [&](Node& node) {
+        if (auto* element = as_if<Element>(node); element && element->has_style()) {
             style_computer().style_engine().record_element_style_input_change(element->style_node_id(),
-                CSS::StyleEngine::PublishedStyle | CSS::StyleEngine::RecomputeStyle | CSS::StyleEngine::PseudoInputsMayHaveChanged);
+                CSS::StyleEngine::PseudoInputsMayHaveChanged);
         }
-        return TraversalDecision::Continue;
-    });
+    };
+    auto record_subtree = [&](Node& root, Range const* range) {
+        // NB: Ancestors supply inherited highlight styles, and text controls paint through
+        //     their internal shadow trees. Neither requires visiting unrelated subtrees.
+        for (auto* ancestor = root.parent_or_shadow_host(); ancestor; ancestor = ancestor->parent_or_shadow_host())
+            record_element(*ancestor);
+        root.for_each_shadow_including_inclusive_descendant([&](Node& node) {
+            if (range && &node.root() == &range->start_container()->root() && !range->intersects_node(node))
+                return TraversalDecision::SkipChildrenAndContinue;
+            record_element(node);
+            return TraversalDecision::Continue;
+        });
+    };
+    if (selection && !selection->is_collapsed()) {
+        auto range = selection->range();
+        auto root = range->common_ancestor_container();
+        record_subtree(root, range.ptr());
+    }
+    if (text_control_selection_is_observable)
+        record_subtree(*focused_area(), nullptr);
 }
 
 void Document::update_style()

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3862,6 +3862,7 @@ void Document::set_focused_area(GC::Ptr<Node> node, InvalidateFocusPseudoClasses
     }
 
     m_focused_area = node;
+    set_needs_selection_style_update();
 
     auto* new_focused_element = as_if<Element>(node.ptr());
     if (new_focused_element)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -10157,15 +10157,11 @@ Optional<CSSPixelRect> Document::current_caret_rect()
             return to_viewport_rect(result.rect);
     }
 
-    // Empty editable elements have no fragments; fall back to the caret position for the cursor's child offset
-    // (which accounts for empty lines rendered by <br>), or the padding-box corner.
+    // Empty editable elements have no fragments; use the same child-offset position and font metrics as caret
+    // painting, including empty lines rendered by <br>.
     if (auto* node_with_style = as_if<Layout::NodeWithStyle>(*layout_node)) {
-        if (Painting::is_paintable_with_lines(*node_with_style))
+        if (Painting::has_committed_box(*node_with_style))
             return to_viewport_rect(Painting::caret_rect_for_child_offset(*node_with_style, position->offset()));
-        if (Painting::has_committed_box(*node_with_style)) {
-            auto content_box = Painting::absolute_padding_box_rect(*node_with_style);
-            return to_viewport_rect(CSSPixelRect { content_box.x(), content_box.y(), 1, node_with_style->line_height() });
-        }
     }
     return {};
 }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -2001,6 +2001,7 @@ private:
     GC::Ptr<Editing::EditingHistory> m_editing_history;
 
     bool m_inside_exec_command { false };
+    bool m_running_editing_command_action { false };
     bool m_preserve_selection_offsets_during_identical_character_data_replacement { false };
 
     // https://w3c.github.io/editing/docs/execCommand/#default-single-line-container-name

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -301,6 +301,7 @@ public:
 
     GC::Ptr<Selection::Selection> get_selection() const;
     bool selection_styles_are_observable() const { return m_selection_styles_are_observable; }
+    void set_needs_selection_style_update() { m_needs_selection_style_update = true; }
 
     WebIDL::ExceptionOr<Utf16String> cookie();
     WebIDL::ExceptionOr<void> set_cookie(Utf16View);
@@ -1816,6 +1817,7 @@ private:
     // https://w3c.github.io/selection-api/#dfn-selection
     GC::Ptr<Selection::Selection> m_selection;
     bool m_selection_styles_are_observable { false };
+    bool m_needs_selection_style_update { true };
     void update_selection_style_observability();
 
     // NOTE: This is a cache to make finding the first <base href> or <base target> element O(1).

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1650,7 +1650,14 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
                     && !pseudo_style_can_escape_originating_element(new_style));
         };
 
-        if (pseudo_element_values && new_pseudo_element_style) {
+        // NB: Selection highlights do not generate boxes or affect layout.
+        if (pseudo_element == CSS::PseudoElement::Selection) {
+            if (!style_record_is_unchanged(style_record_delta)) {
+                document().style_invalidation_counters().element_computed_style_changes++;
+                invalidation.ensure_at_least(CSS::InvalidationLevel::Repaint);
+                invalidation.repaint_selection = true;
+            }
+        } else if (pseudo_element_values && new_pseudo_element_style) {
             DOM::AbstractElement abstract_element { *this, pseudo_element };
             auto result = compute_required_invalidation_with_cache(style_computer, *pseudo_element_values, *new_pseudo_element_style, old_state, abstract_element, style_record_delta);
             // A display: contents pseudo-element has no principal layout node to receive its updated style. A
@@ -1713,7 +1720,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
     return invalidation;
 }
 
-CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styles_after_animation_update(Badge<Web::Animations::AnimationUpdateContext>)
+CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styles()
 {
     auto computed_values = this->computed_style();
     VERIFY(computed_values);
@@ -1955,8 +1962,13 @@ bool Element::apply_box_presence_change_in_place(SetNeedsLayoutTreeUpdateReason 
 void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation)
 {
     auto* layout_node = unsafe_layout_node();
-    if (invalidation.needs_layout_tree_rebuild() || !layout_node)
+    if (invalidation.needs_layout_tree_rebuild())
         return;
+
+    if (!layout_node) {
+        apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(invalidation);
+        return;
+    }
 
     // If we're keeping the layout tree, we can just apply the new style to the existing layout tree.
     VERIFY(has_style());
@@ -1971,6 +1983,17 @@ void Element::apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(CSS
 {
     if (invalidation.needs_layout_tree_rebuild())
         return;
+
+    if (invalidation.repaint_selection) {
+        // NB: A display:contents element has no box of its own. Invalidate the nearest
+        //     painted ancestor's subtree so cached text commands take the new highlight.
+        for (Node const* node = this; node; node = node->parent_or_shadow_host()) {
+            if (auto* layout_node = node->unsafe_layout_node(); layout_node && Painting::has_committed_box(*layout_node)) {
+                Painting::set_needs_repaint_in_subtree(*layout_node);
+                break;
+            }
+        }
+    }
 
     for_each_synthetic_pseudo_element([&](CSS::PseudoElement pseudo_element_type, SyntheticPseudoElement const& pseudo_element) {
         if (!has_style(pseudo_element_type))

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -351,7 +351,7 @@ public:
     // The custom-property environment an engine-computed record was published with: the one the
     // element inherits, or one the engine resolved over it. Nothing when it cannot be installed.
     [[nodiscard]] RefPtr<CSS::CustomPropertyData const> custom_property_environment_of_engine_record(CSS::StyleRecordID, bool& installable) const;
-    CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles_after_animation_update(Badge<Web::Animations::AnimationUpdateContext>);
+    CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles();
 
     void set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason, CSS::LayoutTreeRebuildRoot);
     bool apply_box_presence_change_in_place(SetNeedsLayoutTreeUpdateReason);

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -433,6 +433,8 @@ u64 Node::character_data_version() const
 
 void Node::bump_dom_tree_version()
 {
+    // NB: Inserted or moved content can enter a selection without moving its boundary points.
+    document().set_needs_selection_style_update();
     if (auto* holder = tree_version_holder(*this))
         holder->m_dom_tree_version = ++s_last_tree_version;
 }

--- a/Libraries/LibWeb/DOM/SelectionchangeEventDispatching.h
+++ b/Libraries/LibWeb/DOM/SelectionchangeEventDispatching.h
@@ -30,6 +30,9 @@ concept SelectionChangeTarget = DerivedFrom<T, EventTarget> && requires(T t) {
 template<SelectionChangeTarget T>
 void schedule_a_selectionchange_event(T& target, Document& document)
 {
+    // NB: Style must observe every range change, even when the event is already queued.
+    document.set_needs_selection_style_update();
+
     // 1. If target's has scheduled selectionchange event is true, abort these steps.
     if (target.has_scheduled_selectionchange_event())
         return;

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -169,7 +169,10 @@ WebIDL::ExceptionOr<bool> Document::exec_command_internal(Utf16FlyString const& 
     };
 
     // 5. Take the action for command, passing value to the instructions as an argument.
-    auto command_result = command_definition.action(*this, value);
+    auto command_result = [&] {
+        TemporaryChange running_action { m_running_editing_command_action, true };
+        return command_definition.action(*this, value);
+    }();
 
     // INTEROP: Chromium removes the trailing placeholder line break after pasting into an existing text node. The
     //          execCommand draft only removes it when insertion creates a new text node. Perform this while the paste

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -432,6 +432,15 @@ static bool has_content(Layout::Node const& node)
         || Layout::RustFFI::layout_arena_paintable_has_child_paintables(node.arena_handle(), committed_row_slot(node));
 }
 
+static CSSPixelRect caret_rect_for_empty_line(Layout::NodeWithStyle const& node, CSSPixelPoint position)
+{
+    // NB: Match the font-height caret used by text fragments, centered in the empty line's line-height box.
+    auto const& font_metrics = node.first_available_font().pixel_metrics();
+    auto line_height = node.line_height();
+    auto caret_height = min(line_height, CSSPixels::nearest_value_for(font_metrics.ascent + font_metrics.descent));
+    return { position.x(), position.y() + (line_height - caret_height) / 2, 1, caret_height };
+}
+
 // Caret rect for a cursor parked on this paintable's DOM node at the given child offset, e.g. on an empty line
 // rendered by a <br> child or in an empty editable element.
 CSSPixelRect caret_rect_for_child_offset(Layout::Node const& block, size_t offset)
@@ -442,7 +451,8 @@ CSSPixelRect caret_rect_for_child_offset(Layout::Node const& block, size_t offse
 
     auto content_box = absolute_padding_box_rect(block);
     auto line_height = styled_block.line_height();
-    CSSPixelRect rect { content_box.x(), content_box.y(), 1, line_height };
+    auto rect = caret_rect_for_empty_line(styled_block, content_box.location());
+    auto caret_offset_in_line = rect.y() - content_box.y();
 
     auto dom_node = block.dom_node();
     if (!dom_node)
@@ -521,7 +531,7 @@ CSSPixelRect caret_rect_for_child_offset(Layout::Node const& block, size_t offse
         return TraversalDecision::Continue;
     });
 
-    rect.set_y(preceding_content_bottom.value_or(content_box.y()) + line_height * preceding_empty_lines);
+    rect.set_y(preceding_content_bottom.value_or(content_box.y()) + line_height * preceding_empty_lines + caret_offset_in_line);
     return rect;
 }
 
@@ -604,7 +614,7 @@ Layout::RustFFI::FfiCaretPaint resolve_document_caret_paint(DOM::Document& docum
         if (has_content(*layout_node))
             return caret;
         auto position = box_type_agnostic_position(*layout_node);
-        fill(Layout::RustFFI::FfiCaretPaintKind::EmptyInline, committed_row_slot(*layout_node), no_slot, CSSPixelRect { position.x(), position.y(), 1, styled_node.line_height() }, styled_node.caret_color());
+        fill(Layout::RustFFI::FfiCaretPaintKind::EmptyInline, committed_row_slot(*layout_node), no_slot, caret_rect_for_empty_line(styled_node, position), styled_node.caret_color());
         return caret;
     }
     if (!is_visible(*layout_node))

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -448,6 +448,28 @@ CSSPixelRect caret_rect_for_child_offset(Layout::Node const& block, size_t offse
     if (!dom_node)
         return rect;
 
+    // NB: A boundary beside a text child has the same geometry as the corresponding text offset.
+    //     Editors can leave the selection on the parent after inserting their first character.
+    //     Use the text fragment's position and font metrics instead of the empty-block fallback.
+    auto caret_rect_in_text = [&](DOM::Node const* node, size_t text_offset) -> Optional<CSSPixelRect> {
+        auto const* text = as_if<DOM::Text>(node);
+        auto const* layout_node = text ? text->unsafe_layout_node() : nullptr;
+        if (!layout_node)
+            return {};
+        auto result = Layout::RustFFI::layout_arena_text_caret_rect_for_position(
+            block.arena_handle(), Layout::Node::slot_id(layout_node), text_offset, true);
+        if (result.found)
+            return result.rect;
+        return {};
+    };
+    if (offset > 0) {
+        auto const* previous_child = dom_node->child_at_index(offset - 1);
+        if (auto text_rect = caret_rect_in_text(previous_child, previous_child ? previous_child->length() : 0); text_rect.has_value())
+            return *text_rect;
+    }
+    if (auto text_rect = caret_rect_in_text(dom_node->child_at_index(offset), 0); text_rect.has_value())
+        return *text_rect;
+
     // A boundary immediately after an atomic inline element paints after that element. Atomic inline elements have
     if (offset > 0) {
         auto* previous_child = dom_node->child_at_index(offset - 1);

--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -784,6 +784,24 @@ impl StyleEngine {
         let direct_action_node_bytes = direct_action_nodes.capacity_bytes();
         self.memory
             .reserve_required(MemoryCategory::BatchScratch, direct_action_node_bytes);
+        // A pseudo-only action does not invalidate the originating element's style. Keep
+        // that shortcut only when the transaction contains no other changes: a selector,
+        // declaration, or environment edit may independently require its normal cascade.
+        let only_pseudo_inputs_changed = transaction.markers.is_empty()
+            && transaction.program_joins.is_empty()
+            && transaction.rule_declaration_changes.is_empty()
+            && transaction.inputs.iter().all(|input| {
+                matches!(
+                    (input.key, input.new),
+                    (
+                        InputKey::ElementStyleInput(_),
+                        InputValue::ElementStyleInput {
+                            reaction: transaction::STYLE_REACTION_PSEUDO_INPUTS_MAY_HAVE_CHANGED,
+                            inherited_style_groups: 0,
+                        }
+                    )
+                )
+            });
         let mut style_input_reactions: Vec<(StyleNodeID, u8, u8)> = transaction
             .inputs
             .iter()
@@ -794,7 +812,16 @@ impl StyleEngine {
                         reaction,
                         inherited_style_groups,
                     },
-                ) => Some((node, reaction, inherited_style_groups)),
+                ) => {
+                    let reaction = if reaction == transaction::STYLE_REACTION_PSEUDO_INPUTS_MAY_HAVE_CHANGED
+                        && !only_pseudo_inputs_changed
+                    {
+                        reaction | transaction::STYLE_REACTION_PUBLISHED_STYLE
+                    } else {
+                        reaction
+                    };
+                    Some((node, reaction, inherited_style_groups))
+                }
                 _ => None,
             })
             .collect();

--- a/Tests/LibWeb/Ref/expected/caret-after-first-character-ref.html
+++ b/Tests/LibWeb/Ref/expected/caret-after-first-character-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    div { font: 20px/40px monospace; }
+</style>
+<div contenteditable><p>a</p></div>
+<script>
+    document.querySelector("div").focus();
+    getSelection().collapse(document.querySelector("p").firstChild, 1);
+</script>

--- a/Tests/LibWeb/Ref/expected/empty-caret-with-placeholder-ref.html
+++ b/Tests/LibWeb/Ref/expected/empty-caret-with-placeholder-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    div { font: 20px/40px monospace; color: transparent; caret-color: black; }
+    p::before { content: "Placeholder"; position: absolute; color: gray; }
+</style>
+<div contenteditable><p>a</p></div>
+<script>
+    document.querySelector("div").focus();
+    getSelection().collapse(document.querySelector("p").firstChild, 0);
+</script>

--- a/Tests/LibWeb/Ref/expected/selection-focus-between-text-controls-ref.html
+++ b/Tests/LibWeb/Ref/expected/selection-focus-between-text-controls-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+input { outline: none; }
+input::selection { background: lime; color: black; }
+</style>
+<input value="first">
+<input id="second" value="second">
+<script>
+    second.focus();
+    second.select();
+</script>

--- a/Tests/LibWeb/Ref/expected/selection-insert-between-boundaries-ref.html
+++ b/Tests/LibWeb/Ref/expected/selection-insert-between-boundaries-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<div><span style="background: lime; color: black">firstmiddlelast</span></div>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/selection-moves-between-subtrees-ref.html
+++ b/Tests/LibWeb/Ref/expected/selection-moves-between-subtrees-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<div><span>first</span></div>
+<div><span style="background: lime; color: black">second</span></div>

--- a/Tests/LibWeb/Ref/input/caret-after-first-character.html
+++ b/Tests/LibWeb/Ref/input/caret-after-first-character.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/caret-after-first-character-ref.html">
+<style>
+    div { font: 20px/40px monospace; }
+</style>
+<div contenteditable><p>a</p></div>
+<script>
+    document.querySelector("div").focus();
+    getSelection().collapse(document.querySelector("p"), 1);
+</script>

--- a/Tests/LibWeb/Ref/input/empty-caret-with-placeholder.html
+++ b/Tests/LibWeb/Ref/input/empty-caret-with-placeholder.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/empty-caret-with-placeholder-ref.html">
+<style>
+    div { font: 20px/40px monospace; }
+    p::before { content: "Placeholder"; position: absolute; color: gray; }
+</style>
+<div contenteditable><p><br></p></div>
+<script>
+    document.querySelector("div").focus();
+    getSelection().collapse(document.querySelector("p"), 0);
+</script>

--- a/Tests/LibWeb/Ref/input/selection-focus-between-text-controls.html
+++ b/Tests/LibWeb/Ref/input/selection-focus-between-text-controls.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/selection-focus-between-text-controls-ref.html">
+<style>
+input { outline: none; }
+input::selection { background: lime; color: black; }
+</style>
+<input id="first" value="first">
+<input id="second" value="second">
+<script>
+    first.focus();
+    first.select();
+    first.getBoundingClientRect();
+    second.select();
+    second.getBoundingClientRect();
+    second.focus();
+    second.getBoundingClientRect();
+</script>

--- a/Tests/LibWeb/Ref/input/selection-insert-between-boundaries.html
+++ b/Tests/LibWeb/Ref/input/selection-insert-between-boundaries.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/selection-insert-between-boundaries-ref.html">
+<style>
+span::selection { background: lime; color: black; }
+</style>
+<div id="selected"><span id="first">first</span><span id="last">last</span></div>
+<div><span id="moved">middle</span></div>
+<script>
+    const range = document.createRange();
+    range.setStart(first.firstChild, 0);
+    range.setEnd(last.firstChild, 4);
+    getSelection().addRange(range);
+    selected.getBoundingClientRect();
+    selected.insertBefore(moved, last);
+    selected.getBoundingClientRect();
+</script>

--- a/Tests/LibWeb/Ref/input/selection-moves-between-subtrees.html
+++ b/Tests/LibWeb/Ref/input/selection-moves-between-subtrees.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/selection-moves-between-subtrees-ref.html">
+<style id="rules">
+    span::selection { background: red; color: black; }
+</style>
+<div><span id="first">first</span></div>
+<div><span id="second">second</span></div>
+<script>
+    const selection = getSelection();
+    selection.selectAllChildren(first);
+    first.getBoundingClientRect();
+    selection.removeAllRanges();
+    second.getBoundingClientRect();
+    rules.sheet.cssRules[0].style.backgroundColor = "lime";
+    second.getBoundingClientRect();
+    selection.selectAllChildren(first);
+    first.getBoundingClientRect();
+    // Move an already active selection before its queued selectionchange event fires.
+    selection.selectAllChildren(second);
+    second.getBoundingClientRect();
+</script>

--- a/Tests/LibWeb/Text/expected/Editing/caret-at-text-child-boundary.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-at-text-child-boundary.txt
@@ -1,0 +1,12 @@
+LTR before text: true
+LTR after text: true
+LTR between text nodes: true
+RTL before text: true
+RTL after text: true
+RTL between text nodes: true
+vertical before text: true
+vertical after text: true
+vertical between text nodes: true
+first character caret: true
+second character advances: true
+caret height stays stable: true

--- a/Tests/LibWeb/Text/expected/Editing/empty-caret-font-height.txt
+++ b/Tests/LibWeb/Text/expected/Editing/empty-caret-font-height.txt
@@ -1,0 +1,6 @@
+empty block uses text height: true
+empty block aligns with text: true
+empty paragraph uses text height: true
+empty paragraph aligns with text: true
+empty inline uses text height: true
+empty inline aligns with text: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/deferred-selection-style-computation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/deferred-selection-style-computation.txt
@@ -1,7 +1,16 @@
 selection styles deferred: true
 unselected query: rgb(10, 20, 30)
 query stays local: true
+activation preserves element styles: true
+activation stays local: true
+activation preserves layout: true
 selection styles activated: true
 selected query: rgb(40, 50, 60)
+extension updates only intersecting subtrees: true
 deselected styles deferred: true
 deselected query: rgb(70, 80, 90)
+reactivation preserves element styles: true
+reactivated query: rgb(70, 80, 90)
+unselected query while active: rgb(70, 80, 90)
+activation with pending rule and class changes: rgb(90, 100, 110)
+activation with pending inline style: rgb(120, 130, 140)

--- a/Tests/LibWeb/Text/expected/css/style-engine/deferred-selection-style-reactions.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/deferred-selection-style-reactions.txt
@@ -18,5 +18,5 @@ replace selection: rgb(255, 192, 203)
 detach stays selective: true
 detach color: rgb(0, 0, 128)
 detach selection: rgb(0, 0, 255)
-unqueried selection activated: true
+unqueried selection activated locally: true
 active selection: rgb(0, 0, 255)

--- a/Tests/LibWeb/Text/expected/css/style-engine/typing-selection-style-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/typing-selection-style-invalidation.txt
@@ -1,0 +1,12 @@
+typing stays local: true
+typing leaves a caret: true
+repeated typing stays local: true
+repeated typing leaves a caret: true
+typing with a formatting override stays local: true
+typing with a formatting override leaves a caret: true
+inserted text: textabc
+formatting preserved: 700
+selection query: rgb(10, 20, 30)
+input handler selection: rgb(40, 50, 60)
+input handler leaves a selection: true
+selection styles activated: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/typing-selection-style-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/typing-selection-style-invalidation.txt
@@ -9,4 +9,4 @@ formatting preserved: 700
 selection query: rgb(10, 20, 30)
 input handler selection: rgb(40, 50, 60)
 input handler leaves a selection: true
-selection styles activated: true
+selection styles activated locally: true

--- a/Tests/LibWeb/Text/expected/display_list/selection-display-contents-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/selection-display-contents-invalidation.txt
@@ -1,0 +1,3 @@
+highlight commands rerecorded: true
+updated highlight color: true
+layout preserved: true

--- a/Tests/LibWeb/Text/input/Editing/caret-at-text-child-boundary.html
+++ b/Tests/LibWeb/Text/input/Editing/caret-at-text-child-boundary.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #editor { font: 20px/40px monospace; }
+</style>
+<div id="editor" contenteditable></div>
+<script>
+    test(() => {
+        editor.focus();
+        const selection = getSelection();
+        function rectAt(node, offset) {
+            selection.collapse(node, offset);
+            return internals.currentCaretRect();
+        }
+        function sameRect(a, b) {
+            return a && b && a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+        }
+        for (const [label, style, text] of [
+            ["LTR", "", "ab"],
+            ["RTL", "direction: rtl", "אב"],
+            ["vertical", "writing-mode: vertical-rl", "ab"],
+        ]) {
+            editor.style = style;
+            editor.textContent = text;
+            println(`${label} before text: ${sameRect(rectAt(editor, 0), rectAt(editor.firstChild, 0))}`);
+            println(`${label} after text: ${sameRect(rectAt(editor, 1), rectAt(editor.firstChild, text.length))}`);
+            editor.firstChild.splitText(1);
+            println(`${label} between text nodes: ${sameRect(rectAt(editor, 1), rectAt(editor.firstChild, 1))}`);
+        }
+        editor.style = "";
+        editor.innerHTML = "<p><br></p>";
+        const paragraph = editor.firstChild;
+        selection.collapse(paragraph, 0);
+        editor.addEventListener("input", () => {
+            selection.collapse(paragraph, paragraph.childNodes.length);
+        }, { once: true });
+        internals.sendText(editor, "a");
+        const firstCaret = internals.currentCaretRect();
+        println(`first character caret: ${sameRect(firstCaret, rectAt(paragraph.firstChild, 1))}`);
+        internals.sendText(editor, "b");
+        const secondCaret = internals.currentCaretRect();
+        println(`second character advances: ${secondCaret.x > firstCaret.x}`);
+        println(`caret height stays stable: ${firstCaret.height === secondCaret.height}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Editing/empty-caret-font-height.html
+++ b/Tests/LibWeb/Text/input/Editing/empty-caret-font-height.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #editor { font: 20px/40px monospace; }
+</style>
+<div id="editor" contenteditable></div>
+<script>
+    test(() => {
+        editor.focus();
+        const selection = getSelection();
+        for (const [label, markup] of [
+            ["empty block", ""],
+            ["empty paragraph", "<p><br></p>"],
+            ["empty inline", "<span></span>"],
+        ]) {
+            editor.innerHTML = markup;
+            const target = editor.firstChild || editor;
+            selection.collapse(target, 0);
+            const empty = internals.currentCaretRect();
+            target.textContent = "a";
+            selection.collapse(target.firstChild, 0);
+            const filled = internals.currentCaretRect();
+            println(`${label} uses text height: ${empty.height === filled.height}`);
+            println(`${label} aligns with text: ${empty.y === filled.y}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/deferred-selection-style-computation.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/deferred-selection-style-computation.html
@@ -19,12 +19,29 @@
         const afterQuery = internals.styleEngineCounters().computedPseudoAssignmentsPublished;
         println(`query stays local: ${afterQuery - after <= 2}`);
 
+        getComputedStyle(container.lastElementChild, "::selection").backgroundColor;
+        target.getBoundingClientRect();
         const range = document.createRange();
         range.selectNodeContents(target);
         document.getSelection().addRange(range);
+        const beforeActivationNodes = internals.styleEngineCounters().invalidatedStyleNodes;
+        const beforeActivation = internals.getStyleInvalidationCounters();
         internals.updateStyle();
+        target.getBoundingClientRect();
+        const afterActivation = internals.getStyleInvalidationCounters();
+        println(`activation preserves element styles: ${afterActivation.elementStyleRecomputations === beforeActivation.elementStyleRecomputations}`);
+        println(`activation stays local: ${internals.styleEngineCounters().invalidatedStyleNodes - beforeActivationNodes < 16}`);
+        println(`activation preserves layout: ${afterActivation.relayoutsPerformed === beforeActivation.relayoutsPerformed}`);
         println(`selection styles activated: ${internals.styleEngineCounters().computedPseudoAssignmentsPublished > afterQuery}`);
         println(`selected query: ${getComputedStyle(target, "::selection").backgroundColor}`);
+
+        internals.updateStyle();
+        const beforeExtension = internals.styleEngineCounters().invalidatedStyleNodes;
+        range.setEnd(target.nextElementSibling.firstChild, 3);
+        internals.updateStyle();
+        const extensionNodes = internals.styleEngineCounters().invalidatedStyleNodes - beforeExtension;
+        println(`extension updates only intersecting subtrees: ${extensionNodes > 0 && extensionNodes < 16}`);
+
 
         document.getSelection().removeAllRanges();
         rules.sheet.cssRules[0].style.backgroundColor = "rgb(70, 80, 90)";
@@ -32,5 +49,28 @@
         internals.updateStyle();
         println(`deselected styles deferred: ${internals.styleEngineCounters().computedPseudoAssignmentsPublished === beforeDeselectedUpdate}`);
         println(`deselected query: ${getComputedStyle(target, "::selection").backgroundColor}`);
+
+        internals.updateStyle();
+        const beforeReactivation = internals.getStyleInvalidationCounters().elementStyleRecomputations;
+        document.getSelection().addRange(range);
+        internals.updateStyle();
+        println(`reactivation preserves element styles: ${internals.getStyleInvalidationCounters().elementStyleRecomputations === beforeReactivation}`);
+        println(`reactivated query: ${getComputedStyle(target, "::selection").backgroundColor}`);
+        println(`unselected query while active: ${getComputedStyle(container.lastElementChild, "::selection").backgroundColor}`);
+
+        document.getSelection().removeAllRanges();
+        internals.updateStyle();
+        rules.sheet.insertRule(".changed { color: rgb(90, 100, 110); }");
+        target.className = "changed";
+        document.getSelection().addRange(range);
+        internals.updateStyle();
+        println(`activation with pending rule and class changes: ${getComputedStyle(target).color}`);
+
+        document.getSelection().removeAllRanges();
+        internals.updateStyle();
+        target.style.color = "rgb(120, 130, 140)";
+        document.getSelection().addRange(range);
+        internals.updateStyle();
+        println(`activation with pending inline style: ${getComputedStyle(target).color}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-engine/deferred-selection-style-reactions.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/deferred-selection-style-reactions.html
@@ -43,7 +43,8 @@
         document.getSelection().addRange(range);
         const before = internals.styleEngineCounters().computedPseudoAssignmentsPublished;
         internals.updateStyle();
-        println(`unqueried selection activated: ${internals.styleEngineCounters().computedPseudoAssignmentsPublished - before >= 64}`);
+        const activated = internals.styleEngineCounters().computedPseudoAssignmentsPublished - before;
+        println(`unqueried selection activated locally: ${activated > 0 && activated < 16}`);
         println(`active selection: ${getComputedStyle(container.lastElementChild, "::selection").color}`);
         document.getSelection().removeAllRanges();
     });

--- a/Tests/LibWeb/Text/input/css/style-engine/typing-selection-style-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/typing-selection-style-invalidation.html
@@ -40,6 +40,7 @@
         }, { once: true });
         internals.sendText(editor, "d");
         println(`input handler leaves a selection: ${!selection.isCollapsed}`);
-        println(`selection styles activated: ${internals.styleEngineCounters().computedPseudoAssignmentsPublished - beforeSelection >= 64}`);
+        const activated = internals.styleEngineCounters().computedPseudoAssignmentsPublished - beforeSelection;
+        println(`selection styles activated locally: ${activated > 0 && activated < 16}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-engine/typing-selection-style-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/typing-selection-style-invalidation.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    ::selection { color: rgb(10, 20, 30); background-color: rgb(40, 50, 60); }
+</style>
+<div id="unrelated"></div>
+<div id="editor" contenteditable>text</div>
+<script>
+    test(() => {
+        for (let index = 0; index < 64; ++index) {
+            const child = unrelated.appendChild(document.createElement("div"));
+            child.textContent = "selectable text";
+        }
+        editor.focus();
+        const selection = document.getSelection();
+        selection.collapse(editor.firstChild, 4);
+        internals.updateStyle();
+
+        function type(label, text) {
+            internals.resetStyleInvalidationCounters();
+            internals.sendText(editor, text);
+            internals.updateStyle();
+            println(`${label} stays local: ${internals.getStyleInvalidationCounters().elementStyleRecomputations < 16}`);
+            println(`${label} leaves a caret: ${selection.isCollapsed}`);
+        }
+
+        type("typing", "a");
+        type("repeated typing", "b");
+        document.execCommand("bold");
+        type("typing with a formatting override", "c");
+        println(`inserted text: ${editor.textContent}`);
+        println(`formatting preserved: ${getComputedStyle(selection.anchorNode.parentElement).fontWeight}`);
+        println(`selection query: ${getComputedStyle(editor, "::selection").color}`);
+
+        const beforeSelection = internals.styleEngineCounters().computedPseudoAssignmentsPublished;
+        editor.addEventListener("input", () => {
+            selection.selectAllChildren(editor);
+            internals.updateStyle();
+            println(`input handler selection: ${getComputedStyle(editor, "::selection").backgroundColor}`);
+        }, { once: true });
+        internals.sendText(editor, "d");
+        println(`input handler leaves a selection: ${!selection.isCollapsed}`);
+        println(`selection styles activated: ${internals.styleEngineCounters().computedPseudoAssignmentsPublished - beforeSelection >= 64}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/display_list/selection-display-contents-invalidation.html
+++ b/Tests/LibWeb/Text/input/display_list/selection-display-contents-invalidation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style id="rules">
+    #target { display: contents; }
+    #target::selection { background-color: rgb(10, 20, 30); }
+</style>
+<div id="owner"><span id="target">selected text</span></div>
+<script>
+    test(() => {
+        getSelection().selectAllChildren(target);
+        internals.recordDisplayListForTesting();
+        const layouts = internals.fullLayoutCount() + internals.partialLayoutCount();
+        internals.beginDisplayListTrace();
+        rules.sheet.cssRules[1].style.backgroundColor = "rgb(40, 50, 60)";
+        internals.recordDisplayListForTesting();
+        const trace = internals.takeDisplayListTrace();
+        const unchangedLayout = internals.fullLayoutCount() + internals.partialLayoutCount() === layouts;
+        const displayList = internals.dumpDisplayList();
+        println(`highlight commands rerecorded: ${trace.includes("BlockContainer<DIV>#owner/foreground RECORD")}`);
+        println(`updated highlight color: ${displayList.includes("color=rgb(40, 50, 60)")}`);
+        println(`layout preserved: ${unchangedLayout}`);
+    });
+</script>


### PR DESCRIPTION
Avoid activating selection styles for temporary editing selections, and limit real selection updates to the selected region instead of restyling the document. Selection highlights now repaint without rebuilding layout.

On logged-in ChatGPT, typing dropped from roughly 120–175 ms to 4–5 ms per character, and isolated selection updates dropped from 105–138 ms to 2.1–3.3 ms.

Also fix caret placement after the first character and excessive caret height in empty editors with placeholder text.
