### PR TITLE
Meta: Ensure we always build with link-time optimization (LTO) on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,9 @@ endif()
 set(LADYBIRD_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LADYBIRD_SOURCE_DIR}/Meta/CMake")
 
+include(cmake_options)
 include(compile_options)
 include(check_for_dependencies)
-include(cmake_options)
 include(ladybird_helper_processes)
 
 if(ENABLE_ALL_THE_DEBUG_MACROS)


### PR DESCRIPTION
**Problem:** The first configure of a Release or Distribution tree built LB without link-time optimization, then the next run of CMake in the same tree turned LTO on, and rebuilt every object. So every CI build (the numbers the web-benchmarks job publishes included) and **every local first build built a slower/larger binary than a tree that had been configured twice.** On a current Mac, `WebContent` came out at 163MB with 390k symbols after the first configure and 149MB after the second.

**Cause:** 1d83e8c8963 put `compile_options` ahead of `cmake_options` in the root `CMakeLists.txt`. `compile_options.cmake` tests `ENABLE_LTO_FOR_RELEASE`, the option `cmake_options.cmake` defines with a default of ON. On a first configure, that variable was still undefined at the point of the test. So, the IPO check never ran — and LTO stayed off. On a later configure, the cache already carried the option from the earlier run — so LTO came on. `compile_options.cmake` reads 6 more options the same way (fuzzers, sanitizers, coverage, and baseline CPU). That only works because those default to OFF, and get passed on the command line when wanted, and a `-D` populates the cache before any `CMakeLists` runs. The Flatpak manifest passes `-DENABLE_LTO_FOR_RELEASE=ON` explicitly, so it always got LTO.

**Fix:** Move `include(cmake_options)` up, ahead of `check_for_dependencies` and `compile_options`. `cmake_options.cmake` reads nothing that those two set (only its own `RELEASE_LTO_DEFAULT`, plus `CMAKE_CURRENT_LIST_DIR` and `PROJECT_BINARY_DIR`) — **so the move is safe.** A Distribution 1st configure now puts `-flto=thin` on every compile line, exactly as a 2nd one did.
