### PR TITLE
LibWeb: Use UTF-16 keys in AudioParamMap

### DIFF
--- a/Libraries/LibWeb/WebAudio/AudioParamMap.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParamMap.cpp
@@ -45,13 +45,13 @@ GC::Ref<JS::Map> map_entries(JS::Realm& realm, WebAudio::AudioParamMap& map)
 {
     auto map_entries = JS::Map::create(realm);
     for (auto const& entry : map.entries()) {
-        auto key = JS::PrimitiveString::create(realm.vm(), Utf16String::from_utf8(entry.key));
+        auto key = JS::PrimitiveString::create(realm.vm(), entry.key);
         map_entries->map_set(JS::Value { key.ptr() }, wrapped_param(realm, entry.value));
     }
     return map_entries;
 }
 
-Optional<JS::Value> map_get(JS::Realm& realm, WebAudio::AudioParamMap& map, FlyString const& key)
+Optional<JS::Value> map_get(JS::Realm& realm, WebAudio::AudioParamMap& map, Utf16View key)
 {
     auto it = map.entries().find(key);
     if (it == map.entries().end())
@@ -59,7 +59,7 @@ Optional<JS::Value> map_get(JS::Realm& realm, WebAudio::AudioParamMap& map, FlyS
     return wrapped_param(realm, it->value);
 }
 
-bool map_has(WebAudio::AudioParamMap& map, FlyString const& key)
+bool map_has(WebAudio::AudioParamMap& map, Utf16View key)
 {
     return map.entries().contains(key);
 }

--- a/Libraries/LibWeb/WebAudio/AudioParamMap.h
+++ b/Libraries/LibWeb/WebAudio/AudioParamMap.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/FlyString.h>
 #include <AK/HashMap.h>
+#include <AK/Utf16FlyString.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -24,15 +24,15 @@ public:
 
     virtual ~AudioParamMap() override;
 
-    OrderedHashMap<FlyString, GC::Ref<AudioParam>> const& entries() const { return m_entries; }
-    void set_entry(FlyString key, GC::Ref<AudioParam> value) { m_entries.set(move(key), value); }
+    OrderedHashMap<Utf16FlyString, GC::Ref<AudioParam>> const& entries() const { return m_entries; }
+    void set_entry(Utf16FlyString key, GC::Ref<AudioParam> value) { m_entries.set(move(key), value); }
 
 private:
     AudioParamMap();
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    OrderedHashMap<FlyString, GC::Ref<AudioParam>> m_entries;
+    OrderedHashMap<Utf16FlyString, GC::Ref<AudioParam>> m_entries;
 };
 
 }

--- a/Libraries/LibWeb/WebAudio/AudioWorkletNode.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioWorkletNode.cpp
@@ -85,7 +85,7 @@ WebIDL::ExceptionOr<GC::Ref<AudioWorkletNode>> AudioWorkletNode::construct_impl(
             if (auto it = options.parameter_data->find(descriptor.name); it != options.parameter_data->end())
                 TRY(param->set_value(static_cast<float>(it->value)));
         }
-        parameter_map->set_entry(FlyString(descriptor.name.to_utf8()), param);
+        parameter_map->set_entry(descriptor.name, param);
     }
 
     // 4. Let messageChannel be a new MessageChannel (collapsed): node.port and the processor's port are

--- a/Libraries/LibWeb/WebAudio/BindingsGlue.h
+++ b/Libraries/LibWeb/WebAudio/BindingsGlue.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/FlyString.h>
 #include <AK/Optional.h>
+#include <AK/Utf16View.h>
 #include <LibGC/Forward.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Value.h>
@@ -18,7 +18,7 @@ namespace Web::Bindings {
 
 // Maplike glue for AudioParamMap (see Meta/Generators/libweb_bindings/glue_headers.py).
 WEB_API GC::Ref<JS::Map> map_entries(JS::Realm&, WebAudio::AudioParamMap&);
-WEB_API Optional<JS::Value> map_get(JS::Realm&, WebAudio::AudioParamMap&, FlyString const& key);
-WEB_API bool map_has(WebAudio::AudioParamMap&, FlyString const& key);
+WEB_API Optional<JS::Value> map_get(JS::Realm&, WebAudio::AudioParamMap&, Utf16View key);
+WEB_API bool map_has(WebAudio::AudioParamMap&, Utf16View key);
 
 }


### PR DESCRIPTION
Fixes build from stale WebAudio merge.