### PR TITLE
LibJS: Snapshot the source of an object binding pattern

### DIFF
--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -7892,6 +7892,10 @@ fn generate_object_binding_pattern(
 ) {
     generator.emit(Instruction::ThrowIfNullish { src: object.operand() });
 
+    // Every property is read from the value the pattern started with, even after an earlier entry
+    // has assigned the variable that value came from (`var { a, b: e } = e`).
+    let object = &generator.copy_if_needed_to_preserve_evaluation_order(object);
+
     let mut excluded_names: Vec<ScopedOperand> = Vec::new();
     let has_rest = pattern.entries.last().is_some_and(|e| e.is_rest);
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -42,7 +42,7 @@ use crate::bytecode::validator::validate_bytecode;
 use crate::u32_from_usize;
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
-const FORMAT_VERSION: u32 = 16;
+const FORMAT_VERSION: u32 = 17;
 const SOURCE_HASH_SIZE: usize = 32;
 const BYTECODE_ALIGNMENT: usize = 8;
 const COMPLETION_TYPE_VARIANT_COUNT: u32 = 6;

--- a/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
@@ -15,7 +15,7 @@ block0:
   [  78] End value:reg5
 
 
-f$4cf5fc59 assign-to-let-variable-tdz.js:7:5
+f$4fb9ed69 assign-to-let-variable-tdz.js:7:5
   Registers: 10
   Blocks:    3
   Locals:    a~0
@@ -26,21 +26,22 @@ f$4cf5fc59 assign-to-let-variable-tdz.js:7:5
 block0:
   [   0] Enter
   [   8] ThrowIfNullish src:arg0
-  [  10] GetById dst:reg5, base:arg0, `location`
-  [  28] Mov dst:a~0, src:reg5
-  [  38] Typeof dst:reg5, src:a~0
-  [  48] LooselyEquals dst:reg6, lhs:String("string"), rhs:reg5
-  [  58] Mov dst:reg5, src:reg6
-  [  68] JumpFalse condition:reg6, target:block2
+  [  10] Mov dst:reg5, src:arg0
+  [  20] GetById dst:reg6, base:reg5, `location`
+  [  38] Mov dst:a~0, src:reg6
+  [  48] Typeof dst:reg5, src:a~0
+  [  58] LooselyEquals dst:reg6, lhs:String("string"), rhs:reg5
+  [  68] Mov dst:reg5, src:reg6
+  [  78] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  78] GetGlobal dst:reg8, `g`
-  [  88] Mov dst:reg9, src:a~0
-  [  98] Call dst:reg7, callee:reg8, this_value:Undefined, g, arguments:[reg9]
-  [  c0] Mov2 c0_dst:a~0, c0_src:reg7, c1_dst:reg5, c1_src:reg7
+  [  88] GetGlobal dst:reg8, `g`
+  [  98] Mov dst:reg9, src:a~0
+  [  a8] Call dst:reg7, callee:reg8, this_value:Undefined, g, arguments:[reg9]
+  [  d0] Mov2 c0_dst:a~0, c0_src:reg7, c1_dst:reg5, c1_src:reg7
 
 block2:
-  [  d8] Return value:a~0
+  [  e8] Return value:a~0
 
 
 g$702c1d97 assign-to-let-variable-tdz.js:4:17

--- a/Tests/LibJS/Bytecode/expected/destructuring-let-compound-assign.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-let-compound-assign.txt
@@ -13,7 +13,7 @@ block0:
   [  60] End value:reg5
 
 
-f$7e72fcf4 destructuring-let-compound-assign.js:2:5
+f$762729c4 destructuring-let-compound-assign.js:2:5
   Registers: 8
   Blocks:    1
   Locals:    a~0
@@ -24,10 +24,11 @@ f$7e72fcf4 destructuring-let-compound-assign.js:2:5
 block0:
   [   0] Enter
   [   8] ThrowIfNullish src:arg0
-  [  10] GetById dst:reg5, base:arg0, `patchFlag`
-  [  28] Mov3 c0_dst:a~0, c0_src:reg5, c1_dst:reg5, c1_src:a~0, c2_dst:reg6, c2_src:arg1
-  [  48] GetById dst:reg7, base:reg6, `patchFlag` (e.patchFlag)
-  [  60] BitwiseAnd dst:reg6, lhs:Int32(16), rhs:reg7
-  [  70] BitwiseOr dst:reg7, lhs:reg5, rhs:reg6
-  [  80] Mov dst:a~0, src:reg7
-  [  90] End value:Undefined
+  [  10] Mov dst:reg5, src:arg0
+  [  20] GetById dst:reg6, base:reg5, `patchFlag`
+  [  38] Mov3 c0_dst:a~0, c0_src:reg6, c1_dst:reg5, c1_src:a~0, c2_dst:reg6, c2_src:arg1
+  [  58] GetById dst:reg7, base:reg6, `patchFlag` (e.patchFlag)
+  [  70] BitwiseAnd dst:reg6, lhs:Int32(16), rhs:reg7
+  [  80] BitwiseOr dst:reg7, lhs:reg5, rhs:reg6
+  [  90] Mov dst:a~0, src:reg7
+  [  a0] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
@@ -17,8 +17,8 @@ block0:
   [  90] End value:reg5
 
 
-f$c8d012c1 destructuring-param-no-param-expressions.js:7:5
-  Registers: 6
+f$c0843f91 destructuring-param-no-param-expressions.js:7:5
+  Registers: 7
   Blocks:    1
   Locals:    local~0
 
@@ -26,9 +26,10 @@ block0:
   [   0] Enter
   [   8] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
   [  18] ThrowIfNullish src:arg0
-  [  20] GetById dst:reg5, base:arg0, `captured`
-  [  38] InitializeLexicalBinding `captured`, src:reg5
-  [  50] GetById dst:reg5, base:arg0, `local`
-  [  68] Mov dst:local~0, src:reg5
-  [  78] NewFunction dst:reg5, shared_function_data_index:0
-  [  90] Return value:reg5
+  [  20] Mov dst:reg5, src:arg0
+  [  30] GetById dst:reg6, base:reg5, `captured`
+  [  48] InitializeLexicalBinding `captured`, src:reg6
+  [  60] GetById dst:reg6, base:reg5, `local`
+  [  78] Mov dst:local~0, src:reg6
+  [  88] NewFunction dst:reg5, shared_function_data_index:0
+  [  a0] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/object-destructuring-rebinds-source-variable.txt
+++ b/Tests/LibJS/Bytecode/expected/object-destructuring-rebinds-source-variable.txt
@@ -1,0 +1,48 @@
+$def8dd96 object-destructuring-rebinds-source-variable.js:5:1
+  Registers: 11
+  Blocks:    1
+  Constants:
+    [0] = Undefined
+    [1] = Int32(1)
+    [2] = Int32(2)
+    [3] = Int32(3)
+
+block0:
+  [   0] Enter
+  [   8] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `run`
+  [  40] NewObject dst:reg10
+  [  50] InitObjectLiteralProperty object:reg10, `first`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  68] InitObjectLiteralProperty object:reg10, `second`, src:Int32(2), shape_cache_index:0, property_slot:1
+  [  80] InitObjectLiteralProperty object:reg10, `third`, src:Int32(3), shape_cache_index:0, property_slot:2
+  [  98] CacheObjectShape object:reg10
+  [  a8] Call dst:reg8, callee:reg9, this_value:Undefined, run, arguments:[reg10]
+  [  d0] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  f8] End value:reg5
+
+
+run$41ed7d93 object-destructuring-rebinds-source-variable.js:2:5
+  Registers: 9
+  Blocks:    1
+  Locals:    first~0, third~1
+  Constants:
+    [0] = Undefined
+
+block0:
+  [   0] Enter
+  [   8] MovUndefined2 c0_dst:first~0, c1_dst:third~1
+  [  18] ThrowIfNullish src:arg0
+  [  20] Mov dst:reg5, src:arg0
+  [  30] GetById dst:reg6, base:reg5, `first`
+  [  48] Mov dst:first~0, src:reg6
+  [  58] GetById dst:reg6, base:reg5, `second`
+  [  70] Mov dst:arg0, src:reg6
+  [  80] GetById dst:reg6, base:reg5, `third`
+  [  98] Mov3 c0_dst:third~1, c0_src:reg6, c1_dst:reg5, c1_src:first~0, c2_dst:reg6, c2_src:arg0
+  [  b8] Mov dst:reg7, src:third~1
+  [  c8] NewArray dst:reg8, elements:[reg5, reg6, reg7]
+  [  e8] Return value:reg8
+
+
+[ 1, 2, 3 ]

--- a/Tests/LibJS/Bytecode/input/object-destructuring-rebinds-source-variable.js
+++ b/Tests/LibJS/Bytecode/input/object-destructuring-rebinds-source-variable.js
@@ -1,0 +1,5 @@
+function run(source) {
+    var { first, second: source, third } = source;
+    return [first, source, third];
+}
+console.log(run({ first: 1, second: 2, third: 3 }));

--- a/Tests/LibJS/Runtime/regress/object-destructuring-rebinds-source-variable.js
+++ b/Tests/LibJS/Runtime/regress/object-destructuring-rebinds-source-variable.js
@@ -1,0 +1,56 @@
+describe("object destructuring keeps reading from the original value after rebinding its source", () => {
+    test("var declaration whose pattern rebinds the source variable", () => {
+        function run(source) {
+            var { first, second: source, third, fourth = "default" } = source;
+            return { first, source, third, fourth };
+        }
+        const result = run({ first: 1, second: 2, third: 3 });
+        expect(result.first).toBe(1);
+        expect(result.source).toBe(2);
+        expect(result.third).toBe(3);
+        expect(result.fourth).toBe("default");
+    });
+
+    test("destructuring assignment whose pattern rebinds the source variable", () => {
+        let source = { first: 1, second: 2 };
+        let first, second;
+        ({ first, second: source, second } = source);
+        expect(first).toBe(1);
+        expect(source).toBe(2);
+        expect(second).toBe(2);
+    });
+
+    test("nested pattern rebinding the outer source variable", () => {
+        function run(source) {
+            var {
+                inner: { value: source },
+                after,
+            } = source;
+            return { source, after };
+        }
+        const result = run({ inner: { value: "inner" }, after: "after" });
+        expect(result.source).toBe("inner");
+        expect(result.after).toBe("after");
+    });
+
+    test("rest property collected after the source variable is rebound", () => {
+        function run(source) {
+            var { first: source, ...rest } = source;
+            return { source, rest };
+        }
+        const result = run({ first: 1, second: 2, third: 3 });
+        expect(result.source).toBe(1);
+        expect(result.rest).toEqual({ second: 2, third: 3 });
+    });
+
+    test("computed key read after the source variable is rebound", () => {
+        function run(source) {
+            var key = "second";
+            var { first: source, [key]: second } = source;
+            return { source, second };
+        }
+        const result = run({ first: 1, second: 2 });
+        expect(result.source).toBe(1);
+        expect(result.second).toBe(2);
+    });
+});


### PR DESCRIPTION
Otherwise, a pattern that rebinds its own source variable, such as `var { a, b: e } = e`, reads every property after `b` from the newly assigned value instead of the original object.

Bumps the bytecode cache format version so cached blobs are recompiled.

Fixes the video player on Apple's event pages failing to start.