### PR TITLE
LibWeb: Ignore a null location in the scalar WebGL uniform setters

### DIFF
--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
@@ -281,9 +281,10 @@ void WebGL2RenderingContextImpl::uniform1ui(GC::Ptr<WebGLUniformLocation> locati
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform1ui(location_handle, v0);
 }
@@ -292,9 +293,10 @@ void WebGL2RenderingContextImpl::uniform2ui(GC::Ptr<WebGLUniformLocation> locati
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform2ui(location_handle, v0, v1);
 }
@@ -303,9 +305,10 @@ void WebGL2RenderingContextImpl::uniform3ui(GC::Ptr<WebGLUniformLocation> locati
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform3ui(location_handle, v0, v1, v2);
 }
@@ -314,9 +317,10 @@ void WebGL2RenderingContextImpl::uniform4ui(GC::Ptr<WebGLUniformLocation> locati
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform4ui(location_handle, v0, v1, v2, v3);
 }

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
@@ -2381,9 +2381,10 @@ void WebGLRenderingContextImpl::uniform1f(GC::Ptr<WebGLUniformLocation> location
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform1f(location_handle, x);
 }
@@ -2392,9 +2393,10 @@ void WebGLRenderingContextImpl::uniform2f(GC::Ptr<WebGLUniformLocation> location
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform2f(location_handle, x, y);
 }
@@ -2403,9 +2405,10 @@ void WebGLRenderingContextImpl::uniform3f(GC::Ptr<WebGLUniformLocation> location
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform3f(location_handle, x, y, z);
 }
@@ -2414,9 +2417,10 @@ void WebGLRenderingContextImpl::uniform4f(GC::Ptr<WebGLUniformLocation> location
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform4f(location_handle, x, y, z, w);
 }
@@ -2425,9 +2429,10 @@ void WebGLRenderingContextImpl::uniform1i(GC::Ptr<WebGLUniformLocation> location
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform1i(location_handle, x);
 }
@@ -2436,9 +2441,10 @@ void WebGLRenderingContextImpl::uniform2i(GC::Ptr<WebGLUniformLocation> location
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform2i(location_handle, x, y);
 }
@@ -2447,9 +2453,10 @@ void WebGLRenderingContextImpl::uniform3i(GC::Ptr<WebGLUniformLocation> location
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform3i(location_handle, x, y, z);
 }
@@ -2458,9 +2465,10 @@ void WebGLRenderingContextImpl::uniform4i(GC::Ptr<WebGLUniformLocation> location
 {
     m_context->make_current();
 
-    GLuint location_handle = 0;
-    if (location)
-        location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
+    if (!location)
+        return;
+
+    GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     m_context->uniform4i(location_handle, x, y, z, w);
 }

--- a/Tests/LibWeb/Text/expected/WebGL/uniform-null-location.txt
+++ b/Tests/LibWeb/Text/expected/WebGL/uniform-null-location.txt
@@ -1,0 +1,6 @@
+webgl: pixel before: close to [51,51,0,255], error: 0
+webgl: error after null-location setters: 0
+webgl: pixel after: close to [51,51,0,255]
+webgl2: pixel before: close to [51,51,51,255], error: 0
+webgl2: error after null-location setters: 0
+webgl2: pixel after: close to [51,51,51,255]

--- a/Tests/LibWeb/Text/input/WebGL/uniform-null-location.html
+++ b/Tests/LibWeb/Text/input/WebGL/uniform-null-location.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<canvas id="canvas1" width="8" height="8"></canvas>
+<canvas id="canvas2" width="8" height="8"></canvas>
+<script>
+    // Every uniform is active, so one of them sits at location 0: the location an implementation that substitutes 0
+    // for null would write to. The fragment color exposes the uniform values, and 7 clamps to 255 in every channel.
+    const shaders = {
+        webgl: {
+            vertex: "void main() { gl_Position = vec4(0.0, 0.0, 0.0, 1.0); gl_PointSize = 8.0; }",
+            fragment: "precision mediump float; uniform float f; uniform int i; void main() { gl_FragColor = vec4(f, float(i) * 0.2, 0.0, 1.0); }",
+            uniforms: ["f", "i"],
+            expected: [51, 51, 0, 255],
+        },
+        webgl2: {
+            vertex: "#version 300 es\nvoid main() { gl_Position = vec4(0.0, 0.0, 0.0, 1.0); gl_PointSize = 8.0; }",
+            fragment: "#version 300 es\nprecision mediump float; uniform float f; uniform int i; uniform uint u; out vec4 color; void main() { color = vec4(f, float(i) * 0.2, float(u) * 0.2, 1.0); }",
+            uniforms: ["f", "i", "u"],
+            expected: [51, 51, 51, 255],
+        },
+    };
+
+    function compile(gl, type, source) {
+        const shader = gl.createShader(type);
+        gl.shaderSource(shader, source);
+        gl.compileShader(shader);
+        return shader;
+    }
+
+    function setViaNull(gl) {
+        gl.uniform1f(null, 7);
+        gl.uniform2f(null, 7, 7);
+        gl.uniform3f(null, 7, 7, 7);
+        gl.uniform4f(null, 7, 7, 7, 7);
+        gl.uniform1i(null, 7);
+        gl.uniform2i(null, 7, 7);
+        gl.uniform3i(null, 7, 7, 7);
+        gl.uniform4i(null, 7, 7, 7, 7);
+        if (gl instanceof WebGL2RenderingContext) {
+            gl.uniform1ui(null, 7);
+            gl.uniform2ui(null, 7, 7);
+            gl.uniform3ui(null, 7, 7, 7);
+            gl.uniform4ui(null, 7, 7, 7, 7);
+        }
+    }
+
+    function centerPixel(gl) {
+        gl.clearColor(0, 0, 0, 0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.drawArrays(gl.POINTS, 0, 1);
+        const pixel = new Uint8Array(4);
+        gl.readPixels(4, 4, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+        return Array.from(pixel);
+    }
+
+    function describe(pixel, expected) {
+        const matches = pixel.every((value, index) => Math.abs(value - expected[index]) <= 2);
+        return matches ? `close to [${expected}]` : `[${pixel}], expected [${expected}]`;
+    }
+
+    test(() => {
+        for (const [kind, canvasId] of [["webgl", "canvas1"], ["webgl2", "canvas2"]]) {
+            const gl = document.getElementById(canvasId).getContext(kind);
+            const program = gl.createProgram();
+            gl.attachShader(program, compile(gl, gl.VERTEX_SHADER, shaders[kind].vertex));
+            gl.attachShader(program, compile(gl, gl.FRAGMENT_SHADER, shaders[kind].fragment));
+            gl.linkProgram(program);
+            gl.useProgram(program);
+
+            const locations = shaders[kind].uniforms.map(name => gl.getUniformLocation(program, name));
+            gl.uniform1f(locations[0], 0.2);
+            gl.uniform1i(locations[1], 1);
+            if (kind === "webgl2")
+                gl.uniform1ui(locations[2], 1);
+            println(`${kind}: pixel before: ${describe(centerPixel(gl), shaders[kind].expected)}, error: ${gl.getError()}`);
+
+            setViaNull(gl);
+
+            println(`${kind}: error after null-location setters: ${gl.getError()}`);
+            println(`${kind}: pixel after: ${describe(centerPixel(gl), shaders[kind].expected)}`);
+        }
+    });
+</script>


### PR DESCRIPTION
This matches the vector variants. Fixes some of the visualizations being blank on Webamp.