### PR TITLE
LibTextCodec: Use the mimalloc-backed Rust allocator

### DIFF
--- a/Libraries/LibTextCodec/Rust/src/lib.rs
+++ b/Libraries/LibTextCodec/Rust/src/lib.rs
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+/// cbindgen:ignore
+#[path = "../../../RustAllocator.rs"]
+mod rust_allocator;
+
 #[path = "../../../RustPanic.rs"]
 mod rust_panic;
 


### PR DESCRIPTION
LibTextCodec's Rust static library exported the default allocator shims, while LibJS used the mimalloc-backed allocator. Depending on DSO load order, LibJS could allocate through the former and free through the latter.

Linking LibURL (via LibCore) happens to mask this by loading another Rust library with the Ladybird allocator first. Use the shared Rust allocator in LibTextCodec so allocator selection is consistent and independent of link order.