### PR TITLE
LibWeb: Restrict root blockification and unbox `display: contents` in SVG and MathML

### DIFF
--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -394,6 +394,8 @@ static bool element_may_have_presentational_hints(DOM::Element const& element)
 u32 element_box_type_adjustment_facts(DOM::Element const& element)
 {
     bool is_html_element = element.namespace_uri() == Namespace::HTML;
+    bool is_svg_element = element.namespace_uri() == Namespace::SVG;
+    bool is_mathml_element = element.namespace_uri() == Namespace::MathML;
     auto local_name = element.local_name();
 
     bool input_allows_adjustment = false;
@@ -412,29 +414,53 @@ u32 element_box_type_adjustment_facts(DOM::Element const& element)
         input_is_single_line = input_allows_adjustment && input.is_single_line();
     }
 
+    bool is_outermost_svg_element = false;
     bool force_position_static = false;
-    if (element.namespace_uri() == Namespace::SVG) {
+    if (is_svg_element) {
         force_position_static = true;
         if (local_name == "svg"sv) {
-            force_position_static = false;
+            is_outermost_svg_element = true;
             for (auto ancestor = element.parent_element(); ancestor; ancestor = ancestor->parent_element()) {
                 if (ancestor->namespace_uri() == Namespace::SVG && ancestor->local_name() == "foreignObject"sv)
                     break;
                 if (ancestor->namespace_uri() == Namespace::SVG && ancestor->local_name() == "svg"sv) {
-                    force_position_static = true;
+                    is_outermost_svg_element = false;
                     break;
                 }
             }
+            force_position_static = !is_outermost_svg_element;
         }
     }
 
     bool force_symbol_display_inline = false;
-    if (element.namespace_uri() == Namespace::SVG && local_name == "symbol"sv) {
+    if (is_svg_element && local_name == "symbol"sv) {
         if (auto* shadow_root = as_if<DOM::ShadowRoot>(element.parent())) {
             if (auto* host = shadow_root->host())
                 force_symbol_display_inline = host->namespace_uri() == Namespace::SVG && host->local_name() == "use"sv;
         }
     }
+
+    bool display_contents_computes_to_none = false;
+
+    // https://drafts.csswg.org/css-display-3/#unbox-svg
+    // - An svg element that has CSS box layout (this includes all svg whose parent is an HTML element, as well as
+    //   document root elements):
+    //     display: contents computes to display: none.
+    display_contents_computes_to_none |= is_outermost_svg_element;
+
+    // - All other SVG container elements that are also renderable elements
+    // - SVG text content child elements
+    // - <use>
+    //     display: contents strips the element from the formatting tree, and hoists its contents up to display in its
+    //     place. These contents include the shadow-DOM content for use.
+    // - any other SVG elements
+    //     display: contents computes to display: none.
+    display_contents_computes_to_none |= is_svg_element
+        && !first_is_one_of(local_name, "a"sv, "g"sv, "svg"sv, "switch"sv, "textPath"sv, "tspan"sv, "use"sv);
+
+    // https://drafts.csswg.org/css-display-3/#unbox-mathml
+    // For all MathML elements, display: contents computes to display: none.
+    display_contents_computes_to_none |= is_mathml_element;
 
     u32 facts = 0;
     auto set = [&](bool condition, ElementStyleAdjustmentFact fact) {
@@ -443,7 +469,7 @@ u32 element_box_type_adjustment_facts(DOM::Element const& element)
     };
     set(is<HTML::HTMLBRElement>(element), ElementStyleAdjustmentFact::IsBr);
     set(is_html_element && local_name == HTML::TagNames::wbr, ElementStyleAdjustmentFact::IsWbr);
-    set(input_allows_adjustment || (is_html_element && first_is_one_of(local_name, HTML::TagNames::textarea, HTML::TagNames::audio, HTML::TagNames::video, HTML::TagNames::canvas, HTML::TagNames::object, HTML::TagNames::iframe, HTML::TagNames::progress, HTML::TagNames::embed, HTML::TagNames::frame, HTML::TagNames::meter, HTML::TagNames::frameset, HTML::TagNames::img)), ElementStyleAdjustmentFact::DisallowDisplayContents);
+    set(input_allows_adjustment || display_contents_computes_to_none || (is_html_element && first_is_one_of(local_name, HTML::TagNames::textarea, HTML::TagNames::audio, HTML::TagNames::video, HTML::TagNames::canvas, HTML::TagNames::object, HTML::TagNames::iframe, HTML::TagNames::progress, HTML::TagNames::embed, HTML::TagNames::frame, HTML::TagNames::meter, HTML::TagNames::frameset, HTML::TagNames::img)), ElementStyleAdjustmentFact::DisallowDisplayContents);
     set(input_allows_adjustment || (is_html_element && first_is_one_of(local_name, HTML::TagNames::textarea, HTML::TagNames::audio, HTML::TagNames::video, HTML::TagNames::select)), ElementStyleAdjustmentFact::RewriteInlineFlow);
     set(is_html_element && local_name == HTML::TagNames::button, ElementStyleAdjustmentFact::IsButton);
     set(is_html_element && local_name == HTML::TagNames::select, ElementStyleAdjustmentFact::ForceLineHeightNormal);
@@ -452,7 +478,7 @@ u32 element_box_type_adjustment_facts(DOM::Element const& element)
     set(is_html_element && local_name == HTML::TagNames::table, ElementStyleAdjustmentFact::IsTable);
     set(force_position_static, ElementStyleAdjustmentFact::ForcePositionStatic);
     set(force_symbol_display_inline, ElementStyleAdjustmentFact::ForceSymbolDisplayInline);
-    set(element.namespace_uri() == Namespace::MathML, ElementStyleAdjustmentFact::IsMathML);
+    set(is_mathml_element, ElementStyleAdjustmentFact::IsMathML);
     set(local_name.equals_ignoring_ascii_case("mtable"sv), ElementStyleAdjustmentFact::IsMathMLMtable);
     set(local_name.equals_ignoring_ascii_case("mtr"sv), ElementStyleAdjustmentFact::IsMathMLMtr);
     set(local_name.equals_ignoring_ascii_case("mtd"sv), ElementStyleAdjustmentFact::IsMathMLMtd);

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -3407,8 +3407,8 @@ mod pseudo_kind {
 }
 
 /// The element facts a pseudo-element's computation reads: the C++ adjustments for what the
-/// originating element is stay off for its pseudo-elements, past the ones about the element's
-/// place in the document and its markup language.
+/// originating element is stay off for its pseudo-elements, past the ones about its markup
+/// language.
 const PSEUDO_ELEMENT_ADJUSTMENT_FACTS: u32 = {
     use bridge::element_adjustment_fact as fact;
     fact::IS_MATHML
@@ -3416,7 +3416,6 @@ const PSEUDO_ELEMENT_ADJUSTMENT_FACTS: u32 = {
         | fact::IS_MATHML_MTR
         | fact::IS_MATHML_MTD
         | fact::IS_TH
-        | fact::IS_DOCUMENT_ELEMENT
         | fact::HAS_ANIMATIONS
 };
 

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -5851,7 +5851,7 @@ pub extern "C" fn rust_box_type_transformation_input(
         position: keyword::STATIC,
         float_value: keyword::NONE,
         is_br_element: adjust_element && has(fact::IS_BR),
-        is_document_element: has(fact::IS_DOCUMENT_ELEMENT),
+        is_document_element: adjust_element && has(fact::IS_DOCUMENT_ELEMENT),
         is_mathml_element: has(fact::IS_MATHML),
         is_mathml_mtable: has(fact::IS_MATHML_MTABLE),
         is_mathml_mtr: has(fact::IS_MATHML_MTR),

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-pseudo/first-letter-of-html-root-crash-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-pseudo/first-letter-of-html-root-crash-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>CSS Test Reference</title>
+<body style="margin:0">PASS</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-pseudo/first-letter-of-html-root-refcrash.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-pseudo/first-letter-of-html-root-refcrash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Test: ::first-letter of html root element crash in combination with removal of body</title>
+<link rel="help" href="https://crbug.com/993764">
+<link rel="match" href="../../../../expected/wpt-import/css/css-pseudo/first-letter-of-html-root-crash-ref.html">
+<style id="sheet">
+  html::first-letter { font-size: initial }
+</style>FAIL
+<script>
+  const sel = window.getSelection();
+  sel.selectAllChildren(document.documentElement);
+  const range = sel.getRangeAt(0);
+  document.body.remove();
+  document.documentElement.appendChild(document.createTextNode("PASS"));
+  document.documentElement.offsetTop;
+  range.surroundContents(sheet);
+</script>

--- a/Tests/LibWeb/Text/expected/css/display-contents-unboxing-in-svg.txt
+++ b/Tests/LibWeb/Text/expected/css/display-contents-unboxing-in-svg.txt
@@ -1,0 +1,13 @@
+outer: none
+inner: contents
+a: contents
+g: contents
+switch: contents
+text: none
+tspan: contents
+textPath: contents
+use: contents
+defs: none
+symbol: none
+foreignObject: none
+rect: none

--- a/Tests/LibWeb/Text/expected/css/document-element-pseudo-element-adjustments.txt
+++ b/Tests/LibWeb/Text/expected/css/document-element-pseudo-element-adjustments.txt
@@ -1,0 +1,2 @@
+html::first-letter display: inline
+html::first-letter font-size: 64px

--- a/Tests/LibWeb/Text/expected/wpt-import/mathml/relations/css-styling/display-contents.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/mathml/relations/css-styling/display-contents.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	display: contents computes to display: none

--- a/Tests/LibWeb/Text/input/css/display-contents-unboxing-in-svg.html
+++ b/Tests/LibWeb/Text/input/css/display-contents-unboxing-in-svg.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .contents {
+        display: contents;
+    }
+</style>
+<svg id="outer" class="contents">
+    <svg id="inner" class="contents">
+        <a id="a" class="contents">
+            <g id="g" class="contents">
+                <switch id="switch" class="contents"></switch>
+            </g>
+        </a>
+        <text id="text" class="contents">
+            <tspan id="tspan" class="contents">x</tspan>
+            <textPath id="textPath" class="contents">y</textPath>
+        </text>
+        <use id="use" class="contents"></use>
+        <defs id="defs" class="contents"><symbol id="symbol" class="contents"></symbol></defs>
+        <foreignObject id="foreignObject" class="contents"></foreignObject>
+        <rect id="rect" class="contents"></rect>
+    </svg>
+</svg>
+<script>
+    test(() => {
+        const ids = ["outer", "inner", "a", "g", "switch", "text", "tspan", "textPath", "use", "defs", "symbol",
+            "foreignObject", "rect"];
+        for (const id of ids)
+            println(`${id}: ${getComputedStyle(document.getElementById(id)).display}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/document-element-pseudo-element-adjustments.html
+++ b/Tests/LibWeb/Text/input/css/document-element-pseudo-element-adjustments.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    html {
+        font-size: 32px;
+    }
+    html::first-letter {
+        font-size: 2em;
+    }
+</style>
+x
+<script>
+    test(() => {
+        const style = getComputedStyle(document.documentElement, "::first-letter");
+        println(`html::first-letter display: ${style.display}`);
+        println(`html::first-letter font-size: ${style.fontSize}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/mathml/relations/css-styling/display-contents.html
+++ b/Tests/LibWeb/Text/input/wpt-import/mathml/relations/css-styling/display-contents.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>display: contents</title>
+<link rel="help" href="https://w3c.github.io/mathml-core/#css-styling">
+<meta name="assert" content="Verify that display: contents computes to display: none">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../support/mathml-fragments.js"></script>
+<script>
+  setup({ explicit_done: true });
+  window.addEventListener("load", runTests);
+  function runTests() {
+      var container = document.getElementById("container");
+      for (tag in MathMLFragments) {
+          container.insertAdjacentHTML("beforeend", `<math>${MathMLFragments[tag]}</math>`);
+      }
+      test(function() {
+          Array.from(document.getElementsByClassName("element")).forEach(element => {
+              var style = window.getComputedStyle(element);
+              element.setAttribute("style", "display: contents");
+              assert_equals(style.getPropertyValue("display"), "none", `${tag}`);
+          });
+      }, "display: contents computes to display: none");
+      done();
+  }
+</script>
+</head>
+<body>
+  <div id="log"></div>
+  <div id="container">
+    <math class="element"></math>
+  </div>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/mathml/support/mathml-fragments.js
+++ b/Tests/LibWeb/Text/input/wpt-import/mathml/support/mathml-fragments.js
@@ -1,0 +1,190 @@
+var MathMLFragments = {
+    "a": "<a class='element mathml-container'></a>",
+    "annotation": "\
+<semantics>\
+  <mrow></mrow>\
+  <annotation class='element text-container'></annotation>\
+</semantics>",
+    "annotation-xml": "\
+<semantics>\
+  <mrow></mrow>\
+  <annotation-xml class='element text-container foreign-container'></annotation-xml>\
+</semantics>",
+    "maction": "\
+<maction class='element' actiontype='statusline'>\
+  <mrow class='mathml-container'></mrow>\
+  <mtext class='text-container'></mtext>\
+</maction>",
+    "menclose": "<menclose class='element mathml-container'></menclose>",
+    "merror": "<merror class='element mathml-container'></merror>",
+    "mfrac": "\
+<mfrac class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</mfrac>",
+    "mi": "<mi class='element text-container foreign-container'></mi>",
+    "mmultiscripts": "\
+<mmultiscripts class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</mmultiscripts>",
+    "mn": "<mn class='element text-container foreign-container'></mn>",
+    "mo": "<mo class='element text-container foreign-container'></mo>",
+    "mover": "\
+<mover class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</mover>",
+    "mpadded": "<mpadded class='element mathml-container'></mpadded>",
+    "mphantom": "<mphantom class='element mathml-container'></mphantom>",
+    "mprescripts": "\
+<mmultiscripts>\
+  <mrow class='mathml-container'></mrow>\
+  <mprescripts class='element'/>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</mmultiscripts>",
+    "mroot": "\
+<mroot class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</mroot>",
+    "mrow": "<mrow class='element mathml-container'></mrow>",
+    "ms": "<ms class='element text-container foreign-container'></ms>",
+    "mspace": "<mspace class='element'></mspace>",
+    "msqrt": "<msqrt class='element mathml-container'></msqrt>",
+    "mstyle": "<mstyle class='element mathml-container'></mstyle>",
+    "msub": "\
+<msub class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</msub>",
+    "msubsup": "\
+<msubsup class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</msubsup>",
+    "msup": "\
+<msup class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</msup>",
+    "mtable": "\
+<mtable class='element'>\
+  <mtr>\
+    <mtd class='mathml-container'>\
+    </mtd>\
+  </mtr>\
+</mtable>",
+    "mtd": "\
+<mtable>\
+  <mtr>\
+    <mtd class='element mathml-container'>\
+    </mtd>\
+  </mtr>\
+</mtable>",
+    "mtext": "<mtext class='element text-container foreign-container'></mtext>",
+    "mtr": "\
+<mtable>\
+  <mtr class='element'>\
+    <mtd class='mathml-container'>\
+    </mtd>\
+  </mtr>\
+</mtable>",
+    "munder": "\
+<munder class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</munder>",
+    "munderover": "\
+<munderover class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+  <mrow class='mathml-container'></mrow>\
+</munderover>",
+    "none": "\
+<mmultiscripts>\
+  <mrow class='mathml-container'></mrow>\
+  <none class='element'/>\
+  <mrow class='mathml-container'></mrow>\
+</mmultiscripts>",
+    "semantics": "\
+<semantics class='element'>\
+  <mrow class='mathml-container'></mrow>\
+  <annotation class='text-container'></annotation>\
+</semantics>"
+};
+
+var FragmentHelper = {
+    mathml_namespace: "http://www.w3.org/1998/Math/MathML",
+
+    createElement: function(tag) {
+        return document.createElementNS(this.mathml_namespace, tag);
+    },
+
+    isValidChildOfMrow: function(tag) {
+        return !(tag == "annotation" ||
+                 tag == "annotation-xml" ||
+                 tag == "mprescripts" ||
+                 tag == "none" ||
+                 tag == "mtr" ||
+                 tag == "mtd");
+    },
+
+    isTokenElement: function(tag) {
+        return (tag == "mi" ||
+                tag == "mtext" ||
+                tag == "mo" ||
+                tag == "mn" ||
+                tag == "ms")
+    },
+
+    isEmpty: function(tag) {
+        return tag === "mspace" || tag == "mprescripts" || tag == "none";
+    },
+
+    element: function(fragment) {
+        return fragment.getElementsByClassName('element')[0];
+    },
+
+    appendChild: function(fragment, allowInvalid) {
+        var element = this.element(fragment) || fragment;
+        if (element.classList.contains("foreign-container")) {
+            var el = document.createElement("span");
+            el.textContent = "a";
+            return element.appendChild(el);
+        }
+        if (element.classList.contains("mathml-container") || allowInvalid) {
+            var el = this.createElement("mtext");
+            el.textContent = "a";
+            return element.appendChild(el);
+        }
+        throw "Cannot append child to the element";
+    },
+
+    forceNonEmptyElement: function(fragment) {
+        var element = this.element(fragment) || fragment;
+        if (element.firstElementChild)
+            return element.firstElementChild;
+        return this.appendChild(fragment);
+    },
+
+    forceNonEmptyDescendants: function(fragment) {
+        var element = this.element(fragment) || fragment;
+        if (element.classList.contains("mathml-container") ||
+            element.classList.contains("foreign-container")) {
+            for (var i = 0; i < 10; i++)
+                this.appendChild(element);
+            return;
+        }
+        var child = element.firstElementChild;
+        if (child) {
+            for (; child; child = child.nextElementSibling) {
+                this.forceNonEmptyDescendants(child);
+            }
+            return;
+        }
+    },
+}


### PR DESCRIPTION
These changes fix 2 crashes that caused the same Rust panic.

In a run of 10,000 Domato cases this fixes 8 / 26 crashes.

See individual commits for details.