### PR TITLE
LibWeb: Find inline containing blocks across shadow roots

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -237,23 +237,23 @@ bool NodeWithStyle::has_css_transform() const
 //        other containing-block-establishing properties) between this node and its containing block
 //        in the DOM tree. If found, it is stored in the arena's inline_containing_block slot.
 //
-//        We check the DOM tree here (rather than the layout tree) because when a block element is inside
-//        an inline element, the layout tree restructures so the block becomes a sibling of the inline.
-//        But the CSS containing block relationship is based on the DOM structure.
+//        We check the shadow-including DOM tree here (rather than the layout tree) because when a block
+//        element is inside an inline element, the layout tree restructures so the block becomes a sibling
+//        of the inline. But the CSS containing block relationship is based on the DOM structure.
 NodeWithStyle const* Node::find_inline_containing_block(Box const& containing_block) const
 {
     auto const* containing_block_dom_node = containing_block.dom_node();
 
     // For pseudo-elements, we need to start from the generating element itself, since it may
-    // be the inline containing block. For regular elements, start from parent_element().
+    // be the inline containing block. For regular elements, start from the parent or shadow host.
     GC::Ptr<DOM::Element const> first_ancestor_to_check;
     if (is_generated_for_pseudo_element()) {
         first_ancestor_to_check = m_pseudo_element_generator.ptr();
     } else if (auto const* this_dom_node = dom_node()) {
-        first_ancestor_to_check = this_dom_node->parent_element();
+        first_ancestor_to_check = this_dom_node->parent_or_shadow_host_element();
     }
 
-    for (auto dom_ancestor = first_ancestor_to_check; dom_ancestor; dom_ancestor = dom_ancestor->parent_element()) {
+    for (auto dom_ancestor = first_ancestor_to_check; dom_ancestor; dom_ancestor = dom_ancestor->parent_or_shadow_host_element()) {
         // Stop if we reach the DOM node of the containing block.
         if (dom_ancestor.ptr() == containing_block_dom_node)
             break;

--- a/Tests/LibWeb/Text/expected/css/abspos-inline-containing-block-in-shadow-tree.txt
+++ b/Tests/LibWeb/Text/expected/css/abspos-inline-containing-block-in-shadow-tree.txt
@@ -1,0 +1,4 @@
+x: true
+y: true
+width: true
+height: true

--- a/Tests/LibWeb/Text/input/css/abspos-inline-containing-block-in-shadow-tree.html
+++ b/Tests/LibWeb/Text/input/css/abspos-inline-containing-block-in-shadow-tree.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    positioned-inline { position: relative; }
+</style>
+<div style="height: 100px;"></div>
+<positioned-inline>inline containing block</positioned-inline>
+<script>
+    const host = document.querySelector("positioned-inline");
+    host.attachShadow({ mode: "open" }).innerHTML = `
+        <style>
+            #absolutely-positioned {
+                position: absolute;
+                inset: 0;
+            }
+        </style>
+        <div id="absolutely-positioned"></div>
+        <slot></slot>
+    `;
+
+    test(() => {
+        const hostRect = host.getBoundingClientRect();
+        const absolutelyPositionedRect = host.shadowRoot
+            .querySelector("#absolutely-positioned").getBoundingClientRect();
+
+        println(`x: ${absolutelyPositionedRect.x === hostRect.x}`);
+        println(`y: ${absolutelyPositionedRect.y === hostRect.y}`);
+        println(`width: ${absolutelyPositionedRect.width === hostRect.width}`);
+        println(`height: ${absolutelyPositionedRect.height === hostRect.height}`);
+    });
+</script>


### PR DESCRIPTION
Absolutely positioned shadow tree descendants failed to use a positioned inline shadow host as their containing block. The ancestor walk stopped at the shadow root and incorrectly fell back to the viewport.

Walk through shadow hosts when locating inline containing blocks, and add coverage for an absolutely positioned shadow tree descendant.

Fixes an issue in the mobile layout on https://azure.com/

| Before | After |
| - | - |
| <img width="571" height="785" alt="Screenshot 2026-09-10 at 00 17 44" src="https://github.com/user-attachments/assets/ff69d285-977a-4052-ad16-2b7de18650ea" /> | <img width="549" height="785" alt="Screenshot 2026-09-10 at 00 17 18" src="https://github.com/user-attachments/assets/5bb46c76-a18d-4974-b719-79674db569a6" /> |
