### PR TITLE
LibWeb: Delay decoding HTML bytes that are encoding-sensitive

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -213,6 +213,7 @@ void HTMLParser::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_root_insertion_target);
     visitor.visit(m_active_speculative_html_parser);
     visitor.visit(m_change_encoding_callback);
+    visitor.visit(m_ready_for_more_input_callback);
     visitor.visit(m_parsing_complete_callback);
 
     rust_html_parser_visit_edges(m_rust_parser, &visitor);
@@ -1133,6 +1134,13 @@ void HTMLParser::resume_after_parser_blocking_script()
     // document.write).
     run();
 
+    // AD-HOC: The spec converts input bytes as the tokenizer consumes them, so a declaration can still re-encode
+    //         anything unconsumed. IncrementalDocumentParser pushes decoded characters instead and withholds bytes
+    //         whose encoding is still in question while the tokenizer is stopped; this hands them over, and can pause
+    //         us again.
+    if (!m_parser_pause_flag && m_ready_for_more_input_callback)
+        m_ready_for_more_input_callback->function()();
+
     if (m_parser_pause_flag)
         return;
 
@@ -1141,8 +1149,13 @@ void HTMLParser::resume_after_parser_blocking_script()
 
 void HTMLParser::invoke_post_parse_action()
 {
-    if (auto callback = exchange(m_parsing_complete_callback, nullptr))
-        callback->function()();
+    // AD-HOC: A resume from a parser-blocking script also lands here, with the input byte stream still open when more
+    //         bytes are on the way. The input retained for a late encoding declaration is only safe to drop once it
+    //         closes.
+    if (m_tokenizer.is_input_stream_closed()) {
+        if (auto callback = exchange(m_parsing_complete_callback, nullptr))
+            callback->function()();
+    }
     if (auto action = exchange(m_post_parse_action, nullptr))
         action();
 }

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -94,6 +94,7 @@ public:
 
     EncodingConfidence encoding_confidence() const { return m_encoding_confidence; }
     void set_change_encoding_callback(GC::Ref<GC::Function<bool(StringView)>> callback) { m_change_encoding_callback = callback; }
+    void set_ready_for_more_input_callback(GC::Ref<GC::Function<void()>> callback) { m_ready_for_more_input_callback = callback; }
     void set_parsing_complete_callback(GC::Ref<GC::Function<void()>> callback) { m_parsing_complete_callback = callback; }
 
     size_t script_nesting_level() const { return m_script_nesting_level; }
@@ -161,6 +162,7 @@ private:
     // https://html.spec.whatwg.org/multipage/parsing.html#concept-encoding-confidence
     EncodingConfidence m_encoding_confidence;
     GC::Ptr<GC::Function<bool(StringView)>> m_change_encoding_callback;
+    GC::Ptr<GC::Function<void()>> m_ready_for_more_input_callback;
     GC::Ptr<GC::Function<void()>> m_parsing_complete_callback;
 
     Function<void()> m_post_parse_action;

--- a/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.cpp
@@ -108,6 +108,9 @@ void IncrementalDocumentParser::initialize_parser(ReadonlyBytes sniff_bytes)
     m_parser->set_parsing_complete_callback(GC::create_function(GC::Heap::the(), [this]() {
         release_encoding_change_buffers();
     }));
+    m_parser->set_ready_for_more_input_callback(GC::create_function(GC::Heap::the(), [this]() {
+        feed_parser();
+    }));
     m_parser->set_allow_declarative_shadow_roots(m_allow_declarative_shadow_roots);
 
     start_incremental_read();
@@ -137,6 +140,23 @@ bool IncrementalDocumentParser::should_continue() const
     return m_parser && !m_parser->aborted() && m_document->parser() == m_parser;
 }
 
+ReadonlyBytes IncrementalDocumentParser::decoded_input_bytes() const
+{
+    return m_input_bytes.span().slice(0, m_decoded_byte_count);
+}
+
+ReadonlyBytes IncrementalDocumentParser::undecoded_input_bytes() const
+{
+    return m_input_bytes.span().slice(m_decoded_byte_count);
+}
+
+// pump() runs the tokenizer to the end of its input, so the only reasons decoded characters can be left unconsumed
+// are the parser waiting for scripts to be allowed to run and the parser being paused on a parser-blocking script.
+bool IncrementalDocumentParser::tokenizer_will_consume_input_immediately() const
+{
+    return m_document->ready_to_run_scripts() && !m_parser->is_paused();
+}
+
 void IncrementalDocumentParser::append_decoded(Utf16View decoded)
 {
     m_source.append(decoded);
@@ -146,7 +166,7 @@ void IncrementalDocumentParser::append_decoded(Utf16View decoded)
 void IncrementalDocumentParser::process_body_chunk(ByteBuffer bytes)
 {
     if (!should_continue()) {
-        release_encoding_change_buffers();
+        discard_input_bytes();
         return;
     }
 
@@ -154,52 +174,74 @@ void IncrementalDocumentParser::process_body_chunk(ByteBuffer bytes)
     // Each task that the networking task source places on the task queue while fetching runs must
     // fill the parser's input byte stream with the fetched bytes and cause the HTML parser to
     // perform the appropriate processing of the input stream.
-    auto bytes_to_decode = bytes.bytes();
+    if (m_input_bytes.is_empty())
+        m_input_bytes = move(bytes);
+    else
+        m_input_bytes.append(bytes);
 
-    if (m_parser->encoding_confidence() == EncodingConfidence::Tentative) {
-        auto current_encoding = TextCodec::get_standardized_encoding(m_document->encoding().value());
-        VERIFY(current_encoding.has_value());
+    feed_parser();
+}
 
-        // If a meta declaration precedes the first encoding-sensitive byte in this chunk, allow the parser to process
-        // the encoding-independent prefix first. This lets the declaration switch the decoder before the remainder of
-        // the chunk is decoded, while still allowing charset-less documents to parse progressively.
-        if (!current_encoding->is_one_of_ignoring_ascii_case("UTF-16BE"sv, "UTF-16LE"sv)) {
-            size_t encoding_independent_prefix_length = 0;
-            while (encoding_independent_prefix_length < bytes_to_decode.size()) {
-                auto byte = bytes_to_decode[encoding_independent_prefix_length];
+static size_t encoding_independent_prefix_length(ReadonlyBytes bytes)
+{
+    size_t length = 0;
+    while (length < bytes.size()) {
+        // Non-ASCII bytes may have different Unicode interpretations in different encodings. ESC is also
+        // encoding-sensitive because it can change the state of an ISO-2022-JP decoder, affecting how
+        // subsequent ASCII-range bytes are interpreted.
+        auto byte = bytes[length];
+        if (!is_ascii(byte) || byte == 0x1B)
+            break;
 
-                // Non-ASCII bytes may have different Unicode interpretations in different encodings. ESC is also
-                // encoding-sensitive because it can change the state of an ISO-2022-JP decoder, affecting how
-                // subsequent ASCII-range bytes are interpreted.
-                if (!is_ascii(byte) || byte == 0x1B)
-                    break;
+        ++length;
+    }
+    return length;
+}
 
-                ++encoding_independent_prefix_length;
-            }
+void IncrementalDocumentParser::feed_parser()
+{
+    while (!undecoded_input_bytes().is_empty()) {
+        if (!should_continue()) {
+            discard_input_bytes();
+            return;
+        }
 
-            if (encoding_independent_prefix_length > 0) {
-                auto encoding_independent_prefix = bytes_to_decode.trim(encoding_independent_prefix_length);
-                m_input_bytes.append(encoding_independent_prefix);
-                decode_and_process(encoding_independent_prefix);
+        auto undecoded_bytes = undecoded_input_bytes();
+        auto length_to_decode = undecoded_bytes.size();
 
-                if (!should_continue()) {
-                    release_encoding_change_buffers();
+        if (m_parser->encoding_confidence() == EncodingConfidence::Tentative) {
+            auto current_encoding = TextCodec::get_standardized_encoding(m_document->encoding().value());
+            VERIFY(current_encoding.has_value());
+
+            // Every byte of a UTF-16 stream is encoding-sensitive, and step 1 of the change-the-encoding algorithm
+            // refuses to move away from UTF-16BE/LE anyway, so there is no declaration left to hold bytes for.
+            if (!current_encoding->is_one_of_ignoring_ascii_case("UTF-16BE"sv, "UTF-16LE"sv)) {
+                auto prefix_length = encoding_independent_prefix_length(undecoded_bytes);
+
+                // Step 5 of the change-the-encoding algorithm only swaps the decoder for bytes that read the same
+                // in both encodings, so converting an encoding-sensitive byte commits any declaration behind it to
+                // the step 6 restart we do not implement. Holding them until the tokenizer catches up rules one out.
+                if (prefix_length == 0 && !tokenizer_will_consume_input_immediately()) {
+                    // Nothing is decoded this round, so pump() cannot arm the wake-up that brings us back. A parser
+                    // paused on a script has the resume hook; one that cannot run scripts yet needs this.
+                    if (!m_document->ready_to_run_scripts())
+                        register_deferred_start();
                     return;
                 }
 
-                bytes_to_decode = bytes_to_decode.slice(encoding_independent_prefix_length);
+                if (prefix_length > 0)
+                    length_to_decode = prefix_length;
             }
         }
-    }
 
-    if (!bytes_to_decode.is_empty()) {
-        if (m_parser->encoding_confidence() == EncodingConfidence::Tentative)
-            m_input_bytes.append(bytes_to_decode);
-        decode_and_process(bytes_to_decode);
+        decode_and_process(length_to_decode);
     }
 
     if (!should_continue() || m_parser->encoding_confidence() != EncodingConfidence::Tentative)
         release_encoding_change_buffers();
+
+    if (m_body_is_exhausted)
+        finish_body();
 }
 
 void IncrementalDocumentParser::process_end_of_body()
@@ -208,11 +250,27 @@ void IncrementalDocumentParser::process_end_of_body()
     // to the new document until its load event. So, drop the body as soon as it's exhausted — rather than keeping the
     // previous document alive until the new one has finished loading. Blink, WebKit, and Gecko all do this too.
     m_body = nullptr;
+    m_body_is_exhausted = true;
 
     if (!should_continue()) {
-        release_encoding_change_buffers();
+        discard_input_bytes();
         return;
     }
+
+    // Bytes held back for a still-possible encoding declaration are fed first; the implied EOF character waits for
+    // them in finish_body().
+    feed_parser();
+}
+
+void IncrementalDocumentParser::finish_body()
+{
+    if (m_processed_implied_eof)
+        return;
+    if (!should_continue())
+        return;
+
+    VERIFY(m_body_is_exhausted);
+    VERIFY(undecoded_input_bytes().is_empty());
 
     auto decoded = m_decoder->finish_to_utf16().release_value_but_fixme_should_propagate_errors();
     append_decoded(decoded);
@@ -220,7 +278,7 @@ void IncrementalDocumentParser::process_end_of_body()
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-html
     // When no more bytes are available, have the parser process the implied EOF character.
     m_document->set_source(m_source.to_string());
-    m_reached_end_of_body = true;
+    m_processed_implied_eof = true;
     m_parser->tokenizer().close_input_stream();
     pump();
 
@@ -236,14 +294,14 @@ ErrorOr<bool> IncrementalDocumentParser::change_encoding(StringView new_encoding
     auto decoder = make<TextCodec::StreamingDecoder>(new_encoding, TextCodec::IgnoreBOM::No, TextCodec::ErrorMode::Replacement);
 
     Utf16StringBuilder builder;
-    builder.append(TRY(decoder->to_utf16(m_input_bytes.bytes())));
-    if (m_reached_end_of_body)
+    builder.append(TRY(decoder->to_utf16(decoded_input_bytes())));
+    if (m_processed_implied_eof)
         builder.append(TRY(decoder->finish_to_utf16()));
     auto redecoded_source = builder.to_string();
 
-    auto current_source = m_reached_end_of_body ? m_document->source().utf16_view() : m_source.view();
+    auto current_source = m_processed_implied_eof ? m_document->source().utf16_view() : m_source.view();
     if (!redecoded_source.starts_with(current_source)
-        || (m_reached_end_of_body && redecoded_source.length_in_code_units() != current_source.length_in_code_units())) {
+        || (m_processed_implied_eof && redecoded_source.length_in_code_units() != current_source.length_in_code_units())) {
         // FIXME: A mismatch requires restarting the navigation with the new encoding, as described by step 6 of the
         //        change-the-encoding algorithm.
         release_encoding_change_buffers();
@@ -252,7 +310,7 @@ ErrorOr<bool> IncrementalDocumentParser::change_encoding(StringView new_encoding
 
     auto additionally_decoded_source = redecoded_source.utf16_view().substring_view(current_source.length_in_code_units());
     if (!additionally_decoded_source.is_empty()) {
-        VERIFY(!m_reached_end_of_body);
+        VERIFY(!m_processed_implied_eof);
         append_decoded(additionally_decoded_source);
     }
 
@@ -261,22 +319,47 @@ ErrorOr<bool> IncrementalDocumentParser::change_encoding(StringView new_encoding
     return true;
 }
 
-void IncrementalDocumentParser::decode_and_process(ReadonlyBytes bytes)
+void IncrementalDocumentParser::decode_and_process(size_t length)
 {
-    auto decoded = m_decoder->to_utf16(bytes).release_value_but_fixme_should_propagate_errors();
+    auto undecoded_bytes = undecoded_input_bytes();
+    VERIFY(length <= undecoded_bytes.size());
+
+    auto decoded = m_decoder->to_utf16(undecoded_bytes.trim(length)).release_value_but_fixme_should_propagate_errors();
+
+    // Count the bytes as converted before running the parser: a script it runs can deliver another body chunk, and
+    // feed_parser() would otherwise convert these a second time.
+    m_decoded_byte_count += length;
+
     append_decoded(decoded);
     pump();
 }
 
 void IncrementalDocumentParser::release_encoding_change_buffers()
 {
+    // Only bytes the decoder has yet to convert are still needed; the rest were kept solely to compare decoders.
+    auto undecoded_bytes = undecoded_input_bytes();
+    auto undecoded_size = undecoded_bytes.size();
+    undecoded_bytes.copy_to(m_input_bytes.span());
+    m_input_bytes.resize(undecoded_size);
+    m_decoded_byte_count = 0;
+}
+
+void IncrementalDocumentParser::discard_input_bytes()
+{
     m_input_bytes.clear();
+    m_decoded_byte_count = 0;
 }
 
 void IncrementalDocumentParser::process_body_error(JS::Value)
 {
     m_body = nullptr;
-    release_encoding_change_buffers();
+
+    // Bytes withheld while the tokenizer was behind are still part of the document. This ends the parse, so no
+    // declaration can still change how they decode: feed them to the tokenizer with the encoding as it stands.
+    if (should_continue() && !undecoded_input_bytes().is_empty())
+        decode_and_process(undecoded_input_bytes().size());
+
+    discard_input_bytes();
     dbgln("FIXME: Load html page with an error if incremental read of body failed.");
     HTMLParser::the_end(m_document, m_parser);
 }
@@ -289,6 +372,9 @@ void IncrementalDocumentParser::register_deferred_start()
     auto parser = GC::Ref { *this };
     m_document->set_deferred_parser_start(GC::create_function(GC::Heap::the(), [parser] {
         parser->pump();
+
+        // The tokenizer can consume input again, so hand over any bytes withheld while it could not.
+        parser->feed_parser();
     }));
 }
 

--- a/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.h
+++ b/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.h
@@ -44,12 +44,18 @@ private:
     void process_body_error(JS::Value);
     ErrorOr<bool> change_encoding(StringView);
 
-    void decode_and_process(ReadonlyBytes);
+    void feed_parser();
+    void finish_body();
+    void decode_and_process(size_t length);
     void release_encoding_change_buffers();
+    void discard_input_bytes();
     void append_decoded(Utf16View);
     void pump();
     void register_deferred_start();
     bool should_continue() const;
+    bool tokenizer_will_consume_input_immediately() const;
+    ReadonlyBytes decoded_input_bytes() const;
+    ReadonlyBytes undecoded_input_bytes() const;
 
     GC::Ref<DOM::Document> m_document;
     GC::Ptr<Fetch::Infrastructure::Body> m_body;
@@ -60,9 +66,13 @@ private:
     GC::Ptr<HTMLParser> m_parser;
     OwnPtr<TextCodec::StreamingDecoder> m_decoder;
 
+    // Everything received while a declaration could still change the encoding, and how much of it the decoder has
+    // converted. The bytes past that point are the ones held back from a tokenizer that has not caught up.
     ByteBuffer m_input_bytes;
+    size_t m_decoded_byte_count { 0 };
     Utf16StringBuilder m_source;
-    bool m_reached_end_of_body { false };
+    bool m_body_is_exhausted { false };
+    bool m_processed_implied_eof { false };
 };
 
 }

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -99,6 +99,7 @@ Text/input/navigation/location-reload-fetch.html
 Text/input/HTML/image-load-after-adoption-from-removed-iframe.html
 Text/input/HTML/session-storage-event-fired-to-lazy-window.html
 Text/input/HTML/parser-streams-bytes.html
+Text/input/HTML/parser-streams-late-meta-charset-blocked-parser.html
 Text/input/HTML/parser-streams-late-meta-charset.html
 Text/input/HTML/parser-streams-with-document-write.html
 Text/input/HTML/parser-streams-utf8-split.html

--- a/Tests/LibWeb/Text/expected/HTML/parser-streams-late-meta-charset-blocked-parser.txt
+++ b/Tests/LibWeb/Text/expected/HTML/parser-streams-late-meta-charset-blocked-parser.txt
@@ -1,0 +1,6 @@
+paused charset: windows-1252
+paused script: true
+paused body: Â©
+resumed charset: windows-1252
+resumed script: true
+resumed body: Â©

--- a/Tests/LibWeb/Text/expected/HTML/parser-streams-late-meta-charset-blocked-parser.txt
+++ b/Tests/LibWeb/Text/expected/HTML/parser-streams-late-meta-charset-blocked-parser.txt
@@ -1,6 +1,6 @@
-paused charset: windows-1252
+paused charset: UTF-8
 paused script: true
-paused body: Â©
-resumed charset: windows-1252
+paused body: ©
+resumed charset: UTF-8
 resumed script: true
-resumed body: Â©
+resumed body: ©

--- a/Tests/LibWeb/Text/input/HTML/parser-streams-late-meta-charset-blocked-parser.html
+++ b/Tests/LibWeb/Text/input/HTML/parser-streams-late-meta-charset-blocked-parser.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<meta charset="UTF-8" />
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        internals.setTestTimeout(10000);
+
+        const httpServer = httpTestServer();
+        const token = crypto.randomUUID().replaceAll("-", "");
+
+        async function createBlockingScript(name) {
+            return httpServer.createEcho("GET", `/parser-streams-blocked-late-meta-script-${name}-${token}`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "application/javascript",
+                },
+                body: `window.blockingScriptRan = true;`,
+            });
+        }
+
+        async function runCase(name, body, query) {
+            const url = await httpServer.createEcho("GET", `/parser-streams-blocked-late-meta-${name}-${token}`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "text/html",
+                },
+                body,
+            });
+
+            const frame = document.createElement("iframe");
+            await new Promise(resolve => {
+                frame.onload = resolve;
+                frame.src = query ? `${url}?${query}` : url;
+                document.body.appendChild(frame);
+            });
+
+            println(`${name} charset: ${frame.contentDocument.characterSet}`);
+            println(`${name} script: ${frame.contentWindow.blockingScriptRan}`);
+            println(`${name} body: ${frame.contentDocument.getElementById("target").textContent}`);
+            frame.remove();
+        }
+
+        // The comment keeps the declaration past the 1024 bytes the encoding sniffing algorithm prescans, so only the
+        // parser can find it.
+        const padding = `<!--${"a".repeat(1200)}-->`;
+
+        // The declaration trails a parser-blocking script, so the parser is still paused at that script when the rest
+        // of the response arrives.
+        async function runPausedCase() {
+            const scriptURL = await createBlockingScript("paused");
+            const body = `<!DOCTYPE html><head><script src="${scriptURL}"><\/script>${padding}<meta charset="UTF-8"></head><body><span id="target">©</span>`;
+            await runCase("paused", body);
+        }
+
+        // The blocking script resolves during the gap between chunks, so the parser has drained the first chunk before
+        // the declaration arrives in the second.
+        async function runResumedCase() {
+            const scriptURL = await createBlockingScript("resumed");
+            const head = `<!DOCTYPE html><head><script src="${scriptURL}"><\/script>${padding}`;
+            const body = `${head}<meta charset="UTF-8"></head><body><span id="target">©</span>`;
+            await runCase("resumed", body, `chunks=${head.length}&chunk_delay_ms=500`);
+        }
+
+        await runPausedCase();
+        await runResumedCase();
+        done();
+    });
+</script>


### PR DESCRIPTION
Each network chunk was decoded as soon as it arrived, even while the parser was waiting for scripts to be allowed to run or was paused on a parser-blocking script. Step 5 of change-the-encoding only swaps the decoder for bytes that read the same in both encodings, so if decoded input that isn't immediately processed differs in the new encoding, it forces step 6 to restart the navigation to re-decode the entire document, which is not yet implemented.

Instead of forcing a restart, hold encoding-sensitive bytes back while the confidence is tentative until the tokenizer can resume consuming input. The tokenizer notifies the document parser when it is able to start processing input again. When the implied EOF is reached, the buffered data is drained before emitting it.

This prevents a flake in parser-streams-late-meta-charset.html.