### PR TITLE
Gecko/WebKit/Blink never arm a timer for a destroyed document; so let’s not either. (And so, stop letting pages consume massive CPU due to setting timers on iframes they’ve removed)

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
@@ -38,6 +38,13 @@ void TaskQueue::add(GC::Ref<Task> task)
     if (task->document() && task->document()->is_temporary_document_for_fragment_parsing())
         return;
 
+    // AD-HOC: Don't enqueue a task for a destroyed document either: "destroy a document" removes the document's
+    //         tasks from every task queue, and a destroyed document is never fully active again, so a task queued
+    //         for it afterwards could never run. It would only sit in the queue — and queuing it wakes the event
+    //         loop, which then scans the whole queue for a runnable task, but finds none.
+    if (task->document() && task->document()->has_been_destroyed())
+        return;
+
     m_last_added_task = task.ptr();
     if (task->priority() == Task::Priority::Idle)
         m_idle_tasks.append(*task);

--- a/Libraries/LibWeb/HTML/EventLoop/TaskQueue.h
+++ b/Libraries/LibWeb/HTML/EventLoop/TaskQueue.h
@@ -20,6 +20,7 @@ public:
     virtual ~TaskQueue() override;
 
     bool is_empty() const { return m_tasks.is_empty() && m_idle_tasks.is_empty(); }
+    size_t size_slow() const { return m_tasks.size_slow() + m_idle_tasks.size_slow(); }
 
     bool has_runnable_tasks() const;
     bool has_rendering_tasks() const;

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -1266,6 +1266,13 @@ void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout,
     // 1. Assert: if timerKey is given, then the caller of this algorithm is the timer initialization steps. (Other specifications must not pass timerKey.)
     // Note: This is enforced by the caller.
 
+    // NB: Step 5.1 has a Window's timer wait until its associated Document has been fully active for a further
+    //     milliseconds milliseconds. A destroyed document is never fully active again — so a timer set on its window
+    //     can never fire, and there's nothing to arm: an armed one would only wake the event loop every period to
+    //     queue a task that can't run. Blink refuses such a timer outright, and Gecko makes the call a no-op.
+    if (auto* window = as_if<Window>(this_impl()); window && window->associated_document().has_been_destroyed())
+        return;
+
     // NB: A hidden document holds a delayed timer back past its deadline to its next wake-up (see
     //     throttled_timer_delay()), so the delay the timer is armed with can differ from the one it was asked for.
     auto deadline = HighResolutionTime::unsafe_shared_current_time() + timeout;

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -51,6 +51,7 @@ public:
     void clear_timeout(i32);
     void clear_interval(i32);
     void clear_map_of_active_timers();
+    size_t active_timer_count(Badge<Internals::Internals>) const { return m_timers.size(); }
 
     void queue_microtask(WebIDL::CallbackType&);
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -79,6 +79,7 @@
 #include <LibWeb/HTML/SharedResourceRequest.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WindowOrWorkerGlobalScope.h>
+#include <LibWeb/HTML/WindowProxy.h>
 #include <LibWeb/Internals/InternalGamepad.h>
 #include <LibWeb/Internals/Internals.h>
 #include <LibWeb/Layout/NodeArena.h>
@@ -1811,6 +1812,18 @@ void Internals::set_hidden_document_timer_wake_up_interval(double milliseconds)
 void Internals::set_hidden_document_intensive_timer_throttling(double wake_up_interval, double grace_period_once_loaded, double grace_period_while_loading)
 {
     window().set_hidden_document_intensive_timer_throttling({}, wake_up_interval, grace_period_once_loaded, grace_period_while_loading);
+}
+
+WebIDL::UnsignedLongLong Internals::active_timer_count(JS::Object& object)
+{
+    if (auto* window_proxy = as_if<HTML::WindowProxy>(object)) {
+        if (auto window = window_proxy->window())
+            return window->active_timer_count({});
+        return 0;
+    }
+    if (auto* window = HTML::window_from_global_object(object))
+        return window->active_timer_count({});
+    return 0;
 }
 
 Utf16String Internals::canvas_color_scheme()

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1826,6 +1826,11 @@ WebIDL::UnsignedLongLong Internals::active_timer_count(JS::Object& object)
     return 0;
 }
 
+WebIDL::UnsignedLongLong Internals::task_queue_length()
+{
+    return HTML::main_thread_event_loop().task_queue().size_slow();
+}
+
 Utf16String Internals::canvas_color_scheme()
 {
     auto& document = window().associated_document();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -240,6 +240,7 @@ public:
     void set_system_visibility_state(Utf16String const& state);
     void set_hidden_document_timer_wake_up_interval(double milliseconds);
     void set_hidden_document_intensive_timer_throttling(double wake_up_interval, double grace_period_once_loaded, double grace_period_while_loading);
+    WebIDL::UnsignedLongLong active_timer_count(JS::Object& window);
     Utf16String canvas_color_scheme();
     WebIDL::ExceptionOr<GC::Ref<JS::Object>> image_animation_state_for_url(Utf16String const& url);
     bool media_element_is_fetching(HTML::HTMLMediaElement&);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -241,6 +241,7 @@ public:
     void set_hidden_document_timer_wake_up_interval(double milliseconds);
     void set_hidden_document_intensive_timer_throttling(double wake_up_interval, double grace_period_once_loaded, double grace_period_while_loading);
     WebIDL::UnsignedLongLong active_timer_count(JS::Object& window);
+    WebIDL::UnsignedLongLong task_queue_length();
     Utf16String canvas_color_scheme();
     WebIDL::ExceptionOr<GC::Ref<JS::Object>> image_animation_state_for_url(Utf16String const& url);
     bool media_element_is_fetching(HTML::HTMLMediaElement&);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -252,6 +252,8 @@ interface Internals {
     // Overrides the interval between the wake-ups a hidden document holds its chained timers back to once it has been
     // hidden for the grace period, and that grace period, both in milliseconds (60000 ms and 300000 ms by default).
     undefined setHiddenDocumentIntensiveTimerThrottling(double wakeUpInterval, double gracePeriodOnceLoaded, double gracePeriodWhileLoading);
+    // Returns how many timers are armed on the given window (a Window or WindowProxy object).
+    unsigned long long activeTimerCount(object window);
     DOMString canvasColorScheme();
     // Returns the selector-insight cache state for stylesheet invalidation tests.
     object imageAnimationStateForURL(USVString url);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -254,6 +254,8 @@ interface Internals {
     undefined setHiddenDocumentIntensiveTimerThrottling(double wakeUpInterval, double gracePeriodOnceLoaded, double gracePeriodWhileLoading);
     // Returns how many timers are armed on the given window (a Window or WindowProxy object).
     unsigned long long activeTimerCount(object window);
+    // Returns how many tasks sit in the main thread event loop's task queue, runnable or not.
+    unsigned long long taskQueueLength();
     DOMString canvasColorScheme();
     // Returns the selector-insight cache state for stylesheet invalidation tests.
     object imageAnimationStateForURL(USVString url);

--- a/Tests/LibWeb/Text/expected/HTML/destroyed-document-tasks-are-not-queued.txt
+++ b/Tests/LibWeb/Text/expected/HTML/destroyed-document-tasks-are-not-queued.txt
@@ -1,0 +1,1 @@
+tasks queued for the destroyed document: 0

--- a/Tests/LibWeb/Text/expected/HTML/timers-on-a-destroyed-document-window-are-not-armed.txt
+++ b/Tests/LibWeb/Text/expected/HTML/timers-on-a-destroyed-document-window-are-not-armed.txt
@@ -1,0 +1,1 @@
+timers armed on the destroyed window: 0

--- a/Tests/LibWeb/Text/input/HTML/destroyed-document-tasks-are-not-queued.html
+++ b/Tests/LibWeb/Text/input/HTML/destroyed-document-tasks-are-not-queued.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = "<p>frame</p>";
+        document.body.appendChild(iframe);
+        await new Promise(resolve => { iframe.onload = resolve; });
+
+        const removedWindow = iframe.contentWindow;
+        iframe.remove();
+        // The removed iframe's document is destroyed from a queued task; wait for that to have happened.
+        while (!removedWindow.closed)
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+        const queuedBefore = internals.taskQueueLength();
+        for (let i = 0; i < 100; ++i)
+            removedWindow.postMessage("never delivered", "*");
+        println(`tasks queued for the destroyed document: ${internals.taskQueueLength() - queuedBefore}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/timers-on-a-destroyed-document-window-are-not-armed.html
+++ b/Tests/LibWeb/Text/input/HTML/timers-on-a-destroyed-document-window-are-not-armed.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = "<p>frame</p>";
+        document.body.appendChild(iframe);
+        await new Promise(resolve => { iframe.onload = resolve; });
+
+        const removedWindow = iframe.contentWindow;
+        iframe.remove();
+        // The removed iframe's document is destroyed from a queued task; wait for that to have happened.
+        while (!removedWindow.closed)
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+        removedWindow.setTimeout(() => {}, 0);
+        removedWindow.setInterval(() => {}, 0);
+        println(`timers armed on the destroyed window: ${internals.activeTimerCount(removedWindow)}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
A backgrounded https://apnews.com tab kept its WebContent process at most of a CPU core for *hours* — despite nothing visible going on.

The page kept setting timers on windows whose documents the tab had already destroyed. And every `setInterval()` set that way fired *forever:* Every period, it queued a task for the destroyed document. So, the dead tasks piled up. And every firing woke the event loop to scan the whole pile three times over — but just repeatedly kept finding nothing to run. A sample of the process put about 80% of its main thread in `TaskQueue::has_runnable_tasks()`.

So, two fixes:

- **A timer set on the window of a destroyed document is no longer armed at all.** That’s what the other engines do: Blink refuses such a timer outright (`setTimeout()` returns 0 for a destroyed context), Gecko makes the call a no-op, and WebKit installs the timer only to stop it at once. None of them ever runs one.

- **A task queued for a destroyed document is no longer queued at all:** `TaskQueue::add()` now drops it, without waking the event loop.

---
### Performance impact

Measured with the local A/B harness (web-benchmarks `bench_pr.py`): the branch (a46ea3a95aa) against its merge-base (5dab6a4a75f), both built with the Distribution preset (ThinLTO), interleaved suite by suite over 8 paired rounds across all ten suites, on macOS and on Linux.

**Result: performance neutral.** Linux: every test neutral. macOS: every test neutral but one, `WebKitCSS/CSSPropertyUpdateValue` at 2.5% slower — a layout artifact of the base binary that the change never touches (see below).

| Platform | Neutral | Mover | Base | Head | Change | q | Resolution (typical / noisiest tenth) |
|---|---:|---|---:|---:|---:|---:|---|
| macOS (Mac17,7, AppleClang 21) | 777 | `WebKitCSS/CSSPropertyUpdateValue` | 15.30 ms | 15.68 ms | 2.5% slower | 0.014 | ±3.4% / ±8.2% |
| Linux (arm64 VM, Clang 21.1.8) | 779 | none | | | | | ±3.4% / ±10.4% |

**Why the macOS mover is layout, not the change:**

- **The changed code doesn’t run in that test.** The PR adds an early-out for a destroyed document in `TaskQueue` and in timer arming; `CSSPropertyUpdateValue` sets style properties on an element of a live document in a tight loop, and the only timers in play are the benchmark runner’s own, on that live document. So the head binary does a handful of cheap checks more per test, nothing that reaches 0.4 ms per run.
- **The same test moves by the same amount for unrelated changes against this same base.** Three other head binaries built against 5dab6a4a75f show it too: PR #11694 (+2.5%), a diagnostic build of that PR with its work disabled (+2.6%), and PR #11686 (+2.7% on average, just under the flag). Every head binary differs from the base in code layout, and the base binary’s layout happens to favor this test’s hot loop.
- **Flat on the other platform.** On Linux the same test reads head/base 0.99 (0.93 to 1.01 across the rounds), not flagged.

The per-round consistency (1.01 to 1.03 in all 8 rounds) is what a layout effect looks like: deterministic for a given pair of binaries, unrelated to the semantics of the change.

The timer family, the closest thing to this change in the suites, is flat on both platforms: `MicroWeb/timers/set-timeout-batch` (a 1.4 ms test) read 0.97 of base on macOS and 0.91 on Linux, and `MicroWeb/timers/message-channel-ping-pong` 0.99 and 1.00, all within their 0.1 ms quantum noise and none flagged.

<details>
<summary>Run details</summary>

- Baseline 5dab6a4a75f (the merge-base), branch a46ea3a95aa, web-benchmarks 72c6b8f. 8 kept rounds plus a discarded warmup; the two arms interleaved per suite, with the order flipped per suite and per round; one iteration per launch; a paired log-ratio t-test with Benjamini-Hochberg correction over all tests (a mover is q < 0.05, at least 1%, and at least 0.2 ms).
- macOS: Mac17,7, 18 cores, macOS 27.0; Distribution preset, AppleClang 21.0.0, ThinLTO; A-vs-A calibration of 2026-09-09 on record with 0 false movers.
- Linux: a lima VM (12 cores, arm64, Linux 6.8) running the CI image ladybird-ci:2026.08.28; Distribution preset, Clang 21.1.8, ThinLTO; no calibration on record, so the quoted resolution is the run’s own.
- About 90 tests run under 2 ms and resolve only to the 0.1 ms timer quantum; the resolution figures leave them out. `MicroWeb/timers/async-await-loop` was dropped as invalid (a 0.0 ms reading) on both platforms, and `MicroWeb/timers/queue-microtask-chain` on macOS — both read the same 0.0 ms on PR #11686’s run, so that’s the quantum, not this change.

</details>

