### PR TITLE
LibWeb: Take background propagation containment from generated boxes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -27,21 +27,24 @@ bool HTMLHtmlElement::should_use_body_background_properties() const
     // properties from the <body> element to the initial containing block, the viewport, or the canvas background, is
     // disabled. Notably, this affects:
     // - 'background' and its longhands (see CSS Backgrounds 3 § 2.11.2 The Canvas Background and the HTML <body> Element)
-    auto has_containment = [](DOM::Element const& element) {
-        auto const* values = element.style_group<CSS::ComputedValues::BoxValues>();
-        VERIFY(values);
-        return values->size_containment || values->inline_size_containment || values->layout_containment || values->style_containment || values->paint_containment;
+    // NB: Called during rendering, reading style off the layout nodes.
+    auto has_containment = [](Layout::NodeWithStyle const& layout_node) {
+        return !layout_node.contain().is_empty();
     };
-    if (has_containment(*this))
+
+    auto const* layout_node = unsafe_layout_node();
+    if (!layout_node || has_containment(*layout_node))
         return false;
 
-    auto* body_element = first_child_of_type<HTML::HTMLBodyElement>();
-    if (body_element && has_containment(*body_element))
+    auto const* body_element = first_child_of_type<HTML::HTMLBodyElement>();
+    if (!body_element)
+        return false;
+    auto const* body_layout_node = body_element->unsafe_layout_node();
+    if (!body_layout_node || has_containment(*body_layout_node))
         return false;
 
-    // NB: Called during rendering, reading background properties.
-    auto background_color = unsafe_layout_node()->background_color();
-    auto const& background_layers = unsafe_layout_node()->background_layers();
+    auto background_color = layout_node->background_color();
+    auto const& background_layers = layout_node->background_layers();
 
     return !any_of(background_layers, [](auto const& layer) { return layer.background_image != nullptr; }) && background_color == Color::Transparent;
 }

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -470,13 +470,14 @@ int HTMLImageElement::x() const
     // associated with the element, relative to the initial containing block origin, ignoring any transforms that apply
     // to the element and its ancestors, or zero if there is no box.
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLImageElementX);
-    // Scroll frames are created together with the visual context tree at the lazy resolution point,
-    // so resolve it before reading the enclosing scroll node below.
-    const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     auto const* layout_node = this->layout_node();
     if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
+
+    // Scroll frames are created together with the visual context tree at the lazy resolution point,
+    // so resolve it before reading the enclosing scroll node below.
+    const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     return (Painting::absolute_border_box_rect(*layout_node).x() - Painting::cumulative_scroll_compensation(*layout_node).x()).to_int();
 }
@@ -488,13 +489,14 @@ int HTMLImageElement::y() const
     // associated with the element, relative to the initial containing block origin, ignoring any transforms that apply
     // to the element and its ancestors, or zero if there is no box.
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLImageElementY);
-    // Scroll frames are created together with the visual context tree at the lazy resolution point,
-    // so resolve it before reading the enclosing scroll node below.
-    const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     auto const* layout_node = this->layout_node();
     if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
+
+    // Scroll frames are created together with the visual context tree at the lazy resolution point,
+    // so resolve it before reading the enclosing scroll node below.
+    const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     return (Painting::absolute_border_box_rect(*layout_node).y() - Painting::cumulative_scroll_compensation(*layout_node).y()).to_int();
 }

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -48,9 +48,8 @@ static bool body_background_is_propagated_to_root(Layout::NodeWithStyle const& l
 {
     if (!layout_node.is_body())
         return false;
-    // Reachable at invalidation time, when the root element's layout node may already be detached.
     auto const* html_element = layout_node.document().html_element();
-    return html_element && html_element->unsafe_layout_node() && html_element->should_use_body_background_properties();
+    return html_element && html_element->should_use_body_background_properties();
 }
 
 ResolvedSvgFilter resolve_svg_filter_reference(CSS::ComputedValuesFFI::ComputedStyleValueHandle const& url_value, Layout::NodeWithStyle const& layout_node)

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -403,7 +403,7 @@ static Layout::RustFFI::FfiRootBackgroundSource rust_root_background_source(DOM:
     Layout::RustFFI::FfiRootBackgroundSource source {};
     source.body_layout_node = Layout::RustFFI::NodeSlotId { Layout::RustFFI::INVALID_NODE_SLOT_INDEX };
     auto const* html_element = document.html_element();
-    source.use_body_background_properties = html_element && html_element->unsafe_layout_node() && html_element->should_use_body_background_properties();
+    source.use_body_background_properties = html_element && html_element->should_use_body_background_properties();
     if (auto const* body = document.body(); body && body->unsafe_layout_node())
         source.body_layout_node = Layout::Node::slot_id(body->unsafe_layout_node());
     return source;

--- a/Tests/LibWeb/Crash/HTML/canvas-background-with-restyled-body-behind-unstyled-body.html
+++ b/Tests/LibWeb/Crash/HTML/canvas-background-with-restyled-body-behind-unstyled-body.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script>
+    addEventListener("load", () => {
+        const renderedBody = document.body;
+        document.documentElement.insertBefore(document.createElement("body"), renderedBody);
+        renderedBody.style.background = "red";
+    });
+</script>

--- a/Tests/LibWeb/Crash/HTML/canvas-background-with-unstyled-body.html
+++ b/Tests/LibWeb/Crash/HTML/canvas-background-with-unstyled-body.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<script>
+    addEventListener("load", () => {
+        document.documentElement.insertBefore(document.createElement("body"), document.body);
+        document.createElement("img").x;
+    });
+</script>


### PR DESCRIPTION
Deciding whether the body background propagates to the canvas crashed when a `<body>` inserted ahead of the rendered one had not been styled yet, because containment was read from the computed style of the `<html>` and `<body>` elements. We now take it from the boxes those elements generate, so an element without a box contributes no containment, and a `<body>` without a box propagates nothing.

In a run of 10,000 Domato cases this fixes 7 / 26 crashes.

