### PR TITLE
Let a replaced page take its pending rAF and idle callbacks with it, as Gecko/WebKit/Blink do

### DIFF
--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -203,7 +203,9 @@ WebIDL::ExceptionOr<WebIDL::UnsignedLong> request_animation_frame(HTML::Dedicate
 
 WebIDL::UnsignedLong request_idle_callback(HTML::Window& window, WebIDL::CallbackType& callback, IdleRequestOptions const& options)
 {
-    auto handler = [callback = GC::make_root(callback)](GC::Ref<RequestIdleCallback::IdleDeadline> deadline) -> JS::Completion {
+    // NB: A plain GC reference rather than a GC::Root, for the same reason as in request_animation_frame() above: the
+    //     window's idle callback lists trace the handler, so the callback lives exactly as long as the window's document.
+    auto handler = [callback = GC::Ref { callback }](GC::Ref<RequestIdleCallback::IdleDeadline> deadline) -> JS::Completion {
         auto& callback_realm = callback->callback->shape().realm();
         return WebIDL::invoke_callback(*callback, {}, { { wrap(host_defined_wrapper_world(callback_realm), callback_realm, deadline) } });
     };
@@ -258,26 +260,40 @@ void run_animation_frame_callbacks(DOM::Document& document, double now)
     document.window()->animation_frame_callback_driver().run(now);
 }
 
-class IdleCallback : public RefCounted<IdleCallback> {
+// NB: A GC cell, so that the window's two idle callback lists trace the handler, and with it the WebIDL callback the
+//     handler captures, for exactly as long as the window holds the callback.
+class IdleCallback final : public JS::Cell {
+    GC_CELL(IdleCallback, JS::Cell);
+    GC_DECLARE_ALLOCATOR(IdleCallback);
+
 public:
-    explicit IdleCallback(IdleCallbackHandler handler, u32 handle)
-        : m_handler(move(handler))
+    using Handler = GC::Ref<GC::Function<JS::Completion(GC::Ref<RequestIdleCallback::IdleDeadline>)>>;
+
+    IdleCallback(Handler handler, u32 handle)
+        : m_handler(handler)
         , m_handle(handle)
     {
     }
-    ~IdleCallback() = default;
 
-    JS::Completion invoke(GC::Ref<RequestIdleCallback::IdleDeadline> deadline) { return m_handler(deadline); }
+    JS::Completion invoke(GC::Ref<RequestIdleCallback::IdleDeadline> deadline) { return m_handler->function()(deadline); }
     u32 handle() const { return m_handle; }
     Optional<i32> timeout_timer_id() const { return m_timeout_timer_id; }
     void set_timeout_timer_id(i32 timeout_timer_id) { m_timeout_timer_id = timeout_timer_id; }
     void clear_timeout_timer_id() { m_timeout_timer_id.clear(); }
 
 private:
-    IdleCallbackHandler m_handler;
+    virtual void visit_edges(Cell::Visitor& visitor) override
+    {
+        Base::visit_edges(visitor);
+        visitor.visit(m_handler);
+    }
+
+    Handler m_handler;
     u32 m_handle { 0 };
     Optional<i32> m_timeout_timer_id;
 };
+
+GC_DEFINE_ALLOCATOR(IdleCallback);
 
 GC::Ref<Window> Window::create()
 {
@@ -321,6 +337,8 @@ void Window::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_navigator);
     visitor.visit(m_navigation);
     visitor.visit(m_animation_frame_callback_driver);
+    visitor.visit(m_idle_request_callbacks);
+    visitor.visit(m_runnable_idle_callbacks);
     visitor.visit(m_pdf_viewer_plugin_objects);
     visitor.visit(m_pdf_viewer_mime_type_objects);
     visitor.visit(m_close_watcher_manager);
@@ -2036,7 +2054,7 @@ u32 Window::request_idle_callback(IdleCallbackHandler callback, IdleRequestOptio
     auto handle = m_idle_callback_identifier;
 
     // 4. Push callback to the end of window's list of idle request callbacks, associated with handle.
-    auto idle_callback = adopt_ref(*new IdleCallback(move(callback), handle));
+    auto idle_callback = GC::Heap::the().allocate<IdleCallback>(GC::create_function(GC::Heap::the(), move(callback)), handle);
     m_idle_request_callbacks.set(handle, idle_callback);
 
     // 5. Return handle and then continue running this algorithm asynchronously.

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -183,7 +183,11 @@ JS::ThrowCompletionOr<void> post_message_with_options(JS::Realm& realm, HTML::Wi
 
 WebIDL::UnsignedLong request_animation_frame(HTML::Window& window, WebIDL::CallbackType& callback)
 {
-    auto handler = [callback = GC::make_root(callback)](double now) {
+    // NB: The handler captures the callback as a plain GC reference, not a GC::Root: the driver that stores the
+    //     handler belongs to the window, so the callback lives exactly as long as the window's document. A root here
+    //     would keep a callback that never runs (a hidden document gets no animation frames) alive for the life of
+    //     the process, and with it the window, its document, and everything the document holds.
+    auto handler = [callback = GC::Ref { callback }](double now) {
         auto& callback_realm = callback->callback->shape().realm();
         auto result = WebIDL::invoke_callback(*callback, {}, { { JS::Value(now) } });
         if (result.is_error())

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -13,7 +13,6 @@
 #include <AK/HashMap.h>
 #include <AK/IterationDecision.h>
 #include <AK/Optional.h>
-#include <AK/RefPtr.h>
 #include <AK/Variant.h>
 #include <LibGC/Heap.h>
 #include <LibJS/Forward.h>
@@ -359,9 +358,9 @@ private:
     // NB: Both lists are keyed by handle — so a timeout or cancelIdleCallback() finds its callback without walking past
     //     every other pending one — and ordered, so an idle period still runs them first-in first-out.
     // https://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks
-    OrderedHashMap<u32, NonnullRefPtr<IdleCallback>> m_idle_request_callbacks;
+    OrderedHashMap<u32, GC::Ref<IdleCallback>> m_idle_request_callbacks;
     // https://w3c.github.io/requestidlecallback/#dfn-list-of-runnable-idle-callbacks
-    OrderedHashMap<u32, NonnullRefPtr<IdleCallback>> m_runnable_idle_callbacks;
+    OrderedHashMap<u32, GC::Ref<IdleCallback>> m_runnable_idle_callbacks;
     // https://w3c.github.io/requestidlecallback/#dfn-idle-callback-identifier
     u32 m_idle_callback_identifier = 0;
 

--- a/Tests/LibWeb/Text/expected/HTML/replaced-hidden-document-with-pending-animation-frame-is-collectable.txt
+++ b/Tests/LibWeb/Text/expected/HTML/replaced-hidden-document-with-pending-animation-frame-is-collectable.txt
@@ -1,0 +1,1 @@
+collected 5 of 5 replaced documents

--- a/Tests/LibWeb/Text/expected/HTML/replaced-hidden-document-with-pending-idle-callback-is-collectable.txt
+++ b/Tests/LibWeb/Text/expected/HTML/replaced-hidden-document-with-pending-idle-callback-is-collectable.txt
@@ -1,0 +1,1 @@
+collected 5 of 5 replaced documents

--- a/Tests/LibWeb/Text/input/HTML/replaced-hidden-document-with-pending-animation-frame-is-collectable.html
+++ b/Tests/LibWeb/Text/input/HTML/replaced-hidden-document-with-pending-animation-frame-is-collectable.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // A hidden document gets no animation frames, so a requestAnimationFrame() callback it registers never runs. If
+    // the document is then navigated away, that pending callback must not keep the document alive: the callback's
+    // driver belongs to the window, and both go away with the document. Reload a hidden document a few times and
+    // check that every replaced document gets collected.
+    promiseTest(async () => {
+        internals.setSystemVisibilityState("hidden");
+        internals.setHiddenDocumentTimerWakeUpInterval(1);
+
+        const iframe = document.createElement("iframe");
+        document.body.append(iframe);
+
+        const navigate = i =>
+            new Promise(resolve => {
+                iframe.addEventListener("load", resolve, { once: true });
+                iframe.srcdoc = `<!DOCTYPE html><script>requestAnimationFrame(() => {});<\/script><p>${i}</p>`;
+            });
+
+        // Record each document, then navigate away from it. An expando preserves the document's wrapper for as long as
+        // the document itself lives, so the weak reference tracks the document rather than a wrapper that JS may drop
+        // early. The recording starts with the second document: the first one reuses the initial about:blank document's
+        // window, whose realm the navigable's WindowProxy keeps alive for as long as the iframe lives. And the recording
+        // runs in a nested function, so that no document lingers in a register of this function's frame while the
+        // documents are expected to be collected.
+        const weakDocuments = await (async () => {
+            const weakDocuments = [];
+            await navigate(0);
+            await navigate(1);
+            for (let i = 2; i <= 6; i++) {
+                const replacedDocument = iframe.contentDocument;
+                replacedDocument.preserveWrapper = true;
+                weakDocuments.push(new WeakRef(replacedDocument));
+                await navigate(i);
+            }
+            return weakDocuments;
+        })();
+
+        const maximumGcRoundsWhileTeardownTasksDrain = 100;
+        for (let round = 0; round < maximumGcRoundsWhileTeardownTasksDrain; ++round) {
+            await timeout(0);
+            await internals.gcAsync();
+            if (weakDocuments.every(weak => weak.deref() === undefined))
+                break;
+        }
+
+        const collected = weakDocuments.filter(weak => weak.deref() === undefined).length;
+        println(`collected ${collected} of ${weakDocuments.length} replaced documents`);
+        iframe.remove();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/replaced-hidden-document-with-pending-idle-callback-is-collectable.html
+++ b/Tests/LibWeb/Text/input/HTML/replaced-hidden-document-with-pending-idle-callback-is-collectable.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // A hidden document gets no idle periods, so a requestIdleCallback() callback it registers never runs. If the
+    // document is then navigated away, that pending callback must not keep the document alive: the window's list of
+    // idle request callbacks goes away with the document. Reload a hidden document a few times and check that every
+    // replaced document gets collected.
+    promiseTest(async () => {
+        internals.setSystemVisibilityState("hidden");
+        internals.setHiddenDocumentTimerWakeUpInterval(1);
+
+        const iframe = document.createElement("iframe");
+        document.body.append(iframe);
+
+        const navigate = i =>
+            new Promise(resolve => {
+                iframe.addEventListener("load", resolve, { once: true });
+                iframe.srcdoc = `<!DOCTYPE html><script>requestIdleCallback(() => {});<\/script><p>${i}</p>`;
+            });
+
+        // Record each document, then navigate away from it. An expando preserves the document's wrapper for as long as
+        // the document itself lives, so the weak reference tracks the document rather than a wrapper that JS may drop
+        // early. The recording starts with the second document: the first one reuses the initial about:blank document's
+        // window, whose realm the navigable's WindowProxy keeps alive for as long as the iframe lives. And the recording
+        // runs in a nested function, so that no document lingers in a register of this function's frame while the
+        // documents are expected to be collected.
+        const weakDocuments = await (async () => {
+            const weakDocuments = [];
+            await navigate(0);
+            await navigate(1);
+            for (let i = 2; i <= 6; i++) {
+                const replacedDocument = iframe.contentDocument;
+                replacedDocument.preserveWrapper = true;
+                weakDocuments.push(new WeakRef(replacedDocument));
+                await navigate(i);
+            }
+            return weakDocuments;
+        })();
+
+        const maximumGcRoundsWhileTeardownTasksDrain = 100;
+        for (let round = 0; round < maximumGcRoundsWhileTeardownTasksDrain; ++round) {
+            await timeout(0);
+            await internals.gcAsync();
+            if (weakDocuments.every(weak => weak.deref() === undefined))
+                break;
+        }
+
+        const collected = weakDocuments.filter(weak => weak.deref() === undefined).length;
+        println(`collected ${collected} of ${weakDocuments.length} replaced documents`);
+        iframe.remove();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable-while-next-load-is-stalled.html
+++ b/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable-while-next-load-is-stalled.html
@@ -16,6 +16,11 @@
             body: "",
             wait_for_unblock: token,
         });
+        const zerothURL = await server.createEcho("GET", `/stalled-load-zeroth-${runId}`, {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: "<!DOCTYPE html><p>zeroth</p>",
+        });
         const firstURL = await server.createEcho("GET", `/stalled-load-first-${runId}`, {
             status: 200,
             headers: { "Content-Type": "text/html" },
@@ -34,14 +39,24 @@
         const iframe = document.createElement("iframe");
         document.body.append(iframe);
 
-        // The first document is recorded in a nested function, so that it doesn't linger in a register of this
-        // function's frame while it's expected to be collected.
-        const weakFirstDocument = await (async () => {
-            await new Promise(resolve => {
+        const navigate = url =>
+            new Promise(resolve => {
                 iframe.addEventListener("load", resolve, { once: true });
-                iframe.src = firstURL;
+                iframe.src = url;
             });
-            return new WeakRef(iframe.contentDocument);
+
+        // The first document is recorded in a nested function, so that it doesn't linger in a register of this
+        // function's frame while it's expected to be collected. An expando preserves its wrapper for as long as the
+        // document itself lives, so the weak reference tracks the document rather than a wrapper that JS may drop
+        // early. And a zeroth document goes before it: the document that replaces the initial about:blank document
+        // reuses that document's window, whose realm the navigable's WindowProxy keeps alive for as long as the
+        // iframe lives.
+        const weakFirstDocument = await (async () => {
+            await navigate(zerothURL);
+            await navigate(firstURL);
+            const firstDocument = iframe.contentDocument;
+            firstDocument.preserveWrapper = true;
+            return new WeakRef(firstDocument);
         })();
 
         // The second document's body has been read to its end once DOMContentLoaded fires in it, while its load event

--- a/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable.html
+++ b/Tests/LibWeb/Text/input/navigation/replaced-document-is-collectable.html
@@ -22,13 +22,20 @@
                 iframe.src = url;
             });
 
-        // Record each document, then navigate away from it. The recording runs in a nested function — so that no
-        // document lingers in a register of this function's frame while the documents are expected to be collected.
+        // Record each document, then navigate away from it. An expando preserves the document's wrapper for as long as
+        // the document itself lives, so the weak reference tracks the document rather than a wrapper that JS may drop
+        // early. The recording starts with the second document: the first one reuses the initial about:blank document's
+        // window, whose realm the navigable's WindowProxy keeps alive for as long as the iframe lives. And the recording
+        // runs in a nested function, so that no document lingers in a register of this function's frame while the
+        // documents are expected to be collected.
         const weakDocuments = await (async () => {
             const weakDocuments = [];
             await navigate(`${url}?0`);
-            for (let i = 1; i <= 5; i++) {
-                weakDocuments.push(new WeakRef(iframe.contentDocument));
+            await navigate(`${url}?1`);
+            for (let i = 2; i <= 6; i++) {
+                const replacedDocument = iframe.contentDocument;
+                replacedDocument.preserveWrapper = true;
+                weakDocuments.push(new WeakRef(replacedDocument));
                 await navigate(`${url}?${i}`);
             }
             return weakDocuments;


### PR DESCRIPTION
Even after #11645, any page that reloads itself in a background tab grew without bound: Every reload kept the previous document alive — its window, its realm, its compiled scripts, its image data.

https://english.elpais.com reloads every 11 minutes and https://politico.com every 5; after 20 hours, the elpais tab held 2,736 realms and a 15 GB footprint (10 GB of it Metal surfaces), and the politico tab reached 11 GB in four hours. GC reclaimed none of it.

The `requestAnimationFrame()` and `requestIdleCallback()` bindings each wrapped their callback in a `GC::Root` that lived until the callback ran. But a hidden page gets no animation frames and no idle periods — so a callback registered in a background tab never ran, and the next reload destroyed its document without running it either. The root then pinned the callback, its settings object, the old window, its document, and everything the document held: every `SharedResourceRequest`, each SVG image’s private page and realm, and every script the realm had compiled.

So, two fixes — both modeled on how Gecko, WebKit, and Blink avoid the same leak:

- **A pending `requestAnimationFrame()` callback is now a plain `GC::Ref` capture again** — which the window’s animation-frame callback driver traces as an edge. So the callback lives exactly as long as the window’s document, and a pending callback on a replaced document is collected with it. (4be9c6d3ccf introduced the root when it moved the entry point into the bindings layer.)

   That’s how the other engines work: Blink, WebKit, and Gecko all keep pending frame callbacks as traced members of the document’s animation controller (Blink’s `FrameRequestCallbackCollection`, WebKit’s `ScriptedAnimationController`, Gecko’s `FrameRequestManager`). So a document takes its pending callbacks with it.

- **A pending `requestIdleCallback()` callback is now held by a GC cell the window traces:** `IdleCallback` owns its handler as a `GC::Function` and visits it, the window’s two idle-callback lists hold GC refs the window visits, and the binding captures the callback as a `GC::Ref`.

   That matches the other engines too: Blink’s `ScriptedIdleTaskController` traces its pending idle tasks and drops them when the context is destroyed, WebKit’s `IdleCallbackController` is owned by the document and dies with it, and Gecko’s window keeps its idle requests in a cycle-collected list that it empties at teardown.
