### PR TITLE
LibGfx: Enable dynamic MSAA for GPU painting surfaces

### DIFF
--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -15,6 +15,7 @@
 #include <core/SkPaint.h>
 #include <core/SkRect.h>
 #include <core/SkSurface.h>
+#include <core/SkSurfaceProps.h>
 #include <gpu/ganesh/GrBackendSurface.h>
 #include <gpu/ganesh/GrDirectContext.h>
 #include <gpu/ganesh/SkSurfaceGanesh.h>
@@ -133,7 +134,10 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(IntSize size, B
     auto image_info = SkImageInfo::Make(size.width(), size.height(), sk_color_type, sk_alpha_type, SkColorSpace::MakeSRGB());
 
     if (context) {
-        auto surface = SkSurfaces::RenderTarget(context->sk_context(), skgpu::Budgeted::kNo, image_info);
+        // NB: Dynamic MSAA lets Skia render complex antialiased paths on the GPU instead of
+        //     rasterizing coverage masks on the CPU and uploading them as textures.
+        SkSurfaceProps surface_properties { SkSurfaceProps::kDynamicMSAA_Flag, kUnknown_SkPixelGeometry };
+        auto surface = SkSurfaces::RenderTarget(context->sk_context(), skgpu::Budgeted::kNo, image_info, 0, &surface_properties);
         if (surface)
             return adopt_ref(*new PaintingSurface(make<Impl>(context, size, surface, nullptr)));
         dbgln("Unable to create GPU surface for size {}x{}, falling back to CPU", size.width(), size.height());

--- a/Tests/LibWeb/Text/expected/canvas/path2d-complex-fill.txt
+++ b/Tests/LibWeb/Text/expected/canvas/path2d-complex-fill.txt
@@ -1,0 +1,11 @@
+nonzero center: 255,0,0,255
+nonzero arm: 255,0,0,255
+nonzero outside: 0,0,0,0
+evenodd center: 0,0,0,0
+evenodd arm: 0,255,0,255
+copied arm: 0,255,0,255
+preserved center: 255,0,0,255
+rectangle: 255,255,0,255
+clipped center: 0,0,0,0
+clipped arm: 0,0,255,255
+clipped outside: 0,0,0,0

--- a/Tests/LibWeb/Text/input/canvas/path2d-complex-fill.html
+++ b/Tests/LibWeb/Text/input/canvas/path2d-complex-fill.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 200;
+        canvas.height = 100;
+        const context = canvas.getContext("2d");
+
+        // Trace a self-intersecting star repeatedly to exercise complex path rendering.
+        const path = new Path2D();
+        path.moveTo(50, 0);
+        for (let i = 0; i < 21; ++i) {
+            path.lineTo(80, 90);
+            path.lineTo(0, 35);
+            path.lineTo(100, 35);
+            path.lineTo(20, 90);
+            path.lineTo(50, 0);
+        }
+        path.closePath();
+
+        function pixel(label, x, y) {
+            println(`${label}: ${context.getImageData(x, y, 1, 1).data}`);
+        }
+
+        context.fillStyle = "red";
+        context.fill(path, "nonzero");
+        context.save();
+        context.translate(100, 0);
+        context.fillStyle = "lime";
+        context.fill(path, "evenodd");
+        context.restore();
+
+        pixel("nonzero center", 50, 50);
+        pixel("nonzero arm", 50, 20);
+        pixel("nonzero outside", 5, 5);
+        pixel("evenodd center", 150, 50);
+        pixel("evenodd arm", 150, 20);
+
+        // Interleave a path draw, a canvas copy, and a rectangle after readback.
+        const copy = document.createElement("canvas");
+        copy.width = canvas.width;
+        copy.height = canvas.height;
+        copy.getContext("2d").drawImage(canvas, 0, 0);
+        context.fillStyle = "blue";
+        context.fill(path, "evenodd");
+        context.drawImage(copy, 100, 0, 100, 100, 0, 0, 100, 100);
+        context.fillStyle = "yellow";
+        context.fillRect(0, 0, 10, 10);
+
+        pixel("copied arm", 50, 20);
+        pixel("preserved center", 50, 50);
+        pixel("rectangle", 5, 5);
+
+        // Reuse the path as a clip and paint through its even-odd hole.
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        context.save();
+        context.clip(path, "evenodd");
+        context.fillStyle = "blue";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+        context.restore();
+        pixel("clipped center", 50, 50);
+        pixel("clipped arm", 50, 20);
+        pixel("clipped outside", 5, 5);
+    });
+</script>


### PR DESCRIPTION
Allow Skia to use GPU path renderers for complex antialiased paths. Without dynamic MSAA, these fills fall back to CPU coverage masks that must be uploaded as textures, making repeated Path2D fills expensive.

Enable dynamic MSAA when creating GPU render targets so Skia can select multisampling when needed. Add coverage for complex self-intersecting paths with both fill rules, clipping, readback, and interleaved canvas copies and rectangle draws.