### PR TITLE
AK+LibGC: Keep freed memory mapped on Linux until the kernel needs it

### DIFF
--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Platform.h>
 #include <AK/kmalloc.h>
 
 #if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
@@ -57,6 +58,16 @@ void ak_kmalloc_collect()
 }
 
 #else
+
+#    ifdef AK_OS_LINUX
+static struct MimallocConfiguration {
+    MimallocConfiguration()
+    {
+        // mimalloc otherwise purges with MADV_DONTNEED, and every later reuse of a purged page takes a page fault.
+        mi_option_set_default(mi_option_purge_decommits, 0);
+    }
+} s_mimalloc_configuration;
+#    endif
 
 void* ak_kcalloc(size_t count, size_t size)
 {

--- a/Libraries/LibGC/BlockAllocator.cpp
+++ b/Libraries/LibGC/BlockAllocator.cpp
@@ -125,17 +125,15 @@ static void madvise_block_for_decommit(void* block)
         perror("madvise(MADV_FREE_REUSABLE)");
         VERIFY_NOT_REACHED();
     }
-#elif defined(MADV_DONTNEED)
-    // Prefer DONTNEED over FREE on Linux: FREE is lazy and only releases pages
-    // under memory pressure, which leaves freed blocks counted in RSS for
-    // arbitrarily long after a busy page goes idle.
-    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_DONTNEED) < 0) {
-        perror("madvise(MADV_DONTNEED)");
-        VERIFY_NOT_REACHED();
-    }
 #elif defined(MADV_FREE)
+    // MADV_FREE keeps the pages mapped until the kernel needs them, so a block reused before then takes no page fault.
     if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE) < 0) {
         perror("madvise(MADV_FREE)");
+        VERIFY_NOT_REACHED();
+    }
+#elif defined(MADV_DONTNEED)
+    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_DONTNEED) < 0) {
+        perror("madvise(MADV_DONTNEED)");
         VERIFY_NOT_REACHED();
     }
 #endif


### PR DESCRIPTION
Since #11645 fixed a large document object leak, the JavaScript heap stays small and the collector runs several times more often. On Linux each collection handed the freed memory back to the kernel with `MADV_DONTNEED`, so the next allocation burst refaulted and zero-filled it, which showed up as a 6.7% Speedometer3 and 3.4% Speedometer2 drop on the Linux benchmark runner while macOS was flat. Both the LibGC block allocator and mimalloc now release pages with MADV_FREE, which keeps them mapped until the kernel actually needs the memory, matching what macOS already does with MADV_FREE_REUSABLE.

Locally on Linux this measures as a 6.6% reduction in Speedometer3 time and 4.8% in Speedometer2 over `master,` with no suite regressing. I also tested on macOS, which is unaffected. 

| Benchmark | Old score | New score | Score change | Old time (s) | New time (s) | Speedup |
|---|---|---|---|---|---|---|
| Speedometer 2 | 80.04 ± 0.51 | 84.93 ± 0.33 | +6.12% | 6.551 ± 0.034 | 6.243 ± 0.019 | 1.049× |
| Speedometer 3 | 5.12 ± 0.05 | 5.45 ± 0.04 | +6.42% | 4.903 ± 0.036 | 4.603 ± 0.028 | 1.065× |

Reported RSS is higher under load since reclaimable pages stay counted until the kernel takes them, but memory actually in use is unchanged.

| Metric | Before (MiB) | After (MiB) |
|---|---|---|
| RSS, median | 1501 | 2076 |
| RSS, 90th percentile | 2224 | 2486 |
| RSS, peak | 2545 | 2487 |
| LazyFree, median | 0 | 365 |
| LazyFree, peak | 0 | 807 |
| RSS minus LazyFree, median | 1501 | 1446 |
| RSS minus LazyFree, 90th percentile | 2224 | 1862 |
| RSS minus LazyFree, peak | 2545 | 2199 |

LazyFree is the kernel's count of `MADV_FREE` pages it has not yet reclaimed. RSS minus LazyFree is the memory the process is actually using.


