### PR TITLE
LibGC: Scrub the stack below the collector before gathering roots (similar to what JSC does)

### DIFF
--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -14,6 +14,7 @@
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/LexicalPath.h>
+#include <AK/Memory.h>
 #include <AK/NeverDestroyed.h>
 #include <AK/NumberFormat.h>
 #include <AK/Platform.h>
@@ -554,6 +555,14 @@ private:
 
 AK::JsonObject Heap::dump_graph()
 {
+    // A dump gathers roots exactly like a collection does — so it starts from a scrubbed stack too. Otherwise, it would
+    // report the stale pointers in its own frames as StackPointer roots.
+    scrub_stack_below_current_frame(m_stack_info);
+    return dump_graph_impl();
+}
+
+AK::JsonObject Heap::dump_graph_impl()
+{
     // An in-progress incremental sweep would leave parts of the heap as freelist
     // entries while the conservative scan in gather_roots() can still pick up
     // not-yet-swept (but unreachable) cells whose internal pointers lead to
@@ -615,7 +624,35 @@ void Heap::run_post_mark_phases(bool report)
     }
 }
 
+// The conservative scan treats every pointer-sized value in the live stack frames as a possible cell pointer, and the
+// collector's own frames are live frames too. Their slots that nothing has written yet — padding, register spills,
+// sanitizer redzones — hold whatever earlier code left at those addresses: the interpreter's locals, or the marking
+// state of the previous collection. A stale pointer to a dead cell there keeps the cell — and everything reachable from
+// it — alive for another cycle. And a collection that runs from the same stack depth as the last one (the idle timer,
+// a test's gcAsync() task) meets the same residue every time. So the same garbage can stay pinned for good.
+//
+// So a collection starts by zeroing the region its own frames are about to occupy. Only the frames that gather the
+// roots are ever scanned; marking and sweeping run after the scan — so 64 KiB covers them with room to spare, and
+// zeroing it costs a few microseconds against a collection's milliseconds. The caller's frames above can't be cleaned,
+// but they hold the caller's state, not the collector's.
+//
+// JSC does the same in sanitizeStackForVM() before a collection phase runs on the mutator thread.
+static constexpr size_t stack_scrub_size = 64 * KiB;
+
+NO_SANITIZE_ADDRESS NEVER_INLINE void Heap::scrub_stack_below_current_frame(StackInfo const& stack_info)
+{
+    auto bytes = min(stack_scrub_size, stack_info.size_free() / 4);
+    auto* region = static_cast<u8*>(__builtin_alloca(bytes));
+    secure_zero(region, bytes);
+}
+
 void Heap::collect_garbage(CollectionType collection_type, bool print_report)
+{
+    scrub_stack_below_current_frame(m_stack_info);
+    collect_garbage_impl(collection_type, print_report);
+}
+
+void Heap::collect_garbage_impl(CollectionType collection_type, bool print_report)
 {
     VERIFY(!m_collecting_garbage);
 

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -169,6 +169,9 @@ private:
         Yes,
     };
     void gather_roots(HashMap<Cell*, HeapRoot>&, Vector<StackFrameInfo>* out_stack_frames = nullptr, IncludeIncomingCrossHeapMembers = IncludeIncomingCrossHeapMembers::Yes);
+    static void scrub_stack_below_current_frame(StackInfo const&);
+    NEVER_INLINE void collect_garbage_impl(CollectionType, bool print_report);
+    NEVER_INLINE AK::JsonObject dump_graph_impl();
     static void mark_live_cells_across(ReadonlySpan<Heap* const>, HashMap<Cell*, HeapRoot> const& roots);
     void run_post_mark_phases(bool report);
     void gather_conservative_roots(HashMap<Cell*, HeapRoot>&, Vector<StackFrameInfo>* out_stack_frames = nullptr);

--- a/Libraries/LibGC/HeapGroup.cpp
+++ b/Libraries/LibGC/HeapGroup.cpp
@@ -33,6 +33,14 @@ void HeapGroup::remove(Heap& heap)
 
 void HeapGroup::collect_garbage(bool print_report)
 {
+    if (m_heaps.is_empty())
+        return;
+    Heap::scrub_stack_below_current_frame(m_heaps.first()->m_stack_info);
+    collect_garbage_impl(print_report);
+}
+
+void HeapGroup::collect_garbage_impl(bool print_report)
+{
     // Defer all member heaps' collections until the last one, so that cross-heap edges are visible to the mark phase.
     for (auto* heap : m_heaps) {
         VERIFY(!heap->m_collecting_garbage);

--- a/Libraries/LibGC/HeapGroup.h
+++ b/Libraries/LibGC/HeapGroup.h
@@ -26,6 +26,8 @@ public:
     void collect_garbage(bool print_report = false);
 
 private:
+    NEVER_INLINE void collect_garbage_impl(bool print_report);
+
     Vector<Heap*> m_heaps;
 };
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,6 +1,7 @@
 [LoadFromHttpServer]
 Text/input/css/font-cache-first-paint.html
 Text/input/css/font-display-timeline.html
+Text/input/css/unused-font-document-collectable.html
 Text/input/css/canvas-font-display.html
 Ref/input/font-display-periods.html
 Ref/expected/font-display-periods-ref.html

--- a/Tests/LibWeb/Text/expected/css/unused-font-document-collectable.txt
+++ b/Tests/LibWeb/Text/expected/css/unused-font-document-collectable.txt
@@ -1,0 +1,3 @@
+unused face status: unloaded
+removed document collected: true
+unused face collected: true

--- a/Tests/LibWeb/Text/input/css/unused-font-document-collectable.html
+++ b/Tests/LibWeb/Text/input/css/unused-font-document-collectable.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+promiseTest(async () => {
+    const fontBytes = await (await fetch("../../../Assets/HashSans.woff")).arrayBuffer();
+    async function makeRemovedDocument() {
+        const iframe = document.createElement("iframe");
+        const loaded = new Promise(resolve => iframe.onload = resolve);
+        iframe.srcdoc = `<!DOCTYPE html>
+            <style>
+                @font-face { font-family: Unused; src: url("data:font/woff;base64,AA=="); }
+                body { font: 20px monospace; }
+            </style>
+            <body>AAAA`;
+        document.body.append(iframe);
+        await loaded;
+        iframe.onload = null;
+        const preferred = new iframe.contentWindow.FontFace("Preferred", fontBytes);
+        await preferred.load();
+        iframe.contentDocument.fonts.add(preferred);
+        iframe.contentDocument.body.style.fontFamily = "Preferred, Unused, monospace";
+        // Populate the document-owned cascade while the first family covers every character.
+        iframe.contentDocument.body.getBoundingClientRect();
+        const face = [...iframe.contentDocument.fonts][0];
+        println(`unused face status: ${face.status}`);
+        // Preserve the wrappers so collection checks the native objects, not just disposable JS wrappers.
+        iframe.contentDocument.gcSentinel = true;
+        face.gcSentinel = true;
+        const weakDocument = new WeakRef(iframe.contentDocument);
+        const weakFace = new WeakRef(face);
+        iframe.remove();
+        // Release the parent's layout references to the removed iframe before collecting it.
+        document.body.getBoundingClientRect();
+        return { weakDocument, weakFace };
+    }
+    const { weakDocument, weakFace } = await makeRemovedDocument();
+    // Collect outside the creating JS job, after its locals and WeakRef kept-alive objects are released.
+    const maximumGcRoundsWhileIframeTeardownTasksDrain = 100;
+    for (let round = 0; round < maximumGcRoundsWhileIframeTeardownTasksDrain; ++round) {
+        await timeout(0);
+        await internals.gcAsync();
+        if (weakDocument.deref() === undefined && weakFace.deref() === undefined)
+            break;
+    }
+    println(`removed document collected: ${weakDocument.deref() === undefined}`);
+    println(`unused face collected: ${weakFace.deref() === undefined}`);
+});
+</script>


### PR DESCRIPTION
5dab6a4a75f removed the `css/unused-font-document-collectable.html` test as depending on nondeterministic iframe teardown and GC scheduling. It didn’t: The removed document stayed pinned by stale pointers in the collector’s own stack frames. The first commit here fixes that — by scrubbing those before gathering roots, similar to what JSC does. And the second commit restores the test — which, with the first commit in place, collects both objects in its 1st round, on both Release and Sanitizer builds.

**Problem:** The `css/unused-font-document-collectable.html` test failed on the Linux x86_64 Release GNU CI job in 9 of 21 runs across six branches. And on a macOS Sanitizer build, it failed 17 of 20 sequential runs — always with both of its “collected” lines reading false — no matter how many of its 100 GC rounds ran. 5dab6a4a75f removed the test as depending on nondeterministic iframe teardown and GC scheduling. Outside the test, the same mechanism keeps a page’s dead document, and everything reachable from it, alive across collections.

**Cause:** `gather_conservative_roots` scans every pointer-sized value from its own frame up to the base of the stack and treats each one that lands in a live cell as a root. `gather_conservative_roots`, `collect_garbage`, and `gather_roots` frames lie in that range too — and the slots in them nothing had written by the scan time (padding/register spills/sanitizer redzones) still held whatever earlier code left at those addresses: the interpreter’s locals from the preceding task, the previous collection’s own marking state. A graph dump taken inside a failing run’s collection showed the removed `srcdoc` doc reachable from one root: a `StackPointer` root in `collect_garbage`’s own frame, pointing at the iframe’s `Window`. And since every `internals.gcAsync` round ran the collection from the same event-loop depth, the same slot carried the same stale pointer in every round. So no number of rounds could help. Which cell the residue points at depends on the frame layout, so on the compiler and the build type — which is why the GNU job failed while the Clang jobs kept passing.

**Fix:** `collect_garbage` and `dump_graph` become thin wrappers that zero the 64KiB of stack below their frame (clamped to ¼ of what’s free) and then call `NEVER_INLINE` impls. So the frames that gather the roots start out clean. Only those frames are ever scanned — marking+sweeping run after the scan — so 64KiB covers them with room to spare, and zeroing it costs microseconds against a collection’s milliseconds. The caller’s frames above the collector can’t be cleaned, but they hold the caller’s state, not the collector’s residue. `HeapGroup::collect_garbage` gets the same.

JSC does the same in `sanitizeStackForVM()` before a collection phase runs on the mutator thread — which is what this was modeled on.

### Performance impact

Measured with the local A/B harness (web-benchmarks `bench_pr.py`): the branch (bfdd4fe739f) against its merge-base (5dab6a4a75f), both built with the Distribution preset (ThinLTO), interleaved suite by suite over 8 paired rounds across all ten suites, on macOS and on Linux.

**Result: performance neutral.** 778 of 779 tests are neutral on both platforms. Each platform flags one test, a different one on each, and both flags are binary-layout artifacts rather than anything the scrub does (see below).

| Platform | Neutral | Mover | Base | Head | Change | q | Resolution (typical / noisiest tenth) |
|---|---:|---|---:|---:|---:|---:|---|
| macOS (Mac17,7, AppleClang 21) | 778 | `WebKitCSS/CSSPropertyUpdateValue` | 15.57 ms | 15.96 ms | 2.5% slower | 0.04 | ±3.4% / ±6.4% |
| Linux (arm64 VM, Clang 21.1.8) | 778 | `MicroWeb/dom/dataset-access` | 5.46 ms | 4.66 ms | 17.1% faster | 0.004 | ±5.0% / ±12.5% |

**Why both movers are layout, not the change:**

- **Each mover is flat on the other platform.** `CSSPropertyUpdateValue` on Linux: head/base between 1.00 and 1.02 in every round, not flagged. `dataset-access` on macOS: 4.2 ms in both arms, ratio 1.00.
- **A build that does no scrubbing shows the same slowdown.** A diagnostic head build with the scrub size set to 0 (same wrappers and `NEVER_INLINE` split, no zeroing) reproduces the macOS mover exactly: over 15 rounds of WebKitCSS alone, `CSSPropertyUpdateValue` is 2.6% slower (q reported as 0.0000), and `CSSPropertySetterGetter` 3.5% slower. So the zeroing isn’t what moves the test; the binary is.
- **The changed code barely runs inside the measured window.** With per-collection GC reports on (`LIBGC_LOG_LEVEL=1`), exactly one collection runs during `CSSPropertyUpdateValue` in either arm (nine in the whole WebKitCSS suite). Its conservative stack scan takes 3 to 4 µs and the whole collection 1 to 2 ms, once per test — so a 64 KiB memset once per test can’t produce the 0.4 ms per run that the mover shows.

Both movers are consistent, significant, and platform-specific — the signature of code-layout and alignment shifts in a ThinLTO binary once a function is split, not of a runtime cost.

<details>
<summary>Run details</summary>

- Baseline 5dab6a4a75f (the merge-base), branch bfdd4fe739f, web-benchmarks 72c6b8f. 8 kept rounds plus a discarded warmup; the two arms interleaved per suite, with the order flipped per suite and per round; one iteration per launch; a paired log-ratio t-test with Benjamini-Hochberg correction over all 779 tests (a mover is q < 0.05, at least 1%, and at least 0.2 ms).
- macOS: Mac17,7, 18 cores, macOS 27.0; Distribution preset, AppleClang 21.0.0, ThinLTO; A-vs-A calibration of 2026-09-09 on record with 0 false movers. The macOS mover held in every one of the 15 base/head pairs across two runs (ratios 1.01 to 1.04).
- Linux: a lima VM (12 cores, arm64, Linux 6.8) running the CI image ladybird-ci:2026.08.28; Distribution preset, Clang 21.1.8, ThinLTO; no calibration on record, so the quoted resolution is the run’s own. The Linux mover held in all 8 rounds (ratios 0.80 to 0.91).
- About 90 tests run under 2 ms and resolve only to the 0.1 ms timer quantum; the resolution figures leave them out. `MicroWeb/timers/async-await-loop` was dropped as invalid (a 0.0 ms reading) on both platforms.

</details>

