### PR TITLE
CI: Only build the Ladybird target for web benchmarks

### DIFF
--- a/.github/workflows/web-benchmarks.yml
+++ b/.github/workflows/web-benchmarks.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: 'Build'
         working-directory: ${{ github.workspace }}/Build
-        run: cmake --build .
+        run: cmake --build . --target ladybird
 
       - name: 'Save Caches'
         uses: ./.github/actions/cache-save


### PR DESCRIPTION
This should alleviate long build times in the web benchmarks workflow, but by how much really depends on how long it's taking the `ladybird` binary to link.