### PR TITLE
LibGfx: Send the matched style of macOS system UI fonts over IPC

### DIFF
--- a/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Libraries/LibGfx/Font/Typeface.cpp
@@ -187,19 +187,6 @@ void Typeface::copy_font_data_from(Typeface const& other)
 
 namespace IPC {
 
-static NonnullRefPtr<Gfx::Typeface const> match_system_typeface(Optional<Gfx::SystemUIFontKind> system_ui_font_kind, String family_name, u16 weight, u16 width, u8 slope)
-{
-    if (system_ui_font_kind.has_value()) {
-        auto typeface = MUST(Gfx::TypefaceSkia::match_system_ui(system_ui_font_kind.value(), 0, weight, width, slope));
-        if (typeface)
-            return typeface.release_nonnull();
-    }
-
-    auto typeface = MUST(Gfx::TypefaceSkia::match_family_style(family_name.bytes_as_string_view(), weight, width, slope));
-    VERIFY(typeface);
-    return typeface.release_nonnull();
-}
-
 template<>
 ErrorOr<void> encode(Encoder& encoder, Gfx::Typeface const& typeface)
 {
@@ -227,12 +214,21 @@ ErrorOr<NonnullRefPtr<Gfx::Typeface const>> decode(Decoder& decoder)
         return TRY(Gfx::Typeface::try_load_from_resource(*resource, ttc_index));
     }
     case Gfx::Typeface::FontDataFormat::SystemFont: {
-        auto system_ui_font_kind = TRY(decoder.decode<Optional<Gfx::SystemUIFontKind>>());
         auto family_name = TRY(decoder.decode<String>());
         auto weight = TRY(decoder.decode<u16>());
         auto width = TRY(decoder.decode<u16>());
         auto slope = TRY(decoder.decode<u8>());
-        return match_system_typeface(system_ui_font_kind, move(family_name), weight, width, slope);
+        auto typeface = TRY(Gfx::TypefaceSkia::match_family_style(family_name.bytes_as_string_view(), weight, width, slope));
+        if (!typeface)
+            return Error::from_string_literal("Typeface IPC data referred to an unavailable system font");
+        return typeface.release_nonnull();
+    }
+    case Gfx::Typeface::FontDataFormat::SystemUIFont: {
+        auto style = TRY(decoder.decode<Gfx::SystemUIFontStyle>());
+        auto typeface = TRY(Gfx::TypefaceSkia::match_system_ui(style.kind, 0, style.weight, style.width, style.slope));
+        if (!typeface)
+            return Error::from_string_literal("Typeface IPC data referred to an unavailable system UI font");
+        return typeface.release_nonnull();
     }
     case Gfx::Typeface::FontDataFormat::SystemFontId: {
         auto generation = TRY(decoder.decode<u64>());

--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -108,6 +108,7 @@ protected:
         RawFontData,
         ResourceFontData,
         SystemFont,
+        SystemUIFont,
         SystemFontId,
     };
 

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -10,6 +10,7 @@
 #include <AK/NeverDestroyed.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/TypefaceSkia.h>
+#include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 
 #include <core/SkData.h>
@@ -44,7 +45,7 @@ static auto& skia_font_manager()
 }
 
 struct TypefaceSkia::Impl {
-    Impl(sk_sp<SkTypeface> skia_typeface, std::unique_ptr<SkStreamAsset> stream = {}, Optional<SystemUIFontKind> system_ui_font_kind = {}
+    Impl(sk_sp<SkTypeface> skia_typeface, std::unique_ptr<SkStreamAsset> stream = {}, Optional<SystemUIFontStyle> system_ui_font_style = {}
 #ifdef AK_OS_MACOS
         ,
         CGFontRef cg_font = nullptr
@@ -52,7 +53,7 @@ struct TypefaceSkia::Impl {
         )
         : skia_typeface(move(skia_typeface))
         , stream(move(stream))
-        , system_ui_font_kind(move(system_ui_font_kind))
+        , system_ui_font_style(move(system_ui_font_style))
     {
 #ifdef AK_OS_MACOS
         if (cg_font) {
@@ -72,7 +73,10 @@ struct TypefaceSkia::Impl {
 
     sk_sp<SkTypeface> skia_typeface;
     std::unique_ptr<SkStreamAsset> stream;
-    Optional<SystemUIFontKind> system_ui_font_kind;
+
+    // Skia reads a CoreText UI font as upright and regular because its descriptor carries no numeric style traits,
+    // so a system UI typeface answers style queries from the style it was matched for instead.
+    Optional<SystemUIFontStyle> system_ui_font_style;
 #ifdef AK_OS_MACOS
     CGFontRef cg_font { nullptr };
 #endif
@@ -131,7 +135,7 @@ static SkFontStyle::Slant slope_to_skia_slant(u8 slope)
 #ifdef AK_OS_MACOS
 static CTFontRef create_system_ui_font(SystemUIFontKind, float point_size, u8 slope);
 
-ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_core_text_typeface(sk_sp<SkTypeface> skia_typeface, CTFontRef ct_font, SystemUIFontKind system_ui_font_kind)
+ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_core_text_typeface(sk_sp<SkTypeface> skia_typeface, CTFontRef ct_font, SystemUIFontStyle system_ui_font_style)
 {
     if (!skia_typeface)
         return RefPtr<TypefaceSkia> {};
@@ -141,7 +145,7 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_core_text_typeface(sk_
         return Error::from_string_literal("Failed to get graphics font from CoreText font");
 
     auto typeface = adopt_ref(*new TypefaceSkia {
-        make<TypefaceSkia::Impl>(move(skia_typeface), std::unique_ptr<SkStreamAsset> {}, system_ui_font_kind, cg_font),
+        make<TypefaceSkia::Impl>(move(skia_typeface), std::unique_ptr<SkStreamAsset> {}, system_ui_font_style, cg_font),
         {},
         0 });
     CFRelease(cg_font);
@@ -149,7 +153,7 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_core_text_typeface(sk_
 }
 #endif
 
-ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_skia_typeface(sk_sp<SkTypeface> skia_typeface, Optional<SystemUIFontKind> system_ui_font_kind)
+ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_skia_typeface(sk_sp<SkTypeface> skia_typeface, Optional<SystemUIFontStyle> system_ui_font_style)
 {
     if (!skia_typeface)
         return RefPtr<TypefaceSkia> {};
@@ -162,7 +166,7 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_skia_typeface(sk_sp<Sk
         // NB: Safe to reference without copying because we hold on to the stream.
         ReadonlyBytes bytes { static_cast<u8 const*>(stream->getMemoryBase()), stream->getLength() };
         return adopt_ref(*new TypefaceSkia {
-            make<TypefaceSkia::Impl>(skia_typeface, std::move(stream), system_ui_font_kind),
+            make<TypefaceSkia::Impl>(skia_typeface, std::move(stream), system_ui_font_style),
             bytes,
             ttc_index });
     }
@@ -173,7 +177,7 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_skia_typeface(sk_sp<Sk
     auto memory_stream = copy_stream_to_memory_stream(*stream);
     auto bytes = ReadonlyBytes { static_cast<u8 const*>(memory_stream->getMemoryBase()), memory_stream->getLength() };
     return adopt_ref(*new TypefaceSkia {
-        make<TypefaceSkia::Impl>(skia_typeface, move(memory_stream), system_ui_font_kind),
+        make<TypefaceSkia::Impl>(skia_typeface, move(memory_stream), system_ui_font_style),
         bytes,
         ttc_index });
 }
@@ -205,10 +209,15 @@ void TypefaceSkia::encode_font_data_for_ipc(IPC::Encoder& encoder) const
         return;
     }
 
+    if (impl().system_ui_font_style.has_value()) {
+        MUST(encoder.encode(FontDataFormat::SystemUIFont));
+        MUST(encoder.encode(*impl().system_ui_font_style));
+        return;
+    }
+
     auto family_name = family().to_string();
 
     MUST(encoder.encode(FontDataFormat::SystemFont));
-    MUST(encoder.encode(impl().system_ui_font_kind));
     MUST(encoder.encode(family_name));
     MUST(encoder.encode(weight()));
     MUST(encoder.encode(width()));
@@ -280,17 +289,15 @@ static CTFontRef create_system_ui_font(SystemUIFontKind kind, float point_size, 
 }
 #endif
 
-ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::match_system_ui(SystemUIFontKind kind, float point_size, u16 weight, double width, u8 slope)
+ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::match_system_ui(SystemUIFontKind kind, float point_size, u16 weight, u16 width, u8 slope)
 {
 #ifdef AK_OS_MACOS
-    (void)weight;
-    (void)width;
     auto ct_font = create_system_ui_font(kind, point_size, slope);
     if (!ct_font)
         return RefPtr<TypefaceSkia> {};
 
     auto skia_typeface = SkMakeTypefaceFromCTFont(ct_font);
-    auto typeface = typeface_from_core_text_typeface(move(skia_typeface), ct_font, kind);
+    auto typeface = typeface_from_core_text_typeface(move(skia_typeface), ct_font, SystemUIFontStyle { kind, weight, width, slope });
     CFRelease(ct_font);
     return typeface;
 #else
@@ -367,7 +374,7 @@ RefPtr<TypefaceSkia const> TypefaceSkia::clone_with_variations(Vector<FontVariat
 
     if (has_font_data_backing()) {
         auto typeface = adopt_ref(*new TypefaceSkia {
-            make<TypefaceSkia::Impl>(skia_typeface, std::unique_ptr<SkStreamAsset> {}, impl().system_ui_font_kind),
+            make<TypefaceSkia::Impl>(skia_typeface, std::unique_ptr<SkStreamAsset> {}, impl().system_ui_font_style),
             m_buffer,
             m_ttc_index });
         typeface->copy_font_data_from(*this);
@@ -377,13 +384,13 @@ RefPtr<TypefaceSkia const> TypefaceSkia::clone_with_variations(Vector<FontVariat
 #ifdef AK_OS_MACOS
     if (impl().cg_font) {
         return adopt_ref(*new TypefaceSkia {
-            make<TypefaceSkia::Impl>(move(skia_typeface), std::unique_ptr<SkStreamAsset> {}, impl().system_ui_font_kind, impl().cg_font),
+            make<TypefaceSkia::Impl>(move(skia_typeface), std::unique_ptr<SkStreamAsset> {}, impl().system_ui_font_style, impl().cg_font),
             {},
             m_ttc_index });
     }
 #endif
 
-    auto typeface_or_error = typeface_from_skia_typeface(move(skia_typeface), impl().system_ui_font_kind);
+    auto typeface_or_error = typeface_from_skia_typeface(move(skia_typeface), impl().system_ui_font_style);
     if (typeface_or_error.is_error())
         return {};
     return typeface_or_error.release_value();
@@ -465,16 +472,23 @@ FlyString const& TypefaceSkia::family() const
 
 u16 TypefaceSkia::weight() const
 {
+    if (auto const& style = impl().system_ui_font_style; style.has_value())
+        return style->weight;
     return impl().skia_typeface->fontStyle().weight();
 }
 
 u16 TypefaceSkia::width() const
 {
+    if (auto const& style = impl().system_ui_font_style; style.has_value())
+        return style->width;
     return impl().skia_typeface->fontStyle().width();
 }
 
 u8 TypefaceSkia::slope() const
 {
+    if (auto const& style = impl().system_ui_font_style; style.has_value())
+        return style->slope;
+
     auto slant = impl().skia_typeface->fontStyle().slant();
     switch (slant) {
     case SkFontStyle::kUpright_Slant:
@@ -486,6 +500,30 @@ u8 TypefaceSkia::slope() const
     default:
         return 0;
     }
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::SystemUIFontStyle const& style)
+{
+    TRY(encoder.encode(style.kind));
+    TRY(encoder.encode(style.weight));
+    TRY(encoder.encode(style.width));
+    TRY(encoder.encode(style.slope));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::SystemUIFontStyle> decode(Decoder& decoder)
+{
+    auto kind = TRY(decoder.decode<Gfx::SystemUIFontKind>());
+    auto weight = TRY(decoder.decode<u16>());
+    auto width = TRY(decoder.decode<u16>());
+    auto slope = TRY(decoder.decode<u8>());
+    return Gfx::SystemUIFontStyle { kind, weight, width, slope };
 }
 
 }

--- a/Libraries/LibGfx/Font/TypefaceSkia.h
+++ b/Libraries/LibGfx/Font/TypefaceSkia.h
@@ -24,12 +24,19 @@ enum class SystemUIFontKind : u8 {
     Rounded,
 };
 
+struct SystemUIFontStyle {
+    SystemUIFontKind kind;
+    u16 weight;
+    u16 width;
+    u8 slope;
+};
+
 class TypefaceSkia : public Gfx::Typeface {
     AK_MAKE_NONCOPYABLE(TypefaceSkia);
 
 public:
     static ErrorOr<NonnullRefPtr<TypefaceSkia>> load_from_buffer(ReadonlyBytes, u32 ttc_index = 0);
-    static ErrorOr<RefPtr<TypefaceSkia>> match_system_ui(SystemUIFontKind, float point_size, u16 weight, double width, u8 slope);
+    static ErrorOr<RefPtr<TypefaceSkia>> match_system_ui(SystemUIFontKind, float point_size, u16 weight, u16 width, u8 slope);
     static ErrorOr<RefPtr<TypefaceSkia>> match_family_style(StringView family_name, u16 weight, u16 width, u8 slope);
     static ErrorOr<RefPtr<TypefaceSkia>> find_typeface_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji);
     static Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope);
@@ -58,9 +65,9 @@ private:
     Impl& impl() const { return *m_impl; }
     NonnullOwnPtr<Impl> m_impl;
 
-    static ErrorOr<RefPtr<TypefaceSkia>> typeface_from_skia_typeface(sk_sp<SkTypeface>, Optional<SystemUIFontKind> = {});
+    static ErrorOr<RefPtr<TypefaceSkia>> typeface_from_skia_typeface(sk_sp<SkTypeface>, Optional<SystemUIFontStyle> = {});
 #ifdef AK_OS_MACOS
-    static ErrorOr<RefPtr<TypefaceSkia>> typeface_from_core_text_typeface(sk_sp<SkTypeface>, CTFontRef, SystemUIFontKind);
+    static ErrorOr<RefPtr<TypefaceSkia>> typeface_from_core_text_typeface(sk_sp<SkTypeface>, CTFontRef, SystemUIFontStyle);
 #endif
 
     TypefaceSkia(NonnullOwnPtr<Impl>, ReadonlyBytes, u32 ttc_index = 0);
@@ -90,5 +97,15 @@ private:
 
 template<>
 inline bool Typeface::fast_is<TypefaceSkia>() const { return is_skia(); }
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::SystemUIFontStyle const&);
+
+template<>
+ErrorOr<Gfx::SystemUIFontStyle> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -628,7 +628,7 @@ NonnullRefPtr<Gfx::FontCascadeList const> FontComputer::compute_font_for_style_v
     auto find_macos_system_ui_font = [&](Gfx::SystemUIFontKind kind, Utf16FlyString const& family) -> RefPtr<Gfx::FontCascadeList const> {
         auto const& font_feature_values = font_feature_values_for_family(family);
         auto shape_features = font_feature_data.to_shape_features(font_feature_values);
-        auto typeface = Gfx::TypefaceSkia::match_system_ui(kind, font_size_used_value, weight, font_width.value(), slope);
+        auto typeface = Gfx::TypefaceSkia::match_system_ui(kind, font_size_used_value, weight, font_width_bucket_from_percentage(font_width.value()), slope);
         if (typeface.is_error() || !typeface.value())
             return {};
 

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -20,7 +20,7 @@ endforeach()
 target_link_libraries(BenchmarkJPEGLoader PRIVATE LibImageDecoders)
 target_link_libraries(TestImageDecoder PRIVATE LibImageDecoders)
 target_link_libraries(TestImageWriter PRIVATE LibImageDecoders)
-target_link_libraries(TestFont PRIVATE harfbuzz)
+target_link_libraries(TestFont PRIVATE harfbuzz LibIPC)
 target_link_libraries(TestSharedFontProvider PRIVATE LibIPC)
 target_compile_definitions(TestSharedFontProvider PRIVATE LADYBIRD_SOURCE_DIR="${LADYBIRD_SOURCE_DIR}")
 

--- a/Tests/LibGfx/TestFont.cpp
+++ b/Tests/LibGfx/TestFont.cpp
@@ -4,13 +4,18 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/MemoryStream.h>
+#include <AK/Queue.h>
 #include <LibCore/MappedFile.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
 #include <LibGfx/Font/Typeface.h>
+#include <LibGfx/Font/TypefaceSkia.h>
 #include <LibGfx/FontCascadeList.h>
 #include <LibGfx/TextLayout.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 #include <LibTest/TestCase.h>
 #include <harfbuzz/hb.h>
 
@@ -219,3 +224,38 @@ TEST_CASE(failed_font_allows_loading_the_next_face)
     cascade->set_last_resort_font(font);
     EXPECT(cascade->font_for_code_point('a').is_invisible());
 }
+
+#ifdef AK_OS_MACOS
+static NonnullRefPtr<Gfx::Typeface const> round_trip_typeface_through_ipc(Gfx::Typeface const& typeface)
+{
+    IPC::MessageBuffer message_buffer;
+    IPC::Encoder encoder { message_buffer };
+    MUST(encoder.encode(typeface));
+
+    auto data = message_buffer.take_data();
+    FixedMemoryStream stream { data.span() };
+    Queue<IPC::Attachment> attachments;
+    IPC::Decoder decoder { stream, attachments };
+    return MUST(IPC::decode<NonnullRefPtr<Gfx::Typeface const>>(decoder));
+}
+
+TEST_CASE(system_ui_italic_keeps_its_slope_when_the_variation_clone_collapses)
+{
+    // At 28px the system font's opsz axis sits at its maximum, so applying the default variation hands back the base
+    // CoreText UI font, which Skia reads as upright.
+    float const font_size = 28;
+    auto typeface = MUST(Gfx::TypefaceSkia::match_system_ui(Gfx::SystemUIFontKind::System, font_size, 400, Gfx::FontWidth::Normal, 1));
+    EXPECT(typeface);
+
+    Gfx::FontVariationSettings variations;
+    variations.set_weight(400);
+    variations.set_width(100);
+    variations.set_optical_sizing(font_size);
+    auto font = typeface->font(font_size * 0.75f, variations);
+    EXPECT_EQ(font->typeface().slope(), 1u);
+
+    auto decoded = round_trip_typeface_through_ipc(font->typeface());
+    EXPECT_EQ(decoded->slope(), 1u);
+    EXPECT_EQ(decoded->glyph_id_for_code_point('m'), font->typeface().glyph_id_for_code_point('m'));
+}
+#endif

--- a/Tests/LibWeb/Ref/expected/macos-system-ui-font-italic-ref.html
+++ b/Tests/LibWeb/Ref/expected/macos-system-ui-font-italic-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<!-- A weight a hair off the default forces a real variation clone, so the italic never collapses onto the base UI font. -->
+<style>
+    p {
+        font-family: -apple-system;
+        font-style: italic;
+        font-variation-settings: "wght" 400.01;
+    }
+</style>
+<p style="font-size: 28px">merely (and the first such character)</p>
+<p style="font-size: 19.796875px">merely (and the first such character)</p>

--- a/Tests/LibWeb/Ref/input/macos-system-ui-font-italic.html
+++ b/Tests/LibWeb/Ref/input/macos-system-ui-font-italic.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/macos-system-ui-font-italic-ref.html" />
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-200" />
+<style>
+    p {
+        font-family: -apple-system;
+        font-style: italic;
+    }
+</style>
+<p style="font-size: 28px">merely (and the first such character)</p>
+<p style="font-size: 19.796875px">merely (and the first such character)</p>


### PR DESCRIPTION
Skia derives a CoreText UI font's style from numeric descriptor traits the UI font does not carry, so it reports the system italic as upright. That is masked while the variation clone yields a real derived font, but at fractional sizes and at 28px and above the clone collapses back to the base font, and the Compositor re-matched an upright face and drew italic glyph IDs with the wrong file.

System UI typefaces now remember the kind, weight, width and slope they were matched for, answer style queries from it, and cross IPC as that record in its own font data format.

Fixes italic text rendering as mojibake on bram.us.

Before:
<img width="703" height="266" alt="Screenshot 2026-09-10 at 16 08 37" src="https://github.com/user-attachments/assets/656b8a90-58b7-4e38-86c5-c0f58f861493" />


After:
<img width="710" height="252" alt="Screenshot 2026-09-10 at 16 05 21" src="https://github.com/user-attachments/assets/238f1ff0-35ac-4e37-9910-2b2abaa6d239" />
