### PR TITLE
LibWeb: Keep a style record C++ published over an engine derivation

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -2343,8 +2343,10 @@ pub unsafe extern "C" fn style_engine_publish_computed_groups(
     let publication = if engine.computed_record_verification_counters.is_none()
         && let Some(node) = StyleNodeID::from_raw(node)
     {
+        let target = super::computed::ComputedStyleTarget::new(node, pseudo_kind);
+        engine.forget_engine_computed_record(target);
         engine.publish_computed_groups(
-            super::computed::ComputedStyleTarget::new(node, pseudo_kind),
+            target,
             payloads,
             inherited_group_count,
             custom_property_environment,
@@ -2575,6 +2577,7 @@ pub unsafe extern "C" fn style_engine_assign_shared_style_record(
             new_style_record: style_record,
         };
     }
+    engine.forget_engine_computed_record(target);
     let publication = engine.assign_shared_style_record(
         target,
         style_record,

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -64,6 +64,7 @@ impl StyleEngine {
             .inherited_group_count_for_shared_style(shared.record)?;
         self.published_match_answers.mark_observed(node);
         self.prepare_shared_exact_cascade_state(node);
+        self.forget_engine_computed_record(computed::ComputedStyleTarget::new(node, u8::MAX));
         let publication = self.assign_shared_style_record(
             computed::ComputedStyleTarget::new(node, u8::MAX),
             shared.record,
@@ -743,6 +744,16 @@ impl StyleEngine {
             }
         }
         self.published_match_answers.mark_observed(node);
+    }
+
+    pub(super) fn forget_engine_computed_record(&mut self, target: computed::ComputedStyleTarget) {
+        let Some(pending_records) = self.engine_computed_records_pending.get_mut(&target.node()) else {
+            return;
+        };
+        pending_records.retain(|pending| pending.pseudo_kind != target.pseudo_kind());
+        if pending_records.is_empty() {
+            self.engine_computed_records_pending.remove(&target.node());
+        }
     }
 
     /// The transaction's outputs are gone: every derived record C++ did not install goes back to

--- a/Tests/LibWeb/Text/expected/css/inherited-style-after-refused-engine-record.txt
+++ b/Tests/LibWeb/Text/expected/css/inherited-style-after-refused-engine-record.txt
@@ -1,0 +1,2 @@
+child color: rgb(255, 0, 0)
+grandchild color: rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/input/css/inherited-style-after-refused-engine-record.html
+++ b/Tests/LibWeb/Text/input/css/inherited-style-after-refused-engine-record.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .declares-custom-property {
+        --x: 1px;
+        fill: currentcolor;
+        text-align: left;
+    }
+    .moved {
+        color: red;
+    }
+</style>
+<div id="outer"><div id="child" class="declares-custom-property" align="left"><span id="grandchild">text</span></div></div>
+<script>
+    test(() => {
+        const outer = document.getElementById("outer");
+        const child = document.getElementById("child");
+        const grandchild = document.getElementById("grandchild");
+        document.body.offsetHeight;
+        outer.classList.add("moved");
+        document.body.offsetHeight;
+        println(`child color: ${getComputedStyle(child).color}`);
+        println(`grandchild color: ${getComputedStyle(grandchild).color}`);
+    });
+</script>


### PR DESCRIPTION
A descendant could inherit stale style, and a later style update could read a retired style record, after C++ declined an engine-derived record for an element and computed the same record itself. The engine still held the declined derivation, and once the update finished it reverted the element to its previous record, past the record C++ had installed. The engine now forgets any derivation it holds for an element or pseudo-element when C++ publishes a record for it, so the element stays on the record C++ installed.

Fixes a crash found when scrolling the front page of https://reddit.com.