### PR TITLE
LibWeb: Compute glyph run bounds during layout

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/inline_content.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_content.rs
@@ -70,13 +70,11 @@ impl LineRecord {
 pub struct GlyphRunRecord {
     pub glyphs: Vec<libgfx_rust::text_layout::DrawGlyph>,
     pub font: libgfx_rust::font::FontHandle,
+    // Conservative painted bounds in CSS pixels, relative to the run's baseline origin.
+    pub bounding_box: libgfx_rust::FloatRect,
 }
 
 impl GlyphRunRecord {
-    pub fn bounding_box(&self, scale: f32) -> [f32; 4] {
-        libgfx_rust::text_layout::glyph_run_bounding_box(&self.font, &self.glyphs, scale)
-    }
-
     pub fn glyph_intercepts(&self, scale: f32, y_top: f32, y_bottom: f32) -> Vec<f32> {
         libgfx_rust::text_layout::glyph_run_glyph_intercepts(&self.font, &self.glyphs, scale, y_top, y_bottom)
     }
@@ -154,9 +152,13 @@ impl InlineContent {
                     continue;
                 }
                 fragment.record.glyph_run = fragment.glyphs.take().map(|glyph_data| {
+                    let bounding_box = libgfx_rust::FloatRect::from_array(
+                        libgfx_rust::text_layout::glyph_run_bounding_box(&glyph_data.font, &glyph_data.glyphs, 1.0),
+                    );
                     Rc::new(GlyphRunRecord {
                         glyphs: glyph_data.glyphs,
                         font: glyph_data.font,
+                        bounding_box,
                     })
                 });
                 fragment.record.line_index = line_index as u32;

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
@@ -213,7 +213,7 @@ pub(crate) fn glyph_run_emission(
     fragment_absolute_rect: CssPixelRect,
     scale: f64,
 ) -> GlyphRunEmission {
-    let blob_bounds = run.bounding_box(scale as f32);
+    let bounds = run.bounding_box;
     let baseline_start = FloatPoint {
         x: (fragment_absolute_rect.x.to_float() as f64 * scale) as f32,
         y: ((fragment_absolute_rect.y.to_float() + fragment.baseline.to_float()) as f64 * scale) as f32,
@@ -224,10 +224,10 @@ pub(crate) fn glyph_run_emission(
         Orientation::Vertical
     };
     let glyph_bounding_rect = IntRect::new(
-        (blob_bounds[0] + baseline_start.x).round_ties_even() as i32,
-        (blob_bounds[1] + baseline_start.y).round_ties_even() as i32,
-        blob_bounds[2].round_ties_even() as i32,
-        blob_bounds[3].round_ties_even() as i32,
+        (bounds.x * scale as f32 + baseline_start.x).round_ties_even() as i32,
+        (bounds.y * scale as f32 + baseline_start.y).round_ties_even() as i32,
+        (bounds.width * scale as f32).round_ties_even() as i32,
+        (bounds.height * scale as f32).round_ties_even() as i32,
     );
     GlyphRunEmission {
         glyphs: glyphs_of(run),


### PR DESCRIPTION
Glyph run bounds were recomputed during display list recording even when the retained glyph positions and font were unchanged.

Compute the bounds once when inline layout finalizes each glyph run and store them in CSS pixels. Recording scales and positions the stored bounds for text drawing and background-clip: text.