### PR TITLE
LibWeb: Drop eager paint invalidation when requesting layout

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -404,12 +404,7 @@ impl LayoutNodeArena {
             }
         }
 
-        if !node_was_already_dirty {
-            self.set_node_flag(node, NodeFlag::NeedsLayoutUpdate, true);
-            // Relayout may rebuild an identical fragment whose cached paint output the commit diff
-            // then keeps, even when what this node paints changed (its image data arrived).
-            self.invalidate_paint_cache(node);
-        }
+        self.set_node_flag(node, NodeFlag::NeedsLayoutUpdate, true);
 
         if node_is_box {
             self.reset_cached_intrinsic_sizes(node);

--- a/Tests/LibWeb/Ref/input/svg-image-source-switch-same-size.html
+++ b/Tests/LibWeb/Ref/input/svg-image-source-switch-same-size.html
@@ -7,8 +7,6 @@
     }
     img {
         display: block;
-        width: 100px;
-        height: 100px;
     }
 </style>
 <img id="target" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='red'/%3E%3C/svg%3E">
@@ -27,6 +25,7 @@
     const switchSourceAfterPaint = () => {
         requestAnimationFrame(() => {
             requestAnimationFrame(() => {
+                // Intrinsic sizing requests relayout, but the new image has identical dimensions.
                 target.addEventListener("load", finish);
                 target.src = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='green'/%3E%3C/svg%3E";
             });

--- a/Tests/LibWeb/Text/expected/display_list/paint-cache-unchanged-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/paint-cache-unchanged-relayout.txt
@@ -1,0 +1,2 @@
+PASS: unchanged canvas preserves cached paint after full relayout (work + checks)
+PASS: unchanged canvas preserves cached paint after partial relayout (work + checks)

--- a/Tests/LibWeb/Text/input/display_list/paint-cache-unchanged-relayout.html
+++ b/Tests/LibWeb/Text/input/display_list/paint-cache-unchanged-relayout.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script src="recording-test.js"></script>
+<style>
+    body { margin: 0; }
+    canvas { display: block; width: 100px; height: 100px; background: green; }
+    #boundary { position: absolute; left: 200px; top: 0; width: 100px; height: 100px; }
+</style>
+<canvas id="full" width="100" height="100"></canvas>
+<div id="boundary"><canvas id="partial" width="100" height="100"></canvas></div>
+<script>
+let previousLayoutCount;
+displayListTest({
+    setup: removeBodyWhitespace,
+    steps: [
+        {
+            name: "unchanged canvas preserves cached paint after full relayout",
+            mutate: () => {
+                previousLayoutCount = internals.fullLayoutCount();
+                // Reassigning the width requests layout even when the value is unchanged.
+                // Without a rendering context, there is no canvas content to reset.
+                full.width = full.width;
+            },
+            check: equal => {
+                equal(internals.fullLayoutCount(), previousLayoutCount + 1, "full layout count");
+                equal(full.getBoundingClientRect().width, 100, "canvas width");
+            },
+            expect: `
+                @canvas RECORD (empty)
+                @viewport REUSE WHOLE CAPTURE
+            `,
+        },
+        {
+            name: "unchanged canvas preserves cached paint after partial relayout",
+            mutate: () => {
+                previousLayoutCount = internals.partialLayoutCount();
+                partial.width = partial.width;
+            },
+            check: equal => {
+                equal(internals.partialLayoutCount(), previousLayoutCount + 1, "partial layout count");
+                equal(partial.getBoundingClientRect().width, 100, "canvas width");
+            },
+            expect: `
+                @canvas RECORD (empty)
+                @viewport WALK
+                  @viewport/background/hit-test REUSE
+                  @viewport/scroll-metadata RECORD (empty)
+                  @viewport/background SKIP
+                  @viewport/border SKIP
+                  BlockContainer<HTML>/descendants(background-and-borders) WALK
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
+                  BlockContainer<HTML>/descendants(foreground) WALK
+                  BlockContainer<HTML> WALK
+                    BlockContainer<HTML>/background/hit-test REUSE
+                    BlockContainer<HTML>/scroll-metadata RECORD (empty)
+                    BlockContainer<HTML>/background REUSE
+                    BlockContainer<HTML>/border SKIP
+                    BlockContainer<BODY>/descendants(background-and-borders) WALK
+                      BlockContainer<BODY>/background/hit-test REUSE
+                      BlockContainer<BODY>/scroll-metadata RECORD (empty)
+                      BlockContainer<BODY>/background SKIP
+                      BlockContainer<BODY>/border SKIP
+                      CanvasBox<CANVAS>#full/descendants(background-and-borders) REUSE WHOLE CAPTURE
+                      BlockContainer<DIV>#boundary/descendants(background-and-borders) WALK
+                    BlockContainer<BODY>/descendants(inline-background-and-borders) WALK
+                      CanvasBox<CANVAS>#full/descendants(inline-background-and-borders) REUSE WHOLE CAPTURE
+                      BlockContainer<DIV>#boundary/descendants(inline-background-and-borders) WALK
+                    BlockContainer<HTML>/foreground/hit-test REUSE
+                    BlockContainer<HTML>/foreground REUSE
+                    BlockContainer<BODY>/descendants(foreground) WALK
+                      BlockContainer<BODY>/foreground/hit-test REUSE
+                      BlockContainer<BODY>/foreground REUSE
+                      CanvasBox<CANVAS>#full/descendants(foreground) REUSE WHOLE CAPTURE
+                      BlockContainer<DIV>#boundary/descendants(foreground) WALK
+                      BlockContainer<BODY>/outline SKIP
+                      BlockContainer<BODY>/overlay/hit-test REUSE
+                      BlockContainer<BODY>/overlay SKIP
+                    BlockContainer<DIV>#boundary WALK
+                      BlockContainer<DIV>#boundary/background/hit-test RECORD
+                      BlockContainer<DIV>#boundary/scroll-metadata RECORD (empty)
+                      BlockContainer<DIV>#boundary/background SKIP
+                      BlockContainer<DIV>#boundary/border SKIP
+                      CanvasBox<CANVAS>#partial/descendants(background-and-borders) REUSE WHOLE CAPTURE
+                      CanvasBox<CANVAS>#partial/descendants(floats) REUSE WHOLE CAPTURE
+                      CanvasBox<CANVAS>#partial/descendants(inline-background-and-borders) REUSE WHOLE CAPTURE
+                      BlockContainer<DIV>#boundary/foreground/hit-test RECORD (empty)
+                      BlockContainer<DIV>#boundary/foreground RECORD (empty)
+                      CanvasBox<CANVAS>#partial/descendants(foreground) REUSE WHOLE CAPTURE
+                      BlockContainer<DIV>#boundary/outline SKIP
+                      BlockContainer<DIV>#boundary/overlay/hit-test RECORD (empty)
+                      BlockContainer<DIV>#boundary/overlay SKIP
+                    BlockContainer<HTML>/outline SKIP
+                  @viewport/outline SKIP
+            `,
+        },
+    ],
+});
+</script>


### PR DESCRIPTION
Marking a node for layout invalidated its paint cache immediately, even when layout later committed an identical fragment at the same position. This forced unchanged output to be recorded again.

Leave paint invalidation for layout changes to the existing commit diff. Changes to image data and other paint inputs retain their explicit paint invalidation, so identical geometry can still repaint changed content.

Add a display-list regression covering cached canvas output after full and partial relayout. Update the same-size image source replacement test to use intrinsic sizing, exercising repaint when relayout preserves the image's dimensions.