### PR TITLE
LibWeb: Track focused and hovered elements for style invalidation

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -1815,8 +1815,12 @@ impl StyleEngine {
     /// subject check, and the change reaches nothing at all. The feature in flux counts as carried
     /// by the node it changed on, whichever direction it moved.
     pub(super) fn feature_in_flux(input: &NormalizedInput) -> Option<(StyleNodeID, DispatchKey)> {
-        let InputKey::LocalFeature(node, feature) = input.key else {
-            return None;
+        let (node, feature) = match input.key {
+            InputKey::LocalFeature(node, feature) => (node, feature),
+            InputKey::State(node, fact) => {
+                return fact.has_selector_posting().then_some((node, DispatchKey::State(fact)));
+            }
+            _ => return None,
         };
         let key = match feature {
             LocalFeatureKey::Class(atom) => DispatchKey::Class(atom),

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -1614,17 +1614,18 @@ pub enum FeatureKey {
 impl FeatureKey {
     #[must_use]
     pub fn has_selector_posting(self) -> bool {
-        matches!(
-            self,
+        match self {
             Self::Part(_)
-                | Self::CustomState(_)
-                | Self::TagName(_)
-                | Self::Id(_)
-                | Self::Class(_)
-                | Self::AttributeName(_)
-                | Self::AttributeValue(_)
-                | Self::Directionality(_)
-        )
+            | Self::CustomState(_)
+            | Self::TagName(_)
+            | Self::Id(_)
+            | Self::Class(_)
+            | Self::AttributeName(_)
+            | Self::AttributeValue(_)
+            | Self::Directionality(_) => true,
+            Self::State(fact) => fact.has_selector_posting(),
+            _ => false,
+        }
     }
 
     fn atom(self) -> Option<StyleAtomID> {
@@ -4121,6 +4122,17 @@ impl ElementFactStore {
                     return None;
                 }
             }
+            for state in self
+                .rows
+                .states_of(row)
+                .facts()
+                .filter(|state| state.has_selector_posting())
+            {
+                let key = SelectorPostingKey::State(state);
+                if !self.rebuild_missing_posting(&mut rebuilt, key, node, memory) {
+                    return None;
+                }
+            }
             for &class in self.rows.classes_of(row) {
                 let key = SelectorPostingKey::Class(class);
                 if !self.rebuild_missing_posting(&mut rebuilt, key, node, memory) {
@@ -4993,14 +5005,25 @@ impl ElementFactStore {
             .is_some_and(Option::is_some)
     }
 
-    pub fn set_state(&mut self, node: StyleNodeID, fact: StateFact, value: bool) {
-        self.edit_staged_row(node, |facts| {
+    pub fn set_state(&mut self, node: StyleNodeID, fact: StateFact, value: bool, memory: &mut MemoryController) {
+        let changed = self.edit_staged_row(node, |facts| {
+            if facts.states.contains(fact) == value {
+                return false;
+            }
             if value {
                 facts.states.insert(fact);
             } else {
                 facts.states.remove(fact);
             }
+            true
         });
+        if changed && fact.has_selector_posting() {
+            if value {
+                self.postings.insert(SelectorPostingKey::State(fact), node, memory);
+            } else {
+                self.postings.remove(SelectorPostingKey::State(fact), node);
+            }
+        }
     }
 
     pub fn set_parts(&mut self, node: StyleNodeID, parts: &[StyleAtomID], memory: &mut MemoryController) {
@@ -5071,6 +5094,14 @@ impl ElementFactStore {
         }
         for &state in self.rows.custom_states_of(row) {
             self.postings.remove(SelectorPostingKey::CustomState(state), node);
+        }
+        for state in self
+            .rows
+            .states_of(row)
+            .facts()
+            .filter(|state| state.has_selector_posting())
+        {
+            self.postings.remove(SelectorPostingKey::State(state), node);
         }
         for &AttributeFact { name, value, .. } in self.rows.attributes_of(row) {
             for key in self.attribute_name_keys(name) {
@@ -5470,6 +5501,35 @@ mod tests {
     }
 
     #[test]
+    fn interaction_states_keep_a_posting() {
+        let mut memory = MemoryController::new(DeviceClass::ForegroundDesktop);
+        let mut facts = ElementFactStore::new();
+        let node = StyleNodeID::element(1);
+        facts.set_state(node, StateFact::Focus, true, &mut memory);
+        facts.set_state(node, StateFact::Enabled, true, &mut memory);
+        facts.apply_staged(&mut memory);
+        assert!(known_posting(facts.postings(), SelectorPostingKey::State(StateFact::Focus)).contains(node));
+        assert!(matches!(
+            facts.postings().lookup(SelectorPostingKey::State(StateFact::Enabled)),
+            Lookup::KnownAbsent
+        ));
+
+        facts.set_state(node, StateFact::Focus, false, &mut memory);
+        assert!(matches!(
+            facts.postings().lookup(SelectorPostingKey::State(StateFact::Focus)),
+            Lookup::KnownAbsent
+        ));
+
+        facts.set_state(node, StateFact::Focus, true, &mut memory);
+        facts.apply_staged(&mut memory);
+        facts.forget(node);
+        assert!(matches!(
+            facts.postings().lookup(SelectorPostingKey::State(StateFact::Focus)),
+            Lookup::KnownAbsent
+        ));
+    }
+
+    #[test]
     fn a_posting_stays_sorted_across_chunk_splits() {
         let mut memory = MemoryController::new(DeviceClass::ForegroundDesktop);
         let mut postings = FeaturePostings::new();
@@ -5666,7 +5726,7 @@ mod tests {
         assert_eq!(facts.primary().stale_rows(), 0);
 
         facts.set_class(node, second_class, true, &mut memory);
-        facts.set_state(node, StateFact::Hover, true);
+        facts.set_state(node, StateFact::Hover, true, &mut memory);
         facts.set_parts(node, &[part], &mut memory);
         facts.set_custom_states(node, &[custom_state], &mut memory);
         facts.apply_staged(&mut memory);
@@ -5697,7 +5757,7 @@ mod tests {
         facts.apply_staged(&mut memory);
         let payload_lengths = (facts.rows.classes.len(), facts.rows.attributes.len());
 
-        facts.set_state(node, StateFact::Hover, true);
+        facts.set_state(node, StateFact::Hover, true, &mut memory);
         facts.apply_staged(&mut memory);
 
         assert_eq!((facts.rows.classes.len(), facts.rows.attributes.len()), payload_lengths);

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -1197,7 +1197,9 @@ impl StyleEngine {
                         .set_attribute(node, name, atom, value.holds(), &mut self.memory);
                 }
             },
-            (InputKey::State(node, fact), InputValue::State(value)) => self.facts.set_state(node, fact, value),
+            (InputKey::State(node, fact), InputValue::State(value)) => {
+                self.facts.set_state(node, fact, value, &mut self.memory);
+            }
             _ => {}
         }
     }

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -1921,6 +1921,14 @@ impl SelectorProgram {
                 out.push(DispatchKey::Directionality(value));
                 true
             }
+            // A state is a necessary feature of any compound testing it, and one with a posting
+            // also names the compound's candidates: the focused element, the hovered chain. A state
+            // without one names nothing, and admitting it as a candidate key would take the
+            // compound away from names that do.
+            SelectorOp::State(state) if query == DispatchQuery::Required || state.has_selector_posting() => {
+                out.push(DispatchKey::State(state));
+                true
+            }
             _ => query == DispatchQuery::Required,
         }
     }
@@ -2506,11 +2514,11 @@ fn dispatch_selectivity(key: DispatchKey) -> u8 {
         // A document usually resolves to one direction, so this names most of it.
         DispatchKey::Directionality(_) => 4,
         // These three are ranked behind every name a compound can carry, even though `:root` names
-        // one element and most states name none. A name has a posting to enumerate from and these
-        // do not, so preferring one would trade a tighter reaction batch for a dispatch that is
-        // no more selective in practice: `a:hover` is as well found in the `a` bucket. What they
-        // are for is the compound that carries no name at all, which is where a bare `:root` or
-        // `:hover` rule would otherwise sit in front of every element in the document.
+        // one element and most states name none. A name has a posting to enumerate from and most
+        // of these do not, so preferring one would trade a tighter reaction batch for a dispatch
+        // that is no more selective in practice: `a:hover` is as well found in the `a` bucket.
+        // What they are for is the compound that carries no name at all, which is where a bare
+        // `:root` or `:hover` rule would otherwise sit in front of every element in the document.
         DispatchKey::Root => 5,
         DispatchKey::State(_) => 5,
         DispatchKey::Heading => 5,

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -2800,6 +2800,65 @@ fn add_hover_sibling_target_rule(engine: &mut StyleEngine, target: StyleAtomID) 
     engine.replace_rule_version(rule, version);
 }
 
+fn add_focused_grandchild_rule(engine: &mut StyleEngine, guard: StyleAtomID, mid: StyleAtomID) {
+    let mut builder = selector::SelectorProgramBuilder::new();
+    let guard_test = builder.push_feature(selector::FeatureTest::Class(guard));
+    let guard_parent = builder.push(selector::SelectorOp::Parent(guard_test));
+    let mid_test = builder.push_feature(selector::FeatureTest::Class(mid));
+    let mid_compound = builder.push_compound(&[mid_test, guard_parent]);
+    let mid_parent = builder.push(selector::SelectorOp::Parent(mid_compound));
+    let focus = builder.push(selector::SelectorOp::State(StateFact::Focus));
+    let subject = builder.push_compound(&[focus, mid_parent]);
+    builder.push_entry(subject);
+    let program = engine.programs.add(builder.finish());
+
+    let sheet = engine.add_sheet(StyleSheetObjectID(1), CascadeOrigin::Author);
+    engine.attach_sheet(sheet, TreeScopeID::DOCUMENT);
+    let rule = engine.append_rule(sheet, None, RuleKind::Style);
+    engine.add_routing_rule(rule, program);
+    let mut version = engine.program.rule_version(rule);
+    version.selector_program = Some(program);
+    version.declaration_block = Some(DeclarationBlockID(1));
+    engine.replace_rule_version(rule, version);
+}
+
+#[test]
+fn an_unfocused_subject_state_routes_to_no_descendant() {
+    let (mut engine, nodes) = nested_document();
+    let guard = StyleAtomID(200);
+    let mid = StyleAtomID(201);
+    add_focused_grandchild_rule(&mut engine, guard, mid);
+    add_feature(&mut engine, nodes[2], LocalFeatureKey::Class(mid));
+    discard_transaction(&mut engine);
+
+    add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+    let batch_nodes_before = engine.counters().get(Counter::ExactRegionBatchNodes);
+    let convergence_nodes_before = engine.counters().get(Counter::PrefixConvergenceNodes);
+    let mut planned = Vec::new();
+    assert!(engine.take_style_transaction_nodes(nodes[0], |nodes| planned.extend_from_slice(nodes)));
+    assert!(planned.is_empty());
+    assert_eq!(
+        engine.counters().get(Counter::ExactRegionBatchNodes),
+        batch_nodes_before
+    );
+    assert_eq!(
+        engine.counters().get(Counter::PrefixConvergenceNodes),
+        convergence_nodes_before
+    );
+
+    engine.record_input(
+        InputKey::State(nodes[3], StateFact::Focus),
+        InputValue::State(false),
+        InputValue::State(true),
+    );
+    discard_transaction(&mut engine);
+
+    remove_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+    let mut planned = Vec::new();
+    assert!(engine.take_style_transaction_nodes(nodes[0], |nodes| planned.extend_from_slice(nodes)));
+    assert!(planned.contains(&nodes[3].raw()));
+}
+
 #[test]
 fn clearing_state_while_departing_routes_following_siblings() {
     let (mut engine, nodes) = linear_document();

--- a/Libraries/LibWeb/Rust/src/css/style/transaction.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/transaction.rs
@@ -53,6 +53,32 @@ pub struct StyleTransactionVersion(pub u64);
 // a bitset cannot carry their argument.
 include!(concat!(env!("OUT_DIR"), "/style_state_fact_generated.rs"));
 
+impl StateFact {
+    /// Whether the elements in this state are enumerated by a feature posting.
+    ///
+    /// A state a user interaction puts an element in holds on a handful of elements at a time: the
+    /// focused element and the ancestors focus is within, the hovered chain, the activated chain,
+    /// the top layer. A subject compound carrying nothing but such a state names its subjects as
+    /// well as an ID does, so a change elsewhere in the selector reaches those subjects rather than
+    /// every element its combinators could lead to. A state an element's nature decides, such as
+    /// being a link or enabled, holds on most of a document and is left to the compound's names.
+    #[must_use]
+    pub fn has_selector_posting(self) -> bool {
+        matches!(
+            self,
+            Self::Active
+                | Self::Focus
+                | Self::FocusVisible
+                | Self::FocusWithin
+                | Self::Fullscreen
+                | Self::Hover
+                | Self::Modal
+                | Self::PopoverOpen
+                | Self::Target
+        )
+    }
+}
+
 /// Declarations sourced from one style node rather than a stylesheet rule. Each kind keeps its
 /// language-defined cascade placement: presentational hints do not masquerade as inline style, and
 /// none of them enter the selector program merely because their source syntax is an attribute.

--- a/Tests/LibWeb/Text/expected/css/style-engine/child-combinator-rule-bounded-to-its-shadow-tree.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/child-combinator-rule-bounded-to-its-shadow-tree.txt
@@ -1,5 +1,5 @@
-li > div > :focus: 1
+li > div > :focus: 0
 li > div > *: 1
-li :focus: 2
+li :focus: 0
 before focus: rgb(0, 0, 0)
 after focus: rgb(1, 2, 3)

--- a/Tests/LibWeb/Text/expected/css/style-engine/unfocused-subject-skips-descendants.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/unfocused-subject-skips-descendants.txt
@@ -1,0 +1,4 @@
+unfocused probe: rgb(0, 0, 0)
+recomputes with no focused element: 0
+focused probe: rgb(0, 128, 0)
+recomputes with one focused element: 4

--- a/Tests/LibWeb/Text/input/css/style-engine/unfocused-subject-skips-descendants.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/unfocused-subject-skips-descendants.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .item.completed > div > :focus {
+        color: rgb(0, 128, 0);
+    }
+</style>
+<ul id="list"></ul>
+<script>
+    test(() => {
+        for (let index = 0; index < 20; ++index) {
+            const item = document.createElement("li");
+            item.className = "item";
+            const row = document.createElement("div");
+            for (let field = 0; field < 5; ++field)
+                row.appendChild(document.createElement("input"));
+            item.appendChild(row);
+            list.appendChild(item);
+        }
+        const probe = list.children[3].firstChild.children[2];
+        getComputedStyle(probe).color;
+
+        internals.resetStyleInvalidationCounters();
+        for (const item of list.children)
+            item.classList.add("completed");
+        println(`unfocused probe: ${getComputedStyle(probe).color}`);
+        let counters = internals.getStyleInvalidationCounters();
+        println(`recomputes with no focused element: ${counters.elementStyleRecomputations}`);
+
+        for (const item of list.children)
+            item.classList.remove("completed");
+        probe.focus();
+        getComputedStyle(probe).color;
+
+        internals.resetStyleInvalidationCounters();
+        for (const item of list.children)
+            item.classList.add("completed");
+        println(`focused probe: ${getComputedStyle(probe).color}`);
+        counters = internals.getStyleInvalidationCounters();
+        println(`recomputes with one focused element: ${counters.elementStyleRecomputations}`);
+    });
+</script>


### PR DESCRIPTION
A rule ending in a pseudo-class such as `.item :focus` had to be checked against every descendant of an element whose class changed, because nothing recorded which elements were focused. Elements in the states a user interaction puts them in, such as `:focus`, `:hover`, `:active` and `:target`, are now tracked the same way elements with a given class are. A class change elsewhere in such a rule then reaches only the few elements in that state, or none when there are none. States that hold on most of a document, such as `:enabled` or `:link`, are not tracked and are still found through the names in the rule.

Improves the performance of many `TodoMVC` tests from Speedometer3
```
Benchmark     Suite                                       Test                   Speedup  Old (Mean ± Range)    New (Mean ± Range)
------------  ------------------------------------------  -------------------  ---------  --------------------  --------------------
Speedometer3  Charts-chartjs                              Draw opaque scatter      1.025  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  Charts-chartjs                              Draw scatter             1.003  0.13 ± 0.01           0.12 ± 0.01
Speedometer3  Charts-chartjs                              Show tooltip             1.005  0.00 ± 0.00           0.00 ± 0.00
Speedometer3  Charts-observable-plot                      Dotted                   1.002  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 20            1.001  0.10 ± 0.00           0.10 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 6             1.022  0.08 ± 0.01           0.08 ± 0.01
Speedometer3  Editor-CodeMirror                           Highlight                1.085  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  Editor-CodeMirror                           Long                     1.036  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  Editor-TipTap                               Highlight                0.982  0.16 ± 0.00           0.17 ± 0.01
Speedometer3  Editor-TipTap                               Long                     1.017  0.11 ± 0.01           0.11 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToPolitics       1.046  0.16 ± 0.00           0.15 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToUS             1.062  0.17 ± 0.01           0.16 ± 0.00
Speedometer3  NewsSite-Next                               NavigateToWorld          1.054  0.16 ± 0.01           0.15 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToPolitics       0.99   0.13 ± 0.00           0.13 ± 0.01
Speedometer3  NewsSite-Nuxt                               NavigateToUS             1.037  0.13 ± 0.00           0.12 ± 0.00
Speedometer3  NewsSite-Nuxt                               NavigateToWorld          1.059  0.13 ± 0.01           0.12 ± 0.00
Speedometer3  Perf-Dashboard                              Render                   0.989  0.05 ± 0.00           0.05 ± 0.01
Speedometer3  Perf-Dashboard                              SelectingPoints          1.006  0.12 ± 0.00           0.11 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingRange           0.999  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  React-Stockcharts-SVG                       PanTheChart              0.966  0.10 ± 0.01           0.10 ± 0.01
Speedometer3  React-Stockcharts-SVG                       Render                   1.03   0.10 ± 0.01           0.10 ± 0.01
Speedometer3  React-Stockcharts-SVG                       ZoomTheChart             1.005  0.31 ± 0.01           0.31 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 Adding100Items           1.049  0.11 ± 0.01           0.11 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 CompletingAllItems       1.005  0.07 ± 0.01           0.07 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 DeletingAllItems         1.004  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Backbone                            Adding100Items           1.116  0.08 ± 0.01           0.07 ± 0.00
Speedometer3  TodoMVC-Backbone                            CompletingAllItems       0.984  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Backbone                            DeletingAllItems         1.027  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      Adding100Items           1.046  0.12 ± 0.01           0.11 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES5                      CompletingAllItems       1.026  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      DeletingAllItems         1.058  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  Adding100Items           1.041  0.11 ± 0.01           0.11 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  CompletingAllItems       0.983  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  DeletingAllItems         1.009  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     Adding100Items           1.077  0.05 ± 0.01           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     CompletingAllItems       1.129  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     DeletingAllItems         1.017  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  Adding100Items           0.955  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  CompletingAllItems       0.955  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  DeletingAllItems         0.901  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   Adding100Items           1.037  0.08 ± 0.00           0.08 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   CompletingAllItems       1.007  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   DeletingAllItems         1.001  0.05 ± 0.00           0.05 ± 0.01
Speedometer3  TodoMVC-React-Redux                         Adding100Items           1.005  0.08 ± 0.00           0.08 ± 0.00
Speedometer3  TodoMVC-React-Redux                         CompletingAllItems       1.036  0.12 ± 0.01           0.11 ± 0.00
Speedometer3  TodoMVC-React-Redux                         DeletingAllItems         1.069  0.06 ± 0.01           0.06 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  Adding100Items           0.963  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  CompletingAllItems       0.964  0.02 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  DeletingAllItems         0.855  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Vue                                 Adding100Items           0.963  0.05 ± 0.00           0.05 ± 0.01
Speedometer3  TodoMVC-Vue                                 CompletingAllItems       1.031  0.04 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Vue                                 DeletingAllItems         1.005  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       Adding100Items           1.012  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-WebComponents                       CompletingAllItems       1.005  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       DeletingAllItems         1.054  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-jQuery                              Adding100Items           0.916  0.14 ± 0.01           0.15 ± 0.01
Speedometer3  TodoMVC-jQuery                              CompletingAllItems       0.977  0.36 ± 0.01           0.36 ± 0.02
Speedometer3  TodoMVC-jQuery                              DeletingAllItems         1.012  0.13 ± 0.01           0.13 ± 0.01

Benchmark     Old Score    New Score      Score Improvement  Old Total Time (s)    New Total Time (s)      Speedup
------------  -----------  -----------  -------------------  --------------------  --------------------  ---------
Speedometer3  5.41 ± 0.04  5.48 ± 0.04                1.014  4.65 ± 0.03           4.59 ± 0.03               1.014
```

---

All benchmarks:
| Benchmark | Old score | New score | Score change | Old time (s) | New time (s) | Speedup |
|---|---|---|---|---|---|---|
| Speedometer 2 | 83.27 ± 0.31 | 84.14 ± 0.27 | +1.05% | 6.341 ± 0.013 | 6.301 ± 0.015 | 1.006× |
| Speedometer 3 | 5.41 ± 0.04 | 5.48 ± 0.04 | +1.41% | 4.648 ± 0.030 | 4.585 ± 0.029 | 1.014× |
| StyleBench | 161.43 ± 0.99 | 161.99 ± 0.78 | +0.35% | 1.538 ± 0.009 | 1.532 ± 0.007 | 1.004× |
