### PR TITLE
Give document scroll state one owner one refresh and one FFI

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1913,7 +1913,7 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, Layout
     m_layout_root->invalidate_text_blocks_cache();
 
     set_needs_to_record_display_list();
-    set_needs_to_refresh_scroll_state(true);
+    invalidate_scroll_state();
 
     // A commit that changed the tree can have replaced boxes referenced by the cached
     // contained-boxes index; refresh it before overflow measurement follows them. A pending full
@@ -9732,11 +9732,11 @@ GC::Ptr<HTML::HTMLElement> Document::topmost_auto_or_hint_popover()
     return {};
 }
 
-void Document::set_needs_to_refresh_scroll_state(bool b)
+void Document::invalidate_scroll_state()
 {
     // NB: Propagating scroll state invalidation.
     if (has_committed_viewport_box())
-        paint_state().set_needs_to_refresh_scroll_state(*this, b);
+        paint_state().invalidate_scroll_state(*this);
 }
 
 Vector<GC::Root<Range>> Document::find_matching_text(Utf16View query, CaseSensitivity case_sensitivity)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -699,7 +699,7 @@ Layout::NodeArena& Document::layout_node_arena()
                 auto& document = *static_cast<Document*>(context);
                 document.chrome_widget_registry().drop_widgets_for_slot(slot);
                 if (kind == Layout::RustFFI::PaintableRowResetKind::Recommitted && Painting::viewport_row_slot(document).index == slot.index)
-                    document.paint_state().viewport_row_was_reset(document);
+                    document.paint_state().viewport_row_was_reset();
             });
     }
     return *m_layout_node_arena;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -10471,8 +10471,6 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
         page().client().page_did_change_background_color(canvas_background_color);
     }
 
-    document_paint_state.refresh_scroll_state(*this);
-
     Painting::InspectorOverlayInputs overlay_inputs;
     if (auto const* layout_node = highlighted_layout_node(); layout_node && Painting::has_committed_box(*layout_node))
         overlay_inputs.highlighted_layout_node = layout_node;
@@ -10547,7 +10545,6 @@ Optional<Painting::HitTestResult> Document::hit_test(CSSPixelPoint position)
     auto hit_test_display_list = ensure_hit_test_display_list();
     if (!hit_test_display_list)
         return {};
-    paint_state().refresh_scroll_state(*this);
     // https://w3c.github.io/pointerevents/#hit-test
     // 1. Let pos be the x,y coordinates relative to the viewport
     // 2. Return [CSSOM-View]'s elementFromPoint() with pos (the frontmost DOM element at pos)
@@ -10576,7 +10573,6 @@ Optional<Painting::CaretPosition> Document::caret_position_from_point(CSSPixelPo
     auto hit_test_display_list = ensure_hit_test_display_list();
     if (!hit_test_display_list)
         return {};
-    paint_state().refresh_scroll_state(*this);
     return hit_test_display_list->caret_position_from_point(position, *this, page().client().device_pixels_per_css_pixel(), page().chrome_metrics(), Painting::CaretPositionMode::Normal);
 }
 
@@ -10585,7 +10581,6 @@ Optional<Painting::CaretPosition> Document::caret_position_from_point_for_select
     auto hit_test_display_list = ensure_hit_test_display_list();
     if (!hit_test_display_list)
         return {};
-    paint_state().refresh_scroll_state(*this);
     return hit_test_display_list->caret_position_from_point(position, *this, page().client().device_pixels_per_css_pixel(), page().chrome_metrics(), Painting::CaretPositionMode::SelectionStart);
 }
 
@@ -10594,7 +10589,6 @@ Optional<Painting::CaretPosition> Document::caret_position_from_point_for_select
     auto hit_test_display_list = ensure_hit_test_display_list();
     if (!hit_test_display_list)
         return {};
-    paint_state().refresh_scroll_state(*this);
     return hit_test_display_list->caret_position_from_point(position, *this, page().client().device_pixels_per_css_pixel(), page().chrome_metrics(), Painting::CaretPositionMode::Selection, constraint_scope);
 }
 
@@ -10603,7 +10597,6 @@ Optional<Painting::CaretPosition> Document::caret_position_at_line_edge(Node con
     auto hit_test_display_list = ensure_hit_test_display_list();
     if (!hit_test_display_list)
         return {};
-    paint_state().refresh_scroll_state(*this);
     return hit_test_display_list->caret_position_at_line_edge(node, offset, affinity, edge);
 }
 
@@ -10612,7 +10605,6 @@ Optional<Painting::CaretPosition> Document::caret_position_on_adjacent_line(Node
     auto hit_test_display_list = ensure_hit_test_display_list();
     if (!hit_test_display_list)
         return {};
-    paint_state().refresh_scroll_state(*this);
     return hit_test_display_list->caret_position_on_adjacent_line(node, offset, affinity, direction, inline_coordinate, scope);
 }
 
@@ -10621,7 +10613,6 @@ Optional<CSSPixels> Document::caret_line_block_coordinate(Node const& node, size
     auto hit_test_display_list = ensure_hit_test_display_list();
     if (!hit_test_display_list)
         return {};
-    paint_state().refresh_scroll_state(*this);
     return hit_test_display_list->caret_line_block_coordinate(node, offset, affinity);
 }
 
@@ -10630,7 +10621,6 @@ TraversalDecision Document::hit_test_all(CSSPixelPoint position, Function<Traver
     auto hit_test_display_list = ensure_hit_test_display_list();
     if (!hit_test_display_list)
         return TraversalDecision::Continue;
-    paint_state().refresh_scroll_state(*this);
     return hit_test_display_list->hit_test_all(position, *this, page().client().device_pixels_per_css_pixel(), page().chrome_metrics(), callback);
 }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1913,7 +1913,6 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, Layout
     m_layout_root->invalidate_text_blocks_cache();
 
     set_needs_to_record_display_list();
-    invalidate_scroll_state();
 
     // A commit that changed the tree can have replaced boxes referenced by the cached
     // contained-boxes index; refresh it before overflow measurement follows them. A pending full

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -856,7 +856,7 @@ public:
     // root set; the layout node arena keeps the escape bit next to those roots.
     void record_partial_relayout_escape(PartialRelayoutEscapeReason);
 
-    void set_needs_to_refresh_scroll_state(bool b);
+    void invalidate_scroll_state();
 
     bool has_active_favicon() const { return !!m_active_favicon; }
     void check_favicon_after_loading_link_resource();

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5827,16 +5827,22 @@ CSSPixelPoint Element::scroll_offset(Optional<CSS::PseudoElement> pseudo_element
 // That is why the unchecked layout node accessor is the right one here.
 void Element::set_scroll_offset(Optional<CSS::PseudoElement> pseudo_element_type, CSSPixelPoint offset)
 {
+    // The document's scroll state mirrors these offsets, so it is invalidated here, next to the
+    // store, rather than by each caller.
     if (pseudo_element_type.has_value()) {
         auto pseudo_element = get_synthetic_pseudo_element(*pseudo_element_type);
         if (!pseudo_element.has_value())
             return;
+        if (pseudo_element->scroll_offset() != offset)
+            document().invalidate_scroll_state();
         pseudo_element->set_scroll_offset(offset);
         if (auto* layout_node = pseudo_element->unsafe_layout_node())
             layout_node->update_has_scroll_offset_flag();
         return;
     }
 
+    if (scroll_offset({}) != offset)
+        document().invalidate_scroll_state();
     if (!offset.is_zero())
         ensure_element_rare_data().scroll_offset = offset;
     else if (auto* rare_data = element_rare_data())

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4431,7 +4431,7 @@ void LocalNavigable::perform_scroll_of_viewport_scrolling_box(CSSPixelPoint new_
 
         if (auto document = active_document()) {
             document->set_needs_repaint(Badge<HTML::LocalNavigable> {}, InvalidateDisplayList::No);
-            document->set_needs_to_refresh_scroll_state(true);
+            document->invalidate_scroll_state();
             document->inform_all_viewport_clients_about_the_current_viewport_rect();
         }
     }
@@ -4494,7 +4494,7 @@ static GC::Ptr<DOM::Element> adopt_async_element_scroll_delta(DOM::Document& doc
 
     element->set_scroll_offset(pseudo_element, scroll_offset);
 
-    document.set_needs_to_refresh_scroll_state(true);
+    document.invalidate_scroll_state();
     document.append_pending_scroll_event({ *element, EventNames::scroll });
     element->set_needs_repaint(InvalidateDisplayList::No);
     return element;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -6172,7 +6172,6 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
 
     VERIFY(document->has_committed_viewport_box());
     auto visual_context_tree_needs_compositor_update = document_paint_state.visual_context_tree_needs_compositor_update();
-    document_paint_state.refresh_scroll_state(*document);
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paint_state.scroll_state_snapshot() };
     scroll_state_snapshot.set_adopted_async_scroll_sequence(m_adopted_async_scroll_sequence);

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4494,7 +4494,6 @@ static GC::Ptr<DOM::Element> adopt_async_element_scroll_delta(DOM::Document& doc
 
     element->set_scroll_offset(pseudo_element, scroll_offset);
 
-    document.invalidate_scroll_state();
     document.append_pending_scroll_event({ *element, EventNames::scroll });
     element->set_needs_repaint(InvalidateDisplayList::No);
     return element;

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -100,12 +100,10 @@ void DocumentPaintState::update_accumulated_visual_contexts(DOM::Document& docum
 {
     bool svg_paint_resources_changed = sync_svg_paint_resources(document);
     auto result = rust_update_accumulated_visual_contexts(document);
-    if (result.performed_full_build) {
-        m_scroll_state_snapshot = {};
+    if (result.performed_full_build)
         ++m_accumulated_visual_context_tree_build_count;
-    } else {
+    else
         ++m_accumulated_visual_context_tree_incremental_update_count;
-    }
     if (result.requires_display_list_recording || svg_paint_resources_changed)
         document.set_needs_to_record_display_list();
     if (result.structural_epoch_changed)
@@ -176,9 +174,7 @@ void DocumentPaintState::invalidate_all_cached_paint(DOM::Document& document)
 
 void DocumentPaintState::refresh_scroll_state(DOM::Document& document)
 {
-    if (!rust_refresh_scroll_state(document))
-        return;
-    m_scroll_state_snapshot = rust_scroll_state_snapshot(document);
+    rust_refresh_scroll_state(document, m_scroll_state_snapshot);
 }
 
 void DocumentPaintState::reset_selection_states(DOM::Document& document)

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -174,7 +174,18 @@ void DocumentPaintState::invalidate_all_cached_paint(DOM::Document& document)
 
 void DocumentPaintState::refresh_scroll_state(DOM::Document& document)
 {
-    rust_refresh_scroll_state(document, m_scroll_state_snapshot);
+    if (rust_refresh_scroll_state(document, m_scroll_state_snapshot))
+        return;
+
+    // LIBWEB_VERIFY_SCROLL_STATE: a skipped refresh must have been skippable. Every producer of a
+    // scroll offset invalidates the state, so re-deriving the snapshot from scratch has to
+    // reproduce the one kept.
+    static bool const verify_scroll_state = getenv("LIBWEB_VERIFY_SCROLL_STATE") != nullptr;
+    if (!verify_scroll_state)
+        return;
+    ScrollStateSnapshot rederived_snapshot;
+    rust_refresh_scroll_state(document, rederived_snapshot, ForceScrollStateRefresh::Yes);
+    VERIFY(rederived_snapshot.device_offsets() == m_scroll_state_snapshot.device_offsets());
 }
 
 void DocumentPaintState::reset_selection_states(DOM::Document& document)

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -81,21 +81,18 @@ void DocumentPaintState::viewport_row_was_reset(DOM::Document& document)
 
 void DocumentPaintState::refresh_sticky_constraints(DOM::Document& document)
 {
-    m_needs_to_refresh_scroll_state = true;
     if (mirror_rust_refresh_sticky_constraints(document))
         m_visual_context_tree_needs_compositor_update = true;
 }
 
-void DocumentPaintState::set_needs_to_refresh_scroll_state(DOM::Document& document, bool value)
+void DocumentPaintState::invalidate_scroll_state(DOM::Document& document)
 {
-    m_needs_to_refresh_scroll_state = value;
-    mirror_rust_set_needs_to_refresh_scroll_state(document, value);
+    rust_invalidate_scroll_state(document);
 }
 
 void DocumentPaintState::clear_scroll_state(DOM::Document& document)
 {
     m_scroll_state_snapshot = {};
-    m_needs_to_refresh_scroll_state = true;
     mirror_rust_clear_scroll_state(document);
 }
 
@@ -109,7 +106,6 @@ void DocumentPaintState::update_accumulated_visual_contexts(DOM::Document& docum
     } else {
         ++m_accumulated_visual_context_tree_incremental_update_count;
     }
-    set_needs_to_refresh_scroll_state(document, true);
     if (result.requires_display_list_recording || svg_paint_resources_changed)
         document.set_needs_to_record_display_list();
     if (result.structural_epoch_changed)
@@ -180,11 +176,9 @@ void DocumentPaintState::invalidate_all_cached_paint(DOM::Document& document)
 
 void DocumentPaintState::refresh_scroll_state(DOM::Document& document)
 {
-    if (!m_needs_to_refresh_scroll_state)
+    if (!rust_refresh_scroll_state(document))
         return;
-    m_needs_to_refresh_scroll_state = false;
     // https://drafts.csswg.org/css-position/#sticky-pos
-    rust_refresh_scroll_state(document);
     m_scroll_state_snapshot = rust_scroll_state_snapshot(document);
     if (has_visual_context_tree())
         resolve_sticky_offsets(visual_context_tree_without_update(document), m_scroll_state_snapshot);

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -72,9 +72,9 @@ BlockingWheelEventRegionState DocumentPaintState::collect_root_blocking_wheel_ev
     return {};
 }
 
-void DocumentPaintState::viewport_row_was_reset(DOM::Document& document)
+void DocumentPaintState::viewport_row_was_reset()
 {
-    clear_scroll_state(document);
+    m_scroll_state_snapshot = {};
     m_boxes_with_auto_content_visibility.clear();
     m_visual_context_tree_needs_compositor_update = false;
 }
@@ -88,12 +88,6 @@ void DocumentPaintState::refresh_sticky_constraints(DOM::Document& document)
 void DocumentPaintState::invalidate_scroll_state(DOM::Document& document)
 {
     rust_invalidate_scroll_state(document);
-}
-
-void DocumentPaintState::clear_scroll_state(DOM::Document& document)
-{
-    m_scroll_state_snapshot = {};
-    mirror_rust_clear_scroll_state(document);
 }
 
 void DocumentPaintState::update_accumulated_visual_contexts(DOM::Document& document)

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -178,10 +178,7 @@ void DocumentPaintState::refresh_scroll_state(DOM::Document& document)
 {
     if (!rust_refresh_scroll_state(document))
         return;
-    // https://drafts.csswg.org/css-position/#sticky-pos
     m_scroll_state_snapshot = rust_scroll_state_snapshot(document);
-    if (has_visual_context_tree())
-        resolve_sticky_offsets(visual_context_tree_without_update(document), m_scroll_state_snapshot);
 }
 
 void DocumentPaintState::reset_selection_states(DOM::Document& document)

--- a/Libraries/LibWeb/Painting/DocumentPaintState.h
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.h
@@ -27,7 +27,7 @@ class WEB_API DocumentPaintState {
 public:
     explicit DocumentPaintState(Layout::NodeArena&);
 
-    void viewport_row_was_reset(DOM::Document&);
+    void viewport_row_was_reset();
 
     BlockingWheelEventRegionState collect_root_blocking_wheel_event_regions(DOM::Document&);
 
@@ -78,7 +78,6 @@ public:
 private:
     Vector<String> m_recording_traces;
     void ensure_visual_context_tree(DOM::Document const&) const;
-    void clear_scroll_state(DOM::Document&);
 
     NonnullRefPtr<Layout::NodeArena> m_layout_node_arena;
 

--- a/Libraries/LibWeb/Painting/DocumentPaintState.h
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.h
@@ -31,6 +31,8 @@ public:
 
     BlockingWheelEventRegionState collect_root_blocking_wheel_event_regions(DOM::Document&);
 
+    // Called from Document::update_paint_and_hit_testing_properties_if_needed() once the visual
+    // context tree is settled; every other consumer reaches the scroll state through that update.
     void refresh_scroll_state(DOM::Document&);
     void refresh_sticky_constraints(DOM::Document&);
 
@@ -51,7 +53,7 @@ public:
 
     void invalidate_all_cached_paint(DOM::Document&);
 
-    void set_needs_to_refresh_scroll_state(DOM::Document&, bool);
+    void invalidate_scroll_state(DOM::Document&);
 
     ScrollStateSnapshot const& scroll_state_snapshot() const { return m_scroll_state_snapshot; }
 
@@ -81,7 +83,6 @@ private:
     NonnullRefPtr<Layout::NodeArena> m_layout_node_arena;
 
     ScrollStateSnapshot m_scroll_state_snapshot;
-    bool m_needs_to_refresh_scroll_state { true };
 
     Vector<Layout::RustFFI::NodeSlotId> m_boxes_with_auto_content_visibility;
 

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -557,11 +557,6 @@ bool mirror_rust_refresh_sticky_constraints(DOM::Document& document)
     return Layout::RustFFI::layout_arena_refresh_sticky_constraints(layout_arena_handle(document), visual_context_host_callbacks(document));
 }
 
-void mirror_rust_clear_scroll_state(DOM::Document& document)
-{
-    Layout::RustFFI::layout_arena_clear_scroll_state(layout_arena_handle(document));
-}
-
 void rust_invalidate_scroll_state(DOM::Document& document)
 {
     Layout::RustFFI::layout_arena_invalidate_scroll_state(layout_arena_handle(document));

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -543,9 +543,9 @@ void rust_update_visual_viewport_transform(DOM::Document& document)
     Layout::RustFFI::layout_arena_update_visual_viewport_transform(layout_arena_handle(document), visual_context_host_callbacks(document));
 }
 
-void rust_refresh_scroll_state(DOM::Document& document)
+bool rust_refresh_scroll_state(DOM::Document& document)
 {
-    Layout::RustFFI::layout_arena_refresh_scroll_state(layout_arena_handle(document), visual_context_host_callbacks(document));
+    return Layout::RustFFI::layout_arena_refresh_scroll_state(layout_arena_handle(document), visual_context_host_callbacks(document));
 }
 
 ScrollStateSnapshot rust_scroll_state_snapshot(DOM::Document& document)
@@ -572,9 +572,9 @@ void mirror_rust_clear_scroll_state(DOM::Document& document)
     Layout::RustFFI::layout_arena_clear_scroll_state(layout_arena_handle(document));
 }
 
-void mirror_rust_set_needs_to_refresh_scroll_state(DOM::Document& document, bool value)
+void rust_invalidate_scroll_state(DOM::Document& document)
 {
-    Layout::RustFFI::layout_arena_set_needs_to_refresh_scroll_state(layout_arena_handle(document), value);
+    Layout::RustFFI::layout_arena_invalidate_scroll_state(layout_arena_handle(document));
 }
 
 void mirror_rust_invalidate_paint_cache(Layout::Node const& node)

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -543,10 +543,10 @@ void rust_update_visual_viewport_transform(DOM::Document& document)
     Layout::RustFFI::layout_arena_update_visual_viewport_transform(layout_arena_handle(document), visual_context_host_callbacks(document));
 }
 
-bool rust_refresh_scroll_state(DOM::Document& document, ScrollStateSnapshot& snapshot)
+bool rust_refresh_scroll_state(DOM::Document& document, ScrollStateSnapshot& snapshot, ForceScrollStateRefresh force)
 {
     return Layout::RustFFI::layout_arena_refresh_scroll_state(
-        layout_arena_handle(document), visual_context_host_callbacks(document),
+        layout_arena_handle(document), visual_context_host_callbacks(document), force == ForceScrollStateRefresh::Yes,
         &snapshot, [](void* sink, Gfx::FloatPoint const* offsets, size_t count) {
             static_cast<ScrollStateSnapshot*>(sink)->assign_device_offsets({ offsets, count });
         });

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -543,23 +543,13 @@ void rust_update_visual_viewport_transform(DOM::Document& document)
     Layout::RustFFI::layout_arena_update_visual_viewport_transform(layout_arena_handle(document), visual_context_host_callbacks(document));
 }
 
-bool rust_refresh_scroll_state(DOM::Document& document)
+bool rust_refresh_scroll_state(DOM::Document& document, ScrollStateSnapshot& snapshot)
 {
-    return Layout::RustFFI::layout_arena_refresh_scroll_state(layout_arena_handle(document), visual_context_host_callbacks(document));
-}
-
-ScrollStateSnapshot rust_scroll_state_snapshot(DOM::Document& document)
-{
-    auto* arena = layout_arena_handle(document);
-    auto count = Layout::RustFFI::layout_arena_scroll_state_snapshot(arena, nullptr, 0);
-    Vector<Gfx::FloatPoint> values;
-    values.resize(count);
-    if (count > 0)
-        Layout::RustFFI::layout_arena_scroll_state_snapshot(arena, values.data(), values.size());
-    ScrollStateSnapshot snapshot;
-    for (size_t index = 0; index < values.size(); ++index)
-        snapshot.set_device_offset_for_index(SpatialNodeIndex { static_cast<u32>(index) }, values[index]);
-    return snapshot;
+    return Layout::RustFFI::layout_arena_refresh_scroll_state(
+        layout_arena_handle(document), visual_context_host_callbacks(document),
+        &snapshot, [](void* sink, Gfx::FloatPoint const* offsets, size_t count) {
+            static_cast<ScrollStateSnapshot*>(sink)->assign_device_offsets({ offsets, count });
+        });
 }
 
 bool mirror_rust_refresh_sticky_constraints(DOM::Document& document)

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -37,8 +37,8 @@ WEB_API Layout::RustFFI::FfiPhysicalOverflowDirections rust_physical_overflow_di
 WEB_API void rust_measure_scrollable_overflow(Layout::Node const&);
 WEB_API Layout::RustFFI::FfiScrollableOverflowUpdateOutcome rust_update_scrollable_overflow(DOM::Document&, bool handled_by_full_layout_commit);
 WEB_API void rust_update_visual_viewport_transform(DOM::Document&);
-WEB_API bool rust_refresh_scroll_state(DOM::Document&);
-WEB_API ScrollStateSnapshot rust_scroll_state_snapshot(DOM::Document&);
+// Refreshes the snapshot from the Rust scroll state; false when nothing had invalidated it.
+WEB_API bool rust_refresh_scroll_state(DOM::Document&, ScrollStateSnapshot&);
 WEB_API bool mirror_rust_refresh_sticky_constraints(DOM::Document&);
 WEB_API void mirror_rust_clear_scroll_state(DOM::Document&);
 WEB_API void rust_invalidate_scroll_state(DOM::Document&);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -37,11 +37,11 @@ WEB_API Layout::RustFFI::FfiPhysicalOverflowDirections rust_physical_overflow_di
 WEB_API void rust_measure_scrollable_overflow(Layout::Node const&);
 WEB_API Layout::RustFFI::FfiScrollableOverflowUpdateOutcome rust_update_scrollable_overflow(DOM::Document&, bool handled_by_full_layout_commit);
 WEB_API void rust_update_visual_viewport_transform(DOM::Document&);
-WEB_API void rust_refresh_scroll_state(DOM::Document&);
+WEB_API bool rust_refresh_scroll_state(DOM::Document&);
 WEB_API ScrollStateSnapshot rust_scroll_state_snapshot(DOM::Document&);
 WEB_API bool mirror_rust_refresh_sticky_constraints(DOM::Document&);
 WEB_API void mirror_rust_clear_scroll_state(DOM::Document&);
-WEB_API void mirror_rust_set_needs_to_refresh_scroll_state(DOM::Document&, bool);
+WEB_API void rust_invalidate_scroll_state(DOM::Document&);
 WEB_API void mirror_rust_invalidate_paint_cache(Layout::Node const&);
 WEB_API void rust_invalidate_propagated_text_decoration_caches(Layout::Node const&);
 struct InspectorOverlayInputs {

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -37,8 +37,13 @@ WEB_API Layout::RustFFI::FfiPhysicalOverflowDirections rust_physical_overflow_di
 WEB_API void rust_measure_scrollable_overflow(Layout::Node const&);
 WEB_API Layout::RustFFI::FfiScrollableOverflowUpdateOutcome rust_update_scrollable_overflow(DOM::Document&, bool handled_by_full_layout_commit);
 WEB_API void rust_update_visual_viewport_transform(DOM::Document&);
-// Refreshes the snapshot from the Rust scroll state; false when nothing had invalidated it.
-WEB_API bool rust_refresh_scroll_state(DOM::Document&, ScrollStateSnapshot&);
+enum class ForceScrollStateRefresh {
+    No,
+    Yes,
+};
+// Refreshes the snapshot from the Rust scroll state; false when nothing had invalidated it and
+// the refresh was not forced.
+WEB_API bool rust_refresh_scroll_state(DOM::Document&, ScrollStateSnapshot&, ForceScrollStateRefresh = ForceScrollStateRefresh::No);
 WEB_API bool mirror_rust_refresh_sticky_constraints(DOM::Document&);
 WEB_API void mirror_rust_clear_scroll_state(DOM::Document&);
 WEB_API void rust_invalidate_scroll_state(DOM::Document&);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -45,7 +45,6 @@ enum class ForceScrollStateRefresh {
 // the refresh was not forced.
 WEB_API bool rust_refresh_scroll_state(DOM::Document&, ScrollStateSnapshot&, ForceScrollStateRefresh = ForceScrollStateRefresh::No);
 WEB_API bool mirror_rust_refresh_sticky_constraints(DOM::Document&);
-WEB_API void mirror_rust_clear_scroll_state(DOM::Document&);
 WEB_API void rust_invalidate_scroll_state(DOM::Document&);
 WEB_API void mirror_rust_invalidate_paint_cache(Layout::Node const&);
 WEB_API void rust_invalidate_propagated_text_decoration_caches(Layout::Node const&);

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -55,6 +55,14 @@ public:
         m_device_offsets[index.value()] = offset;
     }
 
+    // Replaces every offset with a freshly derived dense array, keeping the adopted async scroll
+    // sequence and the node count bound.
+    void assign_device_offsets(ReadonlySpan<Gfx::FloatPoint> offsets)
+    {
+        m_device_offsets.clear_with_capacity();
+        m_device_offsets.append(offsets.data(), min(offsets.size(), m_node_count));
+    }
+
     // Bind the snapshot to the authoritative node count from the AccumulatedVisualContextTree that owns these nodes.
     // Wire-decoded offsets are staged rather than densified. So, this is where a decoded index is first validated:
     // staged pairs are applied through the bounded setter above, dropping any whose index is at or past the node count.

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -20,8 +20,8 @@
 namespace Web::Painting {
 
 // Device-pixel offsets keyed by SpatialNodeIndex: the scroll containers' offsets as produced by
-// the document, plus the sticky nodes' offsets that resolve_sticky_offsets() derives from them
-// and the tree. Stored dense in process so display list replay and hit testing index it directly;
+// the document, plus the sticky nodes' offsets derived from them and the tree (by the document's
+// scroll state refresh in process, by resolve_sticky_offsets() in the compositor). Stored dense in process so display list replay and hit testing index it directly;
 // indices that are not scroll-like nodes read as zero offsets. The IPC representation is sparse
 // (index, offset) pairs.
 //

--- a/Libraries/LibWeb/Painting/Scrolling.cpp
+++ b/Libraries/LibWeb/Painting/Scrolling.cpp
@@ -181,8 +181,6 @@ ScrollHandled set_scroll_offset(Layout::Node& node, CSSPixelPoint offset)
         return ScrollHandled::Yes;
     }
 
-    node.document().invalidate_scroll_state();
-
     if (auto pseudo_element = node.generated_for_pseudo_element(); pseudo_element.has_value()) {
         node.pseudo_element_generator()->set_scroll_offset(*pseudo_element, offset);
     } else if (auto* element = as_if<DOM::Element>(node.dom_node())) {

--- a/Libraries/LibWeb/Painting/Scrolling.cpp
+++ b/Libraries/LibWeb/Painting/Scrolling.cpp
@@ -181,7 +181,7 @@ ScrollHandled set_scroll_offset(Layout::Node& node, CSSPixelPoint offset)
         return ScrollHandled::Yes;
     }
 
-    node.document().set_needs_to_refresh_scroll_state(true);
+    node.document().invalidate_scroll_state();
 
     if (auto pseudo_element = node.generated_for_pseudo_element(); pseudo_element.has_value()) {
         node.pseudo_element_generator()->set_scroll_offset(*pseudo_element, offset);

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1739,7 +1739,6 @@ pub unsafe extern "C" fn layout_arena_clear_scroll_state(arena: *mut c_void) {
     let mut paint_state = arena.paint_state().borrow_mut();
     let state = &mut paint_state.visual_context;
     state.scroll_state.clear();
-    state.scroll_state_snapshot.clear();
     state.needs_to_refresh_scroll_state = true;
 }
 
@@ -1769,37 +1768,46 @@ pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
 }
 
 /// Re-reads the scroll containers' offsets when something invalidated them since the last
-/// refresh and resolves the sticky nodes' offsets on top of them. Returns whether that
-/// happened, so the caller re-pulls the snapshot only then.
+/// refresh, resolves the sticky nodes' offsets on top of them, and hands the dense device-pixel
+/// snapshot to `publish`. Returns whether that happened, so the caller keeps its copy otherwise.
 ///
 /// # Safety
 ///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
+/// `publish` is called synchronously with `sink` and a view of the snapshot that is valid only
+/// for the duration of that call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_refresh_scroll_state(
     arena: *mut c_void,
     callbacks: FfiVisualContextHostCallbacks,
+    sink: *mut c_void,
+    publish: unsafe extern "C" fn(*mut c_void, *const libgfx_rust::FloatPoint, usize),
 ) -> bool {
     let arena = unsafe { arena_from_handle(arena) };
-    let paintable_rows = arena.paintable_rows();
-    let mut paint_state = arena.paint_state().borrow_mut();
-    let state = &mut paint_state.visual_context;
-    if !state.needs_to_refresh_scroll_state {
-        return false;
-    }
-    state.needs_to_refresh_scroll_state = false;
-    crate::painting::visual_context::refresh::refresh_scroll_state(
-        &paintable_rows,
-        &callbacks,
-        &mut state.scroll_state,
-    );
-    state.scroll_state_snapshot = state
-        .scroll_state
-        .snapshot(callbacks.tree_inputs().device_pixels_per_css_pixel);
-    // https://drafts.csswg.org/css-position/#sticky-pos
-    if let Some(tree) = state.tree.as_deref() {
-        tree.resolve_sticky_offsets_in_place(&mut state.scroll_state_snapshot);
-    }
+    let snapshot = {
+        let paintable_rows = arena.paintable_rows();
+        let mut paint_state = arena.paint_state().borrow_mut();
+        let state = &mut paint_state.visual_context;
+        if !state.needs_to_refresh_scroll_state {
+            return false;
+        }
+        state.needs_to_refresh_scroll_state = false;
+        crate::painting::visual_context::refresh::refresh_scroll_state(
+            &paintable_rows,
+            &callbacks,
+            &mut state.scroll_state,
+        );
+        let mut snapshot = state
+            .scroll_state
+            .snapshot(callbacks.tree_inputs().device_pixels_per_css_pixel);
+        // https://drafts.csswg.org/css-position/#sticky-pos
+        if let Some(tree) = state.tree.as_deref() {
+            tree.resolve_sticky_offsets_in_place(&mut snapshot);
+        }
+        snapshot
+    };
+    // SAFETY: The C++ sink copies the offsets synchronously.
+    unsafe { publish(sink, snapshot.as_ptr(), snapshot.len()) };
     true
 }
 
@@ -3834,32 +3842,6 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_destroy(builder: *mut 
     }
     // SAFETY: The caller hands over the boxed tree the create call returned.
     drop(unsafe { Box::from_raw(builder.cast::<crate::painting::visual_context::VisualContextTree>()) });
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread; `out`
-/// must have room for `capacity` points.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_scroll_state_snapshot(
-    arena: *mut c_void,
-    out: *mut libgfx_rust::FloatPoint,
-    capacity: usize,
-) -> usize {
-    let arena = unsafe { arena_from_handle(arena) };
-    let paint_state = arena.paint_state().borrow();
-    let snapshot = &paint_state.visual_context.scroll_state_snapshot;
-    let needed = snapshot.len();
-    if !out.is_null() {
-        for (index, offset) in snapshot.iter().enumerate() {
-            if index >= capacity {
-                break;
-            }
-            // SAFETY: within the caller's capacity.
-            unsafe { *out.add(index) = *offset };
-        }
-    }
-    needed
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1769,7 +1769,8 @@ pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
 
 /// Re-reads the scroll containers' offsets when something invalidated them since the last
 /// refresh, resolves the sticky nodes' offsets on top of them, and hands the dense device-pixel
-/// snapshot to `publish`. Returns whether that happened, so the caller keeps its copy otherwise.
+/// snapshot to `publish`. Returns whether that happened, so the caller keeps its copy otherwise;
+/// `force` re-derives the snapshot even when nothing invalidated it, for verification.
 ///
 /// # Safety
 ///
@@ -1780,6 +1781,7 @@ pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
 pub unsafe extern "C" fn layout_arena_refresh_scroll_state(
     arena: *mut c_void,
     callbacks: FfiVisualContextHostCallbacks,
+    force: bool,
     sink: *mut c_void,
     publish: unsafe extern "C" fn(*mut c_void, *const libgfx_rust::FloatPoint, usize),
 ) -> bool {
@@ -1788,7 +1790,7 @@ pub unsafe extern "C" fn layout_arena_refresh_scroll_state(
         let paintable_rows = arena.paintable_rows();
         let mut paint_state = arena.paint_state().borrow_mut();
         let state = &mut paint_state.visual_context;
-        if !state.needs_to_refresh_scroll_state {
+        if !force && !state.needs_to_refresh_scroll_state {
             return false;
         }
         state.needs_to_refresh_scroll_state = false;

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1734,18 +1734,6 @@ pub unsafe extern "C" fn layout_arena_invalidate_scroll_state(arena: *mut c_void
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_clear_scroll_state(arena: *mut c_void) {
-    let arena = unsafe { arena_from_handle(arena) };
-    let mut paint_state = arena.paint_state().borrow_mut();
-    let state = &mut paint_state.visual_context;
-    state.scroll_state.clear();
-    state.needs_to_refresh_scroll_state = true;
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
     arena: *mut c_void,
     callbacks: FfiVisualContextHostCallbacks,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1721,13 +1721,13 @@ pub unsafe extern "C" fn layout_arena_update_visual_viewport_transform(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_set_needs_to_refresh_scroll_state(arena: *mut c_void, value: bool) {
+pub unsafe extern "C" fn layout_arena_invalidate_scroll_state(arena: *mut c_void) {
     let arena = unsafe { arena_from_handle(arena) };
     arena
         .paint_state()
         .borrow_mut()
         .visual_context
-        .needs_to_refresh_scroll_state = value;
+        .needs_to_refresh_scroll_state = true;
 }
 
 /// # Safety
@@ -1768,6 +1768,9 @@ pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
     any_sticky_payload_changed
 }
 
+/// Re-reads the scroll containers' offsets when something invalidated them since the last
+/// refresh. Returns whether that happened, so the caller re-pulls the snapshot only then.
+///
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
@@ -1775,13 +1778,13 @@ pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
 pub unsafe extern "C" fn layout_arena_refresh_scroll_state(
     arena: *mut c_void,
     callbacks: FfiVisualContextHostCallbacks,
-) {
+) -> bool {
     let arena = unsafe { arena_from_handle(arena) };
     let paintable_rows = arena.paintable_rows();
     let mut paint_state = arena.paint_state().borrow_mut();
     let state = &mut paint_state.visual_context;
     if !state.needs_to_refresh_scroll_state {
-        return;
+        return false;
     }
     state.needs_to_refresh_scroll_state = false;
     crate::painting::visual_context::refresh::refresh_scroll_state(
@@ -1792,6 +1795,7 @@ pub unsafe extern "C" fn layout_arena_refresh_scroll_state(
     state.scroll_state_snapshot = state
         .scroll_state
         .snapshot(callbacks.tree_inputs().device_pixels_per_css_pixel);
+    true
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1769,7 +1769,8 @@ pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
 }
 
 /// Re-reads the scroll containers' offsets when something invalidated them since the last
-/// refresh. Returns whether that happened, so the caller re-pulls the snapshot only then.
+/// refresh and resolves the sticky nodes' offsets on top of them. Returns whether that
+/// happened, so the caller re-pulls the snapshot only then.
 ///
 /// # Safety
 ///
@@ -1795,6 +1796,10 @@ pub unsafe extern "C" fn layout_arena_refresh_scroll_state(
     state.scroll_state_snapshot = state
         .scroll_state
         .snapshot(callbacks.tree_inputs().device_pixels_per_css_pixel);
+    // https://drafts.csswg.org/css-position/#sticky-pos
+    if let Some(tree) = state.tree.as_deref() {
+        tree.resolve_sticky_offsets_in_place(&mut state.scroll_state_snapshot);
+    }
     true
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -127,6 +127,12 @@ impl<'a> PaintableCommit<'a> {
         let arena = self.arena_mut();
         if row_existed_before_this_commit {
             arena.paintable_rows_mut().begin_paintable_row_recommit(node);
+            if node_kind == NodeKind::Viewport {
+                // A recommitted viewport row starts its paint state over: the scroll registry is
+                // dropped here and rebuilt by the next tree update, while the host resets its
+                // snapshot from the row reset notification.
+                arena.paint_state().borrow_mut().visual_context.clear_scroll_state();
+            }
         } else {
             arena.populate_paintable_row(node);
             if node_kind == NodeKind::Viewport {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -633,7 +633,6 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
         tree.structural_epoch = allocate_structural_epoch();
     }
     state.scroll_state = scroll_state;
-    state.scroll_state_snapshot.clear();
     state.needs_to_refresh_scroll_state = true;
     IncrementalUpdateResult::Applied(Box::new(IncrementalUpdateOutcome {
         delta,

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -677,6 +677,11 @@ impl VisualContextState {
         self.tree.as_ref().map_or(0, |tree| tree.structural_epoch)
     }
 
+    pub fn clear_scroll_state(&mut self) {
+        self.scroll_state.clear();
+        self.needs_to_refresh_scroll_state = true;
+    }
+
     pub fn release_quarantined_slots_while_no_handle_is_retained(&mut self) {
         if !self.quarantined_slots_are_releasable {
             return;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -662,7 +662,6 @@ pub struct VisualContextState {
     pub tree: Option<Rc<VisualContextTree>>,
     pub paintables_with_mask_nodes: Vec<crate::layout::node_data::NodeSlotId>,
     pub scroll_state: scroll_state::ScrollState,
-    pub scroll_state_snapshot: Vec<FloatPoint>,
     pub needs_to_refresh_scroll_state: bool,
     pub build_count: u64,
     pub dirty_boxes: dirty::VisualContextDirtySet,

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
@@ -552,25 +552,45 @@ impl VisualContextTree {
         offset
     }
 
+    /// The sticky nodes' resolved offsets as `(node, offset)` pairs in dependency order, for a
+    /// consumer that keeps its own copy of the scroll offsets: the compositor overlays them on the
+    /// snapshot it received.
     pub fn resolve_sticky_offsets(&self, scroll_offsets: &[FloatPoint]) -> Vec<(SpatialNodeIndex, FloatPoint)> {
+        let mut resolved_offsets = scroll_offsets.to_vec();
+        let mut resolved_sticky_entries = Vec::new();
+        self.resolve_sticky_offsets_with(&mut resolved_offsets, |node_index, offset| {
+            resolved_sticky_entries.push((node_index, offset));
+        });
+        resolved_sticky_entries
+    }
+
+    /// Resolves every sticky node's offset on top of the scroll containers' entries in `offsets`
+    /// (their negated scroll offsets in device pixels), writing it at the node's own index and
+    /// growing the vector as needed.
+    pub fn resolve_sticky_offsets_in_place(&self, offsets: &mut Vec<FloatPoint>) {
+        self.resolve_sticky_offsets_with(offsets, |_, _| {});
+    }
+
+    fn resolve_sticky_offsets_with(
+        &self,
+        offsets: &mut Vec<FloatPoint>,
+        mut on_entry: impl FnMut(SpatialNodeIndex, FloatPoint),
+    ) {
         if !self
             .spatial_nodes
             .iter()
             .any(|node| matches!(node.data, SpatialData::Sticky(_)))
         {
-            return Vec::new();
+            return;
         }
-        let mut resolved_offsets = scroll_offsets.to_vec();
-        let mut resolved_sticky_entries = Vec::new();
-        let mut record_entry =
-            |resolved_offsets: &mut Vec<FloatPoint>, node_index: SpatialNodeIndex, offset: FloatPoint| {
-                let slot = node_index.0 as usize;
-                if slot >= resolved_offsets.len() {
-                    resolved_offsets.resize(slot + 1, FloatPoint::default());
-                }
-                resolved_offsets[slot] = offset;
-                resolved_sticky_entries.push((node_index, offset));
-            };
+        let mut record_entry = |offsets: &mut Vec<FloatPoint>, node_index: SpatialNodeIndex, offset: FloatPoint| {
+            let slot = node_index.0 as usize;
+            if slot >= offsets.len() {
+                offsets.resize(slot + 1, FloatPoint::default());
+            }
+            offsets[slot] = offset;
+            on_entry(node_index, offset);
+        };
         for index in self.spatial_dependency_order() {
             let node = &self.spatial_nodes[index as usize];
             let SpatialData::Sticky(sticky) = &node.data else {
@@ -578,7 +598,7 @@ impl VisualContextTree {
             };
             let node_index = SpatialNodeIndex(index);
             if sticky.scroller == VISUAL_VIEWPORT_NODE_INDEX {
-                record_entry(&mut resolved_offsets, node_index, FloatPoint::default());
+                record_entry(offsets, node_index, FloatPoint::default());
                 continue;
             }
 
@@ -587,7 +607,7 @@ impl VisualContextTree {
             let mut parent_sticky_offset = FloatPoint::default();
             let mut ancestor = sticky.parent_sticky;
             while let Some(ancestor_index) = ancestor {
-                let entry = device_offset_for_index(&resolved_offsets, ancestor_index);
+                let entry = device_offset_for_index(offsets, ancestor_index);
                 parent_sticky_offset = FloatPoint {
                     x: parent_sticky_offset.x + entry.x,
                     y: parent_sticky_offset.y + entry.y,
@@ -614,7 +634,7 @@ impl VisualContextTree {
             };
 
             // A scroll container's entry is its negated scroll offset.
-            let scroller_entry = device_offset_for_index(&resolved_offsets, sticky.scroller);
+            let scroller_entry = device_offset_for_index(offsets, sticky.scroller);
             let scrollport_rect = FloatRect::new(
                 -scroller_entry.x,
                 -scroller_entry.y,
@@ -650,9 +670,8 @@ impl VisualContextTree {
                     - position_in_scroller.x;
             }
 
-            record_entry(&mut resolved_offsets, node_index, sticky_offset);
+            record_entry(offsets, node_index, sticky_offset);
         }
-        resolved_sticky_entries
     }
 }
 
@@ -1690,6 +1709,28 @@ mod tests {
             tree.spatial_nodes_in_subtrees_of(&[scroll_node]),
             vec![false, true, false, true]
         );
+    }
+
+    #[test]
+    fn resolving_in_place_writes_the_entries_the_pairs_report() {
+        let mut tree = identity_tree();
+        let scroll_node = tree.append_spatial(scroll(), VISUAL_VIEWPORT_NODE_INDEX);
+        let outer_sticky = tree.append_spatial(sticky(scroll_node, None, 100.0), scroll_node);
+        let inner_sticky = tree.append_spatial(sticky(scroll_node, Some(outer_sticky), 110.0), outer_sticky);
+        // Only the scroll containers' entries are present; the sticky nodes' indices lie past the end.
+        let mut scroll_offsets = vec![FloatPoint::default(); scroll_node.0 as usize + 1];
+        scroll_offsets[scroll_node.0 as usize] = point(0.0, -150.0);
+
+        let entries = tree.resolve_sticky_offsets(&scroll_offsets);
+        let mut resolved_in_place = scroll_offsets.clone();
+        tree.resolve_sticky_offsets_in_place(&mut resolved_in_place);
+
+        assert_eq!(resolved_in_place.len(), inner_sticky.0 as usize + 1);
+        assert_eq!(resolved_in_place[..scroll_offsets.len()], scroll_offsets[..]);
+        assert_eq!(entries.len(), 2);
+        for (node, offset) in entries {
+            assert_eq!(resolved_in_place[node.0 as usize], offset);
+        }
     }
 
     #[test]

--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -52,6 +52,7 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
         "run-ui-process-session-history-tests");
     args_parser.add_option(verify_style, "Enable all style engine verification modes", "verify-style");
     args_parser.add_option(verify_paint_cache, "Re-record every display list that spliced cached paint commands and abort on divergence", "verify-paint-cache");
+    args_parser.add_option(verify_scroll_state, "Re-derive the scroll state snapshot at every refresh that found nothing to do and abort on divergence", "verify-scroll-state");
     args_parser.add_option(per_test_timeout_in_seconds, "Per-test timeout (default: 30)", "per-test-timeout", 't', "seconds");
 
     args_parser.add_option(Core::ArgsParser::Option {
@@ -90,6 +91,8 @@ void Application::create_platform_options(WebView::BrowserOptions& browser_optio
     }
     if (verify_paint_cache)
         MUST(Core::Environment::set("LADYBIRD_VERIFY_PAINT_CACHE"sv, "1"sv, Core::Environment::Overwrite::Yes));
+    if (verify_scroll_state)
+        MUST(Core::Environment::set("LIBWEB_VERIFY_SCROLL_STATE"sv, "1"sv, Core::Environment::Overwrite::Yes));
     browser_options.headless_mode = WebView::HeadlessMode::Test;
     browser_options.disable_sql_database = WebView::DisableSQLDatabase::Yes;
 

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -57,6 +57,7 @@ public:
     bool run_ui_process_session_history_tests { false };
     bool verify_style { false };
     bool verify_paint_cache { false };
+    bool verify_scroll_state { false };
     int per_test_timeout_in_seconds { 30 };
 
     u8 verbosity { 0 };


### PR DESCRIPTION
The scroll state was refreshed from 11 call sites, gated by two dirty bits (C++ and Rust) kept in sync by seven producers, and pulled out of Rust through four FFI calls per refresh. Now: one refresh entry, one dirty bit owned by Rust, one FFI call. No consumer-visible change.

- Drop the 10 redundant refresh calls (only the lazy paint-properties update refreshes).
- Rust owns the dirty bit; the C++ mirror is gone.
- Sticky offsets are resolved inside the Rust refresh instead of a C++ round trip.
- The refresh publishes the finished snapshot itself; the two-call export and the Rust staging vector are gone.
- New verifier: `test-web --verify-scroll-state` re-derives the snapshot at every skipped refresh and aborts on divergence.
- Invalidation moves into `Element::set_scroll_offset()`, the viewport recommit clear moves into Rust, and the redundant mark in `after_layout_commit()` is removed.