### PR TITLE
Keep the hit-test display list across paint-only repaints

### DIFF
--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -860,6 +860,7 @@
     ]
   },
   "border-bottom-left-radius": {
+    "affects-hit-testing": true,
     "affects-accumulated-visual-contexts": true,
     "style-group": "BorderValues",
     "affects-layout": false,
@@ -875,6 +876,7 @@
     "percentages-resolve-to": "length"
   },
   "border-bottom-right-radius": {
+    "affects-hit-testing": true,
     "affects-accumulated-visual-contexts": true,
     "style-group": "BorderValues",
     "affects-layout": false,
@@ -1320,6 +1322,7 @@
     ]
   },
   "border-top-left-radius": {
+    "affects-hit-testing": true,
     "affects-accumulated-visual-contexts": true,
     "style-group": "BorderValues",
     "affects-layout": false,
@@ -1335,6 +1338,7 @@
     "percentages-resolve-to": "length"
   },
   "border-top-right-radius": {
+    "affects-hit-testing": true,
     "affects-accumulated-visual-contexts": true,
     "style-group": "BorderValues",
     "affects-layout": false,
@@ -2179,6 +2183,7 @@
     ]
   },
   "fill": {
+    "affects-hit-testing": true,
     "style-group": "InheritedSVGValues",
     "affects-layout": false,
     "animation-type": "by-computed-value",
@@ -2201,6 +2206,7 @@
     ]
   },
   "fill-rule": {
+    "affects-hit-testing": true,
     "style-group": "InheritedSVGValues",
     "affects-layout": false,
     "animation-type": "discrete",
@@ -4073,6 +4079,7 @@
     ]
   },
   "pointer-events": {
+    "affects-hit-testing": true,
     "style-group": "InheritedUIValues",
     "affects-layout": false,
     "animation-type": "discrete",
@@ -4194,6 +4201,7 @@
     ]
   },
   "resize": {
+    "affects-hit-testing": true,
     "style-group": "BoxValues",
     "animation-type": "none",
     "inherited": false,
@@ -5359,6 +5367,7 @@
     ]
   },
   "visibility": {
+    "affects-hit-testing": true,
     "style-group": "InheritedBoxValues",
     "animation-type": "custom",
     "inherited": true,

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -34,6 +34,7 @@ RequiredInvalidationAfterStyleChange decode_style_invalidation(u32 packed)
     result.changes_containing_block_establishment = packed & to_underlying(ChangesContainingBlock);
     result.repaint_propagated_text_decorations = packed & to_underlying(RepaintTextDecorations);
     result.non_inherited_property_inheritance_sources_changed = packed & to_underlying(NonInheritedInheritanceSource);
+    result.affects_hit_testing = packed & to_underlying(AffectsHitTesting);
     return result;
 }
 

--- a/Libraries/LibWeb/CSS/StyleInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.h
@@ -72,6 +72,13 @@ struct RequiredInvalidationAfterStyleChange {
     //     when the recalculation has to run as a separate step.
     [[nodiscard]] bool needs_scrollable_overflow_recalculation() const { return m_needs_scrollable_overflow_recalculation && !needs_relayout(); }
     [[nodiscard]] AccumulatedVisualContextInvalidation accumulated_visual_contexts() const { return m_accumulated_visual_contexts; }
+    [[nodiscard]] bool invalidates_hit_test_display_list() const
+    {
+        return affects_hit_testing
+            || needs_relayout()
+            || needs_stacking_context_tree_rebuild()
+            || m_accumulated_visual_contexts == AccumulatedVisualContextInvalidation::Rebuild;
+    }
 
     // A scroll snap property changed, so snap containers must re-evaluate their scroll position and re-snap.
     bool needs_scroll_container_resnap : 1 { false };
@@ -93,6 +100,7 @@ struct RequiredInvalidationAfterStyleChange {
     bool repaint_propagated_text_decorations : 1 { false };
     // Selection highlights are painted by text descendants, even when the element has no box.
     bool repaint_selection : 1 { false };
+    bool affects_hit_testing : 1 { false };
     // A non-inherited property changed without any other invalidation, which happens when a running
     // animation covers the property. Descendants that explicitly inherit non-inherited properties
     // still observe the change.
@@ -116,6 +124,7 @@ struct RequiredInvalidationAfterStyleChange {
         changes_containing_block_establishment |= other.changes_containing_block_establishment;
         repaint_propagated_text_decorations |= other.repaint_propagated_text_decorations;
         repaint_selection |= other.repaint_selection;
+        affects_hit_testing |= other.affects_hit_testing;
         non_inherited_property_inheritance_sources_changed |= other.non_inherited_property_inheritance_sources_changed;
     }
 
@@ -129,6 +138,7 @@ struct RequiredInvalidationAfterStyleChange {
             && !inherited_style_changed()
             && !changes_containing_block_establishment
             && !repaint_selection
+            && !affects_hit_testing
             && !repaint_propagated_text_decorations
             && !non_inherited_property_inheritance_sources_changed;
     }

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -87,8 +87,12 @@ static void apply_element_style_invalidation_after_style_change(DOM::Element& el
 
 static void apply_document_style_invalidation_after_style_change(DOM::Document& document, RequiredInvalidationAfterStyleChange const& invalidation)
 {
-    if (invalidation.needs_repaint())
+    if (!invalidation.needs_repaint())
+        return;
+    if (invalidation.invalidates_hit_test_display_list())
         document.set_needs_to_record_display_list();
+    else
+        document.set_needs_to_record_display_list_keeping_hit_test_display_list();
 }
 
 // Consume everything recorded since the last transaction boundary and publish its match answers.

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -10285,8 +10285,15 @@ void Document::set_needs_repaint(InvalidateDisplayList should_invalidate_display
 {
     auto navigable = this->navigable();
 
-    if (should_invalidate_display_list == InvalidateDisplayList::PaintCommandsAndHitTestList) {
+    switch (should_invalidate_display_list) {
+    case InvalidateDisplayList::No:
+        break;
+    case InvalidateDisplayList::PaintCommands:
+        set_needs_to_record_display_list_keeping_hit_test_display_list();
+        break;
+    case InvalidateDisplayList::PaintCommandsAndHitTestList:
         set_needs_to_record_display_list();
+        break;
     }
 
     if (!navigable)
@@ -10445,6 +10452,11 @@ Vector<WeakPtr<Layout::Node const>> Document::collect_scroll_snap_containers()
 void Document::set_needs_to_record_display_list()
 {
     m_hit_test_display_list = nullptr;
+    set_needs_to_record_display_list_keeping_hit_test_display_list();
+}
+
+void Document::set_needs_to_record_display_list_keeping_hit_test_display_list()
+{
     if (auto navigable = this->navigable())
         navigable->set_needs_to_record_display_list();
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -9831,7 +9831,7 @@ void Document::remove_render_blocking_element(GC::Ref<Element> element)
 
     if (auto navigable = this->navigable()) {
         if (auto container = navigable->container())
-            container->set_needs_repaint(InvalidateDisplayList::Yes);
+            container->set_needs_repaint(InvalidateDisplayList::PaintCommandsAndHitTestList);
     }
 
     page().client().request_frame();
@@ -10285,7 +10285,7 @@ void Document::set_needs_repaint(InvalidateDisplayList should_invalidate_display
 {
     auto navigable = this->navigable();
 
-    if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
+    if (should_invalidate_display_list == InvalidateDisplayList::PaintCommandsAndHitTestList) {
         set_needs_to_record_display_list();
     }
 
@@ -10512,7 +10512,7 @@ void Document::set_caret_hit_test_debug_rect(Optional<CSSPixelRect> rect)
         return;
 
     m_caret_hit_test_debug_rect = rect;
-    set_needs_repaint(InvalidateDisplayList::Yes);
+    set_needs_repaint(InvalidateDisplayList::PaintCommandsAndHitTestList);
     page().client().request_frame();
 }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2888,13 +2888,13 @@ void Document::set_highlighted_node(GC::Ptr<Node> node, Optional<CSS::PseudoElem
         return;
 
     if (auto layout_node = highlighted_layout_node(); layout_node && Painting::has_committed_box(*layout_node))
-        Painting::set_needs_repaint(*layout_node);
+        Painting::set_needs_repaint(*layout_node, InvalidateDisplayList::PaintCommands);
 
     m_highlighted_node = node;
     m_highlighted_pseudo_element = pseudo_element;
 
     if (auto layout_node = highlighted_layout_node(); layout_node && Painting::has_committed_box(*layout_node))
-        Painting::set_needs_repaint(*layout_node);
+        Painting::set_needs_repaint(*layout_node, InvalidateDisplayList::PaintCommands);
 }
 
 void Document::set_grid_highlighted_node(GC::Ptr<Node> node, Painting::GridInspectorOverlayOptions options)
@@ -2907,12 +2907,12 @@ void Document::set_grid_highlighted_node(GC::Ptr<Node> node, Painting::GridInspe
             continue;
 
         grid_highlight.options = options;
-        node->set_needs_repaint();
+        node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
         return;
     }
 
     m_grid_highlights.append({ node, options });
-    node->set_needs_repaint();
+    node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 void Document::set_flexbox_highlighted_node(GC::Ptr<Node> node, Painting::FlexboxInspectorOverlayOptions options)
@@ -2925,12 +2925,12 @@ void Document::set_flexbox_highlighted_node(GC::Ptr<Node> node, Painting::Flexbo
             continue;
 
         flexbox_highlight.options = options;
-        node->set_needs_repaint();
+        node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
         return;
     }
 
     m_flexbox_highlights.append({ node, options });
-    node->set_needs_repaint();
+    node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 void Document::clear_flexbox_highlighted_node(GC::Ptr<Node> node)
@@ -2938,7 +2938,7 @@ void Document::clear_flexbox_highlighted_node(GC::Ptr<Node> node)
     if (!node) {
         for (auto const& flexbox_highlight : m_flexbox_highlights) {
             if (flexbox_highlight.node)
-                flexbox_highlight.node->set_needs_repaint();
+                flexbox_highlight.node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
         }
         m_flexbox_highlights.clear();
         return;
@@ -2950,7 +2950,7 @@ void Document::clear_flexbox_highlighted_node(GC::Ptr<Node> node)
     });
 
     if (m_flexbox_highlights.size() != old_size)
-        node->set_needs_repaint();
+        node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 void Document::clear_grid_highlighted_node(GC::Ptr<Node> node)
@@ -2958,7 +2958,7 @@ void Document::clear_grid_highlighted_node(GC::Ptr<Node> node)
     if (!node) {
         for (auto const& grid_highlight : m_grid_highlights) {
             if (grid_highlight.node)
-                grid_highlight.node->set_needs_repaint();
+                grid_highlight.node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
         }
         m_grid_highlights.clear();
         return;
@@ -2970,7 +2970,7 @@ void Document::clear_grid_highlighted_node(GC::Ptr<Node> node)
     });
 
     if (m_grid_highlights.size() != old_size)
-        node->set_needs_repaint();
+        node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 Layout::Node* Document::highlighted_layout_node()
@@ -3881,7 +3881,7 @@ void Document::set_focused_area(GC::Ptr<Node> node, InvalidateFocusPseudoClasses
 
     reset_cursor_blink_cycle();
 
-    set_needs_repaint();
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     update_active_element();
 }
@@ -3898,7 +3898,7 @@ void Document::set_active_element(GC::Ptr<Element> element)
 
     m_active_element = element;
 
-    set_needs_repaint();
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 void Document::set_target_element(GC::Ptr<Element> element)
@@ -3912,7 +3912,7 @@ void Document::set_target_element(GC::Ptr<Element> element)
 
     m_target_element = element;
 
-    set_needs_repaint();
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#flush-autofocus-candidates
@@ -10232,10 +10232,10 @@ void Document::set_cursor_position_needs_repaint()
         auto node = position.node();
         if (auto* text = as_if<DOM::Text>(*node)) {
             if (auto* layout_text_node = as_if<Layout::TextNode>(text->unsafe_layout_node()))
-                layout_text_node->set_needs_repaint();
+                layout_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
             return;
         }
-        node->set_needs_repaint();
+        node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
     };
 
     auto position = cursor_position();
@@ -10524,7 +10524,7 @@ void Document::set_caret_hit_test_debug_rect(Optional<CSSPixelRect> rect)
         return;
 
     m_caret_hit_test_debug_rect = rect;
-    set_needs_repaint(InvalidateDisplayList::PaintCommandsAndHitTestList);
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
     page().client().request_frame();
 }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1285,7 +1285,7 @@ public:
     GC::Ptr<HTML::LocalNavigable> navigable() const;
     void set_navigable(GC::Ptr<HTML::LocalNavigable>);
 
-    void set_needs_repaint(Badge<Node, Painting::BoxViewRepaintAccess, HTML::LocalNavigable, CSS::VisualViewport, Web::EventHandler>, InvalidateDisplayList should_invalidate_display_list = InvalidateDisplayList::Yes)
+    void set_needs_repaint(Badge<Node, Painting::BoxViewRepaintAccess, HTML::LocalNavigable, CSS::VisualViewport, Web::EventHandler>, InvalidateDisplayList should_invalidate_display_list = InvalidateDisplayList::PaintCommandsAndHitTestList)
     {
         set_needs_repaint(should_invalidate_display_list);
     }
@@ -1488,7 +1488,7 @@ private:
 
     GC::Ref<WebIDL::ObservableArray> adopted_style_sheets() const;
 
-    void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes);
+    void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::PaintCommandsAndHitTestList);
 
     // ^JS::Object
     virtual bool is_dom_document() const final { return true; }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1307,6 +1307,7 @@ public:
     void set_caret_hit_test_debug_rect(Optional<CSSPixelRect>);
 
     void set_needs_to_record_display_list();
+    void set_needs_to_record_display_list_keeping_hit_test_display_list();
 
     Unicode::Segmenter& grapheme_segmenter() const;
     Unicode::Segmenter& line_segmenter() const;

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -405,7 +405,7 @@ public:
         return const_cast<Element*>(const_cast<Node const*>(this)->first_letter_owner_for_layout_subtree_from(inclusive_ancestor));
     }
 
-    void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes);
+    void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::PaintCommandsAndHitTestList);
     void set_needs_layout_update(SetNeedsLayoutReason);
     void set_needs_layout_update(SetNeedsLayoutReason, Layout::LayoutUpdatePropagation);
 

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -107,7 +107,7 @@ void Range::set_associated_selection(Badge<Selection::Selection>, GC::Ptr<Select
         auto& document = m_start_container->document();
         if (document.has_committed_viewport_box()) {
             document.paint_state().reset_selection_states(document);
-            Painting::set_needs_repaint(*document.unsafe_layout_node());
+            Painting::set_needs_repaint(*document.unsafe_layout_node(), InvalidateDisplayList::PaintCommands);
         }
 
         // https://w3c.github.io/selection-api/#selectionchange-event
@@ -129,7 +129,7 @@ void Range::update_associated_selection()
     // NB: Called during selection update after range change.
     if (document.has_committed_viewport_box()) {
         document.paint_state().recompute_selection_states(document, *this);
-        Painting::set_needs_repaint(*document.unsafe_layout_node());
+        Painting::set_needs_repaint(*document.unsafe_layout_node(), InvalidateDisplayList::PaintCommands);
     }
 
     document.reset_cursor_blink_cycle();

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -69,7 +69,7 @@ Page* CanvasRenderingContext2D::page_for_compositor()
 
 void CanvasRenderingContext2D::backing_storage_created_hook()
 {
-    m_element->set_needs_repaint();
+    m_element->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 DOM::EventTarget& CanvasRenderingContext2D::context_event_target()

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -1402,7 +1402,7 @@ void FormAssociatedTextControlElement::selection_was_changed(SelectionSource sou
 
     if (m_selection_start == m_selection_end)
         text_node->document().reset_cursor_blink_cycle();
-    layout_text_node->set_needs_repaint();
+    layout_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     // AD-HOC: Only scroll the cursor into view for UI-driven selection changes (like keyboard input). Programmatic
     //         changes (input.value, setSelectionRange) do not cause the cursor to scroll into view. This matches the

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -158,7 +158,7 @@ void HTMLInputElement::set_being_activated(bool activated)
     Base::set_being_activated(activated);
     if (first_is_one_of(type_state(), TypeAttributeState::Checkbox, TypeAttributeState::RadioButton)) {
         Painting::push_form_control_paint_facts(*this);
-        set_needs_repaint();
+        set_needs_repaint(InvalidateDisplayList::PaintCommands);
     }
 }
 
@@ -225,7 +225,7 @@ void HTMLInputElement::set_checked(bool checked)
     CSS::Invalidation::invalidate_style_after_validity_change(*this);
 
     Painting::push_form_control_paint_facts(*this);
-    set_needs_repaint();
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     // NB: The registry unchecks the other members of the group and republishes their validity. The tree walks
     //     below are a fallback for radio buttons that have no registry.
@@ -263,7 +263,7 @@ void HTMLInputElement::set_indeterminate(bool value)
     m_indeterminateness = value;
     CSS::Invalidation::invalidate_style_after_indeterminate_state_change(*this, value);
     Painting::push_form_control_paint_facts(*this);
-    set_needs_repaint();
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#dom-input-list
@@ -1606,10 +1606,10 @@ void HTMLInputElement::did_receive_focus()
 {
     if (!m_text_node)
         return;
-    m_text_node->set_needs_repaint();
+    m_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     if (m_placeholder_text_node)
-        m_placeholder_text_node->set_needs_repaint();
+        m_placeholder_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     if (has_selectable_text()) {
         if (document().last_focus_trigger() == FocusTrigger::Key)
@@ -1622,10 +1622,10 @@ void HTMLInputElement::did_receive_focus()
 void HTMLInputElement::did_lose_focus()
 {
     if (m_text_node)
-        m_text_node->set_needs_repaint();
+        m_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     if (m_placeholder_text_node)
-        m_placeholder_text_node->set_needs_repaint();
+        m_placeholder_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     commit_pending_changes();
 }

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -607,7 +607,7 @@ void HTMLMediaElement::set_duration(double duration)
 
     upon_has_ended_playback_possibly_changed();
 
-    set_needs_repaint();
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 void HTMLMediaElement::play(GC::Ref<WebIDL::Promise> promise)
@@ -2018,7 +2018,7 @@ void HTMLMediaElement::on_video_track_added(Media::Track const& track)
     auto event = TrackEvent::create(HTML::EventNames::addtrack, move(event_init), event_time_stamp_for_element(*this));
     m_video_tracks->dispatch_event(event);
 
-    set_needs_repaint();
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 void HTMLMediaElement::on_metadata_parsed()
@@ -2942,7 +2942,7 @@ void HTMLMediaElement::set_show_poster(bool show_poster)
     m_show_poster = show_poster;
 
     update_natural_dimensions();
-    set_needs_repaint();
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
 }
 
 void HTMLMediaElement::set_paused(bool paused)
@@ -2964,7 +2964,7 @@ void HTMLMediaElement::set_paused(bool paused)
     update_screen_wake_lock();
 
     update_natural_dimensions();
-    set_needs_repaint();
+    set_needs_repaint(InvalidateDisplayList::PaintCommands);
     CSS::Invalidation::invalidate_style_after_media_paused_state_change(*this, paused);
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -64,10 +64,10 @@ void HTMLTextAreaElement::did_receive_focus()
 {
     if (!m_text_node)
         return;
-    m_text_node->set_needs_repaint();
+    m_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     if (m_placeholder_text_node)
-        m_placeholder_text_node->set_needs_repaint();
+        m_placeholder_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     document().get_selection()->remove_all_ranges();
 }
@@ -75,10 +75,10 @@ void HTMLTextAreaElement::did_receive_focus()
 void HTMLTextAreaElement::did_lose_focus()
 {
     if (m_text_node)
-        m_text_node->set_needs_repaint();
+        m_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     if (m_placeholder_text_node)
-        m_placeholder_text_node->set_needs_repaint();
+        m_placeholder_text_node->set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     // The change event fires when the value is committed, if that makes sense for the control,
     // or else when the control loses focus

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -6039,7 +6039,7 @@ void LocalNavigable::set_should_show_caret_hit_test_debug_overlay(bool value)
 
     if (auto document = active_document()) {
         if (value)
-            document->set_needs_repaint(Badge<HTML::LocalNavigable> {}, InvalidateDisplayList::PaintCommandsAndHitTestList);
+            document->set_needs_repaint(Badge<HTML::LocalNavigable> {}, InvalidateDisplayList::PaintCommands);
         else
             document->set_caret_hit_test_debug_rect({});
     }

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4382,7 +4382,7 @@ void LocalNavigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList 
     }
 
     if (auto document = active_document()) {
-        if (invalidate_display_list == InvalidateDisplayList::Yes)
+        if (invalidate_display_list == InvalidateDisplayList::PaintCommandsAndHitTestList)
             document->record_style_environment_change();
         else
             document->invalidate_style_for_viewport_change();
@@ -6039,7 +6039,7 @@ void LocalNavigable::set_should_show_caret_hit_test_debug_overlay(bool value)
 
     if (auto document = active_document()) {
         if (value)
-            document->set_needs_repaint(Badge<HTML::LocalNavigable> {}, InvalidateDisplayList::Yes);
+            document->set_needs_repaint(Badge<HTML::LocalNavigable> {}, InvalidateDisplayList::PaintCommandsAndHitTestList);
         else
             document->set_caret_hit_test_debug_rect({});
     }

--- a/Libraries/LibWeb/InvalidateDisplayList.h
+++ b/Libraries/LibWeb/InvalidateDisplayList.h
@@ -9,8 +9,8 @@
 namespace Web {
 
 enum class InvalidateDisplayList {
-    Yes,
     No,
+    PaintCommandsAndHitTestList,
 };
 
 }

--- a/Libraries/LibWeb/InvalidateDisplayList.h
+++ b/Libraries/LibWeb/InvalidateDisplayList.h
@@ -10,6 +10,7 @@ namespace Web {
 
 enum class InvalidateDisplayList {
     No,
+    PaintCommands,
     PaintCommandsAndHitTestList,
 };
 

--- a/Libraries/LibWeb/Layout/ImageProvider.cpp
+++ b/Libraries/LibWeb/Layout/ImageProvider.cpp
@@ -66,7 +66,7 @@ void ImageProvider::image_provider_contents_changed() const
     if (layout_node->kind() == RustFFI::NodeKind::ImageBox && &static_cast<Box const&>(*layout_node).image_provider() != this)
         return;
     if (Painting::push_replaced_image_paint_facts(*this, *layout_node))
-        Painting::set_needs_repaint(*layout_node);
+        Painting::set_needs_repaint(*layout_node, InvalidateDisplayList::PaintCommands);
 }
 
 }

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -450,7 +450,7 @@ void NodeWithStyle::ImageObserver::image_style_value_did_update(CSS::ImageStyleV
 
     Painting::push_layer_image_paint_facts(*m_owner);
     if (Painting::has_committed_box(*m_owner))
-        Painting::set_needs_repaint(*m_owner);
+        Painting::set_needs_repaint(*m_owner, InvalidateDisplayList::PaintCommands);
 }
 
 NodeWithStyle::~NodeWithStyle()

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -207,7 +207,7 @@ void TextNode::set_needs_repaint(InvalidateDisplayList should_invalidate_display
             Painting::set_needs_repaint(*containing_block, should_invalidate_display_list);
     }
 
-    if (should_invalidate_display_list == InvalidateDisplayList::PaintCommandsAndHitTestList)
+    if (should_invalidate_display_list != InvalidateDisplayList::No)
         RustFFI::layout_arena_invalidate_nearest_self_painting_inline_paint_cache(arena_handle(), slot_id(this));
 }
 

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -207,7 +207,7 @@ void TextNode::set_needs_repaint(InvalidateDisplayList should_invalidate_display
             Painting::set_needs_repaint(*containing_block, should_invalidate_display_list);
     }
 
-    if (should_invalidate_display_list == InvalidateDisplayList::Yes)
+    if (should_invalidate_display_list == InvalidateDisplayList::PaintCommandsAndHitTestList)
         RustFFI::layout_arena_invalidate_nearest_self_painting_inline_paint_cache(arena_handle(), slot_id(this));
 }
 

--- a/Libraries/LibWeb/Layout/TextNode.h
+++ b/Libraries/LibWeb/Layout/TextNode.h
@@ -39,7 +39,7 @@ public:
     // The returned views survive until the next DOM mutation.
     RustFFI::FfiTextSource text_source() const;
 
-    void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes) const;
+    void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::PaintCommandsAndHitTestList) const;
 
     bool update_produces_line_box_fragment_when_empty_flag();
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -2538,7 +2538,7 @@ void EventHandler::finish_selection_from_preserved_mousedown(DOM::Document& docu
         target->set_selection_anchor(*caret_position->boundary.node, caret_position->boundary.offset, caret_position->affinity);
     } else if (auto selection = document.get_selection()) {
         selection->remove_all_ranges();
-        document.set_needs_repaint(Badge<EventHandler> {});
+        document.set_needs_repaint(Badge<EventHandler> {}, InvalidateDisplayList::PaintCommands);
     }
 }
 #endif
@@ -3096,7 +3096,7 @@ bool EventHandler::select_context_menu_url_token(DOM::Document& document, Painti
         target->set_selection_focus(*hit_node, token_end);
     } else if (auto selection = document.get_selection()) {
         set_user_selection(hit_node, token_start, hit_node, token_end, selection, user_select);
-        document.set_needs_repaint(Badge<EventHandler> {});
+        document.set_needs_repaint(Badge<EventHandler> {}, InvalidateDisplayList::PaintCommands);
     }
 
     return true;
@@ -3228,7 +3228,7 @@ void EventHandler::apply_mouse_selection(CSSPixelPoint visual_viewport_position)
                 set_user_selection(*focus_node, focus_index, *focus_node, focus_index, selection, user_select_used_value_for_caret_position(*caret_position));
             }
 
-            document.set_needs_repaint(Badge<EventHandler> {});
+            document.set_needs_repaint(Badge<EventHandler> {}, InvalidateDisplayList::PaintCommands);
         }
     }
 }

--- a/Libraries/LibWeb/Page/MiddleButtonScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/MiddleButtonScrollHandler.cpp
@@ -28,7 +28,7 @@ MiddleButtonScrollHandler::MiddleButtonScrollHandler(DOM::Element& container, CS
 {
     auto const* layout_node = m_container_element->document().layout_node();
     if (layout_node && Painting::has_committed_box(*layout_node))
-        Painting::set_needs_repaint(*layout_node);
+        Painting::set_needs_repaint(*layout_node, InvalidateDisplayList::PaintCommands);
 }
 
 MiddleButtonScrollHandler::~MiddleButtonScrollHandler()
@@ -37,7 +37,7 @@ MiddleButtonScrollHandler::~MiddleButtonScrollHandler()
         return;
     auto const* layout_node = m_container_element->document().layout_node();
     if (layout_node && Painting::has_committed_box(*layout_node))
-        Painting::set_needs_repaint(*layout_node);
+        Painting::set_needs_repaint(*layout_node, InvalidateDisplayList::PaintCommands);
 }
 
 void MiddleButtonScrollHandler::visit_edges(JS::Cell::Visitor& visitor) const

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -799,7 +799,7 @@ void set_needs_repaint(Layout::Node const& node, InvalidateDisplayList should_in
         return;
 
     auto& document = const_cast<DOM::Document&>(node.document());
-    if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
+    if (should_invalidate_display_list == InvalidateDisplayList::PaintCommandsAndHitTestList) {
         Layout::RustFFI::layout_arena_paintable_invalidate_for_repaint(node.arena_handle(), committed_row_slot(node));
 
         // The root element paints the body's propagated background, so a body repaint must also refresh the

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -799,7 +799,7 @@ void set_needs_repaint(Layout::Node const& node, InvalidateDisplayList should_in
         return;
 
     auto& document = const_cast<DOM::Document&>(node.document());
-    if (should_invalidate_display_list == InvalidateDisplayList::PaintCommandsAndHitTestList) {
+    if (should_invalidate_display_list != InvalidateDisplayList::No) {
         Layout::RustFFI::layout_arena_paintable_invalidate_for_repaint(node.arena_handle(), committed_row_slot(node));
 
         // The root element paints the body's propagated background, so a body repaint must also refresh the
@@ -836,7 +836,7 @@ void invalidate_paint_cache(Layout::Node const& node)
 void repaint_after_style_change(Layout::Node const& node, CSS::RequiredInvalidationAfterStyleChange const& invalidation)
 {
     if (invalidation.needs_repaint())
-        set_needs_repaint(node);
+        set_needs_repaint(node, invalidation.invalidates_hit_test_display_list() ? InvalidateDisplayList::PaintCommandsAndHitTestList : InvalidateDisplayList::PaintCommands);
     if (invalidation.repaint_propagated_text_decorations)
         rust_invalidate_propagated_text_decoration_caches(node);
     if (invalidation.needs_stacking_context_tree_rebuild()) {

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -86,7 +86,7 @@ WEB_API Layout::RustFFI::FfiFocusedAreaOutline resolve_focused_area_outline(DOM:
 WEB_API void push_selection_pseudo_style(DOM::Element const&);
 WEB_API void push_selection_pseudo_style_of_parent(Layout::TextNode&);
 
-WEB_API void set_needs_repaint(Layout::Node const&, InvalidateDisplayList = InvalidateDisplayList::Yes);
+WEB_API void set_needs_repaint(Layout::Node const&, InvalidateDisplayList = InvalidateDisplayList::PaintCommandsAndHitTestList);
 WEB_API void set_needs_repaint_in_subtree(Layout::Node const&);
 WEB_API void invalidate_paint_cache(Layout::Node const&);
 WEB_API void repaint_after_style_change(Layout::Node const&, CSS::RequiredInvalidationAfterStyleChange const&);

--- a/Libraries/LibWeb/Painting/PaintFacts.cpp
+++ b/Libraries/LibWeb/Painting/PaintFacts.cpp
@@ -240,7 +240,7 @@ void push_video_paint_facts(HTML::HTMLVideoElement const& video_element)
     if (!layout_node || layout_node->kind() != Layout::RustFFI::NodeKind::VideoBox)
         return;
     if (push_video_paint_facts_onto(video_element, *layout_node))
-        set_needs_repaint(*layout_node);
+        set_needs_repaint(*layout_node, InvalidateDisplayList::PaintCommands);
 }
 
 void push_paint_facts_after_style_attach(Layout::NodeWithStyle& layout_node, StyleHoldsImageValues style_holds_image_values)

--- a/Libraries/LibWeb/Painting/Scrollbar.cpp
+++ b/Libraries/LibWeb/Painting/Scrollbar.cpp
@@ -45,7 +45,7 @@ MouseAction Scrollbar::handle_pointer_event(Utf16FlyString const& type, unsigned
     auto position = Painting::transform_to_local_coordinates(*node, visual_viewport_position);
     if (!scroll_to_mouse_position(position) && !m_thumb_grab_position.has_value())
         return MouseAction::None;
-    Painting::set_needs_repaint(*node);
+    Painting::set_needs_repaint(*node, InvalidateDisplayList::PaintCommands);
 
     if (type == UIEvents::EventNames::pointerup) {
         release_thumb_grab();
@@ -72,7 +72,7 @@ MouseAction Scrollbar::mouse_up(CSSPixelPoint, unsigned)
 {
     release_thumb_grab();
     if (auto* node = layout_node())
-        Painting::set_needs_repaint(*node);
+        Painting::set_needs_repaint(*node, InvalidateDisplayList::PaintCommands);
     return MouseAction::None;
 }
 
@@ -99,7 +99,7 @@ void Scrollbar::mouse_enter()
     m_hovered = true;
     push_enlarged_state();
     if (auto* node = layout_node())
-        Painting::set_needs_repaint(*node);
+        Painting::set_needs_repaint(*node, InvalidateDisplayList::PaintCommands);
 }
 
 void Scrollbar::mouse_leave()
@@ -109,7 +109,7 @@ void Scrollbar::mouse_leave()
     m_hovered = false;
     push_enlarged_state();
     if (auto* node = layout_node())
-        Painting::set_needs_repaint(*node);
+        Painting::set_needs_repaint(*node, InvalidateDisplayList::PaintCommands);
 }
 
 bool Scrollbar::scroll_to_mouse_position(CSSPixelPoint position)

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -1386,6 +1386,7 @@ fn generate_property_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<(),
     let mut affects_stacking_context = vec![false; levels.len()];
     let mut affects_scrollable_overflow = vec![false; levels.len()];
     let mut affects_accumulated_visual_contexts = vec![false; levels.len()];
+    let mut affects_hit_testing = vec![false; levels.len()];
     let mut style_group_indices = vec![u8::MAX; levels.len()];
     let mut initial_values = vec![String::new(); levels.len()];
     let mut numeric_range_rows = vec![String::new(); levels.len()];
@@ -1478,6 +1479,7 @@ fn generate_property_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<(),
         affects_stacking_context[index] = metadata_flag("affects-stacking-context", false);
         affects_scrollable_overflow[index] = metadata_flag("affects-scrollable-overflow", false);
         affects_accumulated_visual_contexts[index] = metadata_flag("affects-accumulated-visual-contexts", false);
+        affects_hit_testing[index] = metadata_flag("affects-hit-testing", false);
         let style_group = property_field(name, "style-group").and_then(|value| value.as_str().map(str::to_owned));
         style_group_indices[index] = match style_group.as_deref() {
             Some("InheritedTableValues") => 0,
@@ -2219,6 +2221,11 @@ fn generate_property_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<(),
         "pub(crate) static PROPERTY_AFFECTS_ACCUMULATED_VISUAL_CONTEXTS: [bool; {}] = {:?};\n",
         affects_accumulated_visual_contexts.len(),
         affects_accumulated_visual_contexts
+    ));
+    output.push_str(&format!(
+        "pub(crate) static PROPERTY_AFFECTS_HIT_TESTING: [bool; {}] = {:?};\n",
+        affects_hit_testing.len(),
+        affects_hit_testing
     ));
     output.push_str(&format!(
         "pub(crate) static PROPERTY_STYLE_GROUP_INDICES: [u8; {}] = {:?};\n",

--- a/Libraries/LibWeb/Rust/src/css/property_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/css/property_metadata.rs
@@ -156,6 +156,10 @@ pub(crate) fn property_affects_accumulated_visual_contexts(property_id: u16) -> 
     PROPERTY_AFFECTS_ACCUMULATED_VISUAL_CONTEXTS[longhand_index(property_id)]
 }
 
+pub(crate) fn property_affects_hit_testing(property_id: u16) -> bool {
+    PROPERTY_AFFECTS_HIT_TESTING[longhand_index(property_id)]
+}
+
 pub(crate) fn property_style_group_index(property_id: u16) -> Option<u8> {
     match PROPERTY_STYLE_GROUP_INDICES[longhand_index(property_id)] {
         u8::MAX => None,

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -94,6 +94,7 @@ pub enum FfiStyleInvalidationField {
     NonInheritedInheritanceSource = 1 << 19,
     AnyComputedValueChanged = 1 << 20,
     CacheHit = 1 << 21,
+    AffectsHitTesting = 1 << 22,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
@@ -39,6 +39,7 @@ struct StyleInvalidation {
     repaint_text_decorations: bool,
     non_inherited_inheritance_source: bool,
     any_computed_value_changed: bool,
+    affects_hit_testing: bool,
 }
 
 impl StyleInvalidation {
@@ -89,6 +90,7 @@ impl StyleInvalidation {
         self.repaint_text_decorations |= other.repaint_text_decorations;
         self.non_inherited_inheritance_source |= other.non_inherited_inheritance_source;
         self.any_computed_value_changed |= other.any_computed_value_changed;
+        self.affects_hit_testing |= other.affects_hit_testing;
     }
 
     fn pack(self) -> u32 {
@@ -108,6 +110,7 @@ impl StyleInvalidation {
             * FfiStyleInvalidationField::NonInheritedInheritanceSource as u32;
         packed |=
             u32::from(self.any_computed_value_changed) * FfiStyleInvalidationField::AnyComputedValueChanged as u32;
+        packed |= u32::from(self.affects_hit_testing) * FfiStyleInvalidationField::AffectsHitTesting as u32;
         packed
     }
 }
@@ -332,7 +335,7 @@ fn clip_path_value_is_a_visual_context_frame(values: ComputedValuesView<'_>) -> 
     matches!(values.mask().clip_path.data(), Some(StyleValueData::BasicShape { .. }))
 }
 
-fn accumulated_visual_context_change_requires_repaint(
+fn accumulated_visual_context_change_alters_hit_test_items(
     property: u16,
     old: ComputedValuesView<'_>,
     new: ComputedValuesView<'_>,
@@ -353,7 +356,7 @@ fn accumulated_visual_context_change_requires_repaint(
     if property == property_id::CLIP {
         return !old.effects().clip_is_rect || !new.effects().clip_is_rect;
     }
-    accumulated_visual_context_property_always_requires_repaint(property)
+    false
 }
 
 fn property_invalidation(property: u16, old: ComputedValuesView<'_>, new: ComputedValuesView<'_>) -> StyleInvalidation {
@@ -415,7 +418,10 @@ fn property_invalidation(property: u16, old: ComputedValuesView<'_>, new: Comput
         return result;
     }
 
-    let mut result = StyleInvalidation::default();
+    let mut result = StyleInvalidation {
+        affects_hit_testing: property_metadata::property_affects_hit_testing(property),
+        ..StyleInvalidation::default()
+    };
     if matches!(property, property_id::CONTAINER_NAME | property_id::CONTAINER_TYPE) {
         result.recompute_descendants = true;
     }
@@ -507,14 +513,17 @@ fn property_invalidation(property: u16, old: ComputedValuesView<'_>, new: Comput
         } else {
             VISUAL_CONTEXT_REBUILD
         });
-        if !accumulated_visual_context_change_requires_repaint(property, old, new)
+        let alters_hit_test_items = accumulated_visual_context_change_alters_hit_test_items(property, old, new);
+        result.affects_hit_testing |= alters_hit_test_items;
+        if !alters_hit_test_items
+            && !accumulated_visual_context_property_always_requires_repaint(property)
             && result.level < INVALIDATION_REPAINT
             && !result.recompute_descendants
         {
             needs_repaint = false;
         }
     }
-    if needs_repaint {
+    if needs_repaint || result.affects_hit_testing {
         result.ensure_level(INVALIDATION_REPAINT);
     }
     result

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -446,7 +446,7 @@ void SVGElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor,
     // build resource boxes, so there may be no layout invalidation to trigger re-recording. Request it explicitly
     // to drop the visual effects of the removed element.
     if (id().has_value())
-        document().set_needs_repaint(Badge<SVGElement> {}, InvalidateDisplayList::Yes);
+        document().set_needs_repaint(Badge<SVGElement> {}, InvalidateDisplayList::PaintCommandsAndHitTestList);
 }
 
 void SVGElement::register_resource_box_referencing_element(Badge<Layout::LayoutTreeBuilderAccess>, DOM::Element& referencing_element)

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -446,7 +446,7 @@ void SVGElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor,
     // build resource boxes, so there may be no layout invalidation to trigger re-recording. Request it explicitly
     // to drop the visual effects of the removed element.
     if (id().has_value())
-        document().set_needs_repaint(Badge<SVGElement> {}, InvalidateDisplayList::PaintCommandsAndHitTestList);
+        document().set_needs_repaint(Badge<SVGElement> {}, InvalidateDisplayList::PaintCommands);
 }
 
 void SVGElement::register_resource_box_referencing_element(Badge<Layout::LayoutTreeBuilderAccess>, DOM::Element& referencing_element)

--- a/Libraries/LibWeb/SVG/SVGFEImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGFEImageElement.cpp
@@ -67,7 +67,7 @@ void SVGFEImageElement::process_href(Optional<Utf16String> const& href)
             document().style_computer().style_engine().record_element_style_input_change(style_node_id());
             document().note_svg_paint_resources_changed();
             document().schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::FilterResourcesChanged);
-            document().set_needs_repaint(Badge<SVGFEImageElement> {});
+            document().set_needs_repaint(Badge<SVGFEImageElement> {}, InvalidateDisplayList::PaintCommands);
         },
         nullptr);
 

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -90,7 +90,7 @@ Optional<RemoteWebGLContext> create_remote_webgl_context(HTML::HTMLCanvasElement
 
     // NB: The display list must be re-recorded so its DrawCanvas command refers to the new remote context's
     //     canvas id. Content updates alone don't invalidate the display list, so do it here.
-    canvas_element.set_needs_repaint();
+    canvas_element.set_needs_repaint(InvalidateDisplayList::PaintCommands);
 
     return RemoteWebGLContext { transport.release_nonnull(), move(result) };
 }

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -485,7 +485,7 @@ Web::Compositor::CompositorContextId PageClient::allocate_compositor_context_id(
 void PageClient::set_viewport(Web::DevicePixelSize const& size, double device_pixel_ratio)
 {
     auto invalidate = m_device_pixel_ratio != device_pixel_ratio
-        ? Web::InvalidateDisplayList::Yes
+        ? Web::InvalidateDisplayList::PaintCommandsAndHitTestList
         : Web::InvalidateDisplayList::No;
 
     m_viewport_size = size;
@@ -506,7 +506,7 @@ void PageClient::set_viewport(Web::DevicePixelSize const& size, double device_pi
 void PageClient::set_zoom_level(double zoom_level)
 {
     m_zoom_level = zoom_level;
-    page().local_root_navigable()->set_viewport_size(page().device_to_css_size(m_viewport_size), Web::InvalidateDisplayList::Yes);
+    page().local_root_navigable()->set_viewport_size(page().device_to_css_size(m_viewport_size), Web::InvalidateDisplayList::PaintCommandsAndHitTestList);
 }
 
 void PageClient::request_frame()

--- a/Tests/LibWeb/Text/expected/hit_testing/paint-only-style-change-keeps-hit-test-display-list.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/paint-only-style-change-keeps-hit-test-display-list.txt
@@ -1,0 +1,12 @@
+color: target=box record pending before hit test=true after=true
+background-color: target=box record pending before hit test=true after=true
+box-shadow: target=box record pending before hit test=true after=true
+outline: target=box record pending before hit test=true after=true
+text-decoration: target=inline record pending before hit test=true after=true
+inline color: target=inline record pending before hit test=true after=true
+pointer-events: none: target=html record pending before hit test=true after=false
+visibility: hidden: target=html record pending before hit test=true after=false
+border-radius corner: target=html record pending before hit test=true after=false
+block opacity: 0: target=box record pending before hit test=true after=false
+inline opacity: 0: target=inline-parent record pending before hit test=true after=false
+transform: scale(0): target=html record pending before hit test=true after=false

--- a/Tests/LibWeb/Text/input/hit_testing/paint-only-style-change-keeps-hit-test-display-list.html
+++ b/Tests/LibWeb/Text/input/hit_testing/paint-only-style-change-keeps-hit-test-display-list.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+    #box {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background: green;
+        opacity: 0.5;
+        transform: scale(1);
+    }
+    #inline-parent {
+        position: absolute;
+        left: 0;
+        top: 200px;
+        font: 20px/1 monospace;
+    }
+    #inline {
+        opacity: 0.5;
+    }
+</style>
+<div id="box"></div>
+<div id="inline-parent"><span id="inline">inline text</span></div>
+<script>
+    promiseTest(async () => {
+        const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+        const settle = async () => {
+            await nextFrame();
+            await nextFrame();
+        };
+        const targetAt = (x, y) => {
+            const element = document.elementFromPoint(x, y);
+            return element ? element.id || element.localName : "null";
+        };
+        // NB: Results are buffered and printed at the end: println() itself mutates the DOM,
+        //     and that invalidation would hide whether the mutation under test kept the list.
+        const results = [];
+        const step = async (label, mutate, x, y) => {
+            await settle();
+            mutate();
+            document.body.offsetWidth;
+            const recordPendingBeforeHitTest = internals.needsDisplayListRecord;
+            const target = targetAt(x, y);
+            const recordPendingAfterHitTest = internals.needsDisplayListRecord;
+            results.push(
+                `${label}: target=${target} record pending before hit test=${recordPendingBeforeHitTest} after=${recordPendingAfterHitTest}`
+            );
+        };
+        const reset = async (mutate) => {
+            await settle();
+            mutate();
+            document.body.offsetWidth;
+        };
+        const inlineParent = document.getElementById("inline-parent");
+        const inlineTextX = 30;
+        const inlineTextY = 210;
+
+        await step("color", () => (box.style.color = "red"), 50, 50);
+        await step("background-color", () => (box.style.backgroundColor = "blue"), 50, 50);
+        await step("box-shadow", () => (box.style.boxShadow = "0 0 10px black"), 50, 50);
+        await step("outline", () => (box.style.outline = "2px solid red"), 50, 50);
+        await step("text-decoration", () => (inlineParent.style.textDecoration = "underline"), inlineTextX, inlineTextY);
+        await step("inline color", () => (inline.style.color = "red"), inlineTextX, inlineTextY);
+
+        await step("pointer-events: none", () => (box.style.pointerEvents = "none"), 50, 50);
+        await reset(() => (box.style.pointerEvents = ""));
+        await step("visibility: hidden", () => (box.style.visibility = "hidden"), 50, 50);
+        await reset(() => (box.style.visibility = ""));
+        await step("border-radius corner", () => (box.style.borderRadius = "50px"), 2, 2);
+        await reset(() => (box.style.borderRadius = ""));
+        await step("block opacity: 0", () => (box.style.opacity = "0"), 50, 50);
+        await reset(() => (box.style.opacity = ""));
+        await step("inline opacity: 0", () => (inline.style.opacity = "0"), inlineTextX, inlineTextY);
+        await reset(() => (inline.style.opacity = ""));
+        await step("transform: scale(0)", () => (box.style.transform = "scale(0)"), 50, 50);
+        await reset(() => (box.style.transform = ""));
+
+        for (const result of results) println(result);
+    });
+</script>


### PR DESCRIPTION
Every repaint dropped the hit-test display list, so the next hit test recorded the whole display list inside the mouse event. A hover sweep over 10k boxes with a :hover background rule forced one ~2.2 ms recording per mouse move.

The hit-test items only read pointer-events, visibility, resize, SVG fill and fill-rule, the border radii, and value changes that hide or reveal content. Layout, paint order and visual context changes already drop the list on their own paths.

- Add an affects_hit_testing bit to the style invalidation, backed by an "affects-hit-testing" property flag.
- Add InvalidateDisplayList::PaintCommands, which re-records the display list at the next frame but keeps the hit-test list. The style path and the paint-only call sites (image, video and canvas content, selection, caret, focus, form control and media state, scrollbar hover and drag, overlays) use it.

The hover sweep now records nothing during the moves (0.03 ms per move instead of 3.0 ms). The new test checks that only hit-test-affecting properties force a recording from elementFromPoint.