### PR TITLE
LibWebView: Add content-blocking subscriptions and background service controls

### DIFF
--- a/Base/res/ladybird/about-pages/about.html
+++ b/Base/res/ladybird/about-pages/about.html
@@ -10,6 +10,7 @@
         <h1>List of About URLs</h1>
         <ul>
             <li><a href="about:about">about:about</a></li>
+            <li><a href="about:blocking">about:blocking</a></li>
             <li><a href="about:bookmarks">about:bookmarks</a></li>
             <li><a href="about:newtab">about:newtab</a></li>
             <li><a href="about:processes">about:processes</a></li>

--- a/Base/res/ladybird/about-pages/about.html
+++ b/Base/res/ladybird/about-pages/about.html
@@ -14,6 +14,7 @@
             <li><a href="about:newtab">about:newtab</a></li>
             <li><a href="about:processes">about:processes</a></li>
             <li><a href="about:settings">about:settings</a></li>
+            <li><a href="about:services">about:services</a></li>
             <li><a href="about:version">about:version</a></li>
         </ul>
     </body>

--- a/Base/res/ladybird/about-pages/blocking.html
+++ b/Base/res/ladybird/about-pages/blocking.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<!--
+Copyright (c) 2026-present, the Ladybird developers.
+SPDX-License-Identifier: BSD-2-Clause
+-->
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Blocking</title>
+        <script>
+            location.replace("about:settings#blocking");
+        </script>
+    </head>
+</html>

--- a/Base/res/ladybird/about-pages/services.html
+++ b/Base/res/ladybird/about-pages/services.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Services</title>
+        <script>
+            location.replace("about:settings#services");
+        </script>
+    </head>
+</html>

--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -543,6 +543,17 @@
                     </div>
                 </div>
             </div>
+
+            <h3 class="card-title">Crash reports</h3>
+            <div class="card">
+                <div class="card-body">
+                    <div class="inline-container">
+                        <p>Open the folder containing saved crash reports.</p>
+                        <button id="open-crash-reports" class="secondary-button">Open folder</button>
+                    </div>
+                    <p id="crash-reports-status" class="description" role="status" hidden></p>
+                </div>
+            </div>
         </div>
 
         <div class="tab-panel" id="tab-search">
@@ -791,16 +802,6 @@
         </div>
 
         <div class="tab-panel" id="tab-advanced">
-            <h2 class="card-title">Crash reports</h2>
-            <div class="card">
-                <div class="card-body">
-                    <div class="inline-container">
-                        <p>Open the folder containing saved crash reports.</p>
-                        <button id="open-crash-reports" class="secondary-button">Open folder</button>
-                    </div>
-                    <p id="crash-reports-status" class="description" role="status" hidden></p>
-                </div>
-            </div>
             <div class="search-container">
                 <svg
                     class="search-icon"

--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -307,6 +307,8 @@
 
                 margin-bottom: 20px;
                 border-bottom: 1px solid var(--border-color);
+
+                overflow-x: auto;
             }
 
             .tab-button {
@@ -322,6 +324,7 @@
                 opacity: 0.6;
 
                 cursor: pointer;
+                white-space: nowrap;
             }
 
             .tab-button:hover {
@@ -340,6 +343,13 @@
             .tab-panel.active {
                 display: block;
             }
+
+            button:focus-visible,
+            summary:focus-visible,
+            input[type="checkbox"]:focus-visible {
+                outline: 2px solid var(--violet-100);
+                outline-offset: 2px;
+            }
         </style>
     </head>
     <body>
@@ -351,13 +361,15 @@
             <h1>Ladybird Settings</h1>
         </header>
 
-        <div class="tab-bar">
-            <button class="tab-button active" data-tab="general">General</button>
-            <button class="tab-button" data-tab="search">Search</button>
-            <button class="tab-button" data-tab="permissions">Permissions</button>
-            <button class="tab-button" data-tab="privacy">Privacy</button>
-            <button class="tab-button" data-tab="network">Network</button>
-            <button class="tab-button" data-tab="advanced">Advanced</button>
+        <div class="tab-bar" role="tablist" aria-label="Settings categories">
+            <button id="tab-button-general" class="tab-button active" data-tab="general" role="tab">General</button>
+            <button id="tab-button-search" class="tab-button" data-tab="search" role="tab">Search</button>
+            <button id="tab-button-permissions" class="tab-button" data-tab="permissions" role="tab">
+                Permissions
+            </button>
+            <button id="tab-button-privacy" class="tab-button" data-tab="privacy" role="tab">Privacy</button>
+            <button id="tab-button-network" class="tab-button" data-tab="network" role="tab">Network</button>
+            <button id="tab-button-advanced" class="tab-button" data-tab="advanced" role="tab">Advanced</button>
         </div>
 
         <div class="tab-panel active" id="tab-general">
@@ -787,6 +799,8 @@
         <script type="module">
             import { tabForDeepLink } from "resource://ladybird/about-pages/settings/dialog-deep-link.js";
 
+            const tabButtons = [...document.querySelectorAll(".tab-button")];
+
             function switchTab(name) {
                 const button = document.querySelector(`.tab-button[data-tab="${name}"]`);
                 const panel = document.getElementById(`tab-${name}`);
@@ -794,24 +808,53 @@
                     return;
                 }
 
-                document.querySelectorAll(".tab-button").forEach(b => b.classList.remove("active"));
-                document.querySelectorAll(".tab-panel").forEach(p => p.classList.remove("active"));
+                tabButtons.forEach(tabButton => {
+                    const active = tabButton === button;
+                    tabButton.classList.toggle("active", active);
+                    tabButton.setAttribute("aria-selected", active ? "true" : "false");
+                    tabButton.tabIndex = active ? 0 : -1;
+                });
+                document.querySelectorAll(".tab-panel").forEach(tabPanel => {
+                    const active = tabPanel === panel;
+                    tabPanel.classList.toggle("active", active);
+                    tabPanel.hidden = !active;
+                });
 
-                button.classList.add("active");
-                panel.classList.add("active");
+                button.scrollIntoView({ block: "nearest", inline: "nearest" });
             }
 
-            document.querySelectorAll(".tab-button").forEach(button => {
+            tabButtons.forEach((button, index) => {
+                const panel = document.getElementById(`tab-${button.dataset.tab}`);
+                button.setAttribute("aria-controls", panel.id);
+                panel.setAttribute("role", "tabpanel");
+                panel.setAttribute("aria-labelledby", button.id);
+
                 button.addEventListener("click", () => {
                     switchTab(button.dataset.tab);
                     history.replaceState(null, "", `#${button.dataset.tab}`);
                 });
+                button.addEventListener("keydown", event => {
+                    let targetIndex;
+                    if (event.key === "ArrowLeft") {
+                        targetIndex = (index - 1 + tabButtons.length) % tabButtons.length;
+                    } else if (event.key === "ArrowRight") {
+                        targetIndex = (index + 1) % tabButtons.length;
+                    } else if (event.key === "Home") {
+                        targetIndex = 0;
+                    } else if (event.key === "End") {
+                        targetIndex = tabButtons.length - 1;
+                    } else {
+                        return;
+                    }
+
+                    event.preventDefault();
+                    tabButtons[targetIndex].click();
+                    tabButtons[targetIndex].focus();
+                });
             });
 
             const hash = location.hash.slice(1);
-            if (hash) {
-                switchTab(tabForDeepLink(hash));
-            }
+            switchTab(hash ? tabForDeepLink(hash) : "general");
 
             // FIXME: Remove this once closedby="any" triggers for Esc key.
             document.querySelectorAll("dialog").forEach(dialog => {

--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -6,6 +6,11 @@
         <link rel="stylesheet" type="text/css" href="resource://ladybird/ladybird.css" />
         <link rel="stylesheet" type="text/css" href="resource://ladybird/about-pages/webui.css" />
         <style>
+            body {
+                font-size: 14px;
+                line-height: 1.5;
+            }
+
             @media (prefers-color-scheme: light) {
                 :root {
                     --input-background-color: white;
@@ -69,8 +74,23 @@
                 flex-shrink: 0;
             }
 
+            .inline-container > label,
+            .filter-list-row label {
+                margin-bottom: 0;
+            }
+
+            .inline-container:has(> input[type="checkbox"]:disabled) {
+                opacity: 0.5;
+                filter: grayscale(1);
+            }
+
+            input[type="checkbox"][switch]:disabled {
+                cursor: default;
+            }
+
             .button-container {
                 display: flex;
+                align-items: center;
                 justify-content: flex-end;
                 gap: 10px;
 
@@ -94,25 +114,58 @@
             }
 
             .forcibly-enabled {
-                font-size: 14px;
                 opacity: 0.6;
             }
 
             .description {
-                margin-top: 8px;
-                font-size: 14px;
+                margin-top: 4px;
                 opacity: 0.7;
+            }
+
+            .description:empty {
+                display: none;
+            }
+
+            .card-body > .description:first-child {
+                margin: 0 0 16px;
+            }
+
+            .filter-list-collection {
+                margin-top: 16px;
+            }
+
+            .filter-list-header {
+                margin-bottom: 16px;
+            }
+
+            .filter-list-header .card-title {
+                margin: 0;
+            }
+
+            .filter-list-metadata {
+                font-size: 12px;
             }
 
             .tab-panel > .description {
                 margin-bottom: 16px;
             }
 
+            .filter-list-row > div:first-child {
+                min-width: 0;
+                overflow-wrap: anywhere;
+            }
+
+            .filter-list-row .input-field-container {
+                flex-shrink: 0;
+            }
+
+            .form-row input {
+                flex: 1;
+            }
+
             label {
                 display: block;
                 margin-bottom: 8px;
-
-                font-size: 14px;
             }
 
             input[type="number"],
@@ -128,6 +181,9 @@
             }
 
             textarea {
+                font-size: inherit;
+                line-height: inherit;
+                padding: 10px 12px;
                 resize: vertical;
             }
 
@@ -181,10 +237,6 @@
                 flex-direction: column;
 
                 padding: 15px 20px;
-            }
-
-            dialog .dialog-body label {
-                font-size: 16px;
             }
 
             dialog .dialog-body hr {
@@ -301,10 +353,6 @@
                 overflow-wrap: anywhere;
             }
 
-            .config-title {
-                font-size: 14px;
-            }
-
             .tab-bar {
                 display: flex;
                 gap: 4px;
@@ -348,11 +396,37 @@
                 display: block;
             }
 
+            .expandable-list summary {
+                cursor: pointer;
+                margin-bottom: 20px;
+            }
+
             button:focus-visible,
             summary:focus-visible,
             input[type="checkbox"]:focus-visible {
                 outline: 2px solid var(--violet-100);
                 outline-offset: 2px;
+            }
+
+            textarea:focus {
+                border-color: var(--violet-100);
+                outline: 2px solid var(--violet-100);
+                outline-offset: 1px;
+            }
+
+            @media (max-width: 600px) {
+                .filter-list-row {
+                    align-items: flex-start;
+                }
+
+                .form-row {
+                    align-items: stretch;
+                    flex-direction: column;
+                }
+
+                .form-row button {
+                    align-self: flex-end;
+                }
             }
         </style>
     </head>
@@ -372,6 +446,7 @@
                 Permissions
             </button>
             <button id="tab-button-privacy" class="tab-button" data-tab="privacy" role="tab">Privacy</button>
+            <button id="tab-button-blocking" class="tab-button" data-tab="blocking" role="tab">Blocking</button>
             <button id="tab-button-services" class="tab-button" data-tab="services" role="tab">Services</button>
             <button id="tab-button-network" class="tab-button" data-tab="network" role="tab">Network</button>
             <button id="tab-button-advanced" class="tab-button" data-tab="advanced" role="tab">Advanced</button>
@@ -583,6 +658,64 @@
                             <input id="global-privacy-control-toggle" type="checkbox" switch />
                         </div>
                     </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="tab-panel" id="tab-blocking">
+            <template id="filter-list-row">
+                <div class="card-group card-separator inline-container filter-list-row">
+                    <div>
+                        <label></label>
+                        <p class="description"></p>
+                        <p class="description filter-list-metadata"></p>
+                    </div>
+                    <div class="input-field-container">
+                        <input type="checkbox" switch />
+                        <button class="secondary-button">Remove</button>
+                    </div>
+                </div>
+            </template>
+            <div class="inline-container filter-list-header">
+                <h3 class="card-title">Filter lists</h3>
+                <button id="update-content-blocker-lists" class="secondary-button">Update enabled lists</button>
+            </div>
+            <div id="built-in-content-blocker-lists" class="card card-body"></div>
+            <details class="expandable-list">
+                <summary>Show language-specific lists</summary>
+                <div id="language-content-blocker-lists" class="card card-body"></div>
+            </details>
+
+            <h3 class="card-title">Add a subscription</h3>
+            <div class="card card-body">
+                <p class="description">
+                    Add a filter list maintained by a source you trust. Automatic updates reveal your IP address to that
+                    source.
+                </p>
+                <div class="input-field-container form-row">
+                    <input id="custom-content-blocker-subscription-url" type="url" placeholder="Filter list URL" />
+                    <button id="add-content-blocker-subscription" class="secondary-button">Add</button>
+                </div>
+                <p id="custom-content-blocker-subscription-status" class="description" role="status"></p>
+                <div id="custom-content-blocker-subscriptions" class="filter-list-collection"></div>
+            </div>
+
+            <h3 class="card-title">Local filter lists</h3>
+            <div class="card card-body">
+                <p class="description">Import Adblock-compatible filter lists stored on this computer.</p>
+                <input id="local-content-blocker-list-picker" type="file" accept=".txt,text/plain" hidden />
+                <button id="import-local-content-blocker-list" class="secondary-button">Import list...</button>
+                <p id="local-content-blocker-list-status" class="description" role="status"></p>
+                <div id="local-content-blocker-lists" class="filter-list-collection"></div>
+            </div>
+
+            <h3 class="card-title">Custom filters</h3>
+            <div class="card card-body">
+                <label for="custom-content-blocker-filters"> Add Adblock-compatible rules, one per line. </label>
+                <textarea id="custom-content-blocker-filters" rows="12" spellcheck="false"></textarea>
+                <div class="button-container">
+                    <span id="custom-content-blocker-filters-status" class="description" role="status"></span>
+                    <button id="save-custom-content-blocker-filters" class="secondary-button">Save changes</button>
                 </div>
             </div>
         </div>
@@ -820,6 +953,7 @@
 
         <script src="resource://ladybird/about-pages/settings/advanced.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/browsing-behavior.js" type="module"></script>
+        <script src="resource://ladybird/about-pages/settings/blocking.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/default-zoom-level.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/force-dark.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/geolocation.js" type="module"></script>

--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -104,6 +104,10 @@
                 opacity: 0.7;
             }
 
+            .tab-panel > .description {
+                margin-bottom: 16px;
+            }
+
             label {
                 display: block;
                 margin-bottom: 8px;
@@ -368,6 +372,7 @@
                 Permissions
             </button>
             <button id="tab-button-privacy" class="tab-button" data-tab="privacy" role="tab">Privacy</button>
+            <button id="tab-button-services" class="tab-button" data-tab="services" role="tab">Services</button>
             <button id="tab-button-network" class="tab-button" data-tab="network" role="tab">Network</button>
             <button id="tab-button-advanced" class="tab-button" data-tab="advanced" role="tab">Advanced</button>
         </div>
@@ -579,6 +584,36 @@
                         </div>
                     </div>
                 </div>
+            </div>
+        </div>
+
+        <div class="tab-panel" id="tab-services">
+            <p class="description">
+                Services are automatic connections Ladybird makes for browser features in the background. These controls
+                do not affect normal browsing or actions you explicitly request, such as updating filter lists.
+            </p>
+
+            <div class="card card-body">
+                <div class="card-group inline-container">
+                    <label for="allow-services-network-access">
+                        Allow automatic service connections
+                        <p class="description">Let individually enabled services connect in the background.</p>
+                    </label>
+                    <input id="allow-services-network-access" type="checkbox" switch />
+                </div>
+            </div>
+
+            <p id="services-paused-note" class="description hidden" role="status">
+                Automatic service connections are paused. Individual service choices are preserved.
+            </p>
+
+            <h3 class="card-title">Services</h3>
+            <div class="card card-body inline-container">
+                <label for="filter-list-updates">
+                    Filter list updates
+                    <p class="description">Periodically download updates for enabled filter list subscriptions.</p>
+                </label>
+                <input id="filter-list-updates" type="checkbox" switch />
             </div>
         </div>
 
@@ -794,6 +829,7 @@
         <script src="resource://ladybird/about-pages/settings/permissions.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/privacy.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/search.js" type="module"></script>
+        <script src="resource://ladybird/about-pages/settings/services.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/tabs.js" type="module"></script>
 
         <script type="module">

--- a/Base/res/ladybird/about-pages/settings/advanced.js
+++ b/Base/res/ladybird/about-pages/settings/advanced.js
@@ -69,7 +69,6 @@ function createRow(variable) {
     row.dataset.filterText = `${variable.name} ${variable.title} ${variable.description}`.toLowerCase();
 
     const title = document.createElement("p");
-    title.classList.add("config-title");
     title.textContent = variable.title;
 
     const name = document.createElement("p");

--- a/Base/res/ladybird/about-pages/settings/blocking.js
+++ b/Base/res/ladybird/about-pages/settings/blocking.js
@@ -1,0 +1,169 @@
+const builtInLists = document.querySelector("#built-in-content-blocker-lists");
+const languageLists = document.querySelector("#language-content-blocker-lists");
+const updateLists = document.querySelector("#update-content-blocker-lists");
+const subscriptionUrl = document.querySelector("#custom-content-blocker-subscription-url");
+const addSubscription = document.querySelector("#add-content-blocker-subscription");
+const customSubscriptions = document.querySelector("#custom-content-blocker-subscriptions");
+const subscriptionStatus = document.querySelector("#custom-content-blocker-subscription-status");
+const localListPicker = document.querySelector("#local-content-blocker-list-picker");
+const importLocalList = document.querySelector("#import-local-content-blocker-list");
+const localLists = document.querySelector("#local-content-blocker-lists");
+const localListStatus = document.querySelector("#local-content-blocker-list-status");
+const customFilters = document.querySelector("#custom-content-blocker-filters");
+const saveCustomFilters = document.querySelector("#save-custom-content-blocker-filters");
+const customFiltersStatus = document.querySelector("#custom-content-blocker-filters-status");
+const maximumCustomFilterSize = 4 * 1024 * 1024;
+let updateTimer;
+let savedCustomFilters = "";
+
+function listStatus(list) {
+    if (list.lastUpdatedAt != null) {
+        return `Updated ${new Date(list.lastUpdatedAt).toLocaleString()}`;
+    }
+    return list.enabled ? "Not downloaded yet" : null;
+}
+
+function createListRow(list, removable = false) {
+    const row = document.querySelector("#filter-list-row").content.firstElementChild.cloneNode(true);
+    const label = row.querySelector("label");
+    const toggle = row.querySelector("input");
+    const details = row.querySelector(".description");
+    const metadata = row.querySelector(".filter-list-metadata");
+    const name = list.name ?? list.url;
+    label.textContent = name;
+    label.htmlFor = toggle.id = `content-blocker-list-${list.identifier}`;
+    details.id = `${toggle.id}-description`;
+    details.textContent = list.description ?? "";
+    metadata.id = `${toggle.id}-metadata`;
+    metadata.textContent = [list.url ? new URL(list.url).host : "Local file", list.url && listStatus(list)]
+        .filter(Boolean)
+        .join(" · ");
+    toggle.setAttribute("aria-describedby", `${details.id} ${metadata.id}`);
+    toggle.checked = list.enabled;
+    toggle.addEventListener("change", () => {
+        ladybird.sendMessage("setContentBlockerListEnabled", { identifier: list.identifier, enabled: toggle.checked });
+    });
+    const remove = row.querySelector("button");
+    if (removable) {
+        remove.setAttribute("aria-label", `Remove ${name}`);
+        remove.addEventListener("click", () => ladybird.sendMessage("removeContentBlockerList", list.identifier));
+    } else {
+        remove.remove();
+    }
+    return row;
+}
+
+function showEmptyState(container, message) {
+    const emptyState = document.createElement("p");
+    emptyState.className = "description";
+    emptyState.innerText = message;
+    container.append(emptyState);
+}
+
+function loadSettings(settings) {
+    const contentBlockers = settings.contentBlockers;
+    if (!contentBlockers) {
+        return;
+    }
+
+    for (const container of [builtInLists, languageLists, customSubscriptions, localLists]) {
+        container.replaceChildren();
+    }
+    for (const list of settings.contentBlockerLists) {
+        const container = list.builtIn
+            ? list.languageSpecific
+                ? languageLists
+                : builtInLists
+            : list.url
+              ? customSubscriptions
+              : localLists;
+        container.append(createListRow(list, !list.builtIn));
+    }
+    if (!customSubscriptions.children.length) showEmptyState(customSubscriptions, "No custom subscriptions added.");
+    if (!localLists.children.length) showEmptyState(localLists, "No local lists imported.");
+
+    if (customFilters.value === savedCustomFilters) {
+        customFilters.value = contentBlockers.customFilters;
+    }
+    savedCustomFilters = contentBlockers.customFilters;
+
+    updateLists.disabled = settings.contentBlockerListUpdateInProgress;
+    updateLists.innerText = settings.contentBlockerListUpdateInProgress ? "Updating…" : "Update enabled lists";
+
+    clearTimeout(updateTimer);
+    if (settings.contentBlockerListUpdateInProgress) {
+        updateTimer = setTimeout(() => ladybird.sendMessage("loadCurrentSettings"), 1000);
+    }
+}
+
+addSubscription.addEventListener("click", () => {
+    if (!subscriptionUrl.reportValidity() || subscriptionUrl.value.length === 0) {
+        return;
+    }
+    const url = new URL(subscriptionUrl.value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+        subscriptionStatus.innerText = "Enter an HTTP or HTTPS URL.";
+        return;
+    }
+    ladybird.sendMessage("addCustomContentBlockerSubscription", subscriptionUrl.value);
+    subscriptionUrl.value = "";
+});
+
+updateLists.addEventListener("click", () => {
+    updateLists.disabled = true;
+    updateLists.innerText = "Updating…";
+    ladybird.sendMessage("updateContentBlockerLists");
+});
+
+importLocalList.addEventListener("click", () => localListPicker.click());
+localListPicker.addEventListener("change", async () => {
+    const file = localListPicker.files[0];
+    if (!file) {
+        return;
+    }
+    if (file.size > 64 * 1024 * 1024) {
+        localListStatus.innerText = "The selected list is larger than 64 MiB.";
+        localListPicker.value = "";
+        return;
+    }
+    const data = {
+        name: file.name,
+        contents: await file.text(),
+    };
+    // IPC's JSON serializer uses six-byte escapes for carriage returns and form feeds.
+    const serialized = JSON.stringify(data, (_, value) =>
+        typeof value === "string" ? value.replace(/[\r\f]/g, "\0") : value
+    );
+    // Leave room for the IPC message headers and method name.
+    const maximumPayloadSize = 64 * 1024 * 1024 - 1024;
+    if (
+        serialized.length > maximumPayloadSize ||
+        new TextEncoder().encode(serialized).byteLength > maximumPayloadSize
+    ) {
+        localListStatus.innerText = "The encoded list is too large to import.";
+        localListPicker.value = "";
+        return;
+    }
+    ladybird.sendMessage("importLocalContentBlockerList", data);
+    localListPicker.value = "";
+});
+
+saveCustomFilters.addEventListener("click", () => {
+    if (new TextEncoder().encode(customFilters.value).byteLength > maximumCustomFilterSize) {
+        customFiltersStatus.innerText = "Custom filters must be 4 MiB or smaller.";
+        customFilters.focus();
+        return;
+    }
+    ladybird.sendMessage("setCustomContentBlockerFilters", customFilters.value);
+    customFiltersStatus.innerText = "Saved";
+});
+
+document.addEventListener("WebUIMessage", event => {
+    if (event.detail.name === "loadSettings") {
+        loadSettings(event.detail.data);
+    } else if (event.detail.name === "contentBlockerResult") {
+        const result = event.detail.data;
+        const status = result.operation === "subscription" ? subscriptionStatus : localListStatus;
+        status.innerText = result.message;
+    }
+});

--- a/Base/res/ladybird/about-pages/settings/services.js
+++ b/Base/res/ladybird/about-pages/settings/services.js
@@ -1,0 +1,18 @@
+const allowServicesNetworkAccess = document.querySelector("#allow-services-network-access");
+const filterListUpdates = document.querySelector("#filter-list-updates");
+
+allowServicesNetworkAccess.addEventListener("change", () => {
+    ladybird.sendMessage("setServicesNetworkAccessEnabled", allowServicesNetworkAccess.checked);
+});
+filterListUpdates.addEventListener("change", () => {
+    ladybird.sendMessage("setFilterListUpdatesEnabled", filterListUpdates.checked);
+});
+
+document.addEventListener("WebUIMessage", event => {
+    if (event.detail.name !== "loadSettings") return;
+    const settings = event.detail.data.backgroundNetworking;
+    allowServicesNetworkAccess.checked = settings.enabled;
+    filterListUpdates.checked = settings.features.contentBlockerSubscriptionUpdates;
+    filterListUpdates.disabled = !settings.enabled;
+    document.querySelector("#services-paused-note").classList.toggle("hidden", settings.enabled);
+});

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <AK/Checked.h>
 #include <AK/Debug.h>
 #include <AK/JsonArray.h>
@@ -20,15 +21,22 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibCore/TimeZoneWatcher.h>
+#include <LibCore/Timer.h>
 #include <LibDatabase/Database.h>
 #include <LibDevTools/DevToolsServer.h>
 #include <LibDevTools/FirefoxClient.h>
 #include <LibFileSystem/FileSystem.h>
+#include <LibHTTP/Cache/CacheMode.h>
+#include <LibHTTP/Cookie/IncludeCredentials.h>
+#include <LibHTTP/HeaderList.h>
 #include <LibIPC/TransportHandle.h>
 #include <LibImageDecoderClient/Client.h>
+#include <LibRequests/NetworkError.h>
+#include <LibRequests/Request.h>
 #include <LibURL/InternalURLs.h>
 #include <LibURL/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Statuses.h>
 #include <LibWeb/Loader/DownloadFilename.h>
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWeb/Page/InputEvent.h>
@@ -737,6 +745,13 @@ ByteString Application::content_blocker_list_path(StringView identifier) const
     return LexicalPath::join(m_content_blocker_lists_directory, ByteString::formatted("{}.txt", identifier)).string();
 }
 
+Optional<UnixDateTime> Application::content_blocker_list_last_updated_at(StringView identifier) const
+{
+    if (auto file_status = Core::File::stat(content_blocker_list_path(identifier)); !file_status.is_error())
+        return UnixDateTime::from_seconds_since_epoch(file_status.value().st_mtime);
+    return {};
+}
+
 void Application::rebuild_content_blocker_list_paths()
 {
     m_browser_options.content_blocker_list_paths = m_explicit_content_blocker_list_paths;
@@ -791,6 +806,146 @@ ErrorOr<void> Application::load_content_blocker_lists()
     return {};
 }
 
+void Application::start_content_blocker_list_update(Optional<StringView> requested_identifier)
+{
+    if (m_web_content_options.is_test_mode == IsTestMode::Yes)
+        return;
+    if (content_blocker_list_update_in_progress() && !requested_identifier.has_value())
+        return;
+
+    for (auto const& list : m_settings->content_blocker_lists()) {
+        if (!list.enabled || !list.url.has_value() || (requested_identifier.has_value() && list.identifier != *requested_identifier))
+            continue;
+        if (m_active_content_blocker_list_update.has_value() && m_active_content_blocker_list_update->identifier == list.identifier)
+            continue;
+        if (any_of(m_pending_content_blocker_list_updates, [&](auto const& update) { return update.identifier == list.identifier; }))
+            continue;
+        m_pending_content_blocker_list_updates.append({ list.identifier, list.name, *list.url, content_blocker_list_path(list.identifier) });
+    }
+
+    if (!m_active_content_blocker_list_update.has_value())
+        start_next_content_blocker_list_update();
+}
+
+void Application::start_next_content_blocker_list_update()
+{
+    m_pending_content_blocker_list_updates.remove_all_matching([&](auto const& update) {
+        auto list = m_settings->content_blocker_list(update.identifier);
+        return !list.has_value() || !list->enabled;
+    });
+    if (m_pending_content_blocker_list_updates.is_empty()) {
+        if (exchange(m_content_blocker_list_update_had_success, false))
+            apply_content_blocker_settings();
+        return;
+    }
+
+    m_active_content_blocker_list_update = m_pending_content_blocker_list_updates.take_first();
+    auto& update = *m_active_content_blocker_list_update;
+
+    auto request_headers = HTTP::HeaderList::create();
+    request_headers->set({ "User-Agent"sv, Web::default_user_agent });
+
+    m_content_blocker_list_update_request = request_server_client().start_request(
+        "GET"sv, update.url, *request_headers, {}, HTTP::CacheMode::NoStore,
+        HTTP::Cookie::IncludeCredentials::No);
+    if (!m_content_blocker_list_update_request) {
+        warnln("Unable to start update request for {}", update.name);
+        finish_current_content_blocker_list_update();
+        return;
+    }
+
+    auto timeout = Core::Timer::create_single_shot(30 * 1000, [this] {
+        warnln("Content blocker list download timed out");
+        stop_current_content_blocker_list_update_and_continue();
+    });
+    m_content_blocker_list_update_request->set_stop_callback([timeout] { timeout->stop(); });
+    timeout->start();
+
+    m_content_blocker_list_update_request->set_unbuffered_request_callbacks(
+        [this](NonnullRefPtr<HTTP::HeaderList> headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>, Requests::CameFromCache) {
+            if (m_content_blocker_list_update_cancelled)
+                return;
+            if (response_code.has_value() && Web::Fetch::Infrastructure::is_redirect_status(*response_code)) {
+                auto update = *m_active_content_blocker_list_update;
+                auto location = headers->get("Location"sv);
+                auto url = location.has_value() ? URL::Parser::basic_parse(*location, update.url) : Optional<URL::URL> {};
+                if (url.has_value() && (url->scheme() == "https"sv || (url->scheme() == "http"sv && update.url.scheme() == "http"sv)) && update.redirect_count < 20) {
+                    update.url = url.release_value();
+                    ++update.redirect_count;
+                    m_pending_content_blocker_list_updates.prepend(move(update));
+                    stop_current_content_blocker_list_update_and_continue();
+                    return;
+                }
+            }
+            m_content_blocker_list_update_response_ok = response_code.has_value() && *response_code >= 200 && *response_code < 300;
+            if (!m_content_blocker_list_update_response_ok) {
+                warnln("Unable to update content blocker list: received HTTP status {} {}", response_code.value_or(0), reason_phrase.value_or(String {}));
+                stop_current_content_blocker_list_update_and_continue();
+            }
+        },
+        [this](Requests::ResponseData data) {
+            did_receive_content_blocker_list_update_data(data.bytes());
+        },
+        [this](Core::ImmutableBytes data) {
+            did_receive_content_blocker_list_update_data(data.bytes());
+        },
+        [this, timeout](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> network_error) {
+            timeout->stop();
+            VERIFY(m_active_content_blocker_list_update.has_value());
+            if (network_error.has_value()) {
+                warnln("Unable to update content blocker list: {}", Requests::network_error_to_string(*network_error));
+            } else if (!m_content_blocker_list_update_cancelled && m_content_blocker_list_update_response_ok) {
+                if (auto result = save_content_blocker_list(m_active_content_blocker_list_update->path, m_content_blocker_list_update_payload.bytes()); result.is_error())
+                    warnln("Unable to save content blocker list update: {}", result.error());
+                else
+                    m_content_blocker_list_update_had_success = true;
+            }
+            finish_current_content_blocker_list_update();
+        });
+}
+
+void Application::did_receive_content_blocker_list_update_data(ReadonlyBytes data)
+{
+    if (m_content_blocker_list_update_cancelled)
+        return;
+
+    VERIFY(m_content_blocker_list_update_payload.size() <= maximum_content_blocker_list_size);
+    if (data.size() > maximum_content_blocker_list_size - m_content_blocker_list_update_payload.size()) {
+        warnln("Unable to update content blocker list: response exceeds {} bytes", maximum_content_blocker_list_size);
+        stop_current_content_blocker_list_update_and_continue();
+        return;
+    }
+
+    if (auto result = m_content_blocker_list_update_payload.try_append(data); result.is_error()) {
+        warnln("Unable to update content blocker list: {}", result.error());
+        stop_current_content_blocker_list_update_and_continue();
+    }
+}
+
+void Application::stop_current_content_blocker_list_update_and_continue()
+{
+    if (!m_content_blocker_list_update_request || m_content_blocker_list_update_cancelled)
+        return;
+
+    m_content_blocker_list_update_cancelled = true;
+    m_content_blocker_list_update_request->stop();
+    finish_current_content_blocker_list_update();
+}
+
+void Application::finish_current_content_blocker_list_update()
+{
+    Core::deferred_invoke([this, request = m_content_blocker_list_update_request] {
+        if (m_content_blocker_list_update_request != request)
+            return;
+        m_content_blocker_list_update_request = nullptr;
+        m_active_content_blocker_list_update.clear();
+        m_content_blocker_list_update_payload.clear();
+        m_content_blocker_list_update_response_ok = false;
+        m_content_blocker_list_update_cancelled = false;
+        start_next_content_blocker_list_update();
+    });
+}
+
 ErrorOr<void> Application::save_content_blocker_list(ByteString const& path, ReadonlyBytes contents)
 {
     TRY(Core::Directory::create(m_content_blocker_lists_directory, Core::Directory::CreateDirectories::Yes));
@@ -822,6 +977,9 @@ void Application::remove_content_blocker_list(Badge<SettingsUI>, StringView iden
 {
     if (!m_settings->remove_content_blocker_list(identifier))
         return;
+    m_pending_content_blocker_list_updates.remove_all_matching([&](auto const& update) { return update.identifier == identifier; });
+    if (m_active_content_blocker_list_update.has_value() && m_active_content_blocker_list_update->identifier == identifier)
+        stop_current_content_blocker_list_update_and_continue();
     (void)FileSystem::remove(content_blocker_list_path(identifier), FileSystem::RecursionMode::Disallowed);
 }
 
@@ -2518,6 +2676,23 @@ void Application::apply_content_blocker_settings()
         client.async_set_content_blockers(*m_content_blocker_list_buffer);
         return IterationDecision::Continue;
     });
+}
+
+bool Application::content_blocker_list_update_in_progress() const
+{
+    return m_active_content_blocker_list_update.has_value() || !m_pending_content_blocker_list_updates.is_empty();
+}
+
+void Application::update_content_blocker_lists(Badge<SettingsUI>)
+{
+    start_content_blocker_list_update();
+}
+
+void Application::download_content_blocker_list_if_needed(Badge<SettingsUI>, StringView identifier)
+{
+    if (content_blocker_list_last_updated_at(identifier).has_value())
+        return;
+    start_content_blocker_list_update(identifier);
 }
 
 void Application::update_bookmark_action_for_current_web_view()

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -14,6 +14,7 @@
 #include <AK/Time.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/Directory.h>
 #include <LibCore/Environment.h>
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
@@ -72,6 +73,9 @@
 
 namespace WebView {
 
+static constexpr size_t maximum_content_blocker_list_size = 64 * MiB;
+static constexpr size_t maximum_combined_content_blocker_list_size = 256 * MiB;
+
 Application* Application::s_the = nullptr;
 
 static constexpr double default_display_refresh_rate = 60.0;
@@ -117,6 +121,11 @@ struct ApplicationSettingsObserver final : public SettingsObserver {
             auto enabled = Application::settings().config_variable_as_bool(ConfigVariableID::ShowAdvancedDebugMenu);
             Application::the().debug_menu().set_visible(enabled);
         }
+    }
+
+    virtual void content_blocker_settings_changed() override
+    {
+        Application::the().content_blocker_settings_changed({});
     }
 };
 
@@ -616,6 +625,9 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     for (auto path : content_blocker_list_paths)
         content_blocker_list_paths_as_byte_strings.unchecked_append(path);
 
+    m_explicit_content_blocker_list_paths = content_blocker_list_paths_as_byte_strings;
+    m_content_blocker_lists_directory = LexicalPath::join(profile().paths().data, "ContentBlocking/Lists"sv).string();
+
     // Disable site isolation when debugging WebContent. Otherwise, the process swap may interfere with the gdb session.
     if (debug_process_types.contains_slow(ProcessType::WebContent))
         site_isolation_mode = SiteIsolationMode::Disabled;
@@ -642,6 +654,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         .disable_sandbox = disable_sandbox ? DisableSandbox::Yes : DisableSandbox::No,
         .content_blocker_list_paths = move(content_blocker_list_paths_as_byte_strings),
     };
+    rebuild_content_blocker_list_paths();
 
     if (screenshot_delay.has_value())
         m_browser_options.screenshot_delay = *screenshot_delay;
@@ -719,10 +732,31 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     return {};
 }
 
+ByteString Application::content_blocker_list_path(StringView identifier) const
+{
+    return LexicalPath::join(m_content_blocker_lists_directory, ByteString::formatted("{}.txt", identifier)).string();
+}
+
+void Application::rebuild_content_blocker_list_paths()
+{
+    m_browser_options.content_blocker_list_paths = m_explicit_content_blocker_list_paths;
+
+    for (auto const& list : m_settings->content_blocker_lists()) {
+        auto path = content_blocker_list_path(list.identifier);
+        if (list.enabled && FileSystem::is_regular_file(path))
+            m_browser_options.content_blocker_list_paths.append(move(path));
+    }
+}
+
 ErrorOr<void> Application::load_content_blocker_lists()
 {
-    if (m_browser_options.content_blocker_list_paths.is_empty())
+    StringView custom_filters;
+    if (m_web_content_options.is_test_mode == IsTestMode::No)
+        custom_filters = m_settings->custom_content_blocker_filters();
+    if (m_browser_options.content_blocker_list_paths.is_empty() && custom_filters.is_empty()) {
+        m_content_blocker_list_buffer = TRY(Core::AnonymousBuffer::create_with_size(0));
         return {};
+    }
 
     Checked<size_t> total_size = 0;
     for (auto const& path : m_browser_options.content_blocker_list_paths) {
@@ -730,8 +764,10 @@ ErrorOr<void> Application::load_content_blocker_lists()
         total_size += TRY(file->size());
         total_size += 1;
     }
+    total_size += custom_filters.bytes().size();
+    total_size += 1;
 
-    if (total_size.has_overflow())
+    if (total_size.has_overflow() || total_size.value() > maximum_combined_content_blocker_list_size)
         return Error::from_string_literal("Content blocker lists are too large");
 
     auto blocker_list_buffer = TRY(Core::AnonymousBuffer::create_with_size(total_size.value()));
@@ -745,11 +781,48 @@ ErrorOr<void> Application::load_content_blocker_lists()
         offset += file_size;
         bytes[offset++] = '\n';
     }
+    custom_filters.bytes().copy_to(bytes.slice(offset));
+    offset += custom_filters.bytes().size();
+    bytes[offset++] = '\n';
     VERIFY(offset == bytes.size());
 
     m_content_blocker_list_buffer = move(blocker_list_buffer);
 
     return {};
+}
+
+ErrorOr<void> Application::save_content_blocker_list(ByteString const& path, ReadonlyBytes contents)
+{
+    TRY(Core::Directory::create(m_content_blocker_lists_directory, Core::Directory::CreateDirectories::Yes));
+    auto temporary_path = ByteString::formatted("{}.tmp", path);
+    {
+        auto file = TRY(Core::File::open(temporary_path, Core::File::OpenMode::Write));
+        TRY(file->write_until_depleted(contents));
+    }
+    return FileSystem::move_file(path, temporary_path);
+}
+
+ErrorOr<void> Application::import_local_content_blocker_list(String name, String contents)
+{
+    if (contents.bytes().size() > maximum_content_blocker_list_size)
+        return Error::from_string_literal("Content blocker list exceeds 64 MiB");
+
+    auto identifier = m_settings->add_content_blocker_list(move(name));
+    auto result = save_content_blocker_list(content_blocker_list_path(identifier), contents.bytes());
+    if (result.is_error()) {
+        m_settings->remove_content_blocker_list(identifier);
+        return result.release_error();
+    }
+
+    apply_content_blocker_settings();
+    return {};
+}
+
+void Application::remove_content_blocker_list(Badge<SettingsUI>, StringView identifier)
+{
+    if (!m_settings->remove_content_blocker_list(identifier))
+        return;
+    (void)FileSystem::remove(content_blocker_list_path(identifier), FileSystem::RecursionMode::Disallowed);
 }
 
 void Application::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTab activate_tab) const
@@ -2406,7 +2479,7 @@ void Application::apply_view_options(Badge<ViewImplementation>, ViewImplementati
     view.debug_request("scripting"sv, m_enable_scripting_action->checked() ? "on"sv : "off"sv);
     view.debug_request("content-blocking"sv, m_enable_content_blocking_action->checked() ? "on"sv : "off"sv);
     if (m_content_blocker_list_buffer.has_value())
-        view.set_content_blockers(*m_content_blocker_list_buffer);
+        view.client().async_set_content_blockers(*m_content_blocker_list_buffer);
     view.debug_request("block-pop-ups"sv, m_block_pop_ups_action->checked() ? "on"sv : "off"sv);
     view.debug_request("spoof-user-agent"sv, m_user_agent_string);
     view.debug_request("navigator-compatibility-mode"sv, m_navigator_compatibility_mode);
@@ -2424,6 +2497,27 @@ void Application::tab_settings_changed(Badge<ApplicationSettingsObserver>)
 {
     update_vertical_tabs_action();
     update_tabs_display();
+}
+
+void Application::content_blocker_settings_changed(Badge<ApplicationSettingsObserver>)
+{
+    apply_content_blocker_settings();
+}
+
+void Application::apply_content_blocker_settings()
+{
+    if (m_web_content_options.is_test_mode == IsTestMode::Yes)
+        return;
+    rebuild_content_blocker_list_paths();
+    if (auto result = load_content_blocker_lists(); result.is_error()) {
+        warnln("Unable to apply content blocker settings: {}", result.error());
+        return;
+    }
+
+    WebContentClient::for_each_client([&](WebContentClient& client) {
+        client.async_set_content_blockers(*m_content_blocker_list_buffer);
+        return IterationDecision::Continue;
+    });
 }
 
 void Application::update_bookmark_action_for_current_web_view()

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -131,6 +131,11 @@ struct ApplicationSettingsObserver final : public SettingsObserver {
         }
     }
 
+    virtual void background_networking_settings_changed() override
+    {
+        Application::the().background_networking_settings_changed({});
+    }
+
     virtual void content_blocker_settings_changed() override
     {
         Application::the().content_blocker_settings_changed({});
@@ -735,6 +740,14 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         m_event_loop = &create_platform_event_loop();
     TRY(launch_services());
 
+    if (m_web_content_options.is_test_mode == IsTestMode::No && m_browser_options.enable_content_blocker == EnableContentBlocker::Yes) {
+        m_content_blocker_list_update_timer = Core::Timer::create_repeating(24 * 60 * 60 * 1000, [this] {
+            start_content_blocker_list_update(ContentBlockerListUpdateTrigger::Automatic);
+        });
+        m_content_blocker_list_update_timer->start();
+        start_content_blocker_list_update(ContentBlockerListUpdateTrigger::Automatic);
+    }
+
     initialize_actions();
 
     return {};
@@ -806,9 +819,11 @@ ErrorOr<void> Application::load_content_blocker_lists()
     return {};
 }
 
-void Application::start_content_blocker_list_update(Optional<StringView> requested_identifier)
+void Application::start_content_blocker_list_update(ContentBlockerListUpdateTrigger trigger, Optional<StringView> requested_identifier)
 {
     if (m_web_content_options.is_test_mode == IsTestMode::Yes)
+        return;
+    if (trigger == ContentBlockerListUpdateTrigger::Automatic && !m_settings->automatic_filter_list_updates_allowed())
         return;
     if (content_blocker_list_update_in_progress() && !requested_identifier.has_value())
         return;
@@ -820,7 +835,10 @@ void Application::start_content_blocker_list_update(Optional<StringView> request
             continue;
         if (any_of(m_pending_content_blocker_list_updates, [&](auto const& update) { return update.identifier == list.identifier; }))
             continue;
-        m_pending_content_blocker_list_updates.append({ list.identifier, list.name, *list.url, content_blocker_list_path(list.identifier) });
+        auto updated_at = content_blocker_list_last_updated_at(list.identifier);
+        if (trigger == ContentBlockerListUpdateTrigger::Automatic && updated_at.has_value() && UnixDateTime::now() - *updated_at < AK::Duration::from_seconds(24 * 60 * 60))
+            continue;
+        m_pending_content_blocker_list_updates.append({ list.identifier, list.name, *list.url, content_blocker_list_path(list.identifier), trigger });
     }
 
     if (!m_active_content_blocker_list_update.has_value())
@@ -2657,6 +2675,18 @@ void Application::tab_settings_changed(Badge<ApplicationSettingsObserver>)
     update_tabs_display();
 }
 
+void Application::background_networking_settings_changed(Badge<ApplicationSettingsObserver>)
+{
+    if (!m_settings->automatic_filter_list_updates_allowed()) {
+        m_pending_content_blocker_list_updates.remove_all_matching([](auto const& update) { return update.trigger == ContentBlockerListUpdateTrigger::Automatic; });
+        if (m_active_content_blocker_list_update.has_value() && m_active_content_blocker_list_update->trigger == ContentBlockerListUpdateTrigger::Automatic)
+            stop_current_content_blocker_list_update_and_continue();
+        return;
+    }
+
+    start_content_blocker_list_update(ContentBlockerListUpdateTrigger::Automatic);
+}
+
 void Application::content_blocker_settings_changed(Badge<ApplicationSettingsObserver>)
 {
     apply_content_blocker_settings();
@@ -2685,14 +2715,14 @@ bool Application::content_blocker_list_update_in_progress() const
 
 void Application::update_content_blocker_lists(Badge<SettingsUI>)
 {
-    start_content_blocker_list_update();
+    start_content_blocker_list_update(ContentBlockerListUpdateTrigger::UserInitiated);
 }
 
 void Application::download_content_blocker_list_if_needed(Badge<SettingsUI>, StringView identifier)
 {
     if (content_blocker_list_last_updated_at(identifier).has_value())
         return;
-    start_content_blocker_list_update(identifier);
+    start_content_blocker_list_update(ContentBlockerListUpdateTrigger::UserInitiated, identifier);
 }
 
 void Application::update_bookmark_action_for_current_web_view()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/ByteString.h>
 #include <AK/Function.h>
 #include <AK/JsonValue.h>
@@ -114,8 +115,12 @@ public:
     void bookmarks_changed(Badge<ApplicationBookmarkStoreObserver>);
     void show_bookmarks_bar_changed(Badge<ApplicationSettingsObserver>);
     void content_blocker_settings_changed(Badge<ApplicationSettingsObserver>);
+    bool content_blocker_list_update_in_progress() const;
+    void update_content_blocker_lists(Badge<SettingsUI>);
+    void download_content_blocker_list_if_needed(Badge<SettingsUI>, StringView identifier);
     ErrorOr<void> import_local_content_blocker_list(String name, String contents);
     void remove_content_blocker_list(Badge<SettingsUI>, StringView identifier);
+    Optional<UnixDateTime> content_blocker_list_last_updated_at(StringView identifier) const;
 
     struct BookmarkID {
         String id;
@@ -367,6 +372,11 @@ private:
     void rebuild_content_blocker_list_paths();
     ByteString content_blocker_list_path(StringView identifier) const;
     ErrorOr<void> save_content_blocker_list(ByteString const& path, ReadonlyBytes);
+    void start_content_blocker_list_update(Optional<StringView> requested_identifier = {});
+    void start_next_content_blocker_list_update();
+    void did_receive_content_blocker_list_update_data(ReadonlyBytes);
+    void stop_current_content_blocker_list_update_and_continue();
+    void finish_current_content_blocker_list_update();
     ErrorOr<NonnullRawPtr<Core::GeolocationProvider>> ensure_geolocation_provider();
 
     void initialize_actions();
@@ -495,8 +505,22 @@ private:
     OwnPtr<FontService> m_font_service;
     JsonValue m_site_compatibility_data;
     Optional<Core::AnonymousBuffer> m_content_blocker_list_buffer;
+    struct PendingContentBlockerListUpdate {
+        String identifier;
+        String name;
+        URL::URL url;
+        ByteString path;
+        u8 redirect_count { 0 };
+    };
     Vector<ByteString> m_explicit_content_blocker_list_paths;
     ByteString m_content_blocker_lists_directory;
+    Vector<PendingContentBlockerListUpdate> m_pending_content_blocker_list_updates;
+    Optional<PendingContentBlockerListUpdate> m_active_content_blocker_list_update;
+    ByteBuffer m_content_blocker_list_update_payload;
+    bool m_content_blocker_list_update_response_ok { false };
+    RefPtr<Requests::Request> m_content_blocker_list_update_request;
+    bool m_content_blocker_list_update_cancelled { false };
+    bool m_content_blocker_list_update_had_success { false };
 
     RefPtr<WebDriverBrowserConnection> m_webdriver_browser_connection;
     bool m_webdriver_browser_connection_failed { false };

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -113,6 +113,9 @@ public:
     void update_bookmark_action_for_current_web_view();
     void bookmarks_changed(Badge<ApplicationBookmarkStoreObserver>);
     void show_bookmarks_bar_changed(Badge<ApplicationSettingsObserver>);
+    void content_blocker_settings_changed(Badge<ApplicationSettingsObserver>);
+    ErrorOr<void> import_local_content_blocker_list(String name, String contents);
+    void remove_content_blocker_list(Badge<SettingsUI>, StringView identifier);
 
     struct BookmarkID {
         String id;
@@ -360,6 +363,10 @@ private:
 #endif
     ErrorOr<void> launch_devtools_server();
     ErrorOr<void> load_content_blocker_lists();
+    void apply_content_blocker_settings();
+    void rebuild_content_blocker_list_paths();
+    ByteString content_blocker_list_path(StringView identifier) const;
+    ErrorOr<void> save_content_blocker_list(ByteString const& path, ReadonlyBytes);
     ErrorOr<NonnullRawPtr<Core::GeolocationProvider>> ensure_geolocation_provider();
 
     void initialize_actions();
@@ -488,6 +495,8 @@ private:
     OwnPtr<FontService> m_font_service;
     JsonValue m_site_compatibility_data;
     Optional<Core::AnonymousBuffer> m_content_blocker_list_buffer;
+    Vector<ByteString> m_explicit_content_blocker_list_paths;
+    ByteString m_content_blocker_lists_directory;
 
     RefPtr<WebDriverBrowserConnection> m_webdriver_browser_connection;
     bool m_webdriver_browser_connection_failed { false };

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -114,6 +114,7 @@ public:
     void update_bookmark_action_for_current_web_view();
     void bookmarks_changed(Badge<ApplicationBookmarkStoreObserver>);
     void show_bookmarks_bar_changed(Badge<ApplicationSettingsObserver>);
+    void background_networking_settings_changed(Badge<ApplicationSettingsObserver>);
     void content_blocker_settings_changed(Badge<ApplicationSettingsObserver>);
     bool content_blocker_list_update_in_progress() const;
     void update_content_blocker_lists(Badge<SettingsUI>);
@@ -372,7 +373,11 @@ private:
     void rebuild_content_blocker_list_paths();
     ByteString content_blocker_list_path(StringView identifier) const;
     ErrorOr<void> save_content_blocker_list(ByteString const& path, ReadonlyBytes);
-    void start_content_blocker_list_update(Optional<StringView> requested_identifier = {});
+    enum class ContentBlockerListUpdateTrigger {
+        Automatic,
+        UserInitiated,
+    };
+    void start_content_blocker_list_update(ContentBlockerListUpdateTrigger, Optional<StringView> requested_identifier = {});
     void start_next_content_blocker_list_update();
     void did_receive_content_blocker_list_update_data(ReadonlyBytes);
     void stop_current_content_blocker_list_update_and_continue();
@@ -505,11 +510,13 @@ private:
     OwnPtr<FontService> m_font_service;
     JsonValue m_site_compatibility_data;
     Optional<Core::AnonymousBuffer> m_content_blocker_list_buffer;
+    RefPtr<Core::Timer> m_content_blocker_list_update_timer;
     struct PendingContentBlockerListUpdate {
         String identifier;
         String name;
         URL::URL url;
         ByteString path;
+        ContentBlockerListUpdateTrigger trigger;
         u8 redirect_count { 0 };
     };
     Vector<ByteString> m_explicit_content_blocker_list_paths;

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -38,6 +38,7 @@ class OutOfProcessWebView;
 class ProcessManager;
 class SessionStore;
 class Settings;
+class SettingsUI;
 class SiteIsolationManager;
 class StorageJar;
 class TraversableSessionHistory;

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -73,6 +73,10 @@ static constexpr auto GLOBAL_PRIVACY_CONTROL_KEY = "globalPrivacyControl"sv;
 static constexpr auto GEOLOCATION_ENABLED_KEY = "geolocationEnabled"sv;
 static constexpr auto FORCE_DARK_ENABLED_KEY = "forceDarkEnabled"sv;
 
+static constexpr auto BACKGROUND_NETWORKING_KEY = "backgroundNetworking"sv;
+static constexpr auto BACKGROUND_NETWORKING_ENABLED_KEY = "enabled"sv;
+static constexpr auto BACKGROUND_NETWORKING_FEATURES_KEY = "features"sv;
+
 static constexpr auto CONTENT_BLOCKERS_KEY = "contentBlockers"sv;
 static constexpr auto CONTENT_BLOCKER_BUILT_IN_LISTS_KEY = "builtInLists"sv;
 static constexpr auto CONTENT_BLOCKER_CUSTOM_SUBSCRIPTIONS_KEY = "customSubscriptions"sv;
@@ -332,6 +336,14 @@ Settings Settings::create(ByteString settings_path)
     if (auto force_dark_enabled = settings_json.value().get_bool(FORCE_DARK_ENABLED_KEY); force_dark_enabled.has_value())
         settings.m_force_dark_enabled = *force_dark_enabled;
 
+    if (auto background_networking = settings_json.value().get_object(BACKGROUND_NETWORKING_KEY); background_networking.has_value()) {
+        if (auto enabled = background_networking->get_bool(BACKGROUND_NETWORKING_ENABLED_KEY); enabled.has_value())
+            settings.m_background_networking_enabled = *enabled;
+
+        if (auto features = background_networking->get_object(BACKGROUND_NETWORKING_FEATURES_KEY); features.has_value())
+            settings.m_filter_list_updates_enabled = features->get_bool("contentBlockerSubscriptionUpdates"sv).value_or(false);
+    }
+
     if (auto content_blockers = settings_json.value().get_object(CONTENT_BLOCKERS_KEY); content_blockers.has_value()) {
         if (auto built_in_lists = content_blockers->get_object(CONTENT_BLOCKER_BUILT_IN_LISTS_KEY); built_in_lists.has_value()) {
             for (auto& list : settings.m_content_blocker_lists)
@@ -517,6 +529,14 @@ JsonValue Settings::serialize_json() const
 
     settings.set(GEOLOCATION_ENABLED_KEY, m_geolocation_enabled);
     settings.set(FORCE_DARK_ENABLED_KEY, m_force_dark_enabled);
+
+    JsonObject background_network_features;
+    background_network_features.set("contentBlockerSubscriptionUpdates"sv, m_filter_list_updates_enabled);
+
+    JsonObject background_networking;
+    background_networking.set(BACKGROUND_NETWORKING_ENABLED_KEY, m_background_networking_enabled);
+    background_networking.set(BACKGROUND_NETWORKING_FEATURES_KEY, move(background_network_features));
+    settings.set(BACKGROUND_NETWORKING_KEY, move(background_networking));
 
     JsonObject built_in_content_blocker_lists;
     JsonArray custom_content_blocker_subscriptions;
@@ -947,6 +967,30 @@ void Settings::set_geolocation_enabled(bool enabled)
 
     for (auto& observer : m_observers)
         observer.geolocation_settings_changed();
+}
+
+void Settings::set_background_networking_enabled(bool enabled)
+{
+    if (m_background_networking_enabled == enabled)
+        return;
+
+    m_background_networking_enabled = enabled;
+    persist_settings();
+
+    for (auto& observer : m_observers)
+        observer.background_networking_settings_changed();
+}
+
+void Settings::set_filter_list_updates_enabled(bool enabled)
+{
+    if (m_filter_list_updates_enabled == enabled)
+        return;
+
+    m_filter_list_updates_enabled = enabled;
+    persist_settings();
+
+    for (auto& observer : m_observers)
+        observer.background_networking_settings_changed();
 }
 
 Optional<ContentBlockerList const&> Settings::content_blocker_list(StringView identifier) const

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -5,10 +5,11 @@
  */
 
 #include <AK/ByteString.h>
-#include <AK/Find.h>
+#include <AK/CharacterTypes.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
+#include <AK/Random.h>
 #include <AK/Utf16String.h>
 #include <LibCore/GeolocationProvider.h>
 #include <LibCore/StandardPaths.h>
@@ -72,9 +73,25 @@ static constexpr auto GLOBAL_PRIVACY_CONTROL_KEY = "globalPrivacyControl"sv;
 static constexpr auto GEOLOCATION_ENABLED_KEY = "geolocationEnabled"sv;
 static constexpr auto FORCE_DARK_ENABLED_KEY = "forceDarkEnabled"sv;
 
+static constexpr auto CONTENT_BLOCKERS_KEY = "contentBlockers"sv;
+static constexpr auto CONTENT_BLOCKER_BUILT_IN_LISTS_KEY = "builtInLists"sv;
+static constexpr auto CONTENT_BLOCKER_CUSTOM_SUBSCRIPTIONS_KEY = "customSubscriptions"sv;
+static constexpr auto CONTENT_BLOCKER_LOCAL_LISTS_KEY = "localLists"sv;
+static constexpr auto CONTENT_BLOCKER_CUSTOM_FILTERS_KEY = "customFilters"sv;
+static constexpr auto CONTENT_BLOCKER_IDENTIFIER_KEY = "identifier"sv;
+static constexpr auto CONTENT_BLOCKER_URL_KEY = "url"sv;
+static constexpr auto CONTENT_BLOCKER_NAME_KEY = "name"sv;
+static constexpr auto CONTENT_BLOCKER_ENABLED_KEY = "enabled"sv;
+
 static constexpr auto DNS_SETTINGS_KEY = "dnsSettings"sv;
 
 static constexpr auto CONFIG_VARIABLES_KEY = "configVariables"sv;
+
+static bool is_valid_content_blocker_list_identifier(StringView identifier)
+{
+    return !identifier.is_empty() && identifier.length() <= 128
+        && all_of(identifier.bytes(), [](u8 byte) { return is_ascii_alphanumeric(byte) || byte == '-'; });
+}
 
 static auto const& CONFIG_VARIABLE_DEFINITIONS = *new Array<ConfigVariableDefinition, static_cast<size_t>(ConfigVariableID::Count)> { {
     {
@@ -315,6 +332,38 @@ Settings Settings::create(ByteString settings_path)
     if (auto force_dark_enabled = settings_json.value().get_bool(FORCE_DARK_ENABLED_KEY); force_dark_enabled.has_value())
         settings.m_force_dark_enabled = *force_dark_enabled;
 
+    if (auto content_blockers = settings_json.value().get_object(CONTENT_BLOCKERS_KEY); content_blockers.has_value()) {
+        if (auto built_in_lists = content_blockers->get_object(CONTENT_BLOCKER_BUILT_IN_LISTS_KEY); built_in_lists.has_value()) {
+            for (auto& list : settings.m_content_blocker_lists)
+                list.enabled = built_in_lists->get_bool(list.identifier).value_or(list.enabled);
+        }
+
+        for (auto key : { CONTENT_BLOCKER_CUSTOM_SUBSCRIPTIONS_KEY, CONTENT_BLOCKER_LOCAL_LISTS_KEY }) {
+            auto lists = content_blockers->get_array(key);
+            if (!lists.has_value())
+                continue;
+            for (auto const& value : lists->values()) {
+                if (!value.is_object())
+                    continue;
+                auto identifier = value.as_object().get_string(CONTENT_BLOCKER_IDENTIFIER_KEY);
+                auto enabled = value.as_object().get_bool(CONTENT_BLOCKER_ENABLED_KEY);
+                auto source = value.as_object().get_string(key == CONTENT_BLOCKER_CUSTOM_SUBSCRIPTIONS_KEY ? CONTENT_BLOCKER_URL_KEY : CONTENT_BLOCKER_NAME_KEY);
+                if (!identifier.has_value() || !is_valid_content_blocker_list_identifier(*identifier) || !enabled.has_value() || !source.has_value() || settings.content_blocker_list(*identifier).has_value())
+                    continue;
+                Optional<URL::URL> url;
+                if (key == CONTENT_BLOCKER_CUSTOM_SUBSCRIPTIONS_KEY) {
+                    url = URL::Parser::basic_parse(*source);
+                    if (!url.has_value() || !(url->scheme() == "http"sv || url->scheme() == "https"sv))
+                        continue;
+                }
+                settings.m_content_blocker_lists.append({ *identifier, *source, move(url), *enabled });
+            }
+        }
+
+        if (auto filters = content_blockers->get_string(CONTENT_BLOCKER_CUSTOM_FILTERS_KEY); filters.has_value())
+            settings.m_custom_content_blocker_filters = *filters;
+    }
+
     if (auto dns_settings = settings_json.value().get(DNS_SETTINGS_KEY); dns_settings.has_value())
         settings.m_dns_settings = parse_dns_settings(*dns_settings);
 
@@ -341,6 +390,39 @@ Settings::Settings(ByteString settings_path)
     for (auto const& variable : config_variable_definitions()) {
         m_config_variables[static_cast<size_t>(variable.id)] = variable.default_value;
     }
+    enum class ListCategory { General,
+        Language };
+    auto add_list = [&](StringView identifier, StringView name, StringView description, StringView url, ListCategory category = ListCategory::General) {
+        m_content_blocker_lists.append({ MUST(String::from_utf8(identifier)), MUST(String::from_utf8(name)),
+            URL::Parser::basic_parse(url), false, true, category == ListCategory::Language, MUST(String::from_utf8(description)) });
+    };
+    add_list("easyList"sv, "EasyList"sv, "Blocks advertising on English-language websites."sv, "https://easylist.to/easylist/easylist.txt"sv);
+    add_list("easyPrivacy"sv, "EasyPrivacy"sv, "Blocks tracking scripts, pixels, and other tracking requests."sv, "https://easylist.to/easylist/easyprivacy.txt"sv);
+    add_list("easyListCookie"sv, "EasyList Cookie List"sv, "Blocks cookie banners and other cookie notices."sv, "https://secure.fanboy.co.nz/fanboy-cookiemonster.txt"sv);
+    add_list("fanboyAnnoyances"sv, "Fanboy's Annoyance List"sv, "Blocks pop-ups, social widgets, newsletters, and other annoyances."sv, "https://secure.fanboy.co.nz/fanboy-annoyance.txt"sv);
+    add_list("fanboySocial"sv, "Fanboy's Social Blocking List"sv, "Blocks social media widgets and other social content."sv, "https://easylist.to/easylist/fanboy-social.txt"sv);
+    add_list("adblockWarningRemoval"sv, "Adblock Warning Removal List"sv, "Blocks warnings aimed at people who use a content blocker."sv, "https://easylist-downloads.adblockplus.org/antiadblockfilters.txt"sv);
+    add_list("abpindo"sv, "ABPindo"sv, "Blocks advertising on Indonesian and Malaysian websites."sv, "https://raw.githubusercontent.com/heradhis/indonesianadblockrules/master/subscriptions/abpindo.txt"sv, ListCategory::Language);
+    add_list("abpvn"sv, "ABPVN List"sv, "Blocks advertising on Vietnamese websites."sv, "https://abpvn.com/filter/abpvn-IPl6HE.txt"sv, ListCategory::Language);
+    add_list("bulgarianList"sv, "Bulgarian list"sv, "Blocks advertising on Bulgarian websites."sv, "https://stanev.org/abp/adblock_bg.txt"sv, ListCategory::Language);
+    add_list("nordicFilters"sv, "Dandelion Sprout's Nordic Filters"sv, "Blocks advertising on Nordic-language websites."sv, "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/NordicFiltersABP-Inclusion.txt"sv, ListCategory::Language);
+    add_list("easyListChina"sv, "EasyList China"sv, "Blocks advertising on Chinese websites."sv, "https://easylist-downloads.adblockplus.org/easylistchina.txt"sv, ListCategory::Language);
+    add_list("easyListCzechAndSlovak"sv, "EasyList Czech and Slovak"sv, "Blocks advertising on Czech and Slovak websites."sv, "https://raw.githubusercontent.com/tomasko126/easylistczechandslovak/master/filters.txt"sv, ListCategory::Language);
+    add_list("easyListDutch"sv, "EasyList Dutch"sv, "Blocks advertising on Dutch websites."sv, "https://easylist-downloads.adblockplus.org/easylistdutch.txt"sv, ListCategory::Language);
+    add_list("easyListGermany"sv, "EasyList Germany"sv, "Blocks advertising on German websites."sv, "https://easylist.to/easylistgermany/easylistgermany.txt"sv, ListCategory::Language);
+    add_list("easyListHebrew"sv, "EasyList Hebrew"sv, "Blocks advertising on Hebrew-language websites."sv, "https://raw.githubusercontent.com/easylist/EasyListHebrew/master/EasyListHebrew.txt"sv, ListCategory::Language);
+    add_list("easyListItaly"sv, "EasyList Italy"sv, "Blocks advertising on Italian websites."sv, "https://easylist-downloads.adblockplus.org/easylistitaly.txt"sv, ListCategory::Language);
+    add_list("easyListLithuania"sv, "EasyList Lithuania"sv, "Blocks advertising on Lithuanian websites."sv, "https://raw.githubusercontent.com/EasyList-Lithuania/easylist_lithuania/master/easylistlithuania.txt"sv, ListCategory::Language);
+    add_list("easyListPolish"sv, "EasyList Polish"sv, "Blocks advertising on Polish websites."sv, "https://easylist-downloads.adblockplus.org/easylistpolish.txt"sv, ListCategory::Language);
+    add_list("easyListPortuguese"sv, "EasyList Portuguese"sv, "Blocks advertising on Portuguese-language websites."sv, "https://easylist-downloads.adblockplus.org/easylistportuguese.txt"sv, ListCategory::Language);
+    add_list("easyListSpanish"sv, "EasyList Spanish"sv, "Blocks advertising on Spanish-language websites."sv, "https://easylist-downloads.adblockplus.org/easylistspanish.txt"sv, ListCategory::Language);
+    add_list("indianList"sv, "IndianList"sv, "Blocks advertising on websites in languages of India and Sri Lanka."sv, "https://easylist-downloads.adblockplus.org/indianlist.txt"sv, ListCategory::Language);
+    add_list("koreanList"sv, "KoreanList"sv, "Blocks advertising on Korean websites."sv, "https://easylist-downloads.adblockplus.org/koreanlist.txt"sv, ListCategory::Language);
+    add_list("latvianList"sv, "Latvian List"sv, "Blocks advertising on Latvian websites."sv, "https://raw.githubusercontent.com/Latvian-List/adblock-latvian/master/lists/latvian-list.txt"sv, ListCategory::Language);
+    add_list("listeAR"sv, "Liste AR"sv, "Blocks advertising on Arabic websites."sv, "https://easylist-downloads.adblockplus.org/liste_ar.txt"sv, ListCategory::Language);
+    add_list("listeFR"sv, "Liste FR"sv, "Blocks advertising on French websites."sv, "https://easylist-downloads.adblockplus.org/liste_fr.txt"sv, ListCategory::Language);
+    add_list("roList"sv, "ROList"sv, "Blocks advertising on Romanian websites."sv, "https://zoso.ro/pages/rolist.txt"sv, ListCategory::Language);
+    add_list("ruAdList"sv, "RU AdList"sv, "Blocks advertising on Russian and Ukrainian websites."sv, "https://easylist-downloads.adblockplus.org/ruadlist.txt"sv, ListCategory::Language);
 }
 
 JsonValue Settings::serialize_json() const
@@ -435,6 +517,33 @@ JsonValue Settings::serialize_json() const
 
     settings.set(GEOLOCATION_ENABLED_KEY, m_geolocation_enabled);
     settings.set(FORCE_DARK_ENABLED_KEY, m_force_dark_enabled);
+
+    JsonObject built_in_content_blocker_lists;
+    JsonArray custom_content_blocker_subscriptions;
+    JsonArray local_content_blocker_lists;
+    for (auto const& list : m_content_blocker_lists) {
+        if (list.built_in) {
+            built_in_content_blocker_lists.set(list.identifier, list.enabled);
+            continue;
+        }
+        JsonObject object;
+        object.set(CONTENT_BLOCKER_IDENTIFIER_KEY, list.identifier);
+        object.set(CONTENT_BLOCKER_ENABLED_KEY, list.enabled);
+        if (list.url.has_value()) {
+            object.set(CONTENT_BLOCKER_URL_KEY, list.url->serialize());
+            custom_content_blocker_subscriptions.must_append(move(object));
+        } else {
+            object.set(CONTENT_BLOCKER_NAME_KEY, list.name);
+            local_content_blocker_lists.must_append(move(object));
+        }
+    }
+
+    JsonObject content_blockers;
+    content_blockers.set(CONTENT_BLOCKER_BUILT_IN_LISTS_KEY, move(built_in_content_blocker_lists));
+    content_blockers.set(CONTENT_BLOCKER_CUSTOM_SUBSCRIPTIONS_KEY, move(custom_content_blocker_subscriptions));
+    content_blockers.set(CONTENT_BLOCKER_LOCAL_LISTS_KEY, move(local_content_blocker_lists));
+    content_blockers.set(CONTENT_BLOCKER_CUSTOM_FILTERS_KEY, m_custom_content_blocker_filters);
+    settings.set(CONTENT_BLOCKERS_KEY, move(content_blockers));
 
     // dnsSettings :: { mode: "system" } | { mode: "custom", server: string, port: u16, type: "udp" | "tls", forciblyEnabled: bool, dnssec: bool }
     JsonObject dns_settings;
@@ -838,6 +947,62 @@ void Settings::set_geolocation_enabled(bool enabled)
 
     for (auto& observer : m_observers)
         observer.geolocation_settings_changed();
+}
+
+Optional<ContentBlockerList const&> Settings::content_blocker_list(StringView identifier) const
+{
+    for (auto const& list : m_content_blocker_lists) {
+        if (list.identifier == identifier)
+            return list;
+    }
+    return {};
+}
+
+void Settings::set_content_blocker_list_enabled(StringView identifier, bool enabled)
+{
+    for (auto& list : m_content_blocker_lists) {
+        if (list.identifier != identifier || list.enabled == enabled)
+            continue;
+        list.enabled = enabled;
+        persist_settings();
+        for (auto& observer : m_observers)
+            observer.content_blocker_settings_changed();
+        return;
+    }
+}
+
+String Settings::add_content_blocker_list(String name, Optional<URL::URL> url)
+{
+    String identifier;
+    do {
+        identifier = MUST(String::formatted("list-{:016x}", get_random<u64>()));
+    } while (content_blocker_list(identifier).has_value());
+    m_content_blocker_lists.append({ identifier, move(name), move(url) });
+    persist_settings();
+    for (auto& observer : m_observers)
+        observer.content_blocker_settings_changed();
+    return identifier;
+}
+
+bool Settings::remove_content_blocker_list(StringView identifier)
+{
+    auto removed = m_content_blocker_lists.remove_all_matching([&](auto const& list) { return !list.built_in && list.identifier == identifier; });
+    if (!removed)
+        return false;
+    persist_settings();
+    for (auto& observer : m_observers)
+        observer.content_blocker_settings_changed();
+    return true;
+}
+
+void Settings::set_custom_content_blocker_filters(String filters)
+{
+    if (m_custom_content_blocker_filters == filters)
+        return;
+    m_custom_content_blocker_filters = move(filters);
+    persist_settings();
+    for (auto& observer : m_observers)
+        observer.content_blocker_settings_changed();
 }
 
 void Settings::set_dns_settings(DNSSettings const& dns_settings, bool override_by_command_line)

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -55,6 +55,16 @@ struct BrowsingDataSettings {
     HTTP::DiskCacheSettings disk_cache_settings;
 };
 
+struct ContentBlockerList {
+    String identifier;
+    String name;
+    Optional<URL::URL> url;
+    bool enabled { true };
+    bool built_in { false };
+    bool language_specific { false };
+    String description {};
+};
+
 enum class GlobalPrivacyControl {
     No,
     Yes,
@@ -106,6 +116,7 @@ public:
     virtual void config_variable_changed(ConfigVariableID) { }
     virtual void geolocation_settings_changed() { }
     virtual void force_dark_settings_changed() { }
+    virtual void content_blocker_settings_changed() { }
 };
 
 class WEBVIEW_API Settings {
@@ -171,6 +182,14 @@ public:
     bool force_dark_enabled() const { return m_force_dark_enabled; }
     void set_force_dark_enabled(bool);
 
+    Vector<ContentBlockerList> const& content_blocker_lists() const { return m_content_blocker_lists; }
+    Optional<ContentBlockerList const&> content_blocker_list(StringView identifier) const;
+    String add_content_blocker_list(String name, Optional<URL::URL> = {});
+    void set_content_blocker_list_enabled(StringView identifier, bool);
+    bool remove_content_blocker_list(StringView identifier);
+    String const& custom_content_blocker_filters() const { return m_custom_content_blocker_filters; }
+    void set_custom_content_blocker_filters(String);
+
     static DNSSettings parse_dns_settings(JsonValue const&);
     DNSSettings const& dns_settings() const { return m_dns_settings; }
     void set_dns_settings(DNSSettings const&, bool override_by_command_line = false);
@@ -209,6 +228,8 @@ private:
     BrowsingDataSettings m_browsing_data_settings;
     bool m_geolocation_enabled { false };
     bool m_force_dark_enabled { false };
+    Vector<ContentBlockerList> m_content_blocker_lists;
+    String m_custom_content_blocker_filters;
     GlobalPrivacyControl m_global_privacy_control { GlobalPrivacyControl::No };
     DNSSettings m_dns_settings { SystemDNS() };
     bool m_dns_override_by_command_line { false };

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -116,6 +116,7 @@ public:
     virtual void config_variable_changed(ConfigVariableID) { }
     virtual void geolocation_settings_changed() { }
     virtual void force_dark_settings_changed() { }
+    virtual void background_networking_settings_changed() { }
     virtual void content_blocker_settings_changed() { }
 };
 
@@ -182,6 +183,12 @@ public:
     bool force_dark_enabled() const { return m_force_dark_enabled; }
     void set_force_dark_enabled(bool);
 
+    bool background_networking_enabled() const { return m_background_networking_enabled; }
+    void set_background_networking_enabled(bool);
+    bool filter_list_updates_enabled() const { return m_filter_list_updates_enabled; }
+    bool automatic_filter_list_updates_allowed() const { return m_background_networking_enabled && m_filter_list_updates_enabled; }
+    void set_filter_list_updates_enabled(bool);
+
     Vector<ContentBlockerList> const& content_blocker_lists() const { return m_content_blocker_lists; }
     Optional<ContentBlockerList const&> content_blocker_list(StringView identifier) const;
     String add_content_blocker_list(String name, Optional<URL::URL> = {});
@@ -228,6 +235,8 @@ private:
     BrowsingDataSettings m_browsing_data_settings;
     bool m_geolocation_enabled { false };
     bool m_force_dark_enabled { false };
+    bool m_background_networking_enabled { true };
+    bool m_filter_list_updates_enabled { false };
     Vector<ContentBlockerList> m_content_blocker_lists;
     String m_custom_content_blocker_filters;
     GlobalPrivacyControl m_global_privacy_control { GlobalPrivacyControl::No };

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1841,11 +1841,6 @@ void ViewImplementation::debug_request(ByteString const& request, ByteString con
     client().async_debug_request(page_id(), request, argument);
 }
 
-void ViewImplementation::set_content_blockers(Core::AnonymousBuffer const& patterns)
-{
-    client().async_set_content_blockers(page_id(), patterns);
-}
-
 void ViewImplementation::run_javascript(String const& js_source)
 {
     client().async_run_javascript(page_id(), js_source);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -283,7 +283,6 @@ public:
     void request_style_sheet_source(Web::CSS::StyleSheetIdentifier const&);
 
     void debug_request(ByteString const& request, ByteString const& argument = {});
-    void set_content_blockers(Core::AnonymousBuffer const& patterns);
 
     void run_javascript(String const&);
     void js_console_input(String const&);

--- a/Libraries/LibWebView/WebUI.cpp
+++ b/Libraries/LibWebView/WebUI.cpp
@@ -19,6 +19,7 @@ namespace WebView {
 
 static constexpr auto s_pages = to_array<WebUI::Page>({
     { "about"sv, "About URLs"sv, WebUI::PageType::Static },
+    { "blocking"sv, "Blocking"sv, WebUI::PageType::Static },
     { "bookmarks"sv, "Bookmarks"sv, WebUI::PageType::Dynamic },
     { "downloads"sv, "Downloads"sv, WebUI::PageType::Dynamic },
     { "history"sv, "History"sv, WebUI::PageType::Dynamic },

--- a/Libraries/LibWebView/WebUI.cpp
+++ b/Libraries/LibWebView/WebUI.cpp
@@ -25,6 +25,7 @@ static constexpr auto s_pages = to_array<WebUI::Page>({
     { "newtab"sv, "New Tab"sv, WebUI::PageType::Static },
     { "processes"sv, "Task Manager"sv, WebUI::PageType::Dynamic },
     { "settings"sv, "Settings"sv, WebUI::PageType::Dynamic },
+    { "services"sv, "Services"sv, WebUI::PageType::Static },
     { "version"sv, "Version"sv, WebUI::PageType::Dynamic },
 });
 

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -125,6 +125,19 @@ void SettingsUI::register_interfaces()
         set_global_privacy_control(data);
     });
 
+    register_interface("setServicesNetworkAccessEnabled"sv, [this](auto const& enabled) {
+        if (!enabled.is_bool())
+            return;
+
+        Application::settings().set_background_networking_enabled(enabled.as_bool());
+        load_current_settings();
+    });
+    register_interface("setFilterListUpdatesEnabled"sv, [this](auto const& enabled) {
+        if (!enabled.is_bool())
+            return;
+        Application::settings().set_filter_list_updates_enabled(enabled.as_bool());
+        load_current_settings();
+    });
     register_interface("setDNSSettings"sv, [this](auto const& data) {
         set_dns_settings(data);
     });

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -138,6 +138,74 @@ void SettingsUI::register_interfaces()
         Application::settings().set_filter_list_updates_enabled(enabled.as_bool());
         load_current_settings();
     });
+    register_interface("updateContentBlockerLists"sv, [this](auto const&) {
+        Application::the().update_content_blocker_lists({});
+        load_current_settings();
+    });
+    register_interface("setContentBlockerListEnabled"sv, [this](auto const& value) {
+        if (!value.is_object())
+            return;
+        auto identifier = value.as_object().get_string("identifier"sv);
+        auto enabled = value.as_object().get_bool("enabled"sv);
+        if (!identifier.has_value() || !enabled.has_value())
+            return;
+        Application::settings().set_content_blocker_list_enabled(*identifier, *enabled);
+        if (*enabled)
+            Application::the().download_content_blocker_list_if_needed({}, *identifier);
+        load_current_settings();
+    });
+    auto report_content_blocker_result = [this](StringView operation, StringView message) {
+        JsonObject result;
+        result.set("operation"sv, operation);
+        result.set("message"sv, message);
+        async_send_message("contentBlockerResult"sv, result);
+    };
+    register_interface("addCustomContentBlockerSubscription"sv, [this, report_content_blocker_result](auto const& value) {
+        if (!value.is_string())
+            return;
+        auto url = URL::Parser::basic_parse(value.as_string());
+        if (!url.has_value() || !(url->scheme() == "http"sv || url->scheme() == "https"sv)) {
+            report_content_blocker_result("subscription"sv, "Enter an HTTP or HTTPS URL."sv);
+            return;
+        }
+        for (auto const& subscription : Application::settings().content_blocker_lists()) {
+            if (!subscription.built_in && subscription.url == url) {
+                report_content_blocker_result("subscription"sv, "Subscription already added."sv);
+                load_current_settings();
+                return;
+            }
+        }
+        auto identifier = Application::settings().add_content_blocker_list(url->serialize(), url);
+        Application::the().download_content_blocker_list_if_needed({}, identifier);
+        report_content_blocker_result("subscription"sv, "Subscription added."sv);
+        load_current_settings();
+    });
+    register_interface("removeContentBlockerList"sv, [this](auto const& value) {
+        if (!value.is_string())
+            return;
+        Application::the().remove_content_blocker_list({}, value.as_string());
+        load_current_settings();
+    });
+    register_interface("importLocalContentBlockerList"sv, [this, report_content_blocker_result](auto const& value) {
+        if (!value.is_object())
+            return;
+        auto name = value.as_object().get_string("name"sv);
+        auto contents = value.as_object().get_string("contents"sv);
+        if (!name.has_value() || name->is_empty() || !contents.has_value())
+            return;
+        if (auto result = Application::the().import_local_content_blocker_list(*name, *contents); result.is_error())
+            report_content_blocker_result("import"sv, MUST(String::formatted("Unable to import list: {}", result.error())));
+        else
+            report_content_blocker_result("import"sv, MUST(String::formatted("{} imported.", *name)));
+        load_current_settings();
+    });
+    register_interface("setCustomContentBlockerFilters"sv, [this](auto const& value) {
+        if (!value.is_string() || value.as_string().bytes().size() > 4 * MiB)
+            return;
+        Application::settings().set_custom_content_blocker_filters(value.as_string());
+        load_current_settings();
+    });
+
     register_interface("setDNSSettings"sv, [this](auto const& data) {
         set_dns_settings(data);
     });
@@ -186,6 +254,24 @@ void SettingsUI::load_current_settings()
     }
 
     settings.as_object().set("configVariableDefinitions"sv, move(config_variables));
+
+    JsonArray lists;
+    for (auto const& list : Application::settings().content_blocker_lists()) {
+        JsonObject object;
+        object.set("identifier"sv, list.identifier);
+        object.set("name"sv, list.name);
+        object.set("description"sv, list.description);
+        object.set("url"sv, list.url.has_value() ? JsonValue(list.url->serialize()) : JsonValue {});
+        object.set("builtIn"sv, list.built_in);
+        object.set("languageSpecific"sv, list.language_specific);
+        object.set("enabled"sv, list.enabled);
+        auto updated = Application::the().content_blocker_list_last_updated_at(list.identifier);
+        object.set("lastUpdatedAt"sv, updated.has_value() ? JsonValue(updated->milliseconds_since_epoch()) : JsonValue {});
+        lists.must_append(move(object));
+    }
+    settings.as_object().set("contentBlockerLists"sv, move(lists));
+    settings.as_object().set("contentBlockerListUpdateInProgress"sv, Application::the().content_blocker_list_update_in_progress());
+
     async_send_message("loadSettings"sv, settings);
 }
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2483,7 +2483,7 @@ void ConnectionFromClient::update_input_method_state(u64 page_id)
     async_did_update_input_method_state(page_id, caret_rect, is_enabled, cursor_position, anchor_position, move(text_before_cursor), move(text_after_cursor));
 }
 
-void ConnectionFromClient::set_content_blockers(u64 page_id, Core::AnonymousBuffer patterns_buffer)
+void ConnectionFromClient::set_content_blockers(Core::AnonymousBuffer patterns_buffer)
 {
     auto& blocker = Web::ContentBlocker::the();
     auto had_cosmetic_rules = blocker.has_cosmetic_rules();
@@ -2493,10 +2493,8 @@ void ConnectionFromClient::set_content_blockers(u64 page_id, Core::AnonymousBuff
         return;
     }
 
-    if (had_cosmetic_rules || blocker.has_cosmetic_rules()) {
-        if (auto page = this->page(page_id); page.has_value())
-            page->page().invalidate_user_style();
-    }
+    if (had_cosmetic_rules || blocker.has_cosmetic_rules())
+        m_page_host->invalidate_user_style();
 }
 
 void ConnectionFromClient::set_autoplay_settings(u64, Web::HTML::AutoplayPolicy policy, Vector<Utf16String> allowlist)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -192,7 +192,7 @@ private:
     virtual void clone_dom_node(u64 page_id, Web::UniqueNodeID node_id) override;
     virtual void remove_dom_node(u64 page_id, Web::UniqueNodeID node_id) override;
 
-    virtual void set_content_blockers(u64 page_id, Core::AnonymousBuffer patterns) override;
+    virtual void set_content_blockers(Core::AnonymousBuffer patterns) override;
     virtual void set_autoplay_settings(u64 page_id, Web::HTML::AutoplayPolicy policy, Vector<Utf16String> allowlist) override;
     virtual void set_preferred_color_scheme(u64 page_id, Web::CSS::PreferredColorScheme) override;
     virtual void set_preferred_contrast(u64 page_id, Web::CSS::PreferredContrast) override;

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -76,6 +76,12 @@ void PageHost::compositor_process_reconnected()
         page->compositor_process_reconnected();
 }
 
+void PageHost::invalidate_user_style()
+{
+    for (auto& [_, page] : m_pages)
+        page->page().invalidate_user_style();
+}
+
 void PageHost::compositor_process_lost()
 {
     for (auto& [_, page] : m_pages)

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -48,6 +48,7 @@ public:
     void ensure_compositor_host();
     void compositor_process_reconnected();
     void compositor_process_lost();
+    void invalidate_user_style();
     Web::Compositor::CompositorHost* compositor_host() { return m_compositor_host.ptr(); }
     Web::Compositor::CompositorHost const* compositor_host() const { return m_compositor_host.ptr(); }
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -190,7 +190,7 @@ endpoint WebContentServer
     find_in_page_next_match(u64 page_id) =|
     find_in_page_previous_match(u64 page_id) =|
 
-    set_content_blockers(u64 page_id, Core::AnonymousBuffer patterns) =|
+    set_content_blockers(Core::AnonymousBuffer patterns) =|
     set_autoplay_settings(u64 page_id, Web::HTML::AutoplayPolicy policy, Vector<Utf16String> allowlist) =|
     set_preferred_color_scheme(u64 page_id, Web::CSS::PreferredColorScheme color_scheme) =|
     set_preferred_contrast(u64 page_id, Web::CSS::PreferredContrast contrast) =|

--- a/Tests/LibWeb/test-web/TestWebView.cpp
+++ b/Tests/LibWeb/test-web/TestWebView.cpp
@@ -30,7 +30,7 @@ TestWebView::TestWebView(Core::AnonymousBuffer theme, Web::DevicePixelSize viewp
 
 void TestWebView::clear_content_blockers()
 {
-    client().async_set_content_blockers(m_client_state.page_index, MUST(Core::AnonymousBuffer::create_with_size(0)));
+    client().async_set_content_blockers(MUST(Core::AnonymousBuffer::create_with_size(0)));
 }
 
 // Force-dark rides on the navigable, so a test that turns it on leaves it on for whatever runs next in this view.

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -133,6 +133,12 @@ if (BUILD_TESTING AND NOT WIN32)
     set_tests_properties(TestWebDriverDeleteSession PROPERTIES TIMEOUT 120)
 
     add_test(
+        NAME TestWebDriverContentBlockers
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-webdriver-content-blockers.py $<TARGET_FILE:WebDriver>
+    )
+    set_tests_properties(TestWebDriverContentBlockers PROPERTIES TIMEOUT 180)
+
+    add_test(
         NAME TestWebDriverSessionHistory
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-webdriver-session-history.py $<TARGET_FILE:WebDriver>
     )

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestApplyHistoryStep.cpp
+    TestBackgroundNetworking.cpp
     TestAutocompleteMuxer.cpp
     TestAutocompleteRanker.cpp
     TestCanonicalBrowsingContextGroup.cpp

--- a/Tests/LibWebView/TestBackgroundNetworking.cpp
+++ b/Tests/LibWebView/TestBackgroundNetworking.cpp
@@ -52,6 +52,44 @@ TEST_CASE(content_blocker_list_registry)
     }
 }
 
+TEST_CASE(feature_policy)
+{
+    remove_settings_file();
+    auto settings = WebView::Settings::create(settings_path());
+
+    EXPECT(!settings.automatic_filter_list_updates_allowed());
+
+    settings.set_filter_list_updates_enabled(true);
+    EXPECT(settings.automatic_filter_list_updates_allowed());
+
+    settings.set_background_networking_enabled(false);
+    EXPECT(!settings.automatic_filter_list_updates_allowed());
+    EXPECT(settings.filter_list_updates_enabled());
+
+    settings.set_background_networking_enabled(true);
+    EXPECT(settings.automatic_filter_list_updates_allowed());
+
+    settings.set_filter_list_updates_enabled(false);
+    EXPECT(!settings.automatic_filter_list_updates_allowed());
+    remove_settings_file();
+}
+
+TEST_CASE(settings_are_persistent)
+{
+    remove_settings_file();
+
+    {
+        auto settings = WebView::Settings::create(settings_path());
+        settings.set_filter_list_updates_enabled(false);
+        settings.set_background_networking_enabled(false);
+    }
+
+    auto settings = WebView::Settings::create(settings_path());
+    EXPECT(!settings.filter_list_updates_enabled());
+    EXPECT(!settings.background_networking_enabled());
+    remove_settings_file();
+}
+
 TEST_CASE(content_blocker_list_settings_are_persistent)
 {
     remove_settings_file();

--- a/Tests/LibWebView/TestBackgroundNetworking.cpp
+++ b/Tests/LibWebView/TestBackgroundNetworking.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/LexicalPath.h>
+#include <LibCore/File.h>
+#include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibWebView/Settings.h>
+
+static ByteString settings_path()
+{
+    return LexicalPath::join(Core::StandardPaths::tempfile_directory(), ByteString::formatted("test-background-networking-{}.json", Core::System::getpid())).string();
+}
+
+static void remove_settings_file()
+{
+    if (FileSystem::exists(settings_path()))
+        MUST(FileSystem::remove(settings_path(), FileSystem::RecursionMode::Disallowed));
+}
+
+static void write_settings_file(StringView contents)
+{
+    auto file = MUST(Core::File::open(settings_path(), Core::File::OpenMode::Write));
+    MUST(file->write_until_depleted(contents.bytes()));
+}
+
+TEST_CASE(content_blocker_list_registry)
+{
+    remove_settings_file();
+    auto settings = WebView::Settings::create(settings_path());
+    auto const& definitions = settings.content_blocker_lists();
+    EXPECT_EQ(definitions.size(), 27u);
+
+    for (size_t i = 0; i < definitions.size(); ++i) {
+        auto const& definition = definitions[i];
+        EXPECT(!definition.enabled);
+        EXPECT(!definition.identifier.is_empty());
+        EXPECT(!definition.name.is_empty());
+        EXPECT(!definition.description.is_empty());
+        auto const& url = definition.url;
+        EXPECT(url.has_value());
+        EXPECT(url->scheme() == "https"sv);
+
+        for (size_t j = i + 1; j < definitions.size(); ++j)
+            EXPECT(definition.identifier != definitions[j].identifier);
+    }
+}
+
+TEST_CASE(content_blocker_list_settings_are_persistent)
+{
+    remove_settings_file();
+
+    String subscription_identifier;
+    String local_identifier;
+    {
+        auto settings = WebView::Settings::create(settings_path());
+        EXPECT(!settings.content_blocker_list("easyList"sv)->enabled);
+        EXPECT(!settings.content_blocker_list("easyPrivacy"sv)->enabled);
+
+        settings.set_content_blocker_list_enabled("easyList"sv, false);
+        settings.set_content_blocker_list_enabled("easyPrivacy"sv, true);
+        subscription_identifier = settings.add_content_blocker_list("https://example.com/filters.txt"_string, URL::Parser::basic_parse("https://example.com/filters.txt"sv));
+        settings.set_content_blocker_list_enabled(subscription_identifier, false);
+        local_identifier = settings.add_content_blocker_list("my-filters.txt"_string);
+        settings.set_content_blocker_list_enabled(local_identifier, false);
+        settings.set_custom_content_blocker_filters("example.com##.advertisement"_string);
+    }
+
+    auto settings = WebView::Settings::create(settings_path());
+    EXPECT(!settings.content_blocker_list("easyList"sv)->enabled);
+    EXPECT(settings.content_blocker_list("easyPrivacy"sv)->enabled);
+    EXPECT_EQ(settings.content_blocker_lists().size(), 27u + 2);
+    auto const& subscription = settings.content_blocker_list(subscription_identifier).value();
+    EXPECT_EQ(subscription.url->serialize(), "https://example.com/filters.txt"sv);
+    EXPECT(!subscription.enabled);
+    auto const& local = settings.content_blocker_list(local_identifier).value();
+    EXPECT_EQ(local.name, "my-filters.txt"sv);
+    EXPECT(!local.url.has_value());
+    EXPECT(!local.enabled);
+    EXPECT_EQ(settings.custom_content_blocker_filters(), "example.com##.advertisement"sv);
+
+    EXPECT(!settings.remove_content_blocker_list("easyList"sv));
+    EXPECT(!settings.remove_content_blocker_list("unknown"sv));
+    EXPECT(settings.remove_content_blocker_list(subscription_identifier));
+    EXPECT(settings.remove_content_blocker_list(local_identifier));
+    EXPECT_EQ(settings.content_blocker_lists().size(), 27u);
+
+    remove_settings_file();
+}
+
+TEST_CASE(content_blocker_list_settings_reject_built_in_identifiers)
+{
+    remove_settings_file();
+    write_settings_file(R"({
+        "contentBlockers": {
+            "customSubscriptions": [
+                { "identifier": "easyList", "url": "https://example.com/reserved.txt", "enabled": true },
+                { "identifier": "custom-list", "url": "https://example.com/custom.txt", "enabled": true }
+            ],
+            "localLists": [
+                { "identifier": "easyPrivacy", "name": "reserved.txt", "enabled": true },
+                { "identifier": "local-list", "name": "local.txt", "enabled": true }
+            ]
+        }
+    })"sv);
+
+    auto settings = WebView::Settings::create(settings_path());
+    EXPECT_EQ(settings.content_blocker_lists().size(), 27u + 2);
+    EXPECT(settings.content_blocker_list("custom-list"sv).has_value());
+    EXPECT(settings.content_blocker_list("local-list"sv).has_value());
+    EXPECT(settings.content_blocker_list("easyList"sv)->built_in);
+    EXPECT(settings.content_blocker_list("easyPrivacy"sv)->built_in);
+    remove_settings_file();
+}

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -206,6 +206,7 @@ TEST_CASE(all_web_ui_pages_are_suggested)
         "about:newtab"sv,
         "about:processes"sv,
         "about:settings"sv,
+        "about:services"sv,
         "about:version"sv,
     };
 

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -200,6 +200,7 @@ TEST_CASE(all_web_ui_pages_are_suggested)
 {
     static constexpr Array expected_urls {
         "about:about"sv,
+        "about:blocking"sv,
         "about:bookmarks"sv,
         "about:downloads"sv,
         "about:history"sv,

--- a/Tests/LibWebView/test-webdriver-content-blockers.py
+++ b/Tests/LibWebView/test-webdriver-content-blockers.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026-present, the Ladybird developers.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import http.server
+import json
+import runpy
+import subprocess
+import sys
+import tempfile
+import threading
+
+from pathlib import Path
+
+helpers = runpy.run_path(str(Path(__file__).with_name("test-webdriver-delete-session.py")))
+request = helpers["request"]
+hits = []
+release_downloads = threading.Event()
+release_stall = threading.Event()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        hits.append(self.path)
+        if self.path == "/favicon.ico":
+            self.send_error(404)
+            return
+        if self.path == "/page":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<!doctype html><body>")
+            return
+        if self.path == "/before-stall":
+            release_downloads.wait()
+        if self.path == "/stall":
+            self.send_response(200)
+            self.send_header("Content-Length", "5")
+            self.end_headers()
+            self.wfile.write(b"!")
+            self.wfile.flush()
+            release_stall.wait()
+            return
+        status = int(self.path.rsplit("/", 1)[1]) if self.path.startswith("/redirect/") else 302
+        self.send_response(200 if self.path in ("/list", "/before-stall", "/after-stall") else status)
+        if self.path != "/missing":
+            self.send_header(
+                "Location",
+                "file:///not-a-filter-list"
+                if self.path == "/unsafe"
+                else "../list"
+                if self.path.startswith("/redirect/")
+                else "/loop",
+            )
+        self.send_header("Content-Length", "5")
+        self.end_headers()
+        self.wfile.write(b"!list")
+
+    def log_message(self, format, *args):
+        pass
+
+
+with tempfile.TemporaryDirectory() as directory:
+    profile = Path(directory)
+    (profile / "config").mkdir()
+    (profile / "legacy.txt").write_text("!legacy")
+    (profile / "config" / "Settings.json").write_text(
+        json.dumps(
+            {
+                "contentBlockers": {"builtInLists": {"easyList": False}},
+                "configVariables": {"content_blocking.list_paths": [str(profile / "legacy.txt")]},
+            }
+        )
+    )
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    port = helpers["unused_port"]()
+    process = subprocess.Popen(
+        [sys.argv[1], "--headless", "-l", "127.0.0.1", "-p", str(port), "--profile-path", directory]
+    )
+    session = None
+    try:
+        helpers["wait_for_port"](port)
+        session = helpers["create_session"](port)
+
+        def command(path, body):
+            status, payload, raw = request(port, "POST", f"/session/{session}/{path}", body)
+            assert status == 200, raw
+            return payload["value"]
+
+        def settings(name="loadCurrentSettings", data=None, wait_for_idle=True):
+            return command(
+                "execute/async",
+                {
+                    "script": """
+                const [name, data, waitForIdle, done] = arguments;
+                const receive = event => {
+                    if (event.detail.name !== 'loadSettings') return;
+                    if (waitForIdle && event.detail.data.contentBlockerListUpdateInProgress) {
+                        setTimeout(() => ladybird.sendMessage('loadCurrentSettings'), 50);
+                        return;
+                    }
+                    document.removeEventListener('WebUIMessage', receive);
+                    done(event.detail.data);
+                };
+                document.addEventListener('WebUIMessage', receive);
+                ladybird.sendMessage(name, data);
+            """,
+                    "args": [name, data, wait_for_idle],
+                },
+            )
+
+        command("timeouts", {"script": 60000})
+        status, payload, raw = request(port, "GET", f"/session/{session}/window")
+        assert status == 200, raw
+        settings_window = payload["value"]
+        page_window = command("window/new", {"type": "tab"})["handle"]
+        command("window", {"handle": page_window})
+        command("url", {"url": f"http://127.0.0.1:{server.server_port}/page"})
+        command(
+            "execute/sync",
+            {
+                "script": """
+                window.popup = window.open('about:blank');
+                for (const page of [window, popup]) {
+                    const advertisement = page.document.createElement('div');
+                    advertisement.className = 'advertisement';
+                    page.document.body.append(advertisement);
+                }
+            """,
+                "args": [],
+            },
+        )
+        command("window", {"handle": settings_window})
+        command("url", {"url": "about:about"})
+        command("url", {"url": "about:services"})
+        settings()
+        command("back", {})
+        assert command("execute/sync", {"script": "return location.href", "args": []}) == "about:about"
+        command("url", {"url": "about:blocking"})
+        state = settings()
+        assert command(
+            "execute/sync",
+            {
+                "script": """
+                const tab = document.querySelector('[aria-selected="true"]');
+                const panel = document.querySelector('#tab-blocking');
+                const description = panel.querySelector('.card-body > .description');
+                const form = description.nextElementSibling;
+                const lists = panel.querySelector('#built-in-content-blocker-lists');
+                const heading = panel.querySelector('.filter-list-header .card-title');
+                const details = lists.querySelector('.description');
+                const metadata = lists.querySelector('.filter-list-metadata');
+                return location.hash === '#blocking' && tab.textContent === 'Blocking'
+                    && heading.getBoundingClientRect().left === lists.getBoundingClientRect().left
+                    && metadata.getBoundingClientRect().top >= details.getBoundingClientRect().bottom
+                    && getComputedStyle(metadata).fontSize === '12px'
+                    && metadata.textContent.includes('easylist.to') && !details.textContent.includes('easylist.to')
+                    && ['label', '.description', 'summary', 'textarea'].every(selector =>
+                        getComputedStyle(panel.querySelector(selector)).fontSize === '14px')
+                    && form.getBoundingClientRect().top - description.getBoundingClientRect().bottom >= 16;
+            """,
+                "args": [],
+            },
+        )
+        for enabled in (False, True):
+            settings("setServicesNetworkAccessEnabled", enabled)
+            assert command(
+                "execute/sync",
+                {
+                    "script": """
+                    const toggle = document.querySelector('#filter-list-updates');
+                    const style = getComputedStyle(toggle.parentElement);
+                    return toggle.disabled === !arguments[0]
+                        && style.opacity === (arguments[0] ? '1' : '0.5')
+                        && (arguments[0] || style.filter === 'grayscale(1)');
+                """,
+                    "args": [enabled],
+                },
+            )
+        for rules, display in [("##.advertisement", "none"), ("", "block")]:
+            settings("setCustomContentBlockerFilters", rules)
+            command("window", {"handle": page_window})
+            assert command(
+                "execute/sync",
+                {
+                    "script": "return [window, popup].map(page => page.getComputedStyle(page.document.querySelector('.advertisement')).display)",
+                    "args": [],
+                },
+            ) == [display, display]
+            command("window", {"handle": settings_window})
+        command("window", {"handle": page_window})
+        command("execute/sync", {"script": "popup.close()", "args": []})
+        command("window", {"handle": settings_window})
+        assert any(item["name"] == "content_blocking.list_paths" for item in state["configVariableDefinitions"])
+        assert state["configVariables"]["content_blocking.list_paths"] == [str(profile / "legacy.txt")]
+        command(
+            "execute/sync",
+            {
+                "script": """
+            const editor = document.querySelector('#custom-content-blocker-filters');
+            editor.value = 'unsaved rules';
+            editor.dispatchEvent(new Event('input', {bubbles: true}));
+            document.querySelector('#tab-button-services').click();
+        """,
+                "args": [],
+            },
+        )
+        settings("setContentBlockerListEnabled", {"identifier": "easyPrivacy", "enabled": False})
+        assert (
+            command(
+                "execute/sync",
+                {"script": "return document.querySelector('#custom-content-blocker-filters').value", "args": []},
+            )
+            == "unsaved rules"
+        )
+        command(
+            "execute/sync",
+            {
+                "script": """
+                document.querySelector('#save-custom-content-blocker-filters').click();
+                const editor = document.querySelector('#custom-content-blocker-filters');
+                editor.value = 'edits made while saving';
+                editor.dispatchEvent(new Event('input', {bubbles: true}));
+            """,
+                "args": [],
+            },
+        )
+        assert settings()["contentBlockers"]["customFilters"] == "unsaved rules"
+
+        for path in [f"/redirect/{status}" for status in (301, 302, 303, 307, 308)] + ["/loop", "/unsafe", "/missing"]:
+            url = f"http://127.0.0.1:{server.server_port}{path}"
+            state = settings("addCustomContentBlockerSubscription", url)
+            identifier = next(item["identifier"] for item in state["contentBlockerLists"] if item["url"] == url)
+            cached = profile / "data" / "ContentBlocking" / "Lists" / f"{identifier}.txt"
+            if path.startswith("/redirect/"):
+                assert cached.read_text() == "!list"
+            else:
+                assert not cached.exists(), path
+        assert hits.count("/loop") == 21, hits
+        duplicate = settings("addCustomContentBlockerSubscription", f"http://127.0.0.1:{server.server_port}/missing")
+        assert len(duplicate["contentBlockerLists"]) == len(state["contentBlockerLists"])
+        assert (
+            command(
+                "execute/sync",
+                {
+                    "script": "return document.querySelector('#custom-content-blocker-subscription-status').textContent",
+                    "args": [],
+                },
+            )
+            == "Subscription already added."
+        )
+        for path in ("/before-stall", "/stall", "/after-stall"):
+            settings("addCustomContentBlockerSubscription", f"http://127.0.0.1:{server.server_port}{path}", False)
+        release_downloads.set()
+        state = settings()
+        for item in state["contentBlockerLists"]:
+            if item["url"] and item["url"].endswith(("/before-stall", "/stall", "/after-stall")):
+                cached = profile / "data" / "ContentBlocking" / "Lists" / f"{item['identifier']}.txt"
+                assert cached.exists() == (not item["url"].endswith("/stall"))
+
+        for character, count in (
+            ("a", 64 * 1024 * 1024),
+            ("\0", 11 * 1024 * 1024),
+            ("\r", 11 * 1024 * 1024),
+            ("\f", 11 * 1024 * 1024),
+            ("!", 1),
+        ):
+            status = command(
+                "execute/async",
+                {
+                    "script": """
+                const [character, count, done] = arguments;
+                const status = document.querySelector('#local-content-blocker-list-status');
+                status.textContent = '';
+                const observer = new MutationObserver(() => {
+                    observer.disconnect();
+                    done(status.textContent);
+                });
+                observer.observe(status, {childList: true, characterData: true, subtree: true});
+                const files = new DataTransfer();
+                files.items.add(new File([character.repeat(count)], 'import.txt'));
+                const picker = document.querySelector('#local-content-blocker-list-picker');
+                picker.files = files.files;
+                picker.dispatchEvent(new Event('change'));
+            """,
+                    "args": [character, count],
+                },
+            )
+            assert status == ("import.txt imported." if count == 1 else "The encoded list is too large to import."), (
+                status
+            )
+            settings()
+        lists_directory = profile / "data" / "ContentBlocking" / "Lists"
+        backup_directory = lists_directory.with_name("Lists-backup")
+        lists_directory.rename(backup_directory)
+        lists_directory.write_text("Not a directory")
+        try:
+            settings("importLocalContentBlockerList", {"name": "failed-import.txt", "contents": "!"})
+            assert command(
+                "execute/sync",
+                {
+                    "script": "return document.querySelector('#local-content-blocker-list-status').textContent",
+                    "args": [],
+                },
+            ).startswith("Unable to import list:")
+        finally:
+            lists_directory.unlink()
+            backup_directory.rename(lists_directory)
+        assert (
+            command(
+                "execute/sync",
+                {"script": "return document.querySelector('#custom-content-blocker-filters').value", "args": []},
+            )
+            == "edits made while saving"
+        )
+    finally:
+        release_downloads.set()
+        release_stall.set()
+        if session:
+            request(port, "DELETE", f"/session/{session}")
+        process.terminate()
+        process.wait(timeout=10)
+        server.shutdown()

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -44,6 +44,7 @@ set(ABOUT_PAGES
     newtab.html
     processes.html
     settings.html
+    services.html
     version.html
     webui.css
 )
@@ -62,6 +63,7 @@ set(ABOUT_SETTINGS_RESOURCES
     permissions.js
     privacy.js
     search.js
+    services.js
     tabs.js
 )
 list(TRANSFORM ABOUT_SETTINGS_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladybird/about-pages/settings/")

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -38,6 +38,7 @@ list(TRANSFORM SITE_COMPATIBILITY_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/WebC
 
 set(ABOUT_PAGES
     about.html
+    blocking.html
     bookmarks.html
     downloads.html
     history.html
@@ -53,6 +54,7 @@ list(TRANSFORM ABOUT_PAGES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladybird/abo
 set(ABOUT_SETTINGS_RESOURCES
     advanced.js
     browsing-behavior.js
+    blocking.js
     default-zoom-level.js
     dialog-deep-link.js
     force-dark.js


### PR DESCRIPTION
Add persistent filter-list subscriptions to the content blocker, with a built-in catalog covering ads, tracking, cookie notices, annoyances, and language-specific lists. All built-in lists are off by default. Users can also subscribe to arbitrary HTTP(S) lists, import local files, and write custom Adblock-compatible rules.

Subscriptions are downloaded and cached per profile, with manual updates and opt-in automatic updates checked at startup and daily. Downloads follow redirects, enforce size limits and timeouts, and replace cached lists atomically. Changes apply to open pages, including cosmetic filters, without restarting. Existing configured list paths remain supported.

Add a Blocking settings tab, accessible through about:blocking, to manage lists and custom rules and show sources and update times. A new Services tab at about:services provides a master switch for automatic service connections and an individual filter-list update toggle. Turning off the master switch cancels automatic work while preserving individual choices and leaving manual updates available.

Also improve settings keyboard navigation, typography, spacing, and disabled-control styling, and move crash reports into General settings.
