### PR TITLE
Tests: Make AudioContext-stops-after-document-inactive deterministic

### DIFF
--- a/Tests/LibWeb/Text/expected/WebAudio/AudioContext-stops-after-document-inactive.txt
+++ b/Tests/LibWeb/Text/expected/WebAudio/AudioContext-stops-after-document-inactive.txt
@@ -1,2 +1,2 @@
 audio clock started: true
-audio clock stopped after document became inactive: true
+audio clock stopped after document became inactive

--- a/Tests/LibWeb/Text/input/WebAudio/AudioContext-stops-after-document-inactive.html
+++ b/Tests/LibWeb/Text/input/WebAudio/AudioContext-stops-after-document-inactive.html
@@ -18,10 +18,18 @@
         println(`audio clock started: ${context.currentTime > 0}`);
 
         iframe.remove();
-        await new Promise(resolve => setTimeout(resolve, 50));
-        const settledTime = context.currentTime;
-        await new Promise(resolve => setTimeout(resolve, 100));
-        println(`audio clock stopped after document became inactive: ${context.currentTime === settledTime}`);
+
+        while (iframe.contentWindow !== null)
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+        let settledTime = context.currentTime;
+        for (;;) {
+            await new Promise(resolve => setTimeout(resolve, 200));
+            if (context.currentTime === settledTime)
+                break;
+            settledTime = context.currentTime;
+        }
+        println("audio clock stopped after document became inactive");
         done();
     });
 </script>


### PR DESCRIPTION
Waiting for an arbitrary time for the document to become inactive, then another arbitrary time to check if the context stopped moving, was just asking for inconsistency. Instead, wait for the iframe to be removed before checking anything.

Currently, the context's currentTime should only advance once after the document became inactive, but really currentTime should be based on the stream's played samples, not the buffer callback. Once it is, that will allow the time to advance more than once after the inactivation, so we check whether the time has settled in a loop.