### PR TITLE
LibJS: Speed up property key string handling

### DIFF
--- a/AK/Utf16FlyString.h
+++ b/AK/Utf16FlyString.h
@@ -50,6 +50,7 @@ public:
     }
 
     [[nodiscard]] FlatPtr raw_identity() const { return m_data.raw({}); }
+    [[nodiscard]] bool has_short_ascii_storage() const { return m_data.has_short_ascii_storage(); }
 
     [[nodiscard]] static Utf16FlyString from_raw(FlatPtr raw)
     {

--- a/AK/Utf16StringBase.h
+++ b/AK/Utf16StringBase.h
@@ -286,6 +286,14 @@ public:
         }
     }
 
+    [[nodiscard]] ALWAYS_INLINE bool has_fly_string_storage() const
+    {
+        if (has_short_ascii_storage())
+            return true;
+        auto const* data = data_without_union_member_assertion();
+        return !data || data->is_fly_string();
+    }
+
     // This is primarily interesting to unit tests.
     [[nodiscard]] ALWAYS_INLINE bool has_long_ascii_storage() const
     {

--- a/AK/Utf16StringBase.h
+++ b/AK/Utf16StringBase.h
@@ -294,6 +294,8 @@ public:
         return !data || data->is_fly_string();
     }
 
+    [[nodiscard]] constexpr FlatPtr raw_identity() const { return raw(); }
+
     // This is primarily interesting to unit tests.
     [[nodiscard]] ALWAYS_INLINE bool has_long_ascii_storage() const
     {

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -175,6 +175,12 @@ size_t PrimitiveString::external_memory_size() const
 void PrimitiveString::finalize()
 {
     Base::finalize();
+
+    for (auto& entry : vm().string_to_atom_cache()) {
+        if (entry.string.ptr() == this)
+            entry = {};
+    }
+
     if (m_utf16_string_is_in_cache) {
         auto const& string = *m_utf16_string;
         if (string.length_in_code_units() <= MAX_LENGTH_FOR_STRING_CACHE)
@@ -202,6 +208,32 @@ Utf16String PrimitiveString::utf16_string() const
 
     VERIFY(has_utf16_string());
     return *m_utf16_string;
+}
+
+PropertyKey PrimitiveString::property_key(VM& vm) const
+{
+    resolve_if_needed();
+
+    VERIFY(has_utf16_string());
+    auto& string = *m_utf16_string;
+    if (string.has_fly_string_storage())
+        return Utf16FlyString { string };
+
+    auto& string_to_atom_cache = vm.string_to_atom_cache();
+    for (size_t i = 0; i < string_to_atom_cache.size(); ++i) {
+        if (string_to_atom_cache[i].string.ptr() != this)
+            continue;
+        if (i != 0)
+            swap(string_to_atom_cache[0], string_to_atom_cache[i]);
+        return *string_to_atom_cache[0].atom;
+    }
+
+    Utf16FlyString fly_string { string };
+    if (!string.has_fly_string_storage()) {
+        string_to_atom_cache[1] = move(string_to_atom_cache[0]);
+        string_to_atom_cache[0] = { *this, fly_string };
+    }
+    return fly_string;
 }
 
 Utf16View PrimitiveString::utf16_string_view() const

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -110,11 +110,19 @@ GC::Ref<PrimitiveString> PrimitiveString::create_from_unsigned_integer(VM& vm, u
         auto& cache_slot = vm.numeric_string_cache()[number];
         if (!cache_slot) {
             auto string = Utf16String::number(number);
-            cache_slot = create(vm, string);
+            cache_slot = create(vm, Utf16FlyString { string });
         }
         return *cache_slot;
     }
-    return create(vm, Utf16String::number(number));
+
+    auto& large_cache = vm.large_numeric_string_cache();
+    auto& cache_entry = large_cache[number & (large_cache.size() - 1)];
+    if (!cache_entry.string || cache_entry.number != number) {
+        cache_entry.number = number;
+        auto string = Utf16String::number(number);
+        cache_entry.string = create(vm, Utf16FlyString { string });
+    }
+    return *cache_entry.string;
 }
 
 GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& lhs, PrimitiveString& rhs)

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -21,13 +21,14 @@
 
 namespace JS {
 
-// Strings shorter than or equal to this length are cached in the VM and deduplicated.
-// Longer strings are not cached to avoid excessive hashing and lookup costs.
-static constexpr size_t MAX_LENGTH_FOR_STRING_CACHE = 256;
-
 GC_DEFINE_ALLOCATOR(PrimitiveString);
 GC_DEFINE_ALLOCATOR(RopeString);
 GC_DEFINE_ALLOCATOR(Substring);
+
+size_t PrimitiveString::fly_string_cache_hash(Utf16FlyString const& string)
+{
+    return u64_hash(string.raw_identity());
+}
 
 Optional<StringView> PrimitiveString::short_flat_string_storage_view() const
 {
@@ -67,25 +68,15 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16String const& stri
     if (string.is_empty())
         return vm.empty_string();
 
-    auto const length_in_code_units = string.length_in_code_units();
-
-    if (length_in_code_units == 1) {
+    if (string.length_in_code_units() == 1) {
         if (auto code_unit = string.code_unit_at(0); is_ascii(code_unit))
             return vm.single_ascii_character_string(static_cast<u8>(code_unit));
     }
 
-    if (length_in_code_units > MAX_LENGTH_FOR_STRING_CACHE) {
-        return vm.heap().allocate<PrimitiveString>(string);
-    }
+    if (string.has_short_ascii_storage())
+        return create(vm, Utf16FlyString { string });
 
-    auto& string_cache = vm.utf16_string_cache();
-    if (auto it = string_cache.find(string); it != string_cache.end())
-        return *it->value;
-
-    auto new_string = vm.heap().allocate<PrimitiveString>(string);
-    new_string->m_utf16_string_is_in_cache = true;
-    string_cache.set(move(string), new_string);
-    return *new_string;
+    return vm.heap().allocate<PrimitiveString>(string);
 }
 
 GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16View const& string)
@@ -95,7 +86,22 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16View const& string
 
 GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16FlyString const& string)
 {
-    return create(vm, string.to_utf16_string());
+    if (string.is_empty())
+        return vm.empty_string();
+
+    if (string.length_in_code_units() == 1) {
+        if (auto code_unit = string.code_unit_at(0); is_ascii(code_unit))
+            return vm.single_ascii_character_string(static_cast<u8>(code_unit));
+    }
+
+    auto& string_cache = vm.fly_string_cache();
+    auto& cache_slot = string_cache[fly_string_cache_hash(string) & (string_cache.size() - 1)];
+    if (cache_slot && cache_slot->m_utf16_string->raw_identity() == string.raw_identity())
+        return *cache_slot;
+
+    auto new_string = vm.heap().allocate<PrimitiveString>(string.to_utf16_string());
+    cache_slot = new_string;
+    return *new_string;
 }
 
 GC::Ref<PrimitiveString> PrimitiveString::create_from_unsigned_integer(VM& vm, u64 number)
@@ -175,17 +181,19 @@ size_t PrimitiveString::external_memory_size() const
 void PrimitiveString::finalize()
 {
     Base::finalize();
-
     for (auto& entry : vm().string_to_atom_cache()) {
         if (entry.string.ptr() == this)
             entry = {};
     }
 
-    if (m_utf16_string_is_in_cache) {
-        auto const& string = *m_utf16_string;
-        if (string.length_in_code_units() <= MAX_LENGTH_FOR_STRING_CACHE)
-            vm().utf16_string_cache().remove(string);
-    }
+    if (!m_utf16_string.has_value() || !m_utf16_string->has_fly_string_storage())
+        return;
+
+    auto fly_string = Utf16FlyString { *m_utf16_string };
+    auto& string_cache = vm().fly_string_cache();
+    auto& cache_slot = string_cache[fly_string_cache_hash(fly_string) & (string_cache.size() - 1)];
+    if (cache_slot.ptr() == this)
+        cache_slot = nullptr;
 }
 
 bool PrimitiveString::is_empty() const

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -70,8 +70,6 @@ protected:
 
     mutable Optional<Utf16String> m_utf16_string;
 
-    bool m_utf16_string_is_in_cache { false };
-
 private:
     friend class RopeString;
     friend class Substring;
@@ -82,6 +80,7 @@ private:
     explicit PrimitiveString(Utf16String);
 
     void resolve_if_needed() const;
+    static size_t fly_string_cache_hash(Utf16FlyString const&);
     Optional<StringView> short_flat_string_storage_view() const;
     static GC::Ptr<PrimitiveString> try_create_short_flat_concatenated_string(VM&, PrimitiveString const& lhs, PrimitiveString const& rhs);
 };

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -45,6 +45,7 @@ public:
 
     [[nodiscard]] Utf16String utf16_string() const;
     [[nodiscard]] Utf16View utf16_string_view() const;
+    [[nodiscard]] PropertyKey property_key(VM&) const;
     bool has_utf16_string() const { return m_utf16_string.has_value(); }
 
     size_t length_in_utf16_code_units() const;

--- a/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Libraries/LibJS/Runtime/PropertyKey.h
@@ -214,8 +214,11 @@ template<>
 struct Traits<JS::PropertyKey> : public DefaultTraits<JS::PropertyKey> {
     static unsigned hash(JS::PropertyKey const& name)
     {
-        if (name.is_string())
+        if (name.is_string()) {
+            if (name.as_string().has_short_ascii_storage())
+                return u64_hash(name.as_string().raw_identity());
             return name.as_string().hash();
+        }
         if (name.is_symbol())
             return ptr_hash(name.as_symbol());
         if (name.is_number())

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -349,6 +349,11 @@ void VM::gather_roots(HashMap<GC::Cell*, GC::HeapRoot>& roots)
         roots.set(string.ptr(), GC::HeapRoot { .type = GC::HeapRoot::Type::VM });
     }
 
+    for (auto const& entry : m_large_numeric_string_cache) {
+        if (entry.string)
+            roots.set(entry.string.ptr(), GC::HeapRoot { .type = GC::HeapRoot::Type::VM });
+    }
+
     roots.set(cached_strings.number.ptr(), GC::HeapRoot { .type = GC::HeapRoot::Type::VM });
     roots.set(cached_strings.undefined.ptr(), GC::HeapRoot { .type = GC::HeapRoot::Type::VM });
     roots.set(cached_strings.object.ptr(), GC::HeapRoot { .type = GC::HeapRoot::Type::VM });

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -174,11 +174,6 @@ public:
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS
 #undef __JS_ENUMERATE
 
-    HashMap<Utf16String, GC::Ptr<PrimitiveString>>& utf16_string_cache()
-    {
-        return m_utf16_string_cache;
-    }
-
     Bytecode::KeyedPropertyLookupCache& keyed_property_lookup_cache() { return *m_keyed_property_lookup_cache; }
 
     struct StringToAtomCacheEntry {
@@ -187,6 +182,7 @@ public:
     };
 
     auto& string_to_atom_cache() { return m_string_to_atom_cache; }
+    auto& fly_string_cache() { return m_fly_string_cache; }
     auto& numeric_string_cache() { return m_numeric_string_cache; }
 
     PrimitiveString& empty_string() { return *m_empty_string; }
@@ -586,11 +582,13 @@ private:
 
     static VM* s_the;
 
-    HashMap<Utf16String, GC::Ptr<PrimitiveString>> m_utf16_string_cache;
     OwnPtr<Bytecode::KeyedPropertyLookupCache> m_keyed_property_lookup_cache;
 
     static constexpr size_t string_to_atom_cache_size = 2;
     AK::Array<StringToAtomCacheEntry, string_to_atom_cache_size> m_string_to_atom_cache;
+
+    static constexpr size_t fly_string_cache_size = 1024;
+    AK::Array<GC::Ptr<PrimitiveString>, fly_string_cache_size> m_fly_string_cache;
 
     static constexpr size_t numeric_string_cache_size = 1000;
     AK::Array<GC::Ptr<PrimitiveString>, numeric_string_cache_size> m_numeric_string_cache;

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -14,6 +14,7 @@
 #include <AK/HashMap.h>
 #include <AK/RefCounted.h>
 #include <AK/StackInfo.h>
+#include <AK/Utf16FlyString.h>
 #include <AK/Variant.h>
 #include <LibCrypto/Forward.h>
 #include <LibGC/Function.h>
@@ -180,6 +181,12 @@ public:
 
     Bytecode::KeyedPropertyLookupCache& keyed_property_lookup_cache() { return *m_keyed_property_lookup_cache; }
 
+    struct StringToAtomCacheEntry {
+        GC::Ptr<PrimitiveString const> string;
+        Optional<Utf16FlyString> atom;
+    };
+
+    auto& string_to_atom_cache() { return m_string_to_atom_cache; }
     auto& numeric_string_cache() { return m_numeric_string_cache; }
 
     PrimitiveString& empty_string() { return *m_empty_string; }
@@ -581,6 +588,9 @@ private:
 
     HashMap<Utf16String, GC::Ptr<PrimitiveString>> m_utf16_string_cache;
     OwnPtr<Bytecode::KeyedPropertyLookupCache> m_keyed_property_lookup_cache;
+
+    static constexpr size_t string_to_atom_cache_size = 2;
+    AK::Array<StringToAtomCacheEntry, string_to_atom_cache_size> m_string_to_atom_cache;
 
     static constexpr size_t numeric_string_cache_size = 1000;
     AK::Array<GC::Ptr<PrimitiveString>, numeric_string_cache_size> m_numeric_string_cache;

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -182,8 +182,15 @@ public:
     };
 
     auto& string_to_atom_cache() { return m_string_to_atom_cache; }
+
+    struct NumericStringCacheEntry {
+        u64 number { 0 };
+        GC::Ptr<PrimitiveString> string;
+    };
+
     auto& fly_string_cache() { return m_fly_string_cache; }
     auto& numeric_string_cache() { return m_numeric_string_cache; }
+    auto& large_numeric_string_cache() { return m_large_numeric_string_cache; }
 
     PrimitiveString& empty_string() { return *m_empty_string; }
 
@@ -592,6 +599,9 @@ private:
 
     static constexpr size_t numeric_string_cache_size = 1000;
     AK::Array<GC::Ptr<PrimitiveString>, numeric_string_cache_size> m_numeric_string_cache;
+
+    static constexpr size_t large_numeric_string_cache_size = 1024;
+    AK::Array<NumericStringCacheEntry, large_numeric_string_cache_size> m_large_numeric_string_cache;
 
     GC::Heap m_heap;
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -960,7 +960,7 @@ ThrowCompletionOr<PropertyKey> Value::to_property_key(VM& vm) const
 
     // OPTIMIZATION: If this is already a string, we can skip all the ceremony.
     if (is_string())
-        return PropertyKey { as_string().utf16_string() };
+        return as_string().property_key(vm);
 
     // 1. Let key be ? ToPrimitive(argument, string).
     auto key = TRY(to_primitive(vm, PreferredType::String));
@@ -970,6 +970,10 @@ ThrowCompletionOr<PropertyKey> Value::to_property_key(VM& vm) const
         // a. Return key.
         return key.as_symbol();
     }
+
+    // OPTIMIZATION: Keep the atomized storage when ToPrimitive produced a string.
+    if (key.is_string())
+        return key.as_string().property_key(vm);
 
     // 3. Return ! ToString(key).
     return MUST(key.to_utf16_string(vm));

--- a/Tests/LibJS/Runtime/builtins/String/String.prototype.replace.js
+++ b/Tests/LibJS/Runtime/builtins/String/String.prototype.replace.js
@@ -45,6 +45,20 @@ test("functional string replacement", () => {
     ).toBe("axc");
 });
 
+test("functional replacement preserves the source string backing storage", () => {
+    const propertyHolder = { "prefix-match-suffix": true };
+    const source = ["prefix", "match", "suffix"].join("-");
+
+    expect(
+        source.replace("match", (search, position, original) => {
+            expect(search).toBe("match");
+            expect(position).toBe(7);
+            propertyHolder[original];
+            return "replacement";
+        })
+    ).toBe("prefix-replacement-suffix");
+});
+
 test("basic regex replacement", () => {
     expect("".replace(/a/, "")).toBe("");
     expect("a".replace(/a/, "")).toBe("");


### PR DESCRIPTION
Speed up property-key lookup and string creation by hashing short ASCII fly strings from their raw identity, caching recently atomized primitive strings without changing their backing storage, replacing content-based primitive string deduplication with a weak fly-string identity cache, and caching strings for large unsigned integers.

Across 45 MicroWeb JS tests over 20 iterations, the median geomean improves by 2.8% versus master. `object-keys-entries` improves by 6.0%, `proxy-get-set` by 6.0%, `reflect-get` by 1.4%, and `proxy-has-delete` by 40.3%.

The atom cache preserves outstanding UTF-16 views across JavaScript callbacks, with regression coverage for functional `String.prototype.replace`.
