### PR TITLE
Stop offscreen animations from keeping WebContent and Compositor busy

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1106,9 +1106,6 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
         return false;
     if (!target->is_connected())
         return cache_result(true);
-    if (target->namespace_uri() == Namespace::SVG)
-        return cache_result(false);
-
     bool has_animated_property = false;
     auto const* key_frame_set = m_key_frame_set.ptr();
     if (!key_frame_set)
@@ -1125,6 +1122,13 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
         }
     }
     if (!has_animated_property)
+        return cache_result(false);
+
+    // NB: Transforms cannot affect rendering without a layout box. This also covers SVG content inside
+    //     display-none subtrees and closed details elements.
+    if (target->document().layout_is_up_to_date() && !target->unsafe_layout_node())
+        return cache_result(true);
+    if (target->namespace_uri() == Namespace::SVG)
         return cache_result(false);
 
     if (m_is_offscreen_throttled)
@@ -1174,8 +1178,18 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
     if ((m_is_compositor_driven || m_is_compositor_replaced) && (!isinf(iteration_count()) || m_is_observation_relevant_compositor_animation))
         return true;
 
+    // Script animations do not dispatch CSS animation events, even when an ancestor listens for them.
+    if (auto animation = associated_animation(); animation && !animation->is_css_animation())
+        return true;
+
     // An infinite effect cannot reach its natural end, so animationend listeners do not require a continuous tick.
-    auto has_css_animation_event_listener_requiring_animation_tick = [](DOM::EventTarget const& event_target) {
+    auto has_css_animation_event_listener_requiring_animation_tick = [this](DOM::EventTarget const& event_target) {
+        // NB: Starting or cancelling an active animation requests an update independently of playback.
+        //     Only iteration events require future updates while a visually throttled infinite effect runs.
+        if (is_in_the_active_phase())
+            return event_target.has_event_listener(HTML::EventNames::animationiteration)
+                || event_target.has_event_listener(HTML::EventNames::webkitAnimationIteration);
+
         return event_target.has_event_listener(HTML::EventNames::animationcancel)
             || event_target.has_event_listener(HTML::EventNames::animationiteration)
             || event_target.has_event_listener(HTML::EventNames::animationstart)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7906,9 +7906,29 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     return build_animation_for_target(target_kind);
 }
 
+static Optional<double> next_throttled_animation_iteration_event_time(Animations::Animation const& animation, Animations::KeyframeEffect const& effect)
+{
+    if (!animation.is_css_animation() || animation.pending()
+        || animation.play_state() != Bindings::AnimationPlayState::Running
+        || animation.playback_rate() <= 0 || !isfinite(animation.playback_rate())
+        || !animation.timeline() || !animation.timeline()->is_monotonically_increasing()
+        || effect.start_delay().type != Animations::TimeValue::Type::Milliseconds
+        || effect.iteration_duration().type != Animations::TimeValue::Type::Milliseconds
+        || effect.iteration_duration().value <= 0 || !isfinite(effect.iteration_duration().value)
+        || !effect.can_skip_per_frame_style_update()
+        || !isinf(effect.iteration_count()) || !effect.is_in_the_active_phase()
+        || effect.can_skip_per_frame_animation_tick())
+        return {};
+
+    // NB: Observable infinite throttled animations need a rendering update at the next iteration boundary,
+    //     not at every display refresh. Seeking and cancellation already request their own updates.
+    return effect.start_delay().value
+        + (effect.previous_current_iteration() + 1 - effect.iteration_start()) * effect.iteration_duration().value;
+}
+
 void Document::schedule_compositor_animation_wakeup(double delay_ms)
 {
-    auto timer_delay_ms = clamp(static_cast<i64>(ceil(delay_ms)), 1, static_cast<i64>(NumericLimits<int>::max()));
+    auto timer_delay_ms = static_cast<int>(ceil(clamp(delay_ms, 1.0, static_cast<double>(NumericLimits<int>::max()))));
     auto deadline = MonotonicTime::now() + AK::Duration::from_milliseconds(timer_delay_ms);
     if (m_compositor_animation_wakeup_timer && m_compositor_animation_wakeup_timer->is_active()
         && m_compositor_animation_wakeup_deadline.has_value() && *m_compositor_animation_wakeup_deadline <= deadline)
@@ -7957,6 +7977,15 @@ void Document::service_compositor_animation_wakeup(double timestamp)
                 reached_wakeup = true;
                 if (is_compositor_handled)
                     reached_compositor_active_start = true;
+            }
+        }
+        if (auto iteration_event_time = next_throttled_animation_iteration_event_time(animation, effect); iteration_event_time.has_value()) {
+            if (current_time->value < *iteration_event_time) {
+                auto delay = (*iteration_event_time - current_time->value) / animation.playback_rate();
+                if (!next_wakeup_delay_ms.has_value() || delay < *next_wakeup_delay_ms)
+                    next_wakeup_delay_ms = delay;
+            } else {
+                reached_wakeup = true;
             }
         }
         if (!is_compositor_handled || isinf(effect.iteration_count()))
@@ -8731,6 +8760,16 @@ void Document::update_animations_and_send_events(double timestamp)
                 continue;
             }
             effect.clear_per_frame_animation_tick_was_skipped();
+            if (auto iteration_event_time = next_throttled_animation_iteration_event_time(animation, effect); iteration_event_time.has_value()) {
+                auto current_time = animation.current_time();
+                if (current_time.has_value() && current_time->type == Animations::TimeValue::Type::Milliseconds) {
+                    auto delay = (*iteration_event_time - current_time->value) / animation.playback_rate();
+                    if (delay > 0) {
+                        schedule_compositor_animation_wakeup(delay);
+                        continue;
+                    }
+                }
+            }
         }
         ++m_style_invalidation_counters.animation_frame_pump_requests;
         page().client().request_frame();

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7761,7 +7761,7 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                     if (!effect.target_properties().contains(CSS::PropertyNameAndID::from_id(property_id)))
                         continue;
                     auto property = entry.properties.get(CSS::PropertyNameAndID::from_id(property_id));
-                    if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
+                    if (!property.has_value()) {
                         if (transform_property_count == 1) {
                             skip_keyframe = true;
                             break;
@@ -7769,7 +7769,17 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                         new_cache.is_valid = false;
                         break;
                     }
-                    auto style_value = resolved_compositor_animation_style_value(property_id, property->get<CSS::RustStyleValueHandle>(), *target);
+                    // NB: Synthesized endpoints use the underlying style, just as main-thread keyframe sampling does.
+                    auto style_value = property->visit(
+                        [&](Animations::KeyframeEffect::KeyFrameSet::UseInitial) -> RefPtr<CSS::StyleValue const> {
+                            auto computed_style = target->computed_style();
+                            if (!computed_style)
+                                return {};
+                            return computed_style->computed_style_value(property_id, CSS::ComputedValues::WithAnimationsApplied::No);
+                        },
+                        [&](CSS::RustStyleValueHandle const& value) {
+                            return resolved_compositor_animation_style_value(property_id, value, *target);
+                        });
                     if (!style_value) {
                         new_cache.is_valid = false;
                         break;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2190,7 +2190,10 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
     if (!navigable || navigable->active_document().ptr() != this)
         return;
 
-    if (reason != UpdateLayoutReason::HTMLEventLoopRenderingUpdate && animation_sampling_scope == ThrottledAnimationSamplingScope::Document)
+    // Internal layout dependencies do not observe compositor animation values.
+    if (reason != UpdateLayoutReason::HTMLEventLoopRenderingUpdate
+        && reason != UpdateLayoutReason::ChildDocumentStyleUpdate
+        && animation_sampling_scope == ThrottledAnimationSamplingScope::Document)
         flush_throttled_animation_style_update();
 
     VERIFY(!m_is_running_update_layout);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7614,8 +7614,17 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     if (any_of(effect.target_properties(), [&](auto const& property) { return !first_is_one_of(property.id(), CSS::PropertyID::Opacity, CSS::PropertyID::BackgroundColor, CSS::PropertyID::Filter) && !is_transform_family_property(property.id()); }))
         return {};
     auto target = effect.target_abstract_element();
-    if (!target.has_value() || target->element().namespace_uri() == Namespace::SVG)
+    if (!target.has_value())
         return {};
+    if (target->element().namespace_uri() == Namespace::SVG) {
+        // NB: An outer SVG viewport embedded in HTML uses the CSS box transform independently of its SVG
+        //     contents. Internal SVG transforms also affect SVG geometry and must remain on the main thread.
+        auto const* layout_node = target->unsafe_layout_node();
+        auto parent = target->element().parent_element();
+        if (!targets_transform || !layout_node || layout_node->kind() != Layout::RustFFI::NodeKind::SVGSVGBox
+            || !parent || parent->namespace_uri() != Namespace::HTML)
+            return {};
+    }
     auto monotonic_time_at_anchor_ms = [&]() -> Optional<double> {
         if (!is_initial_pending_css_transition) {
             auto frame_timestamp = target->document().last_animation_frame_timestamp();

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -32,17 +32,18 @@ Optional<Gfx::IntRect> compute_display_list_damage(
     return damage_rect;
 }
 
-bool rotating_content_may_affect_viewport(
+bool animated_content_may_affect_viewport(
     ReadonlyBytes display_list_commands,
     AccumulatedVisualContextTree const& visual_context_tree,
     ScrollStateSnapshot const& scroll_state,
     ReadonlySpan<SpatialNodeIndex> rotation_nodes,
+    ReadonlySpan<EffectNodeIndex> opacity_nodes,
     Gfx::IntRect viewport_rect)
 {
     auto scroll_offsets = scroll_state.device_offsets();
-    return Layout::RustFFI::display_list_rotating_content_may_affect_viewport(
+    return Layout::RustFFI::display_list_animated_content_may_affect_viewport(
         display_list_commands.data(), display_list_commands.size(), visual_context_tree.rust_handle(),
-        scroll_offsets.data(), scroll_offsets.size(), rotation_nodes.data(), rotation_nodes.size(), viewport_rect);
+        scroll_offsets.data(), scroll_offsets.size(), rotation_nodes.data(), rotation_nodes.size(), opacity_nodes.data(), opacity_nodes.size(), viewport_rect);
 }
 
 }

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -32,4 +32,17 @@ Optional<Gfx::IntRect> compute_display_list_damage(
     return damage_rect;
 }
 
+bool rotating_content_may_affect_viewport(
+    ReadonlyBytes display_list_commands,
+    AccumulatedVisualContextTree const& visual_context_tree,
+    ScrollStateSnapshot const& scroll_state,
+    ReadonlySpan<SpatialNodeIndex> rotation_nodes,
+    Gfx::IntRect viewport_rect)
+{
+    auto scroll_offsets = scroll_state.device_offsets();
+    return Layout::RustFFI::display_list_rotating_content_may_affect_viewport(
+        display_list_commands.data(), display_list_commands.size(), visual_context_tree.rust_handle(),
+        scroll_offsets.data(), scroll_offsets.size(), rotation_nodes.data(), rotation_nodes.size(), viewport_rect);
+}
+
 }

--- a/Libraries/LibWeb/Painting/DisplayListDamage.h
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.h
@@ -26,11 +26,12 @@ WEB_API Optional<Gfx::IntRect> compute_display_list_damage(
     ScrollStateSnapshot const& new_scroll_state,
     Gfx::IntRect viewport_rect);
 
-WEB_API bool rotating_content_may_affect_viewport(
+WEB_API bool animated_content_may_affect_viewport(
     ReadonlyBytes display_list_commands,
     AccumulatedVisualContextTree const&,
     ScrollStateSnapshot const&,
     ReadonlySpan<SpatialNodeIndex> rotation_nodes,
+    ReadonlySpan<EffectNodeIndex> opacity_nodes,
     Gfx::IntRect viewport_rect);
 
 }

--- a/Libraries/LibWeb/Painting/DisplayListDamage.h
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.h
@@ -10,6 +10,7 @@
 #include <AK/Span.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/Export.h>
+#include <LibWeb/Painting/ScrollState.h>
 
 namespace Web::Painting {
 
@@ -23,6 +24,13 @@ WEB_API Optional<Gfx::IntRect> compute_display_list_damage(
     ReadonlyBytes new_display_list_commands,
     AccumulatedVisualContextTree const& new_visual_context_tree,
     ScrollStateSnapshot const& new_scroll_state,
+    Gfx::IntRect viewport_rect);
+
+WEB_API bool rotating_content_may_affect_viewport(
+    ReadonlyBytes display_list_commands,
+    AccumulatedVisualContextTree const&,
+    ScrollStateSnapshot const&,
+    ReadonlySpan<SpatialNodeIndex> rotation_nodes,
     Gfx::IntRect viewport_rect);
 
 }

--- a/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
@@ -525,6 +525,81 @@ impl DamageAccumulator {
     }
 }
 
+// This query is cached until scene geometry or scrolling changes. It deliberately ignores clips when
+// bounding rotating content, so animation phases cannot reveal pixels outside the computed bounds.
+pub fn rotating_content_may_affect_viewport(
+    command_bytes: &[u8],
+    tree: &VisualContextTree,
+    scroll_offsets: &[FloatPoint],
+    rotation_nodes: &[SpatialNodeIndex],
+    viewport_rect: IntRect,
+) -> bool {
+    let in_rotating_subtree = tree.spatial_nodes_in_subtrees_of(rotation_nodes);
+    let mut rotating_nodes = vec![false; tree.spatial_nodes.len()];
+    for node in rotation_nodes {
+        let Some(flag) = rotating_nodes.get_mut(node.0 as usize) else {
+            return true;
+        };
+        *flag = true;
+    }
+    let mut may_affect_viewport = false;
+    for_each_command(command_bytes, |header, _, _| {
+        if may_affect_viewport || header.command_type.is_compositor_metadata() {
+            return;
+        }
+        let spatial_is_animated = in_rotating_subtree[header.context.spatial.0 as usize];
+        let mut clip = header.context.clip;
+        while !clip.is_none() {
+            let node = &tree.clip_nodes[clip.0 as usize];
+            if !spatial_is_animated && in_rotating_subtree[node.spatial.0 as usize] {
+                may_affect_viewport = true;
+                return;
+            }
+            clip = node.parent;
+        }
+        let mut effect = header.context.effect;
+        while !effect.is_none() {
+            let node = &tree.effect_nodes[effect.0 as usize];
+            if !spatial_is_animated && in_rotating_subtree[node.spatial.0 as usize] {
+                may_affect_viewport = true;
+                return;
+            }
+            if spatial_is_animated
+                && let EffectNodeData::Effects(effects) = &node.data
+                && (effects.filter.is_some() || effects.backdrop_filter.is_some())
+            {
+                // Filters can expand the output beyond the command bounds.
+                may_affect_viewport = true;
+                return;
+            }
+            effect = node.parent;
+        }
+        if !spatial_is_animated {
+            return;
+        }
+        if !header.has_bounding_rect {
+            may_affect_viewport = true;
+            return;
+        }
+        let rect = header.bounding_rect;
+        let Some(bounds) = tree.rect_with_rotation_bounds_to_viewport(
+            header.context.spatial,
+            FloatRect::new(rect.x as f32, rect.y as f32, rect.width as f32, rect.height as f32),
+            &rotating_nodes,
+            scroll_offsets,
+        ) else {
+            may_affect_viewport = true;
+            return;
+        };
+        let bounds = bounds.inflated(2.0, 2.0);
+        may_affect_viewport = bounds.x <= viewport_rect.right() as f32
+            && bounds.right() >= viewport_rect.x as f32
+            && bounds.y <= viewport_rect.bottom() as f32
+            && bounds.bottom() >= viewport_rect.y as f32;
+    });
+    may_affect_viewport
+}
+
 pub fn compute_display_list_damage(
     old_display_list_commands: &[u8],
     old_visual_context_tree: &VisualContextTree,

--- a/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
@@ -7,8 +7,8 @@
 use crate::painting::display_list::builder::{for_each_command, inline_transform_entry_offset, read_command};
 use crate::painting::display_list::commands::{
     ContextRef, DisplayListCommandHeader, DisplayListCommandType, DisplayListDataSpan, DisplayListInlineClip,
-    DrawGlyphRun, DrawScaledDecodedImageFrame, INLINE_CLIP_ENTRY_SIZE, OptionalColor, OptionalFloatRect,
-    PaintScrollBar, PaintTextShadow, SpatialNodeIndex, VISUAL_VIEWPORT_NODE_INDEX,
+    DrawGlyphRun, DrawScaledDecodedImageFrame, EffectNodeIndex, INLINE_CLIP_ENTRY_SIZE, OptionalColor,
+    OptionalFloatRect, PaintScrollBar, PaintTextShadow, SpatialNodeIndex, VISUAL_VIEWPORT_NODE_INDEX,
 };
 use crate::painting::visual_context::queries::TreeCullingScratch;
 use crate::painting::visual_context::{
@@ -527,11 +527,12 @@ impl DamageAccumulator {
 
 // This query is cached until scene geometry or scrolling changes. It deliberately ignores clips when
 // bounding rotating content, so animation phases cannot reveal pixels outside the computed bounds.
-pub fn rotating_content_may_affect_viewport(
+pub fn animated_content_may_affect_viewport(
     command_bytes: &[u8],
     tree: &VisualContextTree,
     scroll_offsets: &[FloatPoint],
     rotation_nodes: &[SpatialNodeIndex],
+    opacity_nodes: &[EffectNodeIndex],
     viewport_rect: IntRect,
 ) -> bool {
     let in_rotating_subtree = tree.spatial_nodes_in_subtrees_of(rotation_nodes);
@@ -558,23 +559,28 @@ pub fn rotating_content_may_affect_viewport(
             clip = node.parent;
         }
         let mut effect = header.context.effect;
+        let mut opacity_is_animated = false;
+        let mut has_filter = false;
         while !effect.is_none() {
             let node = &tree.effect_nodes[effect.0 as usize];
+            opacity_is_animated |= opacity_nodes.contains(&effect);
             if !spatial_is_animated && in_rotating_subtree[node.spatial.0 as usize] {
                 may_affect_viewport = true;
                 return;
             }
-            if spatial_is_animated
-                && let EffectNodeData::Effects(effects) = &node.data
+            if let EffectNodeData::Effects(effects) = &node.data
                 && (effects.filter.is_some() || effects.backdrop_filter.is_some())
             {
-                // Filters can expand the output beyond the command bounds.
-                may_affect_viewport = true;
-                return;
+                has_filter = true;
             }
             effect = node.parent;
         }
-        if !spatial_is_animated {
+        if !spatial_is_animated && !opacity_is_animated {
+            return;
+        }
+        // Filters can expand the output beyond the command bounds.
+        if has_filter {
+            may_affect_viewport = true;
             return;
         }
         if !header.has_bounding_rect {

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -625,7 +625,7 @@ pub unsafe extern "C" fn display_list_compute_damage(
 ///
 /// The tree must be a live retained handle and each pointer must address the stated number of values.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn display_list_rotating_content_may_affect_viewport(
+pub unsafe extern "C" fn display_list_animated_content_may_affect_viewport(
     command_bytes: *const u8,
     command_bytes_length: usize,
     tree: *const c_void,
@@ -633,15 +633,18 @@ pub unsafe extern "C" fn display_list_rotating_content_may_affect_viewport(
     scroll_offsets_len: usize,
     rotation_nodes: *const crate::painting::display_list::commands::SpatialNodeIndex,
     rotation_nodes_len: usize,
+    opacity_nodes: *const crate::painting::display_list::commands::EffectNodeIndex,
+    opacity_nodes_len: usize,
     viewport_rect: libgfx_rust::IntRect,
 ) -> bool {
     // SAFETY: The caller guarantees a live tree and valid slices for the duration of the call.
     unsafe {
-        crate::painting::display_list::damage::rotating_content_may_affect_viewport(
+        crate::painting::display_list::damage::animated_content_may_affect_viewport(
             ffi_slice(command_bytes, command_bytes_length),
             tree_from_handle(tree),
             ffi_slice(scroll_offsets, scroll_offsets_len),
             ffi_slice(rotation_nodes, rotation_nodes_len),
+            ffi_slice(opacity_nodes, opacity_nodes_len),
             viewport_rect,
         )
     }

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -623,6 +623,32 @@ pub unsafe extern "C" fn display_list_compute_damage(
 
 /// # Safety
 ///
+/// The tree must be a live retained handle and each pointer must address the stated number of values.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn display_list_rotating_content_may_affect_viewport(
+    command_bytes: *const u8,
+    command_bytes_length: usize,
+    tree: *const c_void,
+    scroll_offsets: *const libgfx_rust::FloatPoint,
+    scroll_offsets_len: usize,
+    rotation_nodes: *const crate::painting::display_list::commands::SpatialNodeIndex,
+    rotation_nodes_len: usize,
+    viewport_rect: libgfx_rust::IntRect,
+) -> bool {
+    // SAFETY: The caller guarantees a live tree and valid slices for the duration of the call.
+    unsafe {
+        crate::painting::display_list::damage::rotating_content_may_affect_viewport(
+            ffi_slice(command_bytes, command_bytes_length),
+            tree_from_handle(tree),
+            ffi_slice(scroll_offsets, scroll_offsets_len),
+            ffi_slice(rotation_nodes, rotation_nodes_len),
+            viewport_rect,
+        )
+    }
+}
+
+/// # Safety
+///
 /// `tree` must be a live retained tree handle, `command_runs` must address `command_run_count`
 /// runs and `scroll_offsets` `scroll_offsets_len` points for the call, and `callbacks` must be
 /// live. The painter callbacks run synchronously and may re-enter this function for a nested

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
@@ -804,6 +804,43 @@ impl VisualContextTree {
         command_runs.iter().all(|run| self.context_is_valid(run.context))
     }
 
+    // Bound every possible angle, rather than just the current sample: content outside the viewport now
+    // may rotate into it later. Repeatedly enclosing rectangles also conservatively handles nested rotations.
+    pub fn rect_with_rotation_bounds_to_viewport(
+        &self,
+        mut index: SpatialNodeIndex,
+        mut rect: FloatRect,
+        rotating_nodes: &[bool],
+        scroll_offsets: &[FloatPoint],
+    ) -> Option<FloatRect> {
+        loop {
+            if rotating_nodes[index.0 as usize] {
+                let SpatialData::Transform(transform) = &self.spatial_nodes[index.0 as usize].data else {
+                    return None;
+                };
+                let origin = transform.origin;
+                let dx = (rect.x - origin.x).abs().max((rect.right() - origin.x).abs());
+                let dy = (rect.y - origin.y).abs().max((rect.bottom() - origin.y).abs());
+                let radius = dx.hypot(dy);
+                rect = FloatRect::new(origin.x - radius, origin.y - radius, 2.0 * radius, 2.0 * radius);
+            } else {
+                let matrix = self.local_spatial_matrix(index, scroll_offsets).matrix;
+                // Projecting a rectangle at each ancestor would discard depth needed by later 3D transforms.
+                if !matrix.is_2d_affine() {
+                    return None;
+                }
+                rect = matrix.extract_2d_affine().map_rect(rect);
+            }
+            if !rect.x.is_finite() || !rect.y.is_finite() || !rect.width.is_finite() || !rect.height.is_finite() {
+                return None;
+            }
+            if index == VISUAL_VIEWPORT_NODE_INDEX {
+                return Some(rect);
+            }
+            index = self.spatial_nodes[index.0 as usize].parent;
+        }
+    }
+
     pub fn spatial_nodes_in_subtrees_of(&self, roots: &[SpatialNodeIndex]) -> Vec<bool> {
         let mut in_subtree = vec![false; self.spatial_nodes.len()];
         for root in roots {

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -580,7 +580,7 @@ void CompositorState::resume_presentation_after_becoming_visible(Web::Compositor
         auto& context = *context_entry.value;
         if (root_context_of(context) != &root_context)
             continue;
-        if (context.has_active_smooth_scroll_animations() || context.has_active_visual_animations())
+        if (context.has_active_smooth_scroll_animations() || context.visual_animations_need_frame())
             vsync_scheduler_for_display(display_id_for_context(context)).schedule(display_refresh_rate_for_context(context));
         if (context.rendering_opportunity_requested())
             vsync_scheduler_for_display(display_id_for_context(context)).schedule(display_refresh_rate_for_context(context));
@@ -689,7 +689,7 @@ void CompositorState::schedule_pending_present_frame(Web::Compositor::Compositor
         // may already be up to date (and therefore not schedule a new present),
         // so explicitly keep the effective display's scheduler ticking while
         // a nested animation is active.
-        if ((context.has_active_smooth_scroll_animations() || context.has_active_visual_animations()) && context_is_effectively_visible(context))
+        if ((context.has_active_smooth_scroll_animations() || context.visual_animations_need_frame()) && context_is_effectively_visible(context))
             vsync_scheduler_for_display(display_id_for_context(context)).schedule(display_refresh_rate_for_context(context));
         return;
     }
@@ -777,14 +777,14 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id, 
             }
         }
 
-        auto has_active_animation_on_display = (context.has_active_smooth_scroll_animations() || context.has_active_visual_animations()) && display_id_for_context(context) == display_id;
+        auto has_active_animation_on_display = (context.has_active_smooth_scroll_animations() || context.visual_animations_need_frame()) && display_id_for_context(context) == display_id;
         if (!context.has_pending_present_frame_scheduled_on(display_id) && !has_active_animation_on_display)
             continue;
 
         if (auto animation_frame = context.advance_smooth_scroll_animations(frame_time); animation_frame.has_value())
             context.queue_present_frame(ContextState::PendingFrame::repainting_changes(*animation_frame));
         publish_pending_async_scroll_updates(context_id, context);
-        if (context.has_active_visual_animations()) {
+        if (context.visual_animations_need_frame()) {
             context.advance_visual_animations(frame_time);
             if (auto viewport_rect = context.viewport_rect_for_ui_overlay(); viewport_rect.has_value())
                 context.queue_present_frame(ContextState::PendingFrame::repainting_changes(*viewport_rect));
@@ -792,12 +792,12 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id, 
 
         auto pending_present_frame = context.take_pending_present_frame_if_unblocked();
         if (!pending_present_frame.has_value()) {
-            has_active_animation_on_display = (context.has_active_smooth_scroll_animations() || context.has_active_visual_animations()) && display_id_for_context(context) == display_id;
+            has_active_animation_on_display = (context.has_active_smooth_scroll_animations() || context.visual_animations_need_frame()) && display_id_for_context(context) == display_id;
             if (context.has_pending_present_frame_scheduled_on(display_id) || has_active_animation_on_display)
                 vsync_scheduler_for_display(display_id).schedule(display_refresh_rate_for_context(context));
             continue;
         }
-        if (context.has_active_smooth_scroll_animations() || context.has_active_visual_animations())
+        if (context.has_active_smooth_scroll_animations() || context.visual_animations_need_frame())
             schedule_present_frame(context_id, context, ContextState::PendingFrame::repainting_changes(pending_present_frame->viewport_rect));
         present_frame(context_id, context, *pending_present_frame);
     }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -652,7 +652,7 @@ bool CompositorState::present_frame(Web::Compositor::CompositorContextId context
     auto composited_context_resolver = resolver_for(context_id);
     auto prepared_frame = context.prepare_frame(*m_display_list_player, pending_frame, &composited_context_resolver);
     if (!prepared_frame.has_value())
-        return false;
+        return !context.pending_present_frame_viewport_rect().has_value();
 
     m_pending_async_presents.append(context_id, pending_frame.viewport_rect, prepared_frame->damage_rect, prepared_frame->bitmap_id);
     auto* pending_present = &m_pending_async_presents.last();
@@ -786,8 +786,6 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id, 
         publish_pending_async_scroll_updates(context_id, context);
         if (context.has_active_visual_animations()) {
             context.advance_visual_animations(frame_time);
-            // Visual animation damage deliberately covers the full viewport until we track the animated nodes' bounds
-            // before and after sampling.
             if (auto viewport_rect = context.viewport_rect_for_ui_overlay(); viewport_rect.has_value())
                 context.queue_present_frame(ContextState::PendingFrame::repainting_changes(*viewport_rect));
         }

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -140,6 +140,9 @@ private:
     void publish_pending_async_scroll_updates(Web::Compositor::CompositorContextId, ContextState&);
 
 public:
+    void present_pending_frames_for_testing() { present_pending_frames_on_vsync({}, MonotonicTime::now()); }
+    size_t pending_async_present_count_for_testing() const { return m_pending_async_presents.size(); }
+
     // What was not published yet, for a caller that needs the compositor's state as of now.
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
 
@@ -172,7 +175,7 @@ private:
         Web::Compositor::CompositorContextId,
         ContextState&,
         ContextState::ContextUpdateResult const&);
-    // Whether the frame was prepared and submitted; a blocked frame is the caller's to schedule.
+    // Whether the request was handled, including unchanged pixels; a blocked frame still needs scheduling.
     bool present_frame(Web::Compositor::CompositorContextId, ContextState&, ContextState::PendingFrame);
     void schedule_present_frame(Web::Compositor::CompositorContextId, ContextState&, ContextState::PendingFrame);
     void schedule_present_frame(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect viewport_rect);

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -348,7 +348,7 @@ void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualCo
 
 void ContextState::update_scroll_state(Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
-    m_rotating_content_may_affect_viewport.clear();
+    m_animated_content_may_affect_viewport.clear();
     m_scroll_state_snapshot = move(scroll_state_snapshot);
     m_scroll_state_snapshot.set_node_count(m_visual_context_tree.has_value() ? m_visual_context_tree->spatial_node_count() : 0);
     retire_reconciled_async_scroll_offsets(m_scroll_state_snapshot.adopted_async_scroll_sequence());
@@ -909,7 +909,7 @@ bool ContextState::has_pending_async_scroll_updates() const
 
 void ContextState::viewport_size_updated(Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
-    m_rotating_content_may_affect_viewport.clear();
+    m_animated_content_may_affect_viewport.clear();
     m_viewport_size = viewport_size;
     auto is_page_presentation_context = m_page_id.has_value() && !m_parent_context_id.has_value();
     m_window_resize_in_progress = is_page_presentation_context
@@ -1308,7 +1308,7 @@ void ContextState::store_pending_async_scroll_offsets(
     Vector<Web::Compositor::AsyncScrollOffset> const& scroll_offsets,
     Optional<Web::Compositor::AsyncScrollOperationID> operation_id)
 {
-    m_rotating_content_may_affect_viewport.clear();
+    m_animated_content_may_affect_viewport.clear();
     for (auto const& scroll_offset : scroll_offsets)
         set_or_append_pending_scroll_offset(m_pending_async_scroll_offsets, scroll_offset);
     if (operation_id.has_value())
@@ -1383,7 +1383,7 @@ void ContextState::discard_sampled_visual_context_tree()
 
 void ContextState::invalidate_visual_context_tree_for_compositing()
 {
-    m_rotating_content_may_affect_viewport.clear();
+    m_animated_content_may_affect_viewport.clear();
     discard_sampled_visual_context_tree();
     m_visual_context_tree_for_compositing.clear();
 }
@@ -1492,12 +1492,18 @@ bool ContextState::visual_animations_need_frame()
 {
     if (!m_has_active_visual_animations)
         return false;
-    if (m_rotating_content_may_affect_viewport.has_value())
-        return *m_rotating_content_may_affect_viewport;
+    if (m_animated_content_may_affect_viewport.has_value())
+        return *m_animated_content_may_affect_viewport;
 
     Vector<Web::Painting::SpatialNodeIndex> rotation_nodes;
+    Vector<Web::Painting::EffectNodeIndex> opacity_nodes;
     for (auto const& animation : m_visual_context_tree->visual_animations()) {
-        // OPTIMIZATION: Bound all angles of pure 2D rotations. Other animations retain continuous sampling.
+        // OPTIMIZATION: Opacity preserves bounds; pure 2D rotations have bounded swept areas.
+        if (animation.target_kind == Web::Compositor::VisualAnimation::TargetKind::Opacity) {
+            for (auto node_index : animation.visual_context_node_indices)
+                opacity_nodes.append(Web::Painting::EffectNodeIndex { node_index });
+            continue;
+        }
         if (animation.target_kind != Web::Compositor::VisualAnimation::TargetKind::Transform)
             return true;
         for (auto const& keyframe : animation.keyframes) {
@@ -1515,9 +1521,9 @@ bool ContextState::visual_animations_need_frame()
     auto tree = m_async_visual_viewport_transform.has_value()
         ? current_visual_context_tree().with_visual_viewport_transform(*m_async_visual_viewport_transform)
         : current_visual_context_tree();
-    m_rotating_content_may_affect_viewport = Web::Painting::rotating_content_may_affect_viewport(
-        m_display_list->command_bytes(), tree, m_scroll_state_snapshot, rotation_nodes, { {}, m_viewport_size });
-    return *m_rotating_content_may_affect_viewport;
+    m_animated_content_may_affect_viewport = Web::Painting::animated_content_may_affect_viewport(
+        m_display_list->command_bytes(), tree, m_scroll_state_snapshot, rotation_nodes, opacity_nodes, { {}, m_viewport_size });
+    return *m_animated_content_may_affect_viewport;
 }
 
 bool ContextState::advance_visual_animations(MonotonicTime now)

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -1116,6 +1116,11 @@ Optional<ContextState::PreparedFrame> ContextState::prepare_frame(Web::Painting:
     }
 
     auto damage_rect = frame_damage_for(pending_frame);
+    // NB: A changed content rect must still reach the client even if the pixels are identical.
+    if (damage_rect.is_empty() && m_presented_frame == pending_frame.viewport_rect) {
+        remember_rasterized_frame(pending_frame.viewport_rect.size());
+        return {};
+    }
     auto render_target = m_backing_store_manager.acquire_render_target(damage_rect);
     if (!render_target.has_value()) {
         queue_present_frame(pending_frame);

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -348,6 +348,7 @@ void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualCo
 
 void ContextState::update_scroll_state(Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
+    m_rotating_content_may_affect_viewport.clear();
     m_scroll_state_snapshot = move(scroll_state_snapshot);
     m_scroll_state_snapshot.set_node_count(m_visual_context_tree.has_value() ? m_visual_context_tree->spatial_node_count() : 0);
     retire_reconciled_async_scroll_offsets(m_scroll_state_snapshot.adopted_async_scroll_sequence());
@@ -908,6 +909,7 @@ bool ContextState::has_pending_async_scroll_updates() const
 
 void ContextState::viewport_size_updated(Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
+    m_rotating_content_may_affect_viewport.clear();
     m_viewport_size = viewport_size;
     auto is_page_presentation_context = m_page_id.has_value() && !m_parent_context_id.has_value();
     m_window_resize_in_progress = is_page_presentation_context
@@ -1306,6 +1308,7 @@ void ContextState::store_pending_async_scroll_offsets(
     Vector<Web::Compositor::AsyncScrollOffset> const& scroll_offsets,
     Optional<Web::Compositor::AsyncScrollOperationID> operation_id)
 {
+    m_rotating_content_may_affect_viewport.clear();
     for (auto const& scroll_offset : scroll_offsets)
         set_or_append_pending_scroll_offset(m_pending_async_scroll_offsets, scroll_offset);
     if (operation_id.has_value())
@@ -1380,6 +1383,7 @@ void ContextState::discard_sampled_visual_context_tree()
 
 void ContextState::invalidate_visual_context_tree_for_compositing()
 {
+    m_rotating_content_may_affect_viewport.clear();
     discard_sampled_visual_context_tree();
     m_visual_context_tree_for_compositing.clear();
 }
@@ -1482,6 +1486,38 @@ void ContextState::remember_rasterized_frame(Gfx::IntSize viewport_size)
         .viewport_size = viewport_size,
         .canvas_content_generations = move(canvas_content_generations),
     };
+}
+
+bool ContextState::visual_animations_need_frame()
+{
+    if (!m_has_active_visual_animations)
+        return false;
+    if (m_rotating_content_may_affect_viewport.has_value())
+        return *m_rotating_content_may_affect_viewport;
+
+    Vector<Web::Painting::SpatialNodeIndex> rotation_nodes;
+    for (auto const& animation : m_visual_context_tree->visual_animations()) {
+        // OPTIMIZATION: Bound all angles of pure 2D rotations. Other animations retain continuous sampling.
+        if (animation.target_kind != Web::Compositor::VisualAnimation::TargetKind::Transform)
+            return true;
+        for (auto const& keyframe : animation.keyframes) {
+            auto const* transforms = keyframe.value.get_pointer<Web::Compositor::VisualAnimationTransformList>();
+            if (!transforms || !all_of(*transforms, [](auto const& transform) {
+                    return transform.kind == Web::Compositor::VisualAnimationTransformOperationKind::Rotate
+                        || transform.kind == Web::Compositor::VisualAnimationTransformOperationKind::RotateZ;
+                }))
+                return true;
+        }
+        for (auto node_index : animation.visual_context_node_indices)
+            rotation_nodes.append(Web::Painting::SpatialNodeIndex { node_index });
+    }
+    // Use the unsampled tree: the query replaces each rotating matrix with its full swept bounds.
+    auto tree = m_async_visual_viewport_transform.has_value()
+        ? current_visual_context_tree().with_visual_viewport_transform(*m_async_visual_viewport_transform)
+        : current_visual_context_tree();
+    m_rotating_content_may_affect_viewport = Web::Painting::rotating_content_may_affect_viewport(
+        m_display_list->command_bytes(), tree, m_scroll_state_snapshot, rotation_nodes, { {}, m_viewport_size });
+    return *m_rotating_content_may_affect_viewport;
 }
 
 bool ContextState::advance_visual_animations(MonotonicTime now)

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -73,10 +73,10 @@ static bool visual_viewport_transforms_match(Web::Painting::TransformWithOrigin 
         && AK::fabs(a.origin.y() - b.origin.y()) <= translation_epsilon;
 }
 
-static double visual_animation_local_time_at(Web::Compositor::VisualAnimation const& animation, MonotonicTime now)
+static double visual_animation_local_time_at(Web::Compositor::VisualAnimation const& animation, i64 sample_time_ns)
 {
-    auto elapsed_nanoseconds = now.nanoseconds() > animation.monotonic_time_at_anchor_ns
-        ? now.nanoseconds() - animation.monotonic_time_at_anchor_ns
+    auto elapsed_nanoseconds = sample_time_ns > animation.monotonic_time_at_anchor_ns
+        ? sample_time_ns - animation.monotonic_time_at_anchor_ns
         : 0;
     return animation.local_time_at_anchor_ms
         + AK::Duration::from_nanoseconds(elapsed_nanoseconds).to_seconds_f64() * 1000.0 * animation.playback_rate;
@@ -84,7 +84,7 @@ static double visual_animation_local_time_at(Web::Compositor::VisualAnimation co
 
 static bool visual_animation_is_active_at(Web::Compositor::VisualAnimation const& animation, MonotonicTime now)
 {
-    auto local_time = visual_animation_local_time_at(animation, now);
+    auto local_time = visual_animation_local_time_at(animation, now.nanoseconds());
     if (!isfinite(local_time))
         return true;
     if (local_time < animation.start_delay_ms)
@@ -1497,7 +1497,18 @@ bool ContextState::visual_animations_need_frame()
 
     Vector<Web::Painting::SpatialNodeIndex> rotation_nodes;
     Vector<Web::Painting::EffectNodeIndex> opacity_nodes;
+    bool has_unfinished_finite_animation = false;
+    bool has_finished_animation = false;
+    auto sample_time_ns = m_visual_animation_sample_time_ns.value_or(MonotonicTime::now().nanoseconds());
     for (auto const& animation : m_visual_context_tree->visual_animations()) {
+        if (isfinite(animation.iteration_count)) {
+            auto active_end = animation.start_delay_ms + animation.iteration_duration_ms * animation.iteration_count;
+            if (visual_animation_local_time_at(animation, sample_time_ns) >= active_end) {
+                has_finished_animation = true;
+                continue;
+            }
+            has_unfinished_finite_animation = true;
+        }
         // OPTIMIZATION: Opacity preserves bounds; pure 2D rotations have bounded swept areas.
         if (animation.target_kind == Web::Compositor::VisualAnimation::TargetKind::Opacity) {
             for (auto node_index : animation.visual_context_node_indices)
@@ -1517,13 +1528,18 @@ bool ContextState::visual_animations_need_frame()
         for (auto node_index : animation.visual_context_node_indices)
             rotation_nodes.append(Web::Painting::SpatialNodeIndex { node_index });
     }
-    // Use the unsampled tree: the query replaces each rotating matrix with its full swept bounds.
+    // Preserve final transforms from finished animations. The query replaces active rotations with swept bounds.
     auto tree = m_async_visual_viewport_transform.has_value()
         ? current_visual_context_tree().with_visual_viewport_transform(*m_async_visual_viewport_transform)
         : current_visual_context_tree();
-    m_animated_content_may_affect_viewport = Web::Painting::animated_content_may_affect_viewport(
+    if (has_finished_animation)
+        tree = tree.with_visual_animation_samples(sample_time_ns);
+    auto may_affect_viewport = Web::Painting::animated_content_may_affect_viewport(
         m_display_list->command_bytes(), tree, m_scroll_state_snapshot, rotation_nodes, opacity_nodes, { {}, m_viewport_size });
-    return *m_animated_content_may_affect_viewport;
+    // A finite animation can stop affecting the viewport without a new scene.
+    if (!has_unfinished_finite_animation)
+        m_animated_content_may_affect_viewport = may_affect_viewport;
+    return may_affect_viewport;
 }
 
 bool ContextState::advance_visual_animations(MonotonicTime now)
@@ -1536,7 +1552,7 @@ bool ContextState::advance_visual_animations(MonotonicTime now)
 
     m_has_active_visual_animations = false;
     for (auto const& animation : m_visual_context_tree->visual_animations()) {
-        auto local_time = visual_animation_local_time_at(animation, now);
+        auto local_time = visual_animation_local_time_at(animation, now.nanoseconds());
         if (local_time < animation.start_delay_ms)
             continue;
         if (!isfinite(local_time) || !isfinite(animation.iteration_count)) {

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -257,7 +257,7 @@ private:
     Optional<Web::Painting::AccumulatedVisualContextTree> m_sampled_visual_context_tree;
     u64 m_visual_context_tree_copy_count { 0 };
     bool m_has_active_visual_animations { false };
-    Optional<bool> m_rotating_content_may_affect_viewport;
+    Optional<bool> m_animated_content_may_affect_viewport;
     Web::Painting::DisplayListResourceStorage m_display_list_resource_storage;
     Web::Painting::ScrollStateSnapshot m_scroll_state_snapshot;
     BackingStoreManager m_backing_store_manager;

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -132,6 +132,7 @@ public:
     bool has_active_smooth_scroll_animations() const { return !m_smooth_scroll_animations.is_empty(); }
     bool advance_visual_animations(MonotonicTime now);
     bool has_active_visual_animations() const { return m_has_active_visual_animations; }
+    bool visual_animations_need_frame();
     Web::Painting::AccumulatedVisualContextTree const& visual_context_tree_for_testing() const { return current_visual_context_tree(); }
     Web::Painting::AccumulatedVisualContextTree const& sampled_visual_context_tree_for_testing() { return visual_context_tree_for_compositing(); }
     bool has_sampled_visual_animation_values_for_testing() const { return m_sampled_visual_context_tree.has_value(); }
@@ -256,6 +257,7 @@ private:
     Optional<Web::Painting::AccumulatedVisualContextTree> m_sampled_visual_context_tree;
     u64 m_visual_context_tree_copy_count { 0 };
     bool m_has_active_visual_animations { false };
+    Optional<bool> m_rotating_content_may_affect_viewport;
     Web::Painting::DisplayListResourceStorage m_display_list_resource_storage;
     Web::Painting::ScrollStateSnapshot m_scroll_state_snapshot;
     BackingStoreManager m_backing_store_manager;

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -1044,6 +1044,15 @@ struct PresentingContextFixture {
         return spin_event_loop_until(event_loop, 100, [&] { return compositor_client.presented_frames.size() > already_presented; });
     }
 
+    void expect_no_frame()
+    {
+        auto already_presented = compositor_client.presented_frames.size();
+        compositor_state->present_frame(context_id, viewport_rect);
+        compositor_state->present_pending_frames_for_testing();
+        EXPECT_EQ(compositor_state->pending_async_present_count_for_testing(), 0u);
+        EXPECT_EQ(compositor_client.presented_frames.size(), already_presented);
+    }
+
     TestCompositorClient::PresentedFrame present(Optional<Gfx::IntRect> rect = {})
     {
         auto already_presented = compositor_client.presented_frames.size();
@@ -1096,7 +1105,7 @@ struct RasterizingContextFixture {
     }
 };
 
-TEST_CASE(re_presenting_identical_state_reports_empty_damage)
+TEST_CASE(re_presenting_identical_state_does_not_submit_a_frame)
 {
     PresentingContextFixture fixture;
     auto visual_context_tree = make_visual_context_tree();
@@ -1106,10 +1115,33 @@ TEST_CASE(re_presenting_identical_state_reports_empty_damage)
     EXPECT_EQ(first_frame.damage_rect, fixture.viewport_rect);
     EXPECT_EQ(first_frame.content_rect, fixture.viewport_rect);
 
-    EXPECT(fixture.present().damage_rect.is_empty());
+    fixture.expect_no_frame();
 
     fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree);
-    EXPECT(fixture.present().damage_rect.is_empty());
+    fixture.expect_no_frame();
+}
+
+TEST_CASE(offscreen_changes_do_not_acquire_a_backing_store_or_block_later_frames)
+{
+    RasterizingContextFixture fixture;
+    auto tree = make_translated_visual_context_tree({ 0, 100 });
+    auto display_list = make_fills_display_list(tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red, in_spatial_node(1) } });
+    fixture.context.install_display_list_update(display_list, tree, {});
+    fixture.rasterize();
+    auto surface = fixture.context.latest_rendered_surface();
+
+    auto offscreen_tree = make_translated_visual_context_tree({ 0, 200 }, tree.structural_epoch());
+    fixture.context.update_visual_context_tree(offscreen_tree, {});
+    EXPECT(!fixture.prepare().has_value());
+    EXPECT(!fixture.context.is_present_blocked());
+    EXPECT_EQ(fixture.context.latest_rendered_surface(), surface);
+
+    auto visible_tree = make_translated_visual_context_tree({ 0, 0 }, tree.structural_epoch());
+    fixture.context.update_visual_context_tree(visible_tree, {});
+    EXPECT_EQ(fixture.rasterize(), (Gfx::IntRect { 1, 1, 6, 15 }));
+    EXPECT_EQ(fixture.pixel(3, 3), Gfx::Color::Red);
+    EXPECT(!fixture.prepare().has_value());
+    EXPECT_EQ(fixture.rasterize(fixture.viewport_rect), fixture.viewport_rect);
 }
 
 TEST_CASE(changed_command_reports_its_inflated_rect)
@@ -1169,7 +1201,7 @@ TEST_CASE(tree_only_update_damages_transformed_commands)
     EXPECT_EQ(fixture.present().damage_rect, (Gfx::IntRect { 1, 1, 10, 6 }));
 
     fixture.compositor_state->update_visual_context_tree(fixture.context_id, make_translated_visual_context_tree({ 8, 0 }), {});
-    EXPECT(fixture.present().damage_rect.is_empty());
+    fixture.expect_no_frame();
 }
 
 TEST_CASE(surface_clear_color_change_forces_full_damage)
@@ -1309,11 +1341,11 @@ TEST_CASE(canvas_content_changes_damage_the_canvas_rect)
     append_display_list_command(command_bytes, draw_canvas, draw_canvas.dst_rect);
     fixture.install(decode_display_list(visual_context_tree, move(command_bytes)), visual_context_tree);
     fixture.present();
-    EXPECT(fixture.present().damage_rect.is_empty());
+    fixture.expect_no_frame();
 
     canvas_surface_registry.set_canvas_surface(canvas_id, make_canvas_surface());
     EXPECT_EQ(fixture.present().damage_rect, (Gfx::IntRect { 3, 3, 6, 6 }));
-    EXPECT(fixture.present().damage_rect.is_empty());
+    fixture.expect_no_frame();
 }
 
 TEST_CASE(compositor_initiated_presents_request_full_damage)
@@ -1351,7 +1383,7 @@ TEST_CASE(child_context_presents_repaint_the_parent)
     fixture.compositor_state->update_display_list(child_context_id, make_fills_display_list(child_visual_context_tree, { { child_viewport_rect, Gfx::Color::Red } }), child_visual_context_tree, {}, {});
     fixture.compositor_state->present_frame(child_context_id, child_viewport_rect);
     fixture.present();
-    EXPECT(fixture.present().damage_rect.is_empty());
+    fixture.expect_no_frame();
 
     fixture.compositor_state->update_display_list(child_context_id, make_fills_display_list(child_visual_context_tree, { { child_viewport_rect, Gfx::Color::Blue } }), child_visual_context_tree, {}, {});
     auto already_presented = fixture.compositor_client.presented_frames.size();

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -1233,6 +1233,51 @@ TEST_CASE(offscreen_opacity_animations_sleep_and_resume_at_the_current_phase)
     EXPECT(fixture.context.visual_animations_need_frame());
 }
 
+TEST_CASE(finished_animations_do_not_keep_offscreen_animations_awake)
+{
+    RasterizingContextFixture fixture;
+    Web::Painting::VisualContextTreeTestBuilder builder;
+    auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    auto effect = builder.append_effects(Web::Painting::NO_EFFECT_NODE, spatial);
+    auto tree = builder.finish();
+    auto finished = rotation_animation(spatial, MonotonicTime::now());
+    finished.iteration_count = 1;
+    finished.local_time_at_anchor_ms = 2000;
+    finished.keyframes = {
+        { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateY, { 0 } } } },
+        { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateY, { -100 } } } },
+    };
+    tree.set_visual_animations({ finished, {
+                                               .target_kind = Web::Compositor::VisualAnimation::TargetKind::Opacity,
+                                               .visual_context_node_indices = { effect.value() },
+                                               .monotonic_time_at_anchor_ns = MonotonicTime::now().nanoseconds(),
+                                               .iteration_duration_ms = 1000,
+                                               .easing = {},
+                                               .keyframes = { { 0, {}, 1.0f }, { 1, {}, 0.5f } },
+                                           } });
+    fixture.context.install_display_list_update(
+        make_fills_display_list(tree, { { { 2, 202, 4, 4 }, Gfx::Color::Red, { spatial, Web::Painting::NO_CLIP_NODE, effect } } }), tree, {});
+    fixture.rasterize();
+    EXPECT(fixture.context.has_active_visual_animations());
+    EXPECT(!fixture.context.visual_animations_need_frame());
+    fixture.context.install_display_list_update(
+        make_fills_display_list(tree, { { { 2, 102, 4, 4 }, Gfx::Color::Red, { spatial, Web::Painting::NO_CLIP_NODE, effect } } }), tree, {});
+    EXPECT(fixture.context.visual_animations_need_frame());
+    Vector<Web::Compositor::VisualAnimation> animations;
+    for (auto const& animation : tree.visual_animations())
+        animations.append(animation);
+    auto anchor = MonotonicTime::now();
+    animations[0].monotonic_time_at_anchor_ns = anchor.nanoseconds();
+    animations[0].local_time_at_anchor_ms = 500;
+    tree.set_visual_animations(move(animations));
+    fixture.context.install_display_list_update(
+        make_fills_display_list(tree, { { { 2, 202, 4, 4 }, Gfx::Color::Red, { spatial, Web::Painting::NO_CLIP_NODE, effect } } }), tree, {});
+    fixture.context.advance_visual_animations(anchor);
+    EXPECT(fixture.context.visual_animations_need_frame());
+    fixture.context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(500));
+    EXPECT(!fixture.context.visual_animations_need_frame());
+}
+
 TEST_CASE(rotation_bounds_include_angles_that_can_reveal_offscreen_content)
 {
     Web::Painting::VisualContextTreeTestBuilder builder;

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/Math.h>
 #include <AK/Queue.h>
 #include <AK/Stream.h>
 #include <Compositor/CompositorState.h>
@@ -15,6 +16,7 @@
 #include <LibIPC/Message.h>
 #include <LibTest/TestCase.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/Painting/DisplayListDamage.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/VisualContextTreeTestBuilder.h>
 #include <LibWebView/PausedDebuggerOverlay.h>
@@ -1142,6 +1144,87 @@ TEST_CASE(offscreen_changes_do_not_acquire_a_backing_store_or_block_later_frames
     EXPECT_EQ(fixture.pixel(3, 3), Gfx::Color::Red);
     EXPECT(!fixture.prepare().has_value());
     EXPECT_EQ(fixture.rasterize(fixture.viewport_rect), fixture.viewport_rect);
+}
+
+static Web::Compositor::VisualAnimation rotation_animation(Web::Painting::SpatialNodeIndex spatial, MonotonicTime anchor)
+{
+    return {
+        .target_kind = Web::Compositor::VisualAnimation::TargetKind::Transform,
+        .visual_context_node_indices = { spatial.value() },
+        .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+        .iteration_duration_ms = 1000,
+        .easing = {},
+        .keyframes = {
+            { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::Rotate, { 0 } } } },
+            { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::Rotate, { 2 * AK::Pi<float> } } } },
+        },
+    };
+}
+
+TEST_CASE(offscreen_rotations_sleep_until_scroll_or_viewport_changes)
+{
+    RasterizingContextFixture fixture;
+    Web::Painting::VisualContextTreeTestBuilder builder;
+    auto scroll = builder.append_scroll(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
+    auto spatial = builder.append_transform(scroll, Gfx::FloatMatrix4x4::identity(), { 4, 104 });
+    auto tree = builder.finish();
+    auto anchor = MonotonicTime::now();
+    tree.set_visual_animations({ rotation_animation(spatial, anchor) });
+    fixture.context.install_display_list_update(
+        make_fills_display_list(tree, { { { 2, 102, 4, 4 }, Gfx::Color::Red, { spatial } } }), tree, {});
+    fixture.rasterize();
+    EXPECT(fixture.context.has_active_visual_animations());
+    EXPECT(!fixture.context.visual_animations_need_frame());
+    EXPECT(!fixture.context.visual_animations_need_frame());
+
+    fixture.context.update_scroll_state(scroll_state_snapshot_with_offset(scroll, { 0, -100 }));
+    EXPECT(fixture.context.visual_animations_need_frame());
+    EXPECT(fixture.context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(2250)));
+    fixture.rasterize();
+    EXPECT_EQ(fixture.pixel(3, 3), Gfx::Color::Red);
+    auto matrix = fixture.context.sampled_visual_context_tree_for_testing().accumulated_matrix(
+        spatial, {}, Web::Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes);
+    EXPECT(fabsf(matrix[0, 0]) < 0.001f);
+    EXPECT(fabsf(matrix[1, 0] - 1) < 0.001f);
+
+    fixture.context.update_scroll_state({});
+    EXPECT(!fixture.context.visual_animations_need_frame());
+    fixture.context.viewport_size_updated({ 16, 120 }, Web::Compositor::WindowResizingInProgress::No);
+    EXPECT(fixture.context.visual_animations_need_frame());
+    fixture.context.viewport_size_updated({ 16, 16 }, Web::Compositor::WindowResizingInProgress::No);
+    EXPECT(!fixture.context.visual_animations_need_frame());
+
+    fixture.context.install_display_list_update(
+        make_fills_display_list(tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red, { spatial } } }), tree, {});
+    EXPECT(fixture.context.visual_animations_need_frame());
+}
+
+TEST_CASE(rotation_bounds_include_angles_that_can_reveal_offscreen_content)
+{
+    Web::Painting::VisualContextTreeTestBuilder builder;
+    auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    auto tree = builder.finish();
+    auto display_list = make_fills_display_list(tree, { { { 50, 0, 4, 4 }, Gfx::Color::Red, { spatial } } });
+    Array rotation_nodes { spatial };
+    EXPECT(Web::Painting::rotating_content_may_affect_viewport(
+        display_list->command_bytes(), tree, {}, rotation_nodes, { 0, 50, 10, 10 }));
+    EXPECT(!Web::Painting::rotating_content_may_affect_viewport(
+        display_list->command_bytes(), tree, {}, rotation_nodes, { 0, 100, 10, 10 }));
+}
+
+TEST_CASE(rotation_bounds_preserve_work_for_unbounded_commands_and_animated_clips)
+{
+    Web::Painting::VisualContextTreeTestBuilder builder;
+    auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity(), { 4, 104 });
+    auto clip = builder.append_clip(Web::Painting::NO_CLIP_NODE, spatial, { 0, 0, 8, 8 });
+    auto tree = builder.finish();
+    Array rotation_nodes { spatial };
+    auto unbounded = make_fills_display_list(tree, { { { 2, 102, 4, 4 }, Gfx::Color::Red, { spatial }, false } });
+    EXPECT(Web::Painting::rotating_content_may_affect_viewport(
+        unbounded->command_bytes(), tree, {}, rotation_nodes, test_viewport_rect));
+    auto clipped = make_fills_display_list(tree, { { { 0, 0, 8, 8 }, Gfx::Color::Red, { Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, clip } } });
+    EXPECT(Web::Painting::rotating_content_may_affect_viewport(
+        clipped->command_bytes(), tree, {}, rotation_nodes, test_viewport_rect));
 }
 
 TEST_CASE(changed_command_reports_its_inflated_rect)

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -1199,6 +1199,40 @@ TEST_CASE(offscreen_rotations_sleep_until_scroll_or_viewport_changes)
     EXPECT(fixture.context.visual_animations_need_frame());
 }
 
+TEST_CASE(offscreen_opacity_animations_sleep_and_resume_at_the_current_phase)
+{
+    RasterizingContextFixture fixture;
+    Web::Painting::VisualContextTreeTestBuilder builder;
+    auto scroll = builder.append_scroll(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
+    auto effect = builder.append_effects(Web::Painting::NO_EFFECT_NODE, scroll);
+    auto child_effect = builder.append_effects(effect, scroll);
+    auto tree = builder.finish();
+    auto anchor = MonotonicTime::now();
+    tree.set_visual_animations({ {
+        .target_kind = Web::Compositor::VisualAnimation::TargetKind::Opacity,
+        .visual_context_node_indices = { effect.value() },
+        .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+        .iteration_duration_ms = 1000,
+        .easing = {},
+        .keyframes = { { 0, {}, 1.0f }, { 1, {}, 0.0f } },
+    } });
+    fixture.context.install_display_list_update(
+        make_fills_display_list(tree, { { { 2, 102, 4, 4 }, Gfx::Color::Red, { scroll, Web::Painting::NO_CLIP_NODE, child_effect } }, { { 0, 0, 1, 1 }, Gfx::Color::Green } }), tree, {});
+    fixture.rasterize();
+    EXPECT(fixture.context.has_active_visual_animations());
+    EXPECT(!fixture.context.visual_animations_need_frame());
+    EXPECT(!fixture.context.visual_animations_need_frame());
+    fixture.context.update_scroll_state(scroll_state_snapshot_with_offset(scroll, { 0, -100 }));
+    EXPECT(fixture.context.visual_animations_need_frame());
+    EXPECT(fixture.context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(2500)));
+    fixture.rasterize();
+    EXPECT_EQ(fixture.pixel(3, 3).alpha(), 128);
+    fixture.context.update_scroll_state({});
+    EXPECT(!fixture.context.visual_animations_need_frame());
+    fixture.context.viewport_size_updated({ 16, 120 }, Web::Compositor::WindowResizingInProgress::No);
+    EXPECT(fixture.context.visual_animations_need_frame());
+}
+
 TEST_CASE(rotation_bounds_include_angles_that_can_reveal_offscreen_content)
 {
     Web::Painting::VisualContextTreeTestBuilder builder;
@@ -1206,10 +1240,10 @@ TEST_CASE(rotation_bounds_include_angles_that_can_reveal_offscreen_content)
     auto tree = builder.finish();
     auto display_list = make_fills_display_list(tree, { { { 50, 0, 4, 4 }, Gfx::Color::Red, { spatial } } });
     Array rotation_nodes { spatial };
-    EXPECT(Web::Painting::rotating_content_may_affect_viewport(
-        display_list->command_bytes(), tree, {}, rotation_nodes, { 0, 50, 10, 10 }));
-    EXPECT(!Web::Painting::rotating_content_may_affect_viewport(
-        display_list->command_bytes(), tree, {}, rotation_nodes, { 0, 100, 10, 10 }));
+    EXPECT(Web::Painting::animated_content_may_affect_viewport(
+        display_list->command_bytes(), tree, {}, rotation_nodes, {}, { 0, 50, 10, 10 }));
+    EXPECT(!Web::Painting::animated_content_may_affect_viewport(
+        display_list->command_bytes(), tree, {}, rotation_nodes, {}, { 0, 100, 10, 10 }));
 }
 
 TEST_CASE(rotation_bounds_preserve_work_for_unbounded_commands_and_animated_clips)
@@ -1220,11 +1254,11 @@ TEST_CASE(rotation_bounds_preserve_work_for_unbounded_commands_and_animated_clip
     auto tree = builder.finish();
     Array rotation_nodes { spatial };
     auto unbounded = make_fills_display_list(tree, { { { 2, 102, 4, 4 }, Gfx::Color::Red, { spatial }, false } });
-    EXPECT(Web::Painting::rotating_content_may_affect_viewport(
-        unbounded->command_bytes(), tree, {}, rotation_nodes, test_viewport_rect));
+    EXPECT(Web::Painting::animated_content_may_affect_viewport(
+        unbounded->command_bytes(), tree, {}, rotation_nodes, {}, test_viewport_rect));
     auto clipped = make_fills_display_list(tree, { { { 0, 0, 8, 8 }, Gfx::Color::Red, { Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, clip } } });
-    EXPECT(Web::Painting::rotating_content_may_affect_viewport(
-        clipped->command_bytes(), tree, {}, rotation_nodes, test_viewport_rect));
+    EXPECT(Web::Painting::animated_content_may_affect_viewport(
+        clipped->command_bytes(), tree, {}, rotation_nodes, {}, test_viewport_rect));
 }
 
 TEST_CASE(changed_command_reports_its_inflated_rect)

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-hidden-iframe.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-hidden-iframe.txt
@@ -1,0 +1,3 @@
+opacity uses compositor: true
+child rendering does not sample parent animations: true
+explicit style observation remains current: true

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-iteration-wakeup.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-iteration-wakeup.txt
@@ -1,0 +1,12 @@
+animation uses compositor: true
+ancestor listeners do not keep frame pump running: true
+iteration wake-up is armed: true
+early wake-up requests no frame: true
+iteration requests one frame: true
+iteration needs no animated style overlays: true
+events: start 0, iteration 1000
+next iteration re-arms the wake-up: true
+adjusted iteration does not wake early: true
+negative delay, iteration start, and playback rate are respected: true
+paused animation does not re-arm iteration wake-up: true
+cancellation still dispatches: true

--- a/Tests/LibWeb/Text/expected/css/compositor-competing-replace-effects.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-competing-replace-effects.txt
@@ -17,4 +17,4 @@ losing finite effect finishes after deterministic advance: true
 both competing finite effects dispatch animationend: true
 losing finite effect restores base opacity: true
 losing infinite effect dispatches iteration events: true
-losing infinite listener keeps the frame pump active: true
+losing infinite listener uses iteration wake-ups: true

--- a/Tests/LibWeb/Text/expected/css/compositor-svg-root-transform.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-svg-root-transform.txt
@@ -1,0 +1,5 @@
+outer SVG uses compositor: true
+no animated style overlays: true
+no main-thread frame pump: true
+rotation uses CSS box center: true
+internal and nested SVG stay on main thread: true

--- a/Tests/LibWeb/Text/expected/css/compositor-transform-synthesized-endpoint.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-transform-synthesized-endpoint.txt
@@ -1,0 +1,4 @@
+synthesized transform endpoint uses compositor: true
+no main-thread animated style work: true
+underlying style change preserves handoff: true
+synthesized endpoint follows underlying style: true

--- a/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
+++ b/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
@@ -1,6 +1,6 @@
 hidden animation overlay builds: 0
 hidden animation frame pump requests: 0
-animation event listener keeps frame pump active: true
+animation event listener uses iteration wake-ups: true
 animation event listener skips past events: 0
 removing animation event listener stops frame pump: 0
 computed style samples hidden animation: true

--- a/Tests/LibWeb/Text/expected/css/throttled-animation-late-iteration-listener.txt
+++ b/Tests/LibWeb/Text/expected/css/throttled-animation-late-iteration-listener.txt
@@ -1,0 +1,8 @@
+visible, display-none, and closed-details rotations skip per-frame work: true
+unobserved rotations need no wake-up timer: true
+late listener receives no past events: true
+late ancestor listener arms wake-up: true
+next iteration reaches late listener: closed 3000, visible 3000
+one wake-up serves the CSS effects: true
+removing iteration listener leaves no periodic wake-up: true
+showing hidden SVG resumes compositor rendering: true

--- a/Tests/LibWeb/Text/input/css/compositor-animation-hidden-iframe.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-hidden-iframe.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="target" style="width: 20px; height: 20px; background: red"></div>
+<script>
+asyncTest(async done => {
+    const frame = document.createElement("iframe");
+    frame.style.display = "none";
+    frame.srcdoc = "<!DOCTYPE html><body>Hidden document";
+    const loaded = new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
+    document.body.appendChild(frame);
+    await loaded;
+    const target = document.getElementById("target");
+    const timeline = internals.createInternalAnimationTimeline();
+    const animation = new Animation(new KeyframeEffect(target,
+        [{ opacity: 1 }, { opacity: 0 }], { duration: 1000, iterations: Infinity }), timeline);
+    // Establish the opacity layer at an explicit phase before checking compositor handoff.
+    timeline.setTime(250);
+    animation.play();
+    animation.startTime = 0;
+    getComputedStyle(target).opacity;
+    for (let i = 0; i < 4; ++i)
+        await new Promise(requestAnimationFrame);
+    println(`opacity uses compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
+    internals.resetStyleInvalidationCounters();
+    timeline.setTime(500);
+    for (let i = 0; i < 4; ++i)
+        await new Promise(requestAnimationFrame);
+    println(`child rendering does not sample parent animations: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
+    timeline.setTimeForObservation(500);
+    println(`explicit style observation remains current: ${getComputedStyle(target).opacity === "0.5"}`);
+    animation.cancel();
+    done();
+});
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-animation-iteration-wakeup.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-iteration-wakeup.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    #spinner { width: 16px; height: 16px; animation: spin 1000s linear infinite; }
+</style>
+<div id="root"><svg id="spinner" viewBox="0 0 16 16"><path d="M15 8A7 7 0 0 0 8 1" /></svg></div>
+<script>
+    asyncTest(async done => {
+        const root = document.getElementById("root");
+        const spinner = document.getElementById("spinner");
+        const events = [];
+        root.addEventListener("animationstart", event => events.push(`start ${event.elapsedTime}`));
+        root.addEventListener("animationiteration", event => events.push(`iteration ${event.elapsedTime}`));
+        root.addEventListener("animationcancel", () => events.push("cancel"));
+        const animation = spinner.getAnimations()[0];
+        const timeline = internals.createInternalAnimationTimeline();
+        animation.timeline = timeline;
+        animation.startTime = 0;
+        timeline.setTime(0);
+        timeline.setTimeForObservation(0);
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`animation uses compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`ancestor listeners do not keep frame pump running: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 0}`);
+        println(`iteration wake-up is armed: ${internals.getStyleInvalidationCounters().compositorAnimationWakeupTimerActive}`);
+
+        timeline.setTimeForObservation(999999);
+        internals.fireCompositorAnimationWakeupForTesting(999999);
+        println(`early wake-up requests no frame: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 0}`);
+        timeline.setTimeForObservation(1000000);
+        internals.fireCompositorAnimationWakeupForTesting(1000000);
+        timeline.setTime(1000000);
+        await new Promise(requestAnimationFrame);
+        println(`iteration requests one frame: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 1}`);
+        println(`iteration needs no animated style overlays: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
+        println(`events: ${events.join(", ")}`);
+
+        internals.resetStyleInvalidationCounters();
+        timeline.setTimeForObservation(2000000);
+        internals.fireCompositorAnimationWakeupForTesting(2000000);
+        timeline.setTime(2000000);
+        await new Promise(requestAnimationFrame);
+        println(`next iteration re-arms the wake-up: ${events.at(-1) === "iteration 2000" && internals.getStyleInvalidationCounters().animationFramePumpRequests === 1}`);
+        animation.effect.updateTiming({ delay: -250000, iterationStart: 0.25 });
+        animation.playbackRate = 2;
+        animation.startTime = 2000000;
+        for (let i = 0; i < 2; ++i)
+            await new Promise(requestAnimationFrame);
+        events.length = 0;
+        internals.resetStyleInvalidationCounters();
+        timeline.setTimeForObservation(2249999);
+        internals.fireCompositorAnimationWakeupForTesting(2249999);
+        println(`adjusted iteration does not wake early: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 0}`);
+        timeline.setTimeForObservation(2250000);
+        internals.fireCompositorAnimationWakeupForTesting(2250000);
+        timeline.setTime(2250000);
+        await new Promise(requestAnimationFrame);
+        println(`negative delay, iteration start, and playback rate are respected: ${events.join(", ") === "iteration 750" && internals.getStyleInvalidationCounters().animationFramePumpRequests === 1}`);
+
+        animation.pause();
+        await new Promise(requestAnimationFrame);
+        internals.resetStyleInvalidationCounters();
+        timeline.setTimeForObservation(3000000);
+        internals.fireCompositorAnimationWakeupForTesting(3000000);
+        println(`paused animation does not re-arm iteration wake-up: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 0 && !internals.getStyleInvalidationCounters().compositorAnimationWakeupTimerActive}`);
+        animation.cancel();
+        await new Promise(requestAnimationFrame);
+        println(`cancellation still dispatches: ${events.at(-1) === "cancel"}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-competing-replace-effects.html
+++ b/Tests/LibWeb/Text/input/css/compositor-competing-replace-effects.html
@@ -170,7 +170,7 @@
         losingInfiniteAnimation.currentTime = 250000;
         await losingInfiniteIterationsObserved;
         println(`losing infinite effect dispatches iteration events: ${losingInfiniteIterations === 2}`);
-        println(`losing infinite listener keeps the frame pump active: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
+        println(`losing infinite listener uses iteration wake-ups: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 0 && internals.getStyleInvalidationCounters().compositorAnimationWakeupTimerActive}`);
         for (const animation of target.getAnimations())
             animation.cancel();
         done();

--- a/Tests/LibWeb/Text/input/css/compositor-svg-root-transform.html
+++ b/Tests/LibWeb/Text/input/css/compositor-svg-root-transform.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #spinner { display: block; width: 40px; height: 20px; transform-origin: 50% 50%; }
+</style>
+<svg id="spinner" viewBox="0 0 80 40"><path d="M0 0H80V40H0Z" fill="green" /></svg>
+<svg width="40" height="40"><g id="internal"><rect width="10" height="10" /></g><svg id="nested" width="10" height="10"></svg></svg>
+<script>
+    asyncTest(async done => {
+        const timeline = internals.createInternalAnimationTimeline();
+        const makeAnimation = target => {
+            const animation = new Animation(new KeyframeEffect(target,
+                [{ transform: "rotate(0deg)" }, { transform: "rotate(360deg)" }],
+                { duration: 1000, iterations: Infinity }), timeline);
+            animation.play();
+            return animation;
+        };
+        const spinner = document.getElementById("spinner");
+        const animation = makeAnimation(spinner);
+        timeline.setTime(0);
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`outer SVG uses compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
+
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        const counters = internals.getStyleInvalidationCounters();
+        println(`no animated style overlays: ${counters.animatedStyleOverlayBuilds === 0}`);
+        println(`no main-thread frame pump: ${counters.animationFramePumpRequests === 0}`);
+
+        timeline.setTimeForObservation(250);
+        const rect = spinner.getBoundingClientRect();
+        println(`rotation uses CSS box center: ${Math.abs(rect.x - 10) < 0.1 && Math.abs(rect.y + 10) < 0.1 && Math.abs(rect.width - 20) < 0.1 && Math.abs(rect.height - 40) < 0.1}`);
+        animation.cancel();
+        makeAnimation(document.getElementById("internal"));
+        makeAnimation(document.getElementById("nested"));
+        timeline.setTime(500);
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`internal and nested SVG stay on main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 0}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-transform-synthesized-endpoint.html
+++ b/Tests/LibWeb/Text/input/css/compositor-transform-synthesized-endpoint.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes spin { to { transform: rotate(360deg); } }
+    svg { width: 16px; height: 16px; animation: spin 1000s linear infinite; }
+</style>
+<svg id="spinner" viewBox="0 0 16 16"><path d="M15 8A7 7 0 0 0 8 1" fill="none" stroke="black" /></svg>
+<script>
+    asyncTest(async done => {
+        const spinner = document.getElementById("spinner");
+        const animation = spinner.getAnimations()[0];
+        const timeline = internals.createInternalAnimationTimeline();
+        animation.timeline = timeline;
+        animation.startTime = 0;
+        timeline.setTime(0);
+        timeline.setTimeForObservation(0);
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`synthesized transform endpoint uses compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`no main-thread animated style work: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
+
+        spinner.style.transform = "rotate(90deg)";
+        for (let i = 0; i < 2; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`underlying style change preserves handoff: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
+        timeline.setTimeForObservation(500000);
+        const matrix = new DOMMatrix(getComputedStyle(spinner).transform);
+        println(`synthesized endpoint follows underlying style: ${Math.abs(matrix.a + Math.SQRT1_2) < 0.001 && Math.abs(matrix.b + Math.SQRT1_2) < 0.001}`);
+        animation.cancel();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
+++ b/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
@@ -41,7 +41,7 @@
         hidden.addEventListener("animationiteration", animationIterationListener);
         internals.resetStyleInvalidationCounters();
         await animationOverlayBuildsOverFrames(4);
-        println(`animation event listener keeps frame pump active: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
+        println(`animation event listener uses iteration wake-ups: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 0 && internals.getStyleInvalidationCounters().compositorAnimationWakeupTimerActive}`);
         println(`animation event listener skips past events: ${animationIterationEvents}`);
         hidden.removeEventListener("animationiteration", animationIterationListener);
         internals.resetStyleInvalidationCounters();

--- a/Tests/LibWeb/Text/input/css/throttled-animation-late-iteration-listener.html
+++ b/Tests/LibWeb/Text/input/css/throttled-animation-late-iteration-listener.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    svg { width: 16px; height: 16px; animation: spin 1000s linear infinite; }
+</style>
+<div id="root"><svg id="visible" viewBox="0 0 16 16"><path d="M15 8A7 7 0 0 0 8 1" /></svg><div style="display: none"><svg id="hidden" viewBox="0 0 16 16"><path d="M15 8A7 7 0 0 0 8 1" /></svg></div><details id="details"><summary>Details</summary><svg id="closed" viewBox="0 0 16 16"><path d="M15 8A7 7 0 0 0 8 1" /></svg></details></div>
+<script>
+    asyncTest(async done => {
+        const root = document.getElementById("root");
+        const timeline = internals.createInternalAnimationTimeline();
+        const hiddenAnimation = document.getElementById("hidden").animate(
+            [{ transform: "rotate(0deg)" }, { transform: "rotate(360deg)" }],
+            { duration: 1000000, iterations: Infinity });
+        const animations = [document.getElementById("visible").getAnimations()[0], hiddenAnimation,
+            document.getElementById("closed").getAnimations()[0]];
+        for (const animation of animations) {
+            animation.timeline = timeline;
+            animation.startTime = 0;
+        }
+        timeline.setTime(0);
+        timeline.setTimeForObservation(0);
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        const idle = internals.getStyleInvalidationCounters();
+        println(`visible, display-none, and closed-details rotations skip per-frame work: ${idle.animationFramePumpRequests === 0 && idle.animatedStyleOverlayBuilds === 0}`);
+        println(`unobserved rotations need no wake-up timer: ${!idle.compositorAnimationWakeupTimerActive}`);
+
+        const events = [];
+        const listener = event => events.push(`${event.target.id} ${event.elapsedTime}`);
+        timeline.setTime(2500000);
+        timeline.setTimeForObservation(2500000);
+        root.addEventListener("animationiteration", listener);
+        timeline.setTime(2500000);
+        await new Promise(requestAnimationFrame);
+        println(`late listener receives no past events: ${events.length === 0}`);
+        println(`late ancestor listener arms wake-up: ${internals.getStyleInvalidationCounters().compositorAnimationWakeupTimerActive}`);
+
+        internals.resetStyleInvalidationCounters();
+        timeline.setTimeForObservation(3000000);
+        internals.fireCompositorAnimationWakeupForTesting(3000000);
+        timeline.setTime(3000000);
+        await new Promise(requestAnimationFrame);
+        println(`next iteration reaches late listener: ${events.sort().join(", ")}`);
+        println(`one wake-up serves the CSS effects: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 1}`);
+
+        root.removeEventListener("animationiteration", listener);
+        root.addEventListener("animationstart", () => {});
+        root.addEventListener("animationcancel", () => {});
+        await new Promise(requestAnimationFrame);
+        internals.resetStyleInvalidationCounters();
+        timeline.setTimeForObservation(4000000);
+        internals.fireCompositorAnimationWakeupForTesting(4000000);
+        const removed = internals.getStyleInvalidationCounters();
+        println(`removing iteration listener leaves no periodic wake-up: ${removed.animationFramePumpRequests === 0 && !removed.compositorAnimationWakeupTimerActive}`);
+        document.getElementById("hidden").parentElement.style.display = "block";
+        document.getElementById("details").open = true;
+        timeline.setTime(4000000);
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`showing hidden SVG resumes compositor rendering: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 3}`);
+        for (const animation of animations)
+            animation.cancel();
+        done();
+    });
+</script>


### PR DESCRIPTION
Hand off CSS transforms on SVG roots to the compositor, stop scheduling frames for offscreen rotations and opacity animations, and skip presenting frames with no pixel changes. Observable CSS animation iterations wake WebContent at iteration boundaries, with support for listeners added during playback.

Also prevent child-document layout updates and completed animations from keeping otherwise idle pages busy.

On a GitHub PR with offscreen CI spinners, CPU usage dropped from roughly 10% each in WebContent and Compositor to around 0.1% each. A saved Plex page with 151 offscreen placeholders dropped from roughly 29% WebContent and 8% Compositor to 0.0% each at idle.
