### PR TITLE
LibWeb: Ignore load event delayer decrement for destroyed documents

### DIFF
--- a/Libraries/LibWeb/DOM/DocumentLoadEventDelayer.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoadEventDelayer.cpp
@@ -45,7 +45,7 @@ DocumentLoadEventDelayer& DocumentLoadEventDelayer::operator=(DocumentLoadEventD
 
 DocumentLoadEventDelayer::~DocumentLoadEventDelayer()
 {
-    if (m_document) {
+    if (m_document && !m_document->has_been_destroyed()) {
         if (m_reason == DocumentLoadEventDelayerReason::StyleSheetRequest)
             m_document->decrement_number_of_pending_style_sheet_requests({});
         m_document->decrement_number_of_things_delaying_the_load_event({});

--- a/Tests/LibWeb/Crash/DOM/shared-resource-request-finalize-while-in-flight.html
+++ b/Tests/LibWeb/Crash/DOM/shared-resource-request-finalize-while-in-flight.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html class="test-wait">
+    <body>
+        <script>
+            function registerDelayedResponse(path, contentType) {
+                const request = new XMLHttpRequest();
+                request.open("POST", "/echo", false);
+                request.setRequestHeader("Content-Type", "application/json");
+                request.send(
+                    JSON.stringify({
+                        method: "GET",
+                        path: `/echo/${path}`,
+                        status: 200,
+                        headers: { "Content-Type": contentType },
+                        wait_for_unblock: path,
+                    })
+                );
+            }
+
+            async function waitForRequest(path) {
+                while (true) {
+                    const response = await fetch(`/recorded-request-headers${path}`, {
+                        cache: "no-store",
+                    });
+
+                    if (response.ok) return;
+
+                    await new Promise(resolve => setTimeout(resolve, 5));
+                }
+            }
+
+            // Unique paths are required so repeated runs do not interfere with each other
+            const runId = crypto.randomUUID();
+            const imagePath = `shared-resource-request-finalize-image-${runId}`;
+            const scriptPath = `shared-resource-request-finalize-script-${runId}`;
+
+            registerDelayedResponse(imagePath, "image/png");
+            registerDelayedResponse(scriptPath, "text/javascript");
+
+            window.addEventListener("message", event => {
+                if (event.data === "child-parser-about-to-block") {
+                    Promise.all([
+                        // Ensure the SharedResourceRequest is in flight
+                        waitForRequest(`/echo/${imagePath}`),
+
+                        // Ensure the HTMLParser is paused
+                        waitForRequest(`/echo/${scriptPath}`),
+                    ]).then(() => {
+                        document.querySelector("iframe").remove();
+                    });
+                }
+
+                if (event.data === "child-unloaded") {
+                    setTimeout(() => {
+                        internals.gc();
+                        document.documentElement.classList.remove("test-wait");
+                    }, 0);
+                }
+            });
+
+            const iframe = document.createElement("iframe");
+
+            iframe.srcdoc = `
+                <div style="background-image: url(/echo/${imagePath})"></div>
+                <script>
+                    addEventListener("unload", () => parent.postMessage("child-unloaded", "*"));
+                    parent.postMessage("child-parser-about-to-block", "*");
+                <\/script>
+                <script src="/echo/${scriptPath}"><\/script>
+            `;
+
+            document.body.append(iframe);
+        </script>
+    </body>
+</html>

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,4 +1,5 @@
 [LoadFromHttpServer]
+Crash/DOM/shared-resource-request-finalize-while-in-flight.html
 Text/input/css/font-cache-first-paint.html
 Text/input/css/font-display-timeline.html
 Text/input/css/canvas-font-display.html


### PR DESCRIPTION
When a document is destroyed, its `SharedResourceRequest`s are released. If a request is still in flight, this can cause it to be finalized while it still owns a  `DocumentLoadEventDelayer`.

Previously, destroying the `DocumentLoadEventDelayer` would decrement the document's "number of things delaying the load event" counter even if the document had already been destroyed. This could schedule an `HTMLParser` resume check if the parser was paused, which would allocate a `GC::Function` callback for deferred invocation, triggering `VERIFY(!m_collecting_garbage)` in `Heap::allocate()`.

We now skip decrementing the load event delayer counter when the associated document has been destroyed.

Fixes #11613