### PR TITLE
LibWeb: Extend partial style recomputation to more kinds of style change

### DIFF
--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -199,6 +199,19 @@ bool Animatable::has_relevant_animations() const
     return false;
 }
 
+bool Animatable::has_relevant_animations_other_than_transitions() const
+{
+    if (!m_impl)
+        return false;
+
+    for (auto const& animation : m_impl->associated_animations) {
+        if (!animation->is_css_transition() && animation->is_relevant())
+            return true;
+    }
+
+    return false;
+}
+
 void Animatable::associate_with_animation(GC::Ref<Animation> animation)
 {
     auto& impl = ensure_impl();

--- a/Libraries/LibWeb/Animations/Animatable.h
+++ b/Libraries/LibWeb/Animations/Animatable.h
@@ -59,6 +59,7 @@ public:
     void invalidate_associated_animation_composite_order();
     bool has_relevant_animations() const;
     bool has_associated_animations() const;
+    bool has_relevant_animations_other_than_transitions() const;
 
     void associate_with_animation(GC::Ref<Animation>);
     void disassociate_with_animation(GC::Ref<Animation>);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3801,7 +3801,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
     auto groups_to_rebuild = sharing.computed_groups_to_rebuild.value_or(ComputedValues::all_style_groups);
     auto& element = abstract_element.element();
     if (groups_to_rebuild != ComputedValues::all_style_groups) {
-        if (element.has_relevant_animations()
+        if (element.has_relevant_animations_other_than_transitions()
             || element.has_css_defined_animations())
             groups_to_rebuild = ComputedValues::all_style_groups;
         else if (auto animated_properties = computed_properties->animated_properties_snapshot(); animated_properties && !animated_properties->is_empty())
@@ -3828,7 +3828,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
     // record retained by value is refused for it. Neither is an animation or transition: it carries
     // state on the element itself, and its values are published by the animation refresh rather
     // than derived here.
-    bool const computation_read_only_the_record = !element.has_relevant_animations()
+    bool const computation_read_only_the_record = !element.has_relevant_animations_other_than_transitions()
         && !element.has_css_defined_animations()
         && !element.style_uses_attr_css_function()
         && !element.style_uses_if_css_function()
@@ -5582,7 +5582,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         .use_retained_style_computation_selection = use_retained_style_computation_selection,
         .selected_transition_properties = selected_transition_properties.data(),
         .selected_transition_property_count = selected_transition_properties.size(),
-        .has_relevant_animations = abstract_element.element().has_relevant_animations(),
+        .has_relevant_animations_other_than_transitions = abstract_element.element().has_relevant_animations_other_than_transitions(),
         .has_css_defined_animations = abstract_element.element().has_css_defined_animations(),
         .stop_after_longhand_drive = stop_after_longhand_drive,
         .callback_context = &native_context,

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3818,15 +3818,15 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
     // container unit or query asks about its container, `attr()` about its attributes, a
     // tree-counting function about its place among its siblings, and `if()` about the environment.
     // The monospace font-size recascade reads the whole ancestor chain rather than the inherited
-    // context, and unfixed random values read the element's random cache. Image URLs also need their
-    // declaration's resource context, which retained winner value identities do not distinguish.
-    // The full declaration key retains source identities for resource-dependent values, so it
-    // can still share their computed styles without enabling winner-only reuse.
-    // `var()` is not among them: what it resolves against is the cascaded custom properties, which
-    // the blocks in the record decide, and the inherited environment, which the
-    // parent in the record decides. Neither is an animation or transition: it carries state on the
-    // element itself, and its values are published by the animation refresh rather than derived here.
-    bool const computation_read_only_the_declaration_key = !element.has_relevant_animations()
+    // context, and unfixed random values read the element's random cache. `var()` is not among
+    // them: what it resolves against is the cascaded custom properties, which the blocks in the
+    // record decide, and the inherited environment, which the parent in the record decides. Neither
+    // is an image URL: its resource context is its declaration's, which the record names through
+    // the declaration's block and the sharing key through the declaration's identity. Only a winner
+    // record retained by value is refused for it. Neither is an animation or transition: it carries
+    // state on the element itself, and its values are published by the animation refresh rather
+    // than derived here.
+    bool const computation_read_only_the_record = !element.has_relevant_animations()
         && !element.has_css_defined_animations()
         && !element.style_uses_attr_css_function()
         && !element.style_uses_if_css_function()
@@ -3835,8 +3835,6 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
         && !element.style_depends_on_viewport_metrics()
         && !element.style_depends_on_size_container_query()
         && !element.style_depends_on_style_container_query()
-        && !sharing.computation_reads_element_context;
-    bool const computation_read_only_the_record = computation_read_only_the_declaration_key
         && !sharing.computation_reads_unkeyed_context;
     // The flags are cleared for the next computation, so the record is what has to answer whether
     // that computation can be skipped.
@@ -3844,6 +3842,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
         auto* record = element.style_input_record();
         VERIFY(record);
         record->read_beyond_the_record = !computation_read_only_the_record;
+        record->style_reads_resource_context = sharing.computation_reads_resource_context;
         record->style_uses_var_css_function = element.style_uses_var_css_function();
         record->style_uses_inherit_css_function = element.style_uses_inherit_css_function();
         record->explicitly_inherited_non_inherited_style_groups = sharing.explicitly_inherited_non_inherited_style_groups;
@@ -3851,7 +3850,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
     if (sharing.is_candidate && sharing.may_reuse_or_publish_shared_style) {
         // The result answers for another element only if it also holds no animated values: an
         // animation or transition is state of this element that the other element does not have.
-        bool const computation_read_only_the_key = computation_read_only_the_declaration_key
+        bool const computation_read_only_the_key = computation_read_only_the_record
             && !computed_values->animated_properties()
             && !computed_values->has_animated_values();
         if (computation_read_only_the_key) {
@@ -3885,6 +3884,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
                 .style_input_declaration_words = move(style_input_declaration_words),
                 .pinned_style_input_values = move(pinned_style_input_values),
                 .read_beyond_the_record = !computation_read_only_the_record,
+                .style_reads_resource_context = sharing.computation_reads_resource_context,
                 .style_uses_var_css_function = element.style_uses_var_css_function(),
                 .style_uses_inherit_css_function = element.style_uses_inherit_css_function(),
             });
@@ -4256,6 +4256,7 @@ void StyleComputer::remember_shared_computed_style_record(DOM::Element& element,
 {
     auto const* input = element.style_input_record();
     if (!input || input->read_beyond_the_record
+        || input->style_reads_resource_context
         || input->cascade_reads_custom_properties
         || input->style_uses_var_css_function
         || input->style_uses_inherit_css_function
@@ -4484,6 +4485,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
         bool style_depends_on_size_container_query { false };
         bool style_depends_on_style_container_query { false };
         u32 explicitly_inherited_non_inherited_style_groups { 0 };
+        bool style_reads_resource_context { false };
     };
     Optional<PreviousComputation> previous_computation;
     auto capture_previous_computation = [](StyleInputRecord const& previous) {
@@ -4499,6 +4501,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
             .style_depends_on_size_container_query = previous.style_depends_on_size_container_query,
             .style_depends_on_style_container_query = previous.style_depends_on_style_container_query,
             .explicitly_inherited_non_inherited_style_groups = previous.explicitly_inherited_non_inherited_style_groups,
+            .style_reads_resource_context = previous.style_reads_resource_context,
         };
     };
     auto record_style_input = [&](StyleSharingEntry const* shared_entry = nullptr) {
@@ -4527,6 +4530,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
         record->style_depends_on_viewport_metrics = false;
         record->style_depends_on_size_container_query = false;
         record->style_depends_on_style_container_query = false;
+        record->style_reads_resource_context = false;
         record->explicitly_inherited_non_inherited_style_groups = 0;
         record->cascade_reads_custom_properties = false;
         record->pinned_parent_custom_property_data = nullptr;
@@ -4661,6 +4665,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
                 record->style_uses_custom_function = previous->style_uses_custom_function;
                 record->style_uses_inherit_css_function = previous->style_uses_inherit_css_function;
                 record->style_uses_tree_counting_function = previous->style_uses_tree_counting_function;
+                record->style_reads_resource_context = previous->style_reads_resource_context;
                 record->style_depends_on_viewport_metrics = previous->style_depends_on_viewport_metrics;
                 record->style_depends_on_size_container_query = previous->style_depends_on_size_container_query;
                 record->style_depends_on_style_container_query = previous->style_depends_on_style_container_query;
@@ -4690,6 +4695,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
                 old_parent_custom_property_data = previous->pinned_parent_custom_property_data;
                 style_input_is_unchanged = true;
                 record->read_beyond_the_record = previous->read_beyond_the_record;
+                record->style_reads_resource_context = previous->style_reads_resource_context;
                 record->style_uses_attr_css_function = previous->style_uses_attr_css_function;
                 record->style_uses_var_css_function = previous->style_uses_var_css_function;
                 record->style_uses_if_css_function = previous->style_uses_if_css_function;
@@ -4932,11 +4938,12 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
             }
             compute_transitioned_properties(*sharing->shared_values, abstract_element);
             // The declaration key can distinguish resource contexts that retained cascade winners
-            // cannot. Preserve that restriction for subsequent partial computation.
+            // cannot. Preserve that restriction for the winner records retained from this element.
             if (!abstract_element.pseudo_element().has_value()) {
                 auto* record = abstract_element.element().style_input_record();
                 VERIFY(record);
                 record->read_beyond_the_record = entry.read_beyond_the_record;
+                record->style_reads_resource_context = entry.style_reads_resource_context;
                 record->style_uses_var_css_function = entry.style_uses_var_css_function;
                 record->style_uses_inherit_css_function = entry.style_uses_inherit_css_function;
                 record->explicitly_inherited_non_inherited_style_groups = entry.explicitly_inherited_non_inherited_style_groups;
@@ -5080,7 +5087,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
             if (!bucket.has_value())
                 continue;
             for (auto const& entry : *bucket) {
-                if (entry.read_beyond_the_record || !entry.style_record_identity.has_value() || !entry.style_node_id)
+                if (entry.read_beyond_the_record || entry.style_reads_resource_context || !entry.style_record_identity.has_value() || !entry.style_node_id)
                     continue;
                 if (!entry.key.equals_without_values(sharing->key))
                     continue;
@@ -5167,6 +5174,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
         new_style_input_record->style_depends_on_viewport_metrics = previous_computation->style_depends_on_viewport_metrics;
         new_style_input_record->style_depends_on_size_container_query = previous_computation->style_depends_on_size_container_query;
         new_style_input_record->style_depends_on_style_container_query = previous_computation->style_depends_on_style_container_query;
+        new_style_input_record->style_reads_resource_context = previous_computation->style_reads_resource_context;
         new_style_input_record->explicitly_inherited_non_inherited_style_groups = previous_computation->explicitly_inherited_non_inherited_style_groups;
         reuse_last_computed_style();
         return {};
@@ -5238,7 +5246,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
         sharing ? sharing->computed_groups_to_rebuild.value_or(ComputedValues::all_style_groups) : ComputedValues::all_style_groups,
         use_retained_style_computation_selection, false, &computed_group_mask,
         sharing ? &sharing->computation_reads_unkeyed_context : nullptr,
-        sharing ? &sharing->computation_reads_element_context : nullptr);
+        sharing ? &sharing->computation_reads_resource_context : nullptr);
     if (new_style_input_record)
         new_style_input_record->bind_next_published_style = true;
     static bool const verify_computed_closure = getenv("LIBWEB_VERIFY_COMPUTED_CLOSURE") != nullptr;
@@ -5401,7 +5409,7 @@ void StyleComputer::ensure_style_metadata_tables_installed()
     (void)installed;
 }
 
-NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::AbstractElement abstract_element, CascadedProperties& cascaded_properties, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups, StyleRecordID previous_style_record, u32 initial_computed_group_mask, bool use_retained_style_computation_selection, bool stop_after_longhand_drive, u32* selected_computed_group_mask, bool* computation_reads_unkeyed_context, bool* computation_reads_element_context) const
+NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::AbstractElement abstract_element, CascadedProperties& cascaded_properties, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups, StyleRecordID previous_style_record, u32 initial_computed_group_mask, bool use_retained_style_computation_selection, bool stop_after_longhand_drive, u32* selected_computed_group_mask, bool* computation_reads_unkeyed_context, bool* computation_reads_resource_context) const
 {
     begin_style_update();
     ScopeGuard end_style_update = [&] { this->end_style_update(); };
@@ -5475,7 +5483,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         bool stop_after_longhand_drive;
         u32* selected_computed_group_mask;
         bool* computation_reads_unkeyed_context;
-        bool* computation_reads_element_context;
+        bool* computation_reads_resource_context;
         PreparePhaseContext prepare_phase_context;
         OwnPtr<NativeLonghandState> state;
     };
@@ -5546,7 +5554,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         .stop_after_longhand_drive = stop_after_longhand_drive,
         .selected_computed_group_mask = selected_computed_group_mask,
         .computation_reads_unkeyed_context = computation_reads_unkeyed_context,
-        .computation_reads_element_context = computation_reads_element_context,
+        .computation_reads_resource_context = computation_reads_resource_context,
         .prepare_phase_context = prepare_phase_context,
         .state = nullptr,
     };
@@ -5575,11 +5583,8 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
                 *context.selected_computed_group_mask = computed_group_mask;
             if (context.computation_reads_unkeyed_context)
                 *context.computation_reads_unkeyed_context = computation_requirements->computation_reads_unkeyed_context;
-            if (context.computation_reads_element_context) {
-                auto random_sharings = ReadonlySpan<ComputedValuesFFI::FfiUnfixedRandomSharing> { computation_requirements->unfixed_random_sharings, computation_requirements->unfixed_random_sharing_count };
-                *context.computation_reads_element_context = computation_requirements->has_monospace_font_family
-                    || any_of(random_sharings, [](auto const& sharing) { return !sharing.element_shared; });
-            }
+            if (context.computation_reads_resource_context)
+                *context.computation_reads_resource_context = computation_requirements->computation_reads_resource_context;
             auto const* computed_properties_to_evaluate = computation_requirements->has_computed_property_selection
                 ? computation_requirements->computed_property_words
                 : nullptr;

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3804,6 +3804,8 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
         if (element.has_relevant_animations()
             || element.has_css_defined_animations())
             groups_to_rebuild = ComputedValues::all_style_groups;
+        else if (auto animated_properties = computed_properties->animated_properties_snapshot(); animated_properties && !animated_properties->is_empty())
+            groups_to_rebuild |= animated_overlay_style_groups(*animated_properties, abstract_element).value_or(ComputedValues::all_style_groups);
     }
     auto computed_values = build_computed_values(
         *computed_properties,
@@ -4029,29 +4031,39 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_computed_values(Compute
     return style;
 }
 
+Optional<u32> StyleComputer::animated_overlay_style_groups(AnimatedProperties const& animated_properties, DOM::AbstractElement abstract_element) const
+{
+    u32 groups = 0;
+    for (auto const& entry : animated_properties.entries()) {
+        auto property_id = static_cast<PropertyID>(entry.property);
+        auto group = ComputedValues::style_group_of_property(property_id);
+        if (!group.has_value())
+            return {};
+        groups |= 1u << to_underlying(group.value());
+        if (property_id != PropertyID::Color)
+            continue;
+        auto style_node_id = abstract_element.element().style_node_id();
+        if (style_node_id == 0)
+            return {};
+        auto current_color_dependent_groups = m_style_engine.current_color_dependent_style_groups(style_node_id, pseudo_element_to_ffi(abstract_element.pseudo_element()));
+        if (!current_color_dependent_groups.has_value())
+            return {};
+        groups |= *current_color_dependent_groups;
+    }
+    return groups;
+}
+
 NonnullRefPtr<ComputedValues const> StyleComputer::build_animated_computed_values(ComputedStyleWorkingSet& computed_properties, DOM::AbstractElement abstract_element, StyleScope const& style_scope, ComputedValues const& previous_values) const
 {
     // The base half of an animated style does not move between frames, and everything the overlay
     // touches is named by the animated property set, so a frame keeps the previous base and
-    // rebuilds only the groups the animation writes. A property whose group is unknown takes the
-    // full build, and so does the color, because currentcolor consumers in other groups bake their
-    // resolved colors against it.
+    // rebuilds only the groups the animation writes.
     auto& counters = document().style_invalidation_counters();
     auto animated_properties = computed_properties.animated_properties_snapshot();
-    u32 groups_to_apply = 0;
-    bool touched_groups_known = animated_properties && !animated_properties->is_empty();
-    if (touched_groups_known) {
-        for (auto const& entry : animated_properties->entries()) {
-            auto property_id = static_cast<PropertyID>(entry.property);
-            auto group = ComputedValues::style_group_of_property(property_id);
-            if (!group.has_value() || property_id == PropertyID::Color) {
-                touched_groups_known = false;
-                break;
-            }
-            groups_to_apply |= 1u << to_underlying(group.value());
-        }
-    }
-    if (!touched_groups_known) {
+    Optional<u32> groups_to_apply;
+    if (animated_properties && !animated_properties->is_empty())
+        groups_to_apply = animated_overlay_style_groups(*animated_properties, abstract_element);
+    if (!groups_to_apply.has_value()) {
         counters.animated_style_full_builds++;
         return build_computed_values(computed_properties, abstract_element, style_scope);
     }
@@ -4060,7 +4072,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_animated_computed_value
     VERIFY(computation_context_cache_is_empty());
     ScopeGuard clear_computation_context_cache = [&] { clear_computation_context_caches(); };
     auto color_resolution_context = [&] {
-        if ((groups_to_apply & (1u << to_underlying(StyleGroupIndex::FontValues))) == 0) {
+        if ((*groups_to_apply & (1u << to_underlying(StyleGroupIndex::FontValues))) == 0) {
             return ColorResolutionContext {
                 .color_scheme = previous_values.color_scheme(),
                 .current_color = InitialValues::color(),
@@ -4078,7 +4090,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_animated_computed_value
     }();
 
     auto base_values = ComputedValues::Builder { previous_values.base_values() }.build();
-    auto animated_values = ComputedValues::create_over_base(computed_properties, document(), style_scope, move(color_resolution_context), *base_values, groups_to_apply);
+    auto animated_values = ComputedValues::create_over_base(computed_properties, document(), style_scope, move(color_resolution_context), *base_values, *groups_to_apply);
     ComputedValues::Builder builder { *animated_values };
     ComputedValuesFFI::FfiStyleFinalizationInput finalization_input {};
     finalization_input.mode = ComputedValuesFFI::FfiStyleFinalizationMode::Overflow;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -326,6 +326,7 @@ public:
 private:
     void clear_style_sharing_cache() const;
     [[nodiscard]] NonnullRefPtr<ComputedValues const> build_and_share_computed_values(NonnullRefPtr<ComputedStyleWorkingSet>, DOM::AbstractElement, StyleScope const&, StyleSharingCandidate&) const;
+    [[nodiscard]] Optional<u32> animated_overlay_style_groups(AnimatedProperties const&, DOM::AbstractElement) const;
     [[nodiscard]] static Vector<GC::Ptr<DOM::ShadowRoot const>, 4> author_context_shadow_roots(DOM::AbstractElement);
 
     // The same input, from StyleEngine's own matching. Empty when the engine could not answer for

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -194,7 +194,7 @@ public:
     // `explicitly_inherited_non_inherited_style_groups` reports the style groups whose values the
     // computation read from the half of the style it inherits from that a child normally cannot
     // see, which decides whether its answer can be offered to another element.
-    [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> compute_properties(DOM::AbstractElement, CascadedProperties&, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups = nullptr, StyleRecordID previous_style_record = {}, u32 initial_computed_group_mask = ComputedValues::all_style_groups, bool use_retained_style_computation_selection = false, bool stop_after_longhand_drive = false, u32* selected_computed_group_mask = nullptr, bool* computation_reads_unkeyed_context = nullptr, bool* computation_reads_element_context = nullptr) const;
+    [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> compute_properties(DOM::AbstractElement, CascadedProperties&, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups = nullptr, StyleRecordID previous_style_record = {}, u32 initial_computed_group_mask = ComputedValues::all_style_groups, bool use_retained_style_computation_selection = false, bool stop_after_longhand_drive = false, u32* selected_computed_group_mask = nullptr, bool* computation_reads_unkeyed_context = nullptr, bool* computation_reads_resource_context = nullptr) const;
 
     void process_animation_definitions(ComputedStyleWorkingSet const& computed_properties, CascadedProperties const&, DOM::AbstractElement& abstract_element, ReadonlySpan<AnimationProperties> animation_definitions) const;
 
@@ -300,7 +300,10 @@ public:
         // mint afresh whenever any of them recomputes.
         bool cascade_reads_custom_properties { false };
         bool computation_reads_unkeyed_context { true };
-        bool computation_reads_element_context { true };
+        // Whether a value read the resource context of its declaration, which an input record names
+        // through the declaration's block and a sharing key through the declaration's identity, but a
+        // winner record retained by value does not.
+        bool computation_reads_resource_context { true };
         RefPtr<CustomPropertyData const> pinned_parent_custom_property_data;
         // The style groups whose values the computation read from the inherited style's
         // non-inherited half, which the key does not name.
@@ -410,6 +413,7 @@ private:
         Vector<u64> style_input_declaration_words;
         Vector<NonnullRefPtr<StyleValue const>> pinned_style_input_values;
         bool read_beyond_the_record { false };
+        bool style_reads_resource_context { false };
         bool style_uses_var_css_function { false };
         bool style_uses_inherit_css_function { false };
     };

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -207,6 +207,14 @@ bool StyleEngine::animation_overlay_changed(StyleRecordID old_style_record, void
     return StyleEngineFFI::style_engine_animation_overlay_changed(m_impl, old_style_record.value(), animated_overlay);
 }
 
+Optional<u32> StyleEngine::current_color_dependent_style_groups(StyleNodeID node, u8 pseudo_kind) const
+{
+    auto groups = StyleEngineFFI::style_engine_current_color_dependent_group_mask(m_impl, node.value(), pseudo_kind);
+    if (groups == NumericLimits<u32>::max())
+        return {};
+    return groups;
+}
+
 StyleEngineFFI::FfiAnimationInvalidation StyleEngine::compare_animation_overlay(StyleRecordID old_style_record, void const* animated_overlay, ReadonlySpan<void const*> payloads, bool is_document_element) const
 {
     return StyleEngineFFI::style_engine_compare_animation_overlay(m_impl, old_style_record.value(), animated_overlay, payloads.data(), payloads.size(), is_document_element);

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -111,6 +111,7 @@ public:
     [[nodiscard]] bool style_records_match_for_verification(StyleNodeID, u8 pseudo_kind, StyleRecordID, StyleRecordID) const;
     [[nodiscard]] u32 compare_style_records(StyleRecordID old_style_record, StyleRecordID new_style_record, bool font_lists_equal, bool element_folds_transform_into_layout) const;
     [[nodiscard]] bool animation_overlay_changed(StyleRecordID old_style_record, void const* animated_overlay) const;
+    [[nodiscard]] Optional<u32> current_color_dependent_style_groups(StyleNodeID node, u8 pseudo_kind) const;
     [[nodiscard]] StyleEngineFFI::FfiAnimationInvalidation compare_animation_overlay(StyleRecordID old_style_record, void const* animated_overlay, ReadonlySpan<void const*> payloads, bool is_document_element) const;
     [[nodiscard]] StyleRecordView style_record_view(StyleRecordID style_record) const;
     void decide_transitions(StyleRecordID before_style_record, void const* after_longhand_table, void const* after_animated_overlay, StyleValueFFI::FfiTransitionInput&, StyleValueFFI::FfiTransitionAction*) const;

--- a/Libraries/LibWeb/CSS/StyleInputRecord.h
+++ b/Libraries/LibWeb/CSS/StyleInputRecord.h
@@ -52,6 +52,7 @@ struct StyleInputRecord {
     bool style_depends_on_viewport_metrics { false };
     bool style_depends_on_size_container_query { false };
     bool style_depends_on_style_container_query { false };
+    bool style_reads_resource_context { false };
     u32 explicitly_inherited_non_inherited_style_groups { 0 };
     bool cascade_reads_custom_properties { false };
     // The viewport environment the computation ran under; compared only when it read a viewport metric.

--- a/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
@@ -555,6 +555,7 @@ pub struct FfiStyleComputationRequirements {
     pub environment_requirements: u8,
     pub has_monospace_font_family: bool,
     pub computation_reads_unkeyed_context: bool,
+    pub computation_reads_resource_context: bool,
     pub computed_group_mask: u32,
     pub has_computed_property_selection: bool,
     pub computed_property_words: *const u64,
@@ -779,9 +780,8 @@ pub(crate) unsafe fn collect_style_computation_requirements(
         .into_boxed_slice();
     let (has_monospace_font_family, computed_group_mask, has_computed_property_selection, computed_property_words) =
         unsafe { plan_style_computation(store, plan_input) };
-    let computation_reads_unkeyed_context = has_monospace_font_family
-        || unfixed_random_sharings.iter().any(|sharing| !sharing.element_shared)
-        || has_resource_context_dependent_values;
+    let computation_reads_unkeyed_context =
+        has_monospace_font_family || unfixed_random_sharings.iter().any(|sharing| !sharing.element_shared);
     let storage = Box::new(StyleComputationRequirementsStorage {
         computed_property_words,
         unfixed_random_sharings,
@@ -796,6 +796,7 @@ pub(crate) unsafe fn collect_style_computation_requirements(
         environment_requirements,
         has_monospace_font_family,
         computation_reads_unkeyed_context,
+        computation_reads_resource_context: has_resource_context_dependent_values,
         computed_group_mask,
         has_computed_property_selection,
         computed_property_words,

--- a/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
@@ -27,7 +27,7 @@ use crate::css::parser::value_parser::{
 };
 use crate::css::property_metadata::{
     FIRST_LONGHAND_PROPERTY_ID, LAST_LONGHAND_PROPERTY_ID, LONGHAND_WORD_COUNT, NUMBER_OF_LONGHAND_PROPERTIES,
-    property_is_in_logical_group, property_logical_group,
+    property_computed_dependents, property_is_in_logical_group, property_logical_group,
 };
 use crate::css::retained_fly_string::RetainedUtf16FlyString;
 use crate::css::style_compute::{expand_shorthands_with, font_family_is_monospace};
@@ -630,48 +630,23 @@ fn select_coupled_border_style_and_width_groups(words: &mut [u64]) {
     }
 }
 
-fn property_has_independent_computed_closure(property_id: u16) -> bool {
-    use crate::css::property_metadata::property_id as prop;
-
-    property_is_in_logical_group(property_id)
-        || matches!(
-            property_id,
-            prop::ASPECT_RATIO
-                | prop::BACKDROP_FILTER
-                | prop::BACKGROUND_COLOR
-                | prop::BOX_SHADOW
-                | prop::CLIP_PATH
-                | prop::CX
-                | prop::CY
-                | prop::FILL
-                | prop::FILTER
-                | prop::ISOLATION
-                | prop::MIX_BLEND_MODE
-                | prop::OBJECT_FIT
-                | prop::OBJECT_POSITION
-                | prop::OPACITY
-                | prop::PERSPECTIVE
-                | prop::PERSPECTIVE_ORIGIN
-                | prop::R
-                | prop::ROTATE
-                | prop::RX
-                | prop::RY
-                | prop::SCALE
-                | prop::STROKE
-                | prop::TRANSFORM
-                | prop::TRANSFORM_ORIGIN
-                | prop::TRANSITION_BEHAVIOR
-                | prop::TRANSITION_DELAY
-                | prop::TRANSITION_DURATION
-                | prop::TRANSITION_PROPERTY
-                | prop::TRANSITION_TIMING_FUNCTION
-                | prop::TRANSLATE
-                | prop::VISIBILITY
-                | prop::WILL_CHANGE
-                | prop::X
-                | prop::Y
-                | prop::Z_INDEX
-        )
+fn select_known_computed_dependents(words: &mut [u64]) -> bool {
+    let mut dependents = [0u64; LONGHAND_WORD_COUNT];
+    for property_id in FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID {
+        if !longhand_is_selected(words, property_id) || property_is_in_logical_group(property_id) {
+            continue;
+        }
+        let Some(property_dependents) = property_computed_dependents(property_id) else {
+            return false;
+        };
+        for &dependent in property_dependents {
+            select_longhand(&mut dependents, dependent);
+        }
+    }
+    for (word, dependents) in words.iter_mut().zip(dependents) {
+        *word |= dependents;
+    }
+    true
 }
 
 unsafe fn plan_style_computation(
@@ -718,17 +693,13 @@ unsafe fn plan_style_computation(
         }
         expand_logical_property_closure(&mut computed_property_words);
         select_coupled_border_style_and_width_groups(&mut computed_property_words);
-        let only_independent_properties_changed =
-            (FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID).all(|property_id| {
-                !longhand_is_selected(&computed_property_words, property_id)
-                    || property_has_independent_computed_closure(property_id)
-            });
+        let selected_closure_is_known = select_known_computed_dependents(&mut computed_property_words);
         // A full initial mask can mean the retained selection could not represent an inherited
-        // change. Independent transition properties do not make that missing input safe to skip.
-        // An empty initial mask means neither cascade winners nor inherited groups changed and is
-        // normalized above only because the driver cannot process an empty group selection.
+        // change. A known closure of the changed longhands does not make that missing input safe
+        // to skip. An empty initial mask means neither cascade winners nor inherited groups changed
+        // and is normalized above only because the driver cannot process an empty group selection.
         has_computed_property_selection = retained_selection.computed_property_closure_is_exact
-            || (input.initial_computed_group_mask != input.all_computed_groups && only_independent_properties_changed);
+            || (input.initial_computed_group_mask != input.all_computed_groups && selected_closure_is_known);
     }
     (
         has_monospace_font_family,
@@ -2214,10 +2185,10 @@ mod tests {
     }
 
     #[test]
-    fn computed_property_closure_identifies_independent_properties() {
-        assert!(property_has_independent_computed_closure(prop::OPACITY));
-        assert!(property_has_independent_computed_closure(prop::MARGIN_BLOCK_START));
-        assert!(!property_has_independent_computed_closure(prop::COLOR));
-        assert!(!property_has_independent_computed_closure(prop::FONT_SIZE));
+    fn computed_dependents_are_named_for_independent_properties() {
+        assert_eq!(property_computed_dependents(prop::OPACITY), Some(&[][..]));
+        assert!(property_is_in_logical_group(prop::MARGIN_BLOCK_START));
+        assert!(property_computed_dependents(prop::COLOR).is_none());
+        assert!(property_computed_dependents(prop::FONT_SIZE).is_none());
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
@@ -544,7 +544,7 @@ pub(crate) struct StyleComputationPlanInput<'a> {
     pub retained_selection: Option<crate::css::style::StyleComputationSelection>,
     pub selected_transition_properties: &'a [u16],
     pub has_retained_transition_candidates: bool,
-    pub has_relevant_animations: bool,
+    pub has_relevant_animations_other_than_transitions: bool,
     pub has_css_defined_animations: bool,
 }
 
@@ -693,11 +693,17 @@ unsafe fn plan_style_computation(
     let retained_transition_candidates = input.has_retained_transition_candidates;
     let must_compute_all_properties = previous_values.is_none()
         || has_monospace_font_family
-        || input.has_relevant_animations
+        || input.has_relevant_animations_other_than_transitions
         || input.has_css_defined_animations;
     let mut computed_group_mask = input.initial_computed_group_mask;
-    if must_compute_all_properties || retained_transition_candidates {
+    if must_compute_all_properties {
         computed_group_mask = input.all_computed_groups;
+    } else if computed_group_mask != input.all_computed_groups {
+        // The transition step compares the after-change value of every transition property with
+        // the before-change one, whether or not the cascade delta named the property.
+        for &property_id in input.selected_transition_properties {
+            computed_group_mask |= crate::css::computed_values::computed_group_output_mask(property_id).unwrap_or(0);
+        }
     }
 
     let mut computed_property_words = [0; LONGHAND_WORD_COUNT];

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -147,6 +147,9 @@ pub struct ComputedLonghandTable {
     /// Whether `inheritance_dependent` was seeded from another table, so that a drive over this
     /// one must replace or drop the record of every row it evaluates.
     inheritance_dependent_is_seeded: bool,
+    /// Which longhands have a recorded inheritance-dependent specified value, so a lookup for
+    /// one of the many that do not never walks the list.
+    inheritance_dependent_bits: [u8; LONGHAND_BITMAP_BYTES],
     /// The winning cascaded font-size retained for monospace recascades.
     raw_cascaded_font_size: Option<RetainedStyleValueData>,
     /// The borrowed view over `inheritance_dependent` handed to C++.
@@ -186,6 +189,7 @@ impl ComputedLonghandTable {
             evaluated_bits: [0; LONGHAND_BITMAP_BYTES],
             inheritance_dependent: Vec::new(),
             inheritance_dependent_is_seeded: false,
+            inheritance_dependent_bits: [0; LONGHAND_BITMAP_BYTES],
             inheritance_dependent_view: Vec::new(),
             raw_cascaded_font_size: None,
             metadata: FfiComputedStyleMetadata {
@@ -436,6 +440,7 @@ impl ComputedLonghandTable {
     fn copy_from(&mut self, source: &ComputedLonghandTable) {
         self.copy_values_and_metadata_from(source);
         self.inheritance_dependent.clone_from(&source.inheritance_dependent);
+        self.inheritance_dependent_bits = source.inheritance_dependent_bits;
         self.rebuild_inheritance_dependent_view();
     }
 
@@ -549,6 +554,7 @@ impl ComputedLonghandTable {
         self.evaluated_bits = [0; LONGHAND_BITMAP_BYTES];
         self.metadata.dependency_flags = 0;
         self.inheritance_dependent.clear();
+        self.inheritance_dependent_bits = [0; LONGHAND_BITMAP_BYTES];
         self.inheritance_dependent_view.clear();
         self.raw_cascaded_font_size = None;
         self.post_compute_restore_values = None;
@@ -578,6 +584,7 @@ impl ComputedLonghandTable {
         self.evaluated_bits = [0; LONGHAND_BITMAP_BYTES];
         self.inheritance_dependent.clear();
         self.inheritance_dependent_is_seeded = false;
+        self.inheritance_dependent_bits = [0; LONGHAND_BITMAP_BYTES];
         self.inheritance_dependent_view.clear();
         self.post_compute_restore_values = None;
     }
@@ -595,6 +602,11 @@ impl ComputedLonghandTable {
             Some((_, existing)) => *existing = value,
             None => self.inheritance_dependent.push((property_id, value)),
         }
+        set_bitmap_bit(
+            &mut self.inheritance_dependent_bits,
+            Self::slot_index(property_id),
+            true,
+        );
         self.rebuild_inheritance_dependent_view();
     }
 
@@ -617,16 +629,23 @@ impl ComputedLonghandTable {
             "the computed longhand table is immutable once its style is created"
         );
         if self.inheritance_dependent_is_seeded {
-            let existing = self
-                .inheritance_dependent
-                .iter()
-                .position(|(property, _)| *property == property_id);
+            let slot = Self::slot_index(property_id);
+            let existing = bitmap_bit(&self.inheritance_dependent_bits, slot).then(|| {
+                self.inheritance_dependent
+                    .iter()
+                    .position(|(property, _)| *property == property_id)
+                    .expect("a longhand with a recorded inheritance-dependent value must be listed")
+            });
             match (existing, value) {
                 (Some(index), Some(value)) => self.inheritance_dependent[index].1 = value,
                 (Some(index), None) => {
                     self.inheritance_dependent.swap_remove(index);
+                    set_bitmap_bit(&mut self.inheritance_dependent_bits, slot, false);
                 }
-                (None, Some(value)) => self.inheritance_dependent.push((property_id, value)),
+                (None, Some(value)) => {
+                    self.inheritance_dependent.push((property_id, value));
+                    set_bitmap_bit(&mut self.inheritance_dependent_bits, slot, true);
+                }
                 (None, None) => {}
             }
             return;
@@ -639,6 +658,11 @@ impl ComputedLonghandTable {
         );
         if let Some(value) = value {
             self.inheritance_dependent.push((property_id, value));
+            set_bitmap_bit(
+                &mut self.inheritance_dependent_bits,
+                Self::slot_index(property_id),
+                true,
+            );
         }
     }
 
@@ -659,10 +683,18 @@ impl ComputedLonghandTable {
             return;
         };
         self.inheritance_dependent.swap_remove(index);
+        set_bitmap_bit(
+            &mut self.inheritance_dependent_bits,
+            Self::slot_index(property_id),
+            false,
+        );
         self.rebuild_inheritance_dependent_view();
     }
 
     fn inheritance_dependent_value(&self, property_id: u16) -> Option<&RetainedStyleValueData> {
+        if !bitmap_bit(&self.inheritance_dependent_bits, Self::slot_index(property_id)) {
+            return None;
+        }
         self.inheritance_dependent
             .iter()
             .find(|(property, _)| *property == property_id)

--- a/Libraries/LibWeb/Rust/src/css/property_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/css/property_metadata.rs
@@ -298,6 +298,65 @@ pub(crate) fn property_logical_group(property_id: u16) -> Option<u8> {
     }
 }
 
+/// `None` for a longhand whose readers no fixed list names, among them `color`, `color-scheme` and
+/// the font properties, whose readers are whichever specified values of the element mention them.
+pub(crate) fn property_computed_dependents(property: u16) -> Option<&'static [u16]> {
+    use property_id as prop;
+
+    match property {
+        // NB: The background properties are coordinated at compute time rather than use time.
+        prop::BACKGROUND_IMAGE => Some(&[
+            prop::BACKGROUND_ATTACHMENT,
+            prop::BACKGROUND_CLIP,
+            prop::BACKGROUND_ORIGIN,
+            prop::BACKGROUND_POSITION_X,
+            prop::BACKGROUND_POSITION_Y,
+            prop::BACKGROUND_REPEAT,
+            prop::BACKGROUND_SIZE,
+        ]),
+        prop::ASPECT_RATIO
+        | prop::BACKDROP_FILTER
+        | prop::BACKGROUND_COLOR
+        | prop::BOX_SHADOW
+        | prop::CLIP_PATH
+        | prop::CX
+        | prop::CY
+        | prop::FILL
+        | prop::FILTER
+        | prop::ISOLATION
+        | prop::MIX_BLEND_MODE
+        | prop::OBJECT_FIT
+        | prop::OBJECT_POSITION
+        | prop::OPACITY
+        | prop::PERSPECTIVE
+        | prop::PERSPECTIVE_ORIGIN
+        | prop::R
+        | prop::ROTATE
+        | prop::RX
+        | prop::RY
+        | prop::SCALE
+        | prop::STROKE
+        | prop::TEXT_DECORATION_COLOR
+        | prop::TEXT_DECORATION_LINE
+        | prop::TEXT_DECORATION_STYLE
+        | prop::TEXT_DECORATION_THICKNESS
+        | prop::TRANSFORM
+        | prop::TRANSFORM_ORIGIN
+        | prop::TRANSITION_BEHAVIOR
+        | prop::TRANSITION_DELAY
+        | prop::TRANSITION_DURATION
+        | prop::TRANSITION_PROPERTY
+        | prop::TRANSITION_TIMING_FUNCTION
+        | prop::TRANSLATE
+        | prop::VISIBILITY
+        | prop::WILL_CHANGE
+        | prop::X
+        | prop::Y
+        | prop::Z_INDEX => Some(&[]),
+        _ => None,
+    }
+}
+
 /// Returns whether `a` wins a keyframe declaration conflict with `b`.
 pub(crate) fn animation_property_is_preferred(a: u16, b: u16) -> bool {
     // https://drafts.csswg.org/web-animations-1/#ref-for-computed-keyframes

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -2724,6 +2724,23 @@ pub unsafe extern "C" fn style_engine_animation_overlay_changed(
     engine.animation_overlay_changed(old_style_record, animated_overlay.cast())
 }
 
+/// The style groups that bake a color resolved from a style target's `currentColor`, or
+/// `u32::MAX` when the target holds no retained style to answer from.
+///
+/// # Safety
+/// `engine` must be live for this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn style_engine_current_color_dependent_group_mask(
+    engine: *const c_void,
+    node: u32,
+    pseudo_kind: u8,
+) -> u32 {
+    let engine = unsafe { &*engine.cast::<StyleEngine>() };
+    StyleNodeID::from_raw(node)
+        .and_then(|node| engine.current_color_dependent_group_mask(node, pseudo_kind))
+        .unwrap_or(u32::MAX)
+}
+
 /// Computes property-dependent damage for the sparse changed values in an animation overlay.
 ///
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -3053,6 +3053,14 @@ impl StyleEngine {
             .map(|(_, selection)| *selection)
     }
 
+    pub(crate) fn current_color_dependent_group_mask(&self, node: StyleNodeID, pseudo_kind: u8) -> Option<u32> {
+        let target = computed::ComputedStyleTarget::new(node, pseudo_kind);
+        let dependencies = self.computed_group_sets.current_color_dependency_mask(target)?;
+        let caret_color_group = computed_group_output_mask(crate::css::property_metadata::property_id::CARET_COLOR)?;
+        let accent_color_group = computed_group_output_mask(crate::css::property_metadata::property_id::ACCENT_COLOR)?;
+        Some(dependencies | caret_color_group | accent_color_group)
+    }
+
     unsafe fn cascade_operator_of_style_value(value: *const StyleValueData) -> CascadeOperator {
         let StyleValueData::Keyword { keyword } = (unsafe { &*value }) else {
             return CascadeOperator::Declared;

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -2836,8 +2836,6 @@ impl StyleEngine {
                 self.computed_group_sets
                     .current_color_dependency_properties(dependency_target)
             });
-        let mut computed_property_closure_is_exact = delta.properties().len() == 1
-            && current_color_dependency_properties.is_some_and(|properties| properties.is_some());
         if let Some(Some(dependencies)) = current_color_dependency_properties {
             for (word, dependencies) in computed_property_words.iter_mut().zip(dependencies) {
                 *word |= dependencies;
@@ -2869,10 +2867,6 @@ impl StyleEngine {
                 self.computed_group_sets
                     .color_scheme_dependency_properties(dependency_target)
             });
-        if delta.properties().len() == 1 {
-            computed_property_closure_is_exact |=
-                color_scheme_dependency_properties.is_some_and(|properties| properties.is_some());
-        }
         if let Some(Some(dependencies)) = color_scheme_dependency_properties {
             for (word, dependencies) in computed_property_words.iter_mut().zip(dependencies) {
                 *word |= dependencies;
@@ -2898,13 +2892,38 @@ impl StyleEngine {
                     .any(|property| computed_group_output_mask(property) == Some(font_group_mask)))
             .then(|| self.computed_group_sets.font_dependency_properties(dependency_target))
         });
-        if delta.properties().len() == 1 {
-            computed_property_closure_is_exact |=
-                font_dependency_properties.is_some_and(|properties| properties.is_some());
-        }
         if let Some(Some(dependencies)) = font_dependency_properties {
             for (word, dependencies) in computed_property_words.iter_mut().zip(dependencies) {
                 *word |= dependencies;
+            }
+        }
+        let property_closure_is_known = |property: u16| {
+            if property == crate::css::property_metadata::property_id::COLOR {
+                return current_color_dependency_properties.is_some_and(|properties| properties.is_some());
+            }
+            if property == crate::css::property_metadata::property_id::COLOR_SCHEME {
+                return color_scheme_dependency_properties.is_some_and(|properties| properties.is_some());
+            }
+            if font_group_mask.is_some() && computed_group_output_mask(property) == font_group_mask {
+                return font_dependency_properties.is_some_and(|properties| properties.is_some());
+            }
+            if !(crate::css::property_metadata::FIRST_LONGHAND_PROPERTY_ID
+                ..=crate::css::property_metadata::LAST_LONGHAND_PROPERTY_ID)
+                .contains(&property)
+            {
+                return false;
+            }
+            crate::css::property_metadata::property_is_in_logical_group(property)
+                || crate::css::property_metadata::property_computed_dependents(property).is_some()
+        };
+        let mut computed_property_closure_is_exact =
+            !delta.properties().is_empty() && delta.properties().iter().copied().all(property_closure_is_known);
+        if computed_property_closure_is_exact {
+            for property in delta.properties().iter().copied() {
+                for &dependent in crate::css::property_metadata::property_computed_dependents(property).unwrap_or(&[]) {
+                    let index = usize::from(dependent - crate::css::property_metadata::FIRST_LONGHAND_PROPERTY_ID);
+                    computed_property_words[index / 64] |= 1 << (index % 64);
+                }
             }
         }
         const INHERITED_STATIC_GROUPS: u8 = (1 << 0) | (1 << 1) | (1 << 3);

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -2701,7 +2701,7 @@ pub struct FfiComputePropertiesInput {
     pub use_retained_style_computation_selection: bool,
     pub selected_transition_properties: *const u16,
     pub selected_transition_property_count: usize,
-    pub has_relevant_animations: bool,
+    pub has_relevant_animations_other_than_transitions: bool,
     pub has_css_defined_animations: bool,
     pub stop_after_longhand_drive: bool,
     pub callback_context: *mut c_void,
@@ -5041,7 +5041,7 @@ pub unsafe extern "C" fn rust_compute_properties(input: *const FfiComputePropert
         retained_selection,
         selected_transition_properties: &selected_transition_properties,
         has_retained_transition_candidates,
-        has_relevant_animations: input.has_relevant_animations,
+        has_relevant_animations_other_than_transitions: input.has_relevant_animations_other_than_transitions,
         has_css_defined_animations: input.has_css_defined_animations,
     };
     let requirements =

--- a/Tests/LibWeb/Text/expected/css/style-engine/animated-style-group-overlay.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/animated-style-group-overlay.txt
@@ -2,6 +2,7 @@ transform: matrix(1, 0, 0, 1, 50, 0)
 background: rgb(0, 0, 255)
 opacity: 0.5
 color: rgb(100, 0, 0)
+border color: rgb(100, 0, 0)
 reconstruction fallbacks: none
 overlay builds: some
-full builds: some
+full builds: none

--- a/Tests/LibWeb/Text/expected/css/style-engine/image-reader-takes-partial-drive.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/image-reader-takes-partial-drive.txt
@@ -1,0 +1,6 @@
+recomputes: 1
+full builds: 0
+partial builds: 1
+unrelated longhands skipped: true
+color: rgb(0, 128, 0)
+background-image kept

--- a/Tests/LibWeb/Text/expected/css/style-engine/multi-longhand-computed-closure.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/multi-longhand-computed-closure.txt
@@ -1,0 +1,8 @@
+mark full builds: 0
+mark partial builds: 16
+mark unrelated longhands skipped: true
+mark color: rgb(100, 100, 100) opacity: 0.5 text-decoration-line: line-through
+unmark full builds: 0
+unmark partial builds: 16
+unmark unrelated longhands skipped: true
+unmark color: rgb(0, 0, 0) opacity: 1 text-decoration-line: none

--- a/Tests/LibWeb/Text/expected/css/style-engine/transition-partial-drive.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/transition-partial-drive.txt
@@ -1,0 +1,11 @@
+complete full builds: 0
+complete longhand drive bounded: true
+transitions started: true
+midpoint color: rgb(50, 50, 50)
+midpoint text-decoration-line: line-through
+recompute mid-transition full builds: 0
+running transition kept: true
+running color: rgb(50, 50, 50)
+uncomplete full builds: 0
+uncomplete longhand drive bounded: true
+uncompleted text-decoration-line: none

--- a/Tests/LibWeb/Text/input/css/style-engine/animated-style-group-overlay.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/animated-style-group-overlay.html
@@ -15,7 +15,7 @@
     }
     #slider { animation: slide 1s linear paused; background-color: rgb(0, 0, 255); }
     #fader { animation: fade 1s linear paused; }
-    #tinter { animation: tint 1s linear paused; }
+    #tinter { animation: tint 1s linear paused; border: 1px solid currentcolor; }
 </style>
 <div id="slider">slide</div>
 <div id="fader">fade</div>
@@ -35,9 +35,10 @@
         println(`background: ${getComputedStyle(slider).backgroundColor}`);
         println(`opacity: ${getComputedStyle(fader).opacity}`);
 
-        // A color animation resolves currentcolor consumers baked in other groups, so it takes the
-        // full build.
+        // A color animation also rebuilds the groups whose values are resolved against the
+        // element's color.
         println(`color: ${getComputedStyle(tinter).color}`);
+        println(`border color: ${getComputedStyle(tinter).borderTopColor}`);
 
         const counters = internals.getStyleInvalidationCounters();
         println(`reconstruction fallbacks: ${counters.animatedStyleReconstructionFallbacks > 0 ? "some" : "none"}`);

--- a/Tests/LibWeb/Text/input/css/style-engine/image-reader-takes-partial-drive.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/image-reader-takes-partial-drive.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .image { background-image: url(data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22/%3E) }
+    .image.marked { color: green }
+</style>
+<div id="target" class="image"></div>
+<script>
+    test(() => {
+        const style = getComputedStyle(target);
+        internals.updateStyle();
+        internals.resetStyleInvalidationCounters();
+        target.classList.add("marked");
+        internals.updateStyle();
+        const counters = internals.getStyleInvalidationCounters();
+        println(`recomputes: ${counters.elementStyleRecomputations}`);
+        println(`full builds: ${counters.baseStyleFullBuilds}`);
+        println(`partial builds: ${counters.baseStylePartialBuilds}`);
+        println(`unrelated longhands skipped: ${counters.computedLonghandEvaluations < 100}`);
+        println(`color: ${style.color}`);
+        println(`background-image ${style.backgroundImage.startsWith("url(") ? "kept" : "lost"}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/multi-longhand-computed-closure.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/multi-longhand-computed-closure.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    /* The image keeps the computation out of the engine's own path. */
+    #container > div { color: black; background-image: url(data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22/%3E); }
+    #container > div.marked { color: rgb(100, 100, 100); opacity: 0.5; text-decoration-line: line-through; }
+</style>
+<div id="container"></div>
+<script>
+    test(() => {
+        for (let index = 0; index < 16; ++index) {
+            const child = container.appendChild(document.createElement("div"));
+            child.style.marginLeft = `${index}px`;
+        }
+        internals.updateStyle();
+
+        function mutate(label, mutation) {
+            const before = internals.getStyleInvalidationCounters();
+            mutation();
+            internals.updateStyle();
+            const after = internals.getStyleInvalidationCounters();
+            println(`${label} full builds: ${after.baseStyleFullBuilds - before.baseStyleFullBuilds}`);
+            println(`${label} partial builds: ${after.baseStylePartialBuilds - before.baseStylePartialBuilds}`);
+            println(`${label} unrelated longhands skipped: ${after.computedLonghandEvaluations - before.computedLonghandEvaluations < 800}`);
+            const style = getComputedStyle(container.firstElementChild);
+            println(`${label} color: ${style.color} opacity: ${style.opacity} text-decoration-line: ${style.textDecorationLine}`);
+        }
+
+        mutate("mark", () => { for (const child of container.children) child.classList.add("marked"); });
+        mutate("unmark", () => { for (const child of container.children) child.classList.remove("marked"); });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/transition-partial-drive.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/transition-partial-drive.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    li { color: black; }
+    li > label { transition: color 1s linear; }
+    li.completed > label { color: rgb(100, 100, 100); text-decoration-line: line-through; }
+    li > label.padded { padding-left: 2px; }
+</style>
+<ul id="list"></ul>
+<script>
+    test(() => {
+        for (let index = 0; index < 16; ++index) {
+            const item = list.appendChild(document.createElement("li"));
+            item.appendChild(document.createElement("label")).textContent = `item ${index}`;
+        }
+        internals.updateStyle();
+        const labels = [...list.querySelectorAll("label")];
+
+        function mutate(label, mutation, { checkLonghandDrive = true } = {}) {
+            const before = internals.getStyleInvalidationCounters();
+            mutation();
+            internals.updateStyle();
+            const after = internals.getStyleInvalidationCounters();
+            println(`${label} full builds: ${after.baseStyleFullBuilds - before.baseStyleFullBuilds}`);
+            if (checkLonghandDrive)
+                println(`${label} longhand drive bounded: ${after.computedLonghandEvaluations - before.computedLonghandEvaluations < 4000}`);
+        }
+
+        mutate("complete", () => { for (const item of list.children) item.classList.add("completed"); });
+        println(`transitions started: ${labels.every(label => label.getAnimations().length === 1)}`);
+        for (const label of labels) {
+            const animation = label.getAnimations()[0];
+            animation.pause();
+            animation.currentTime = 500;
+        }
+        println(`midpoint color: ${getComputedStyle(labels[0]).color}`);
+        println(`midpoint text-decoration-line: ${getComputedStyle(labels[0]).textDecorationLine}`);
+
+        mutate("recompute mid-transition", () => { for (const label of labels) label.classList.add("padded"); }, { checkLonghandDrive: false });
+        println(`running transition kept: ${labels.every(label => label.getAnimations().length === 1)}`);
+        println(`running color: ${getComputedStyle(labels[0]).color}`);
+
+        mutate("uncomplete", () => { for (const item of list.children) item.classList.remove("completed"); });
+        println(`uncompleted text-decoration-line: ${getComputedStyle(labels[0]).textDecorationLine}`);
+    });
+</script>


### PR DESCRIPTION
Several common style changes previously forced a full style recomputation even when only a few properties changed: 
* any change to an element with a declared or running transition.
* any change to an element whose style includes an image URL.
* a change to several properties at once, 
* every frame of an animated `color`. 

These commits keep the recomputation limited to the changed properties and whatever depends on them in each of those cases, and make the partial recomputation itself cheaper by indexing the specified values a computed style keeps.

See individual commits for details

This speeds up both Speedometer2 and Speedometer3. StyleBench is flat:

| Benchmark | Old score | New score | Score change | Old time (s) | New time (s) | Speedup |
|---|---|---|---|---|---|---|
| Speedometer 2 | 84.78 ± 0.34 | 85.68 ± 0.22 | +1.07% | 6.245 ± 0.018 | 6.213 ± 0.011 | 1.005× |
| Speedometer 3 | 5.48 ± 0.02 | 5.52 ± 0.03 | +0.62% | 4.613 ± 0.016 | 4.587 ± 0.016 | 1.006× |
| StyleBench | 162.61 ± 0.89 | 162.50 ± 0.87 | -0.07% | 1.527 ± 0.008 | 1.527 ± 0.008 | 1.000× |
