### PR TITLE
LibWeb: Preserve partial relayout caches in tables with anchors

### DIFF
--- a/Libraries/LibWeb/DOM/AnchorNameMap.h
+++ b/Libraries/LibWeb/DOM/AnchorNameMap.h
@@ -21,8 +21,6 @@ public:
     void unregister_name(Utf16FlyString const& name, GC::Ref<Element>);
     GC::Ptr<Element> last_element_by_name_matching(Utf16FlyString const& name, Function<bool(Element&)> const& is_acceptable) const;
 
-    [[nodiscard]] bool has_registered_names() const { return !m_map.is_empty(); }
-
     template<typename Visitor>
     void visit_edges(Visitor& visitor) { visitor.visit(m_map); }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1807,20 +1807,6 @@ void Document::record_partial_relayout_escape(PartialRelayoutEscapeReason reason
         Layout::RustFFI::layout_arena_record_partial_relayout_escape(m_layout_node_arena->handle());
 }
 
-// Anchor names publish geometry that anchor() functions on positioned boxes anywhere in the
-// document consume, and only a full layout pass re-resolves all of them, so anchor positioning
-// in use takes updates off the partial relayout path entirely.
-bool Document::any_anchor_names_are_registered() const
-{
-    if (m_anchor_name_map.has_registered_names())
-        return true;
-    for (auto const& shadow_root : m_shadow_roots) {
-        if (shadow_root.anchor_name_map().has_registered_names())
-            return true;
-    }
-    return false;
-}
-
 void Document::set_needs_container_query_evaluation_after_layout(Element const& query_container)
 {
     m_query_containers_needing_container_query_evaluation_after_layout.set(const_cast<Element&>(query_container));
@@ -2114,7 +2100,6 @@ Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::Ru
         .document_needs_full_layout_tree_update = needs_full_layout_tree_update(),
         .container_query_evaluation_is_pending = !m_query_containers_needing_container_query_evaluation_after_layout.is_empty(),
         .should_collect_devtools_layout_data = should_collect_devtools_layout_data,
-        .any_anchor_names_are_registered = any_anchor_names_are_registered(),
     };
     if (!Layout::RustFFI::layout_arena_partial_relayout_may_be_attempted(
             layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root),

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1507,7 +1507,6 @@ private:
     void update_active_element();
     void collect_boxes_with_auto_content_visibility();
     bool needs_style_update_after_layout();
-    bool any_anchor_names_are_registered() const;
     PartialRelayoutResult try_partial_relayout(Vector<Layout::RustFFI::NodeSlotId> registered_partial_relayout_root_slots, bool& needs_layout_tree_rebuild, bool should_collect_devtools_layout_data);
 
     void process_pending_list_item_renumbers();

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -559,6 +559,7 @@ pub(crate) struct LayoutNodeArena {
     fc_run_cache_store: super::fc_run_cache::FcRunCacheArenaStore,
     pub(crate) paintable_rows: crate::painting::paintable_rows::PaintableRowStore,
     paint_state: RefCell<crate::painting::paint_state::PaintState>,
+    pub(crate) anchor_positioning_nodes: RefCell<HashSet<NodeSlotId>>,
     pub(crate) partial_relayout_boundary_roots: RefCell<Vec<NodeSlotId>>,
     /// Attribution of pending updates for partial relayout. Invariant: every update recorded
     /// since the last layout pass is either attributed to a boundary in the root set above, or
@@ -609,6 +610,7 @@ impl LayoutNodeArena {
             fc_run_cache_store: super::fc_run_cache::FcRunCacheArenaStore::default(),
             paintable_rows: crate::painting::paintable_rows::PaintableRowStore::default(),
             paint_state: RefCell::new(crate::painting::paint_state::PaintState::default()),
+            anchor_positioning_nodes: RefCell::new(HashSet::default()),
             partial_relayout_boundary_roots: RefCell::new(Vec::new()),
             pending_updates_escape_partial_relayout: Cell::new(false),
             boxes_needing_scrollable_overflow_recalculation: RefCell::new(Vec::new()),
@@ -856,6 +858,7 @@ impl LayoutNodeArena {
         if let Some(reset) = paintable_row_reset {
             self.paintable_row_freed(reset);
         }
+        self.anchor_positioning_nodes.get_mut().remove(&id);
         self.pre_order_labels[index as usize].set(0);
         self.metadata_mut(index).occupied = false;
         self.forget_row_sharing_dom_node(id);
@@ -942,9 +945,27 @@ impl LayoutNodeArena {
         self.assert_owner_thread();
         let data = self.data(id);
         data.style.set(payloads);
+        self.update_anchor_positioning_dependency(id);
         self.style_records[id.slot_index() as usize].set(style_record);
         self.enroll_text_children_for_content_sync(id);
         self.enroll_node_for_replaced_content_facts_sync_if_eligible(id);
+    }
+
+    fn update_anchor_positioning_dependency(&self, node: NodeSlotId) {
+        // NB: Anchor names alone do not create a layout dependency. Track consumers, including
+        //     ones whose anchor is currently missing, so a later tree build cannot introduce
+        //     a cross-subtree dependency unnoticed by the partial relayout planner.
+        let depends_on_anchor_positioning = super::node_facts::kind_is_box(self.data(node).kind.get())
+            && self.node_style_if_live(node).is_some_and(|style| {
+                style.is_absolutely_positioned()
+                    && (style_insets_use_anchor_functions(style) || !style.anchor().position_area.as_slice().is_empty())
+            });
+        let mut nodes = self.anchor_positioning_nodes.borrow_mut();
+        if depends_on_anchor_positioning {
+            nodes.insert(node);
+        } else {
+            nodes.remove(&node);
+        }
     }
 
     pub(crate) fn enroll_node_for_svg_paint_resources_sync(&self, id: NodeSlotId) {
@@ -1140,6 +1161,7 @@ impl LayoutNodeArena {
         self.style_records[slot.slot_index() as usize].set(derived.record);
         self.style_records_pinned_by_arena[slot.slot_index() as usize].set(true);
         data.style.set(derived.payloads);
+        self.update_anchor_positioning_dependency(slot);
         self.enroll_node_for_replaced_content_facts_sync_if_eligible(slot);
     }
 
@@ -1193,6 +1215,7 @@ impl LayoutNodeArena {
         assert!(derived.record != 0 && !derived.payloads.is_null());
         let previous_style_record = self.style_records[slot.slot_index() as usize].replace(derived.record);
         self.data(slot).style.set(derived.payloads);
+        self.update_anchor_positioning_dependency(slot);
         self.enroll_text_children_for_content_sync(slot);
         self.enroll_node_for_replaced_content_facts_sync_if_eligible(slot);
         if previous_style_record != derived.record {

--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -200,7 +200,7 @@ impl LayoutNodeArena {
             || self.node_needs_layout_update(root)
             || facts.container_query_evaluation_is_pending
             || facts.should_collect_devtools_layout_data
-            || facts.any_anchor_names_are_registered)
+            || !self.anchor_positioning_nodes.borrow().is_empty())
     }
 
     /// Selects the boundary subtrees to relay out after the layout tree build. Consumes the
@@ -215,7 +215,10 @@ impl LayoutNodeArena {
     ) -> Option<Vec<NodeSlotId>> {
         let pending_updates_escaped =
             self.pending_updates_escape_partial_relayout.replace(false) || layout_tree_update_escaped_rebuild_roots;
-        if self.node_needs_layout_update(root) || pending_updates_escaped {
+        if self.node_needs_layout_update(root)
+            || pending_updates_escaped
+            || !self.anchor_positioning_nodes.borrow().is_empty()
+        {
             return None;
         }
         self.collect_partial_relayout_roots(registered_root_slots, rebuilt_subtree_root_slots)
@@ -510,7 +513,6 @@ pub struct FfiPartialRelayoutHostFacts {
     pub document_needs_full_layout_tree_update: bool,
     pub container_query_evaluation_is_pending: bool,
     pub should_collect_devtools_layout_data: bool,
-    pub any_anchor_names_are_registered: bool,
 }
 
 /// # Safety
@@ -839,7 +841,6 @@ mod tests {
             document_needs_full_layout_tree_update: false,
             container_query_evaluation_is_pending: false,
             should_collect_devtools_layout_data: false,
-            any_anchor_names_are_registered: false,
         }
     }
 
@@ -910,10 +911,6 @@ mod tests {
             },
             FfiPartialRelayoutHostFacts {
                 should_collect_devtools_layout_data: true,
-                ..permitted
-            },
-            FfiPartialRelayoutHostFacts {
-                any_anchor_names_are_registered: true,
                 ..permitted
             },
         ];

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -747,7 +747,13 @@ fn row_containers_in_layout_order<T: TableTree>(tree: &T, table: Node) -> Vec<No
     ordered
 }
 
-pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> TableGrid {
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MissingTableCells {
+    Include,
+    Exclude,
+}
+
+pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node, missing_cells: MissingTableCells) -> TableGrid {
     let mut cells = Vec::new();
     let mut rows = Vec::new();
     let mut occupancy = HashSet::default();
@@ -783,6 +789,11 @@ pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> Table
         }
         let mut current_column = 0usize;
         for cell_box in matching_children(tree, row, |display| display.is_table_cell()) {
+            if missing_cells == MissingTableCells::Exclude
+                && node_facts::has_flag(tree.node_data(cell_box), NodeFlag::IsMissingTableCell)
+            {
+                continue;
+            }
             while current_column < *column_count && occupancy.contains(&(current_column, *current_row)) {
                 current_column += 1;
             }
@@ -2299,7 +2310,7 @@ impl<'pass> TableFormattingContext<'pass> {
     pub(super) fn run_until_inline_size_calculation(&mut self, input: LayoutInput, skip_row_measurement: bool) {
         self.available_space = input.available_space;
         // Determine the number of rows/columns the table requires.
-        let table_grid = calculate_table_grid(self, self.table_box);
+        let table_grid = calculate_table_grid(self, self.table_box, MissingTableCells::Include);
         self.cells = table_grid.cells;
         self.cell_inside_layout_inputs = vec![AvailableSpace::default(); self.cells.len()];
         self.cell_pre_layout_content_block_sizes = vec![CssPixels::default(); self.cells.len()];

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -3810,10 +3810,30 @@ fn fixup_row(
     table_grid: &table_formatting_context::TableGrid,
     row_index: usize,
 ) {
-    for column_index in 0..table_grid.column_count {
-        if table_grid.occupancy.contains(&(column_index, row_index)) {
-            continue;
+    let required_cell_count = (0..table_grid.column_count)
+        .filter(|&column_index| !table_grid.occupancy.contains(&(column_index, row_index)))
+        .count();
+    let mut existing_cells = Vec::new();
+    let mut missing_cells_are_trailing = true;
+    let mut child = host.first_child(row);
+    while !child.is_invalid() {
+        if node_has_flag(host.data(child), NodeFlag::IsMissingTableCell) {
+            existing_cells.push(child);
+        } else if !existing_cells.is_empty() {
+            missing_cells_are_trailing = false;
         }
+        child = host.next_sibling(child);
+    }
+    // OPTIMIZATION: Preserve trailing anonymous cells that still fill the grid. Recreating
+    //               them on every cell-content change invalidates layout and paint caches
+    //               for otherwise untouched rows throughout the table.
+    let retained_cell_count = if missing_cells_are_trailing {
+        existing_cells.len().min(required_cell_count)
+    } else {
+        0
+    };
+    host.remove_nodes(&existing_cells[retained_cell_count..]);
+    for _ in retained_cell_count..required_cell_count {
         let cell = host.create_anonymous_box(
             row,
             FfiAnonymousStyleKind::MissingTableCell,
@@ -3826,33 +3846,17 @@ fn fixup_row(
     }
 }
 
-fn remove_missing_table_cells(host: &TreeBuilderHost<'_>, table_root: LayoutNode) {
-    let mut cells = Vec::new();
-    host.for_each_in_inclusive_subtree(table_root, |node| {
-        let data = host.data(node);
-        if node != table_root
-            && node_kind_is_box(data.kind.get())
-            && display_for_table_fixup(host, node).is_table_inside()
-        {
-            return TraversalDecision::SkipChildrenAndContinue;
-        }
-        if node_has_flag(data, NodeFlag::IsMissingTableCell) {
-            cells.push(node);
-            return TraversalDecision::SkipChildrenAndContinue;
-        }
-        TraversalDecision::Continue
-    });
-    host.remove_nodes(&cells);
-}
-
 fn missing_cells_fixup(host: &TreeBuilderHost<'_>, table_roots: &[LayoutNode]) {
     // https://drafts.csswg.org/css-tables-3/#missing-cells-fixup
     // Once the amount of columns in a table is known, any table-row box must be modified such that it owns enough
     // cells to fill all the columns of the table, when taking spans into account. New table-cell anonymous boxes must
     // be appended to its rows content until this condition is met.
     for &table_root in table_roots {
-        remove_missing_table_cells(host, table_root);
-        let grid = table_formatting_context::calculate_table_grid(host, table_root);
+        let grid = table_formatting_context::calculate_table_grid(
+            host,
+            table_root,
+            table_formatting_context::MissingTableCells::Exclude,
+        );
         for (row_index, row) in grid.rows.iter().enumerate() {
             fixup_row(host, row.box_, &grid, row_index);
         }

--- a/Tests/LibWeb/Text/expected/abspos-relayout-unused-anchor-names.txt
+++ b/Tests/LibWeb/Text/expected/abspos-relayout-unused-anchor-names.txt
@@ -1,0 +1,12 @@
+Move control with unused header anchor: true
+Control position: 30,80
+Insert anchor consumer: true
+Consumer position: 130,40
+Move control with active consumer: true
+Remove last consumer: true
+Hidden consumer: true
+Show consumer: true
+Static consumer: true
+Make consumer positioned again: true
+position-area consumer: true
+Remove position-area dependency: true

--- a/Tests/LibWeb/Text/expected/table-missing-cells-incremental-fixup.txt
+++ b/Tests/LibWeb/Text/expected/table-missing-cells-incremental-fixup.txt
@@ -1,0 +1,11 @@
+Only changed cells need measurement: true
+Control position: 0,40
+Unchanged grid: true
+Grow grid: true
+Shrink grid: true
+Append authored cell: true
+Remove authored cell: true
+Introduce row span: true
+Remove row span: true
+Restyle row: true
+Remove control: true

--- a/Tests/LibWeb/Text/input/abspos-relayout-unused-anchor-names.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-unused-anchor-names.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #header { anchor-name: --menu; width: 100px; height: 20px; }
+    #boundary { position: absolute; left: 30px; top: 40px; width: 300px; }
+    #local-anchor { anchor-name: --line; width: 100px; height: 20px; }
+    table { width: 300px; border-spacing: 0; }
+    td { position: relative; height: 20px; padding: 0; }
+    .control { position: absolute; left: 0; top: 0; width: 20px; height: 20px; }
+    .consumer { position: absolute; position-anchor: --line; left: anchor(right); top: anchor(top); width: 10px; height: 10px; }
+</style>
+<div id="header"></div>
+<div id="boundary"><div id="local-anchor"></div><table><tr><td id="first">First line</td></tr><tr><td id="second">Second line</td></tr></table></div>
+<script>
+    promiseTest(async () => {
+        const results = [];
+        const boundary = document.getElementById("boundary");
+        const first = document.getElementById("first");
+        const second = document.getElementById("second");
+        const control = document.createElement("div");
+        control.className = "control";
+        first.append(control);
+        document.body.offsetHeight;
+
+        function checkLayout(label, mutate, expectPartial) {
+            const partialBefore = internals.partialLayoutCount();
+            const fullBefore = internals.fullLayoutCount();
+            mutate();
+            document.body.offsetHeight;
+            const partial = internals.partialLayoutCount() - partialBefore;
+            const full = internals.fullLayoutCount() - fullBefore;
+            results.push(`${label}: ${expectPartial ? partial > 0 && full === 0 : partial === 0 && full > 0}`);
+        }
+
+        checkLayout("Move control with unused header anchor", () => second.append(control), true);
+        results.push(`Control position: ${control.getBoundingClientRect().x},${control.getBoundingClientRect().y}`);
+
+        // Creating a consumer during the incremental tree build must still force full layout.
+        const consumer = document.createElement("div");
+        consumer.className = "consumer";
+        checkLayout("Insert anchor consumer", () => boundary.append(consumer), false);
+        results.push(`Consumer position: ${consumer.getBoundingClientRect().x},${consumer.getBoundingClientRect().y}`);
+        checkLayout("Move control with active consumer", () => first.append(control), false);
+
+        consumer.remove();
+        document.body.offsetHeight;
+        checkLayout("Remove last consumer", () => second.append(control), true);
+
+        consumer.style.display = "none";
+        boundary.append(consumer);
+        document.body.offsetHeight;
+        checkLayout("Hidden consumer", () => first.append(control), true);
+        checkLayout("Show consumer", () => consumer.style.display = "block", false);
+        consumer.style.position = "static";
+        document.body.offsetHeight;
+        checkLayout("Static consumer", () => second.append(control), true);
+        checkLayout("Make consumer positioned again", () => consumer.style.position = "absolute", false);
+
+        // position-area consumes anchor geometry without an anchor() inset.
+        consumer.style.left = "auto";
+        consumer.style.top = "auto";
+        consumer.style.positionArea = "span-all";
+        document.body.offsetHeight;
+        checkLayout("position-area consumer", () => first.append(control), false);
+        consumer.style.positionArea = "none";
+        document.body.offsetHeight;
+        checkLayout("Remove position-area dependency", () => second.append(control), true);
+
+        results.forEach(println);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/table-missing-cells-incremental-fixup.html
+++ b/Tests/LibWeb/Text/input/table-missing-cells-incremental-fixup.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    table { table-layout: fixed; width: 300px; border-spacing: 0; }
+    td { position: relative; padding: 0; height: 20px; vertical-align: top; }
+    .control { position: absolute; left: 0; top: 0; width: 10px; height: 10px; }
+</style>
+<table><tbody id="rows"><tr><td colspan="3">Header</td></tr></tbody></table>
+<script>
+    test(() => {
+        const results = [];
+        const rows = document.getElementById("rows");
+        for (let index = 0; index < 100; ++index) {
+            const row = rows.insertRow();
+            row.insertCell().textContent = `Line ${index}`;
+        }
+        document.body.offsetHeight;
+        const control = document.createElement("div");
+        control.className = "control";
+        rows.rows[1].cells[0].append(control);
+        document.body.offsetHeight;
+
+        const measurementsBefore = internals.tableCellMeasurementCacheMissCount();
+        rows.rows[2].cells[0].append(control);
+        document.body.offsetHeight;
+        const measurements = internals.tableCellMeasurementCacheMissCount() - measurementsBefore;
+        results.push(`Only changed cells need measurement: ${measurements < 10}`);
+        results.push(`Control position: ${control.getBoundingClientRect().x},${control.getBoundingClientRect().y}`);
+
+        function checkTree(label, mutate) {
+            mutate();
+            document.body.offsetHeight;
+            results.push(`${label}: ${internals.compareLayoutTreeWithFullRebuild().matches}`);
+        }
+        function replaceCellWithSpan(rowIndex, property, value) {
+            const cell = rows.rows[rowIndex].cells[0];
+            const replacement = cell.cloneNode(true);
+            replacement[property] = value;
+            cell.replaceWith(replacement);
+        }
+        checkTree("Unchanged grid", () => {});
+        checkTree("Grow grid", () => replaceCellWithSpan(0, "colSpan", 4));
+        checkTree("Shrink grid", () => replaceCellWithSpan(0, "colSpan", 2));
+        checkTree("Append authored cell", () => rows.rows[3].insertCell().textContent = "New cell");
+        checkTree("Remove authored cell", () => rows.rows[3].deleteCell(1));
+        checkTree("Introduce row span", () => replaceCellWithSpan(1, "rowSpan", 3));
+        checkTree("Remove row span", () => replaceCellWithSpan(1, "rowSpan", 1));
+        checkTree("Restyle row", () => rows.rows[4].style.color = "red");
+        checkTree("Remove control", () => control.remove());
+        results.forEach(println);
+    });
+</script>


### PR DESCRIPTION
Moving comment controls between rows in a large GitHub diff currently falls back to full layout whenever any anchor name is registered. Even after partial relayout, table missing-cell fixup recreates every synthetic trailing cell, invalidating measurement and paint caches across the table.

Track boxes that actually consume anchor geometry, and only disable partial relayout while such consumers exist. During incremental table fixup, calculate the grid without synthetic cells and retain trailing missing cells that are still valid.

In the 100-row regression case, moving a control now needs fewer than 10 cell measurements instead of invalidating cells across all 100 rows. The coverage also checks dynamically inserted, removed, and restyled anchor consumers and verifies table grid mutations against full rebuilds.