### PR TITLE
LibWeb/HTML: Keep the speculative parser out of script and raw text

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -2255,7 +2255,7 @@ void HTMLParser::start_the_speculative_html_parser()
     //    speculative mock elements. Let speculativeParser parse into speculativeDoc.
     // NOTE: The Rust preload scanner emits speculative fetch candidates directly, so we do not materialize a
     // speculativeDoc tree or speculative mock elements.
-    auto speculative_parser = SpeculativeHTMLParser::create(*m_document, m_tokenizer.unparsed_input(), m_document->base_url());
+    auto speculative_parser = SpeculativeHTMLParser::create(*m_document, m_tokenizer.unparsed_input(), m_document->base_url(), m_scripting_mode);
 
     // 5. Set parser's active speculative HTML parser to speculativeParser.
     m_active_speculative_html_parser = speculative_parser;

--- a/Libraries/LibWeb/HTML/Parser/Rust/src/preload_scanner.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/preload_scanner.rs
@@ -7,11 +7,13 @@
 use crate::known_names::attribute_name;
 use crate::known_names::tag_name;
 use crate::token::Attribute;
+use crate::token::HtmlName;
 use crate::token::KnownName;
 use crate::token::Token;
 use crate::token::TokenPayload;
 use crate::token::TokenType;
 use crate::tokenizer::HtmlTokenizer;
+use crate::tokenizer::State;
 use std::ffi::c_void;
 
 #[repr(C)]
@@ -77,6 +79,7 @@ pub struct RustFfiPreloadScannerEntry {
 pub unsafe extern "C" fn rust_html_preload_scanner_scan(
     input: *const u8,
     input_len: usize,
+    scripting_enabled: bool,
     ctx: *mut c_void,
     callback: unsafe extern "C" fn(ctx: *mut c_void, entry: *const RustFfiPreloadScannerEntry) -> bool,
 ) {
@@ -86,7 +89,9 @@ pub unsafe extern "C" fn rust_html_preload_scanner_scan(
         unsafe { std::slice::from_raw_parts(input, input_len) }
     };
 
-    scan(input, |entry| unsafe { callback(ctx, &raw const *entry) });
+    scan(input, scripting_enabled, |entry| unsafe {
+        callback(ctx, &raw const *entry)
+    });
 }
 
 /// Scan pending UTF-16 parser input for resources the speculative HTML parser can fetch.
@@ -98,6 +103,7 @@ pub unsafe extern "C" fn rust_html_preload_scanner_scan(
 pub unsafe extern "C" fn rust_html_preload_scanner_scan_utf16(
     input: *const u16,
     input_len: usize,
+    scripting_enabled: bool,
     ctx: *mut c_void,
     callback: unsafe extern "C" fn(ctx: *mut c_void, entry: *const RustFfiPreloadScannerEntry) -> bool,
 ) {
@@ -107,27 +113,52 @@ pub unsafe extern "C" fn rust_html_preload_scanner_scan_utf16(
         unsafe { std::slice::from_raw_parts(input, input_len) }
     };
 
-    scan_utf16(input, |entry| unsafe { callback(ctx, &raw const *entry) });
+    scan_utf16(input, scripting_enabled, |entry| unsafe {
+        callback(ctx, &raw const *entry)
+    });
 }
 
-pub(crate) fn scan(input: &[u8], mut callback: impl FnMut(&RustFfiPreloadScannerEntry) -> bool) {
+pub(crate) fn scan(
+    input: &[u8],
+    scripting_enabled: bool,
+    mut callback: impl FnMut(&RustFfiPreloadScannerEntry) -> bool,
+) {
     // SAFETY: The FFI entry point guarantees valid UTF-8.
     let code_units = unsafe { std::str::from_utf8_unchecked(input) }.encode_utf16().collect();
-    scan_code_units(code_units, &mut callback);
+    scan_code_units(code_units, scripting_enabled, &mut callback);
 }
 
-pub(crate) fn scan_utf16(input: &[u16], mut callback: impl FnMut(&RustFfiPreloadScannerEntry) -> bool) {
-    scan_code_units(input.to_vec(), &mut callback);
+pub(crate) fn scan_utf16(
+    input: &[u16],
+    scripting_enabled: bool,
+    mut callback: impl FnMut(&RustFfiPreloadScannerEntry) -> bool,
+) {
+    scan_code_units(input.to_vec(), scripting_enabled, &mut callback);
 }
 
-fn scan_code_units(code_units: Vec<u16>, callback: &mut impl FnMut(&RustFfiPreloadScannerEntry) -> bool) {
+fn scan_code_units(
+    code_units: Vec<u16>,
+    scripting_enabled: bool,
+    callback: &mut impl FnMut(&RustFfiPreloadScannerEntry) -> bool,
+) {
     let mut tokenizer = HtmlTokenizer::new(code_units);
     let mut template_depth: u64 = 0;
     let mut foreign_depth: u64 = 0;
 
     while let Some(token) = tokenizer.next_token(false, false) {
         let should_continue = match token.token_type {
-            TokenType::StartTag => process_start_tag(&token, &mut template_depth, &mut foreign_depth, callback),
+            TokenType::StartTag => {
+                let should_continue = process_start_tag(&token, &mut template_depth, &mut foreign_depth, callback);
+
+                // The tree builder switches the tokenizer out of the data state for these elements, so their
+                // contents are text rather than markup. It never does so for foreign content.
+                if foreign_depth == 0
+                    && let Some(state) = tokenizer_state_after_start_tag(token.tag_name(), scripting_enabled)
+                {
+                    tokenizer.switch_to(state);
+                }
+                should_continue
+            }
             TokenType::EndTag => {
                 process_end_tag(&token, &mut template_depth, &mut foreign_depth);
                 true
@@ -186,6 +217,26 @@ fn process_end_tag(token: &Token, template_depth: &mut u64, foreign_depth: &mut 
         *template_depth -= 1;
     } else if (*tag_name == tag_name!("svg") || *tag_name == tag_name!("math")) && *foreign_depth > 0 {
         *foreign_depth -= 1;
+    }
+}
+
+fn tokenizer_state_after_start_tag(tag_name: &HtmlName, scripting_enabled: bool) -> Option<State> {
+    if *tag_name == tag_name!("script") {
+        Some(State::ScriptData)
+    } else if *tag_name == tag_name!("title") || *tag_name == tag_name!("textarea") {
+        Some(State::RCDATA)
+    } else if *tag_name == tag_name!("style")
+        || *tag_name == tag_name!("xmp")
+        || *tag_name == tag_name!("iframe")
+        || *tag_name == tag_name!("noembed")
+        || *tag_name == tag_name!("noframes")
+        || (*tag_name == tag_name!("noscript") && scripting_enabled)
+    {
+        Some(State::RAWTEXT)
+    } else if *tag_name == tag_name!("plaintext") {
+        Some(State::PLAINTEXT)
+    } else {
+        None
     }
 }
 
@@ -438,8 +489,12 @@ mod tests {
     }
 
     fn collect(input: &str) -> Vec<ScannedEntry> {
+        collect_with_scripting(input, true)
+    }
+
+    fn collect_with_scripting(input: &str, scripting_enabled: bool) -> Vec<ScannedEntry> {
         let mut entries = Vec::new();
-        scan(input.as_bytes(), |entry| {
+        scan(input.as_bytes(), scripting_enabled, |entry| {
             let url = unsafe { std::slice::from_raw_parts(entry.url_ptr, entry.url_len) };
             entries.push(ScannedEntry {
                 action: entry.action,
@@ -455,7 +510,7 @@ mod tests {
     fn collect_utf16(input: &str) -> Vec<ScannedEntry> {
         let input = input.encode_utf16().collect::<Vec<_>>();
         let mut entries = Vec::new();
-        scan_utf16(&input, |entry| {
+        scan_utf16(&input, true, |entry| {
             let url = unsafe { std::slice::from_raw_parts(entry.url_ptr, entry.url_len) };
             entries.push(ScannedEntry {
                 action: entry.action,
@@ -618,11 +673,88 @@ mod tests {
         );
     }
 
+    fn collect_urls(input: &str, scripting_enabled: bool) -> Vec<String> {
+        collect_with_scripting(input, scripting_enabled)
+            .into_iter()
+            .map(|entry| entry.url)
+            .collect()
+    }
+
+    #[test]
+    fn does_not_scan_markup_inside_script_text() {
+        let urls = collect_urls(
+            r#"
+                <script>
+                    var g = ["", "app.js"];
+                    document.write('<script src="https://example.com/' +
+                        g[1] +
+                        '"><\/script>');
+                </script>
+                <img src="./after.png">
+            "#,
+            true,
+        );
+
+        assert_eq!(urls, vec!["./after.png".to_string()]);
+    }
+
+    #[test]
+    fn does_not_scan_markup_inside_raw_text_and_rcdata_elements() {
+        let urls = collect_urls(
+            r#"
+                <style>/* <img src="./style.png"> */</style>
+                <title><img src="./title.png"></title>
+                <textarea><img src="./textarea.png"></textarea>
+                <xmp><script src="./xmp.js"></script></xmp>
+                <iframe><img src="./iframe.png"></iframe>
+                <noembed><img src="./noembed.png"></noembed>
+                <noframes><img src="./noframes.png"></noframes>
+                <img src="./after.png">
+            "#,
+            true,
+        );
+
+        assert_eq!(urls, vec!["./after.png".to_string()]);
+    }
+
+    #[test]
+    fn noscript_content_is_raw_text_only_when_scripting_is_enabled() {
+        let input = r#"<noscript><img src="./fallback.png"></noscript>"#;
+
+        assert_eq!(collect_urls(input, true), Vec::<String>::new());
+        assert_eq!(collect_urls(input, false), vec!["./fallback.png".to_string()]);
+    }
+
+    #[test]
+    fn script_text_cannot_close_a_template() {
+        let urls = collect_urls(
+            r#"<template><script>"</template><img src="./trap.png">"</script></template><img src="./after.png">"#,
+            true,
+        );
+
+        assert_eq!(urls, vec!["./after.png".to_string()]);
+    }
+
+    #[test]
+    fn foreign_content_elements_do_not_switch_tokenizer_state() {
+        let urls = collect_urls(r#"<svg><title>SVG</svg><img src="./after.png">"#, true);
+
+        assert_eq!(urls, vec!["./after.png".to_string()]);
+    }
+
+    #[test]
+    fn plaintext_ends_markup() {
+        let urls = collect_urls(r#"<plaintext><img src="./trap.png">"#, true);
+
+        assert_eq!(urls, Vec::<String>::new());
+    }
+
     #[test]
     fn preserves_modulepreload_fetch_options() {
         let mut options = None;
         scan(
             br#"<link rel="modulepreload" href="./module" nonce="abc" integrity="sha256-xyz" referrerpolicy="origin" fetchpriority="high" media="screen">"#,
+            true,
             |entry| {
                 let string = |pointer, length| {
                     let bytes = unsafe { std::slice::from_raw_parts(pointer, length) };

--- a/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
@@ -26,15 +26,16 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(SpeculativeHTMLParser);
 
-GC::Ref<SpeculativeHTMLParser> SpeculativeHTMLParser::create(GC::Ref<DOM::Document> document, Utf16String pending_input, URL::URL base_url)
+GC::Ref<SpeculativeHTMLParser> SpeculativeHTMLParser::create(GC::Ref<DOM::Document> document, Utf16String pending_input, URL::URL base_url, ParserScriptingMode scripting_mode)
 {
-    return document->relevant_settings_object().realm().create<SpeculativeHTMLParser>(document, move(pending_input), move(base_url));
+    return document->relevant_settings_object().realm().create<SpeculativeHTMLParser>(document, move(pending_input), move(base_url), scripting_mode);
 }
 
-SpeculativeHTMLParser::SpeculativeHTMLParser(GC::Ref<DOM::Document> document, Utf16String pending_input, URL::URL base_url)
+SpeculativeHTMLParser::SpeculativeHTMLParser(GC::Ref<DOM::Document> document, Utf16String pending_input, URL::URL base_url, ParserScriptingMode scripting_mode)
     : m_document(document)
     , m_input(move(pending_input))
     , m_base_url(move(base_url))
+    , m_scripting_mode(scripting_mode)
 {
 }
 
@@ -68,13 +69,14 @@ void SpeculativeHTMLParser::run()
         return !parser.m_stopped;
     };
 
+    auto scripting_enabled = m_scripting_mode != ParserScriptingMode::Disabled;
     auto input = m_input.utf16_view();
     if (input.has_ascii_storage()) {
         auto bytes = input.bytes();
-        rust_html_preload_scanner_scan(bytes.data(), bytes.size(), this, scanner_callback);
+        rust_html_preload_scanner_scan(bytes.data(), bytes.size(), scripting_enabled, this, scanner_callback);
     } else {
         auto code_units = input.utf16_span();
-        rust_html_preload_scanner_scan_utf16(reinterpret_cast<u16 const*>(code_units.data()), code_units.size(), this, scanner_callback);
+        rust_html_preload_scanner_scan_utf16(reinterpret_cast<u16 const*>(code_units.data()), code_units.size(), scripting_enabled, this, scanner_callback);
     }
 }
 

--- a/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.h
@@ -11,6 +11,7 @@
 #include <LibJS/Heap/Cell.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/Parser/ParserScriptingMode.h>
 
 struct RustFfiPreloadScannerEntry;
 
@@ -22,7 +23,7 @@ class SpeculativeHTMLParser final : public JS::Cell {
     GC_DECLARE_ALLOCATOR(SpeculativeHTMLParser);
 
 public:
-    static GC::Ref<SpeculativeHTMLParser> create(GC::Ref<DOM::Document>, Utf16String pending_input, URL::URL base_url);
+    static GC::Ref<SpeculativeHTMLParser> create(GC::Ref<DOM::Document>, Utf16String pending_input, URL::URL base_url, ParserScriptingMode);
 
     virtual ~SpeculativeHTMLParser() override;
 
@@ -30,7 +31,7 @@ public:
     void stop();
 
 private:
-    SpeculativeHTMLParser(GC::Ref<DOM::Document>, Utf16String pending_input, URL::URL base_url);
+    SpeculativeHTMLParser(GC::Ref<DOM::Document>, Utf16String pending_input, URL::URL base_url, ParserScriptingMode);
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
     void process_preload_scanner_entry(RustFfiPreloadScannerEntry const&);
@@ -38,6 +39,7 @@ private:
     GC::Ref<DOM::Document> m_document;
     Utf16String m_input;
     URL::URL m_base_url;
+    ParserScriptingMode m_scripting_mode {};
     bool m_stopped { false };
 };
 

--- a/Tests/LibWeb/Text/expected/HTML/speculative-html-parser/script-text-is-not-scanned.txt
+++ b/Tests/LibWeb/Text/expected/HTML/speculative-html-parser/script-text-is-not-scanned.txt
@@ -1,0 +1,3 @@
+PASS: speculative parser fetched the image while the parser was blocked
+PASS: speculative parser did not fetch the script URL inside script text
+PASS: document.write() inserted script was fetched

--- a/Tests/LibWeb/Text/input/HTML/speculative-html-parser/script-text-is-not-scanned.html
+++ b/Tests/LibWeb/Text/input/HTML/speculative-html-parser/script-text-is-not-scanned.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const server = httpTestServer();
+        const run = crypto.randomUUID();
+        const parserGate = `${run}-parser`;
+        const path = name => `/speculative-html-parser-${run}-${name}`;
+        const javascriptHeaders = { "Content-Type": "text/javascript" };
+
+        const parserBlockerURL = await server.createEcho("GET", path("parser-blocker.js"), {
+            status: 200,
+            headers: javascriptHeaders,
+            body: "",
+            wait_for_unblock: parserGate,
+        });
+        const trapURL = await server.createEcho("GET", path("trap.js"), {
+            status: 200,
+            headers: javascriptHeaders,
+            body: "",
+        });
+        const writtenURL = await server.createEcho("GET", path("written.js"), {
+            status: 200,
+            headers: javascriptHeaders,
+            body: "",
+        });
+        const imageURL = await server.createEcho("GET", path("image.png"), {
+            status: 200,
+            headers: { "Content-Type": "image/png" },
+            body: "",
+        });
+
+        // While the parser is blocked on the first script, the speculative parser scans the rest of the page. The
+        // trap URL only ever appears inside script text, so nothing may fetch it.
+        const scriptStartTag = "<scr" + "ipt";
+        const scriptEndTag = "</scr" + "ipt>";
+        const pageBody = `<!DOCTYPE html>
+            ${scriptStartTag} src="${parserBlockerURL}">${scriptEndTag}
+            ${scriptStartTag}>
+                var trap = '${scriptStartTag} src="${trapURL}"><\\/script>';
+                document.write('${scriptStartTag} src="${writtenURL}"><\\/script>');
+            ${scriptEndTag}
+            <img src="${imageURL}">`;
+        const pageURL = await server.createEcho("GET", path("page.html"), {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: pageBody,
+        });
+
+        const hasRecordedRequest = async url => {
+            try {
+                const response = await fetch(`${server.baseURL}/recorded-request-headers${new URL(url).pathname}`);
+                return response.ok;
+            } catch {
+                return false;
+            }
+        };
+
+        const frame = document.createElement("iframe");
+        const frameLoaded = new Promise(resolve => (frame.onload = resolve));
+        frame.src = pageURL;
+        document.body.appendChild(frame);
+
+        // Only the speculative parser can request the image while the parser-blocking script is held.
+        while (!(await hasRecordedRequest(imageURL))) {}
+        println("PASS: speculative parser fetched the image while the parser was blocked");
+
+        await fetch(`${server.baseURL}/unblock/${parserGate}`);
+        await frameLoaded;
+
+        const trapFetched = await hasRecordedRequest(trapURL);
+        println(`${trapFetched ? "FAIL" : "PASS"}: speculative parser did not fetch the script URL inside script text`);
+        const writtenFetched = await hasRecordedRequest(writtenURL);
+        println(`${writtenFetched ? "PASS" : "FAIL"}: document.write() inserted script was fetched`);
+        done();
+    });
+</script>


### PR DESCRIPTION
The preload scanner drives the tokenizer without a tree builder, so nothing ever moved it into the script data, RAWTEXT, RCDATA or PLAINTEXT states. Any markup-looking string inside a <script>, <style>, <textarea> and friends was tokenized as real elements and speculatively fetched.

Fixes gog.com requesting a garbage script URL assembled from the pieces of a document.write() call inside an inline script.

Found while investigating https://github.com/LadybirdBrowser/ladybird/issues/11710