### PR TITLE
LibWeb/SVG: Compare use element references against the base URL

### DIFF
--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -203,7 +203,7 @@ void SVGUseElement::process_the_url(Optional<Utf16String> const& href)
 
 bool SVGUseElement::is_referenced_element_same_document() const
 {
-    return m_href->equals(document().url(), URL::ExcludeFragment::Yes);
+    return m_href->equals(document().base_url(), URL::ExcludeFragment::Yes);
 }
 
 Gfx::AffineTransform SVGUseElement::additional_element_transform() const

--- a/Tests/LibWeb/Text/expected/SVG/use-element-fragment-href-under-base-element.txt
+++ b/Tests/LibWeb/Text/expected/SVG/use-element-fragment-href-under-base-element.txt
@@ -1,0 +1,1 @@
+Base URL differs from document URL: has instance root: true

--- a/Tests/LibWeb/Text/input/SVG/use-element-fragment-href-under-base-element.html
+++ b/Tests/LibWeb/Text/input/SVG/use-element-fragment-href-under-base-element.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<base href="not-the-document-url/">
+<svg style="display: none">
+    <symbol id="target"><rect width="10" height="10" /></symbol>
+    <use href="#target" />
+</svg>
+<script>
+    test(() => {
+        // The fragment-only href resolves against the base URL, which no longer matches the document URL. It must
+        // still be treated as a reference into this document rather than an external document to fetch.
+        const use = document.querySelector("use");
+        println(`Base URL differs from document URL: has instance root: ${!!internals.getShadowRoot(use).firstElementChild}`);
+    });
+</script>


### PR DESCRIPTION
Otherwise, a fragment-only href resolved against a `<base>` that points elsewhere is treated as an external reference, which fetches the base URL for every use element and renders none of them.

Fixes gog.com fetching its own front page once per SVG icon.

Found while investigating https://github.com/LadybirdBrowser/ladybird/issues/11710