### PR TITLE
LibWeb: Merge sorted custom property name lists when indexing elements

### DIFF
--- a/AK/SetUnion.h
+++ b/AK/SetUnion.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/StdLibExtras.h>
+
+namespace AK {
+
+template<typename Collection>
+concept SortedCollection = requires(Collection const& collection, size_t index) {
+    collection.size();
+    collection[index];
+};
+
+namespace Detail {
+
+template<SortedCollection Collection, typename Comparator>
+constexpr bool is_sorted_without_duplicates(Collection const& collection, Comparator const& less_than)
+{
+    for (size_t index = 1; index < collection.size(); ++index) {
+        if (!less_than(collection[index - 1], collection[index]))
+            return false;
+    }
+    return true;
+}
+
+}
+
+template<SortedCollection Left, SortedCollection Right, typename Output, typename Comparator>
+void set_union(Left const& left, Right const& right, Output& output, Comparator less_than)
+{
+    VERIFY(static_cast<void const*>(&output) != static_cast<void const*>(&left));
+    VERIFY(static_cast<void const*>(&output) != static_cast<void const*>(&right));
+    ASSERT(Detail::is_sorted_without_duplicates(left, less_than));
+    ASSERT(Detail::is_sorted_without_duplicates(right, less_than));
+    size_t left_index = 0;
+    size_t right_index = 0;
+    while (left_index < left.size() && right_index < right.size()) {
+        if (less_than(left[left_index], right[right_index])) {
+            output.append(left[left_index++]);
+        } else if (less_than(right[right_index], left[left_index])) {
+            output.append(right[right_index++]);
+        } else {
+            output.append(left[left_index++]);
+            ++right_index;
+        }
+    }
+    for (; left_index < left.size(); ++left_index)
+        output.append(left[left_index]);
+    for (; right_index < right.size(); ++right_index)
+        output.append(right[right_index]);
+}
+
+template<SortedCollection Left, SortedCollection Right, typename Output>
+void set_union(Left const& left, Right const& right, Output& output)
+{
+    set_union(left, right, output, [](auto const& a, auto const& b) { return a < b; });
+}
+
+}
+
+#if USING_AK_GLOBALLY
+using AK::set_union;
+#endif

--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/QuickSort.h>
+#include <AK/SetUnion.h>
 #include <LibWeb/CSS/CSSPropertyRule.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/Invalidation/LanguageInvalidator.h>
@@ -862,26 +863,44 @@ void record_element_custom_property_names(DOM::Element& element, CustomPropertyD
     if (!style_engine || element.style_node_id() == no_style_node)
         return;
 
+    // OPTIMIZATION: Each environment hands out its declared names sorted and deduplicated, so they are merged
+    //               rather than sorted once more for every element that holds that environment.
+    ReadonlySpan<StyleAtomID> published;
     Vector<StyleAtomID> atoms;
-    auto append_declared_names = [&](CustomPropertyData const* custom_property_data) {
-        if (!custom_property_data)
+    Vector<StyleAtomID> merged;
+    auto merge_names = [&](ReadonlySpan<StyleAtomID> names) {
+        if (names.is_empty())
             return;
-        auto names = custom_property_data->declared_name_atoms(bit_cast<FlatPtr>(&element.document()), style_engine->atom_generation(), [&](Utf16FlyString const& name) { return style_engine->intern_atom(name); });
-        atoms.append(names.data(), names.size());
+        if (published.is_empty()) {
+            published = names;
+            return;
+        }
+        merged.clear_with_capacity();
+        merged.ensure_capacity(published.size() + names.size());
+        set_union(published, names, merged);
+        swap(atoms, merged);
+        published = atoms;
     };
-    append_declared_names(data);
+    Vector<CustomPropertyData const*, 4> merged_environments;
+    auto merge_declared_names = [&](CustomPropertyData const* custom_property_data) {
+        if (!custom_property_data || merged_environments.contains_slow(custom_property_data))
+            return;
+        merged_environments.append(custom_property_data);
+        merge_names(custom_property_data->declared_name_atoms(bit_cast<FlatPtr>(&element.document()), style_engine->atom_generation(), [&](Utf16FlyString const& name) { return style_engine->intern_atom(name); }));
+    };
+    merge_declared_names(data);
     for (auto const& pseudo_data : pseudo_element_data)
-        append_declared_names(pseudo_data.ptr());
-    for (auto const& name : references)
-        atoms.append(style_engine->intern_atom(name));
-    quick_sort(atoms);
-    size_t unique_count = 0;
-    for (size_t index = 0; index < atoms.size(); ++index) {
-        if (index == 0 || atoms[index] != atoms[unique_count - 1])
-            atoms[unique_count++] = atoms[index];
+        merge_declared_names(pseudo_data.ptr());
+    // The references arrive deduplicated, and interning is injective, so their atoms only need sorting.
+    Vector<StyleAtomID> reference_atoms;
+    if (!references.is_empty()) {
+        reference_atoms.ensure_capacity(references.size());
+        for (auto const& name : references)
+            reference_atoms.unchecked_append(style_engine->intern_atom(name));
+        quick_sort(reference_atoms);
+        merge_names(reference_atoms);
     }
-    atoms.shrink(unique_count);
-    style_engine->set_element_custom_property_names(element.style_node_id(), atoms, uses_unnamed, uses_custom_functions);
+    style_engine->set_element_custom_property_names(element.style_node_id(), published, uses_unnamed, uses_custom_functions);
 }
 
 void record_element_custom_property_names(DOM::Element& element, ReadonlySpan<Utf16FlyString> names, bool uses_unnamed, bool uses_custom_functions)

--- a/Libraries/LibWeb/CSS/StyleEngineInput.h
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.h
@@ -116,7 +116,8 @@ WEB_API void record_element_custom_property_names(DOM::Element&, ReadonlySpan<Ut
 
 // The same index, from the environments the element and its pseudo-elements resolved to, plus
 // names read outside substitution (for example by style queries). The names each environment
-// declares are interned into engine identities once for that environment.
+// declares are interned into engine identities once for that environment. The references must hold
+// no duplicates.
 WEB_API void record_element_custom_property_names(DOM::Element&, CustomPropertyData const*, ReadonlySpan<RefPtr<CustomPropertyData const>> pseudo_element_data, ReadonlySpan<Utf16FlyString> references, bool uses_unnamed, bool uses_custom_functions);
 
 // Report that a child of an element arrived, left, or changed in a way that can move whether the

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -58,6 +58,7 @@ set(AK_TEST_SOURCES
     TestRedBlackTree.cpp
     TestRefPtr.cpp
     TestSeqLock.cpp
+    TestSetUnion.cpp
     TestSingleProducerCircularQueue.cpp
     TestSinglyLinkedList.cpp
     TestSourceGenerator.cpp

--- a/Tests/AK/TestSetUnion.cpp
+++ b/Tests/AK/TestSetUnion.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Array.h>
+#include <AK/SetUnion.h>
+#include <AK/Vector.h>
+
+TEST_CASE(appends_shared_elements_once)
+{
+    Vector<int> left { 1, 3, 5, 9 };
+    Array<int, 4> right_storage { 2, 3, 5, 6 };
+    ReadonlySpan<int> right = right_storage;
+    Vector<int> output;
+    set_union(left, right, output);
+    EXPECT_EQ(output, (Vector<int> { 1, 2, 3, 5, 6, 9 }));
+}
+
+TEST_CASE(takes_shared_elements_from_the_left)
+{
+    struct Item {
+        int key;
+        char side;
+        bool operator==(Item const&) const = default;
+    };
+    Vector<Item> left { { 1, 'l' }, { 2, 'l' } };
+    Vector<Item> right { { 2, 'r' }, { 3, 'r' } };
+    Vector<Item> output;
+    set_union(left, right, output, [](Item const& a, Item const& b) { return a.key < b.key; });
+    EXPECT_EQ(output, (Vector<Item> { { 1, 'l' }, { 2, 'l' }, { 3, 'r' } }));
+}
+
+TEST_CASE(merges_with_a_comparator)
+{
+    Vector<int> left { 9, 5, 1 };
+    Vector<int> right { 7, 5, 2 };
+    Vector<int> output;
+    set_union(left, right, output, [](int a, int b) { return a > b; });
+    EXPECT_EQ(output, (Vector<int> { 9, 7, 5, 2, 1 }));
+}
+
+TEST_CASE(merges_with_an_empty_side)
+{
+    Vector<int> empty;
+    Vector<int> values { 4, 8 };
+    Vector<int> output;
+    set_union(empty, values, output);
+    EXPECT_EQ(output, values);
+    output.clear();
+    set_union(values, empty, output);
+    EXPECT_EQ(output, values);
+    output.clear();
+    set_union(empty, empty, output);
+    EXPECT(output.is_empty());
+}
+
+TEST_CASE(rejects_an_output_that_is_an_input)
+{
+    Vector<int> values { 1, 2 };
+    Vector<int> other { 3 };
+    EXPECT_DEATH("merging into the left input", set_union(values, other, values));
+    EXPECT_DEATH("merging into the right input", set_union(other, values, values));
+}


### PR DESCRIPTION
An element that declares no custom properties shares the environment of its nearest declaring ancestor, so the names it publishes to the style engine index are the names that ancestor declared. Every such element copied that list and sorted all of it before publishing, so the cost of indexing an element grew with the number of custom properties declared by its ancestors. Each environment already caches its declared names sorted and deduplicated, so we now merge them with the element's own references instead.

This improves performance of Speedometer3:
| Benchmark | Old score | New score | Score change | Old time (s) | New time (s) | Speedup |
|---|---|---|---|---|---|---|
| Speedometer2 | 85.59 ± 0.39 | 85.89 ± 0.36 | +0.34% | 6.171 ± 0.014 | 6.142 ± 0.017 | 1.005× |
| Speedometer3 | 5.56 ± 0.02 | 5.66 ± 0.03 | +1.86% | 4.557 ± 0.015 | 4.498 ± 0.014 | 1.013× |
| StyleBench | 162.79 ± 0.78 | 163.19 ± 0.84 | +0.25% | 1.525 ± 0.007 | 1.522 ± 0.007 | 1.002× |