### PR TITLE
LibMedia+LibWeb: Fix some issues with video frame pools

### DIFF
--- a/Libraries/LibCore/IOSurface.cpp
+++ b/Libraries/LibCore/IOSurface.cpp
@@ -110,6 +110,11 @@ void IOSurfaceHandle::decrement_use_count()
     IOSurfaceDecrementUseCount(m_ref_wrapper->ref);
 }
 
+bool IOSurfaceHandle::is_in_use() const
+{
+    return IOSurfaceIsInUse(m_ref_wrapper->ref);
+}
+
 ErrorOr<IOSurfaceHandle> IOSurfaceHandle::from_mach_port(MachPort const& port)
 {
     // NOTE: This call does not destroy the port

--- a/Libraries/LibCore/IOSurface.h
+++ b/Libraries/LibCore/IOSurface.h
@@ -31,6 +31,7 @@ public:
     // make it used.
     void increment_use_count();
     void decrement_use_count();
+    bool is_in_use() const;
 
     MachPort create_mach_port() const;
 

--- a/Libraries/LibIPC/TransportMachPort.cpp
+++ b/Libraries/LibIPC/TransportMachPort.cpp
@@ -320,25 +320,26 @@ void TransportMachPort::send_mach_message(PendingMessage& msg)
     header->msgh_id = send_payload_inline ? IPC_INLINE_DATA_MESSAGE_ID : IPC_DATA_MESSAGE_ID;
 
     u8* inline_payload = nullptr;
+    mach_msg_port_descriptor_t* port_descriptors = nullptr;
     if (port_count > 0 || !send_payload_inline) {
         header->msgh_bits |= MACH_MSGH_BITS_COMPLEX;
 
         auto* body = reinterpret_cast<mach_msg_body_t*>(header + 1);
         body->msgh_descriptor_count = port_count + (send_payload_inline ? 0 : 1);
 
-        auto* desc_ptr = reinterpret_cast<mach_msg_port_descriptor_t*>(body + 1);
+        port_descriptors = reinterpret_cast<mach_msg_port_descriptor_t*>(body + 1);
         for (size_t i = 0; i < port_count; ++i) {
             auto disposition = static_cast<mach_msg_type_name_t>(attachments[i].message_right());
             auto port = attachments[i].release_mach_port();
-            desc_ptr[i].name = port.release();
-            desc_ptr[i].disposition = disposition;
-            desc_ptr[i].type = MACH_MSG_PORT_DESCRIPTOR;
+            port_descriptors[i].name = port.release();
+            port_descriptors[i].disposition = disposition;
+            port_descriptors[i].type = MACH_MSG_PORT_DESCRIPTOR;
         }
 
         if (send_payload_inline) {
-            inline_payload = reinterpret_cast<u8*>(&desc_ptr[port_count]);
+            inline_payload = reinterpret_cast<u8*>(&port_descriptors[port_count]);
         } else {
-            auto* ool_desc = reinterpret_cast<mach_msg_ool_descriptor_t*>(&desc_ptr[port_count]);
+            auto* ool_desc = reinterpret_cast<mach_msg_ool_descriptor_t*>(&port_descriptors[port_count]);
             ool_desc->address = const_cast<void*>(static_cast<void const*>(bytes.data()));
             ool_desc->size = bytes.size();
             ool_desc->deallocate = false;
@@ -371,6 +372,12 @@ void TransportMachPort::send_mach_message(PendingMessage& msg)
     // Small payloads are copied inline to avoid allocating a VM region for the out-of-line descriptor path.
     auto const ret = mach_msg(header, MACH_SEND_MSG, msg_size, 0, MACH_PORT_NULL, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
     if (ret != KERN_SUCCESS) {
+        if (ret == MACH_SEND_INVALID_DEST) {
+            for (size_t i = 0; i < port_count; ++i) {
+                auto dropped_attachment = attachment_from_descriptor(port_descriptors[i]);
+                (void)dropped_attachment;
+            }
+        }
         dbgln("TransportMachPort: send failed: {} (send_port={:x})", mach_error_string(ret), m_send_port.port());
         mark_peer_eof();
     }

--- a/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
@@ -117,7 +117,7 @@ FFmpegVideoDecoder::FFmpegVideoDecoder(AVCodecContext* codec_context, AVPacket* 
 
 FFmpegVideoDecoder::~FFmpegVideoDecoder()
 {
-    m_frame_pool->shed_buffers();
+    m_frame_pool->shed_storage();
     av_packet_free(&m_packet);
     av_frame_free(&m_frame);
     avcodec_free_context(&m_codec_context);

--- a/Libraries/LibMedia/Producers/RemoteVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/RemoteVideoProducer.cpp
@@ -47,6 +47,7 @@ void RemoteVideoProducer::release_ring_contents_if_suspended()
         return;
 
     release_all_ring_frames();
+    m_slot_directory->notify_all_pools_retired();
 }
 
 void RemoteVideoProducer::discard_ring_head(VideoEdgeItem const& head)

--- a/Libraries/LibMedia/VideoFramePool.cpp
+++ b/Libraries/LibMedia/VideoFramePool.cpp
@@ -150,6 +150,8 @@ ErrorOr<NonnullRefPtr<PooledVideoFrameSlot>> VideoFramePool::try_adopt_acquired_
 void VideoFrameEntryLedger::publish_acquisition_while_locked(Slot& slot)
 {
     m_shed_storage_on_release = false;
+    if (slot.surface != nullptr)
+        slot.surface_use = slot.surface->begin_use();
     slot.hold_count = 1;
     slot.last_slot_acquisition_id++;
     slot_header(slot.buffer).slot_acquisition_id.store(slot.last_slot_acquisition_id);
@@ -235,6 +237,8 @@ void VideoFrameEntryLedger::release_hold(u32 slot_index)
         VERIFY(slot.hold_count > 0);
         if (--slot.hold_count > 0)
             return;
+        // The decoder is free to hand this surface back now, and the slot is still here to recognize it by.
+        slot.surface_use = {};
         if (m_shed_storage_on_release)
             drop_slot_storage_while_locked(slot);
     }
@@ -300,13 +304,13 @@ Optional<VideoFrameSurfacePool::AcquiredSlot> VideoFrameSurfacePool::try_acquire
         drop_slot_storage_while_locked(unused_slot);
         unused_slot.buffer = buffer_result.release_value();
         new (unused_slot.buffer.data<void>()) SlotHeader;
-        unused_slot.surface = surface;
         unused_slot.allocated_buffer_id++;
         slot_index = unused_slot_index;
     }
 
     auto& slot = m_slots[*slot_index];
     VERIFY(slot.hold_count == 0);
+    slot.surface = surface;
     publish_acquisition_while_locked(slot);
 
     return AcquiredSlot {
@@ -337,6 +341,10 @@ ResolvedVideoFrameSlot::ResolvedVideoFrameSlot(Core::AnonymousBuffer slot_buffer
     , m_slot_acquisition_id(slot_acquisition_id)
     , m_on_release(move(on_release))
 {
+    // The slot this was resolved from can be released from under it, so this is what keeps the pixels it reads from
+    // being decoded into again.
+    if (m_surface != nullptr)
+        m_surface_use = m_surface->begin_use();
 }
 
 ResolvedVideoFrameSlot::~ResolvedVideoFrameSlot()

--- a/Libraries/LibMedia/VideoFramePool.cpp
+++ b/Libraries/LibMedia/VideoFramePool.cpp
@@ -76,8 +76,6 @@ Optional<VideoFramePool::AcquiredSlot> VideoFramePool::try_acquire(size_t byte_c
 
     Sync::MutexLocker locker { m_mutex };
 
-    m_shed_buffers_on_release = false;
-
     Optional<u32> reusable_slot_index;
     Optional<u32> free_slot_index;
     for (u32 index = 0; index < m_slots.size(); index++) {
@@ -124,7 +122,7 @@ Optional<VideoFramePool::AcquiredSlot> VideoFramePool::try_acquire(size_t byte_c
         auto buffer_result = Core::AnonymousBuffer::create_with_size(buffer_size);
         if (buffer_result.is_error())
             return {};
-        drop_slot_buffer_while_locked(*chosen_slot);
+        drop_slot_storage_while_locked(*chosen_slot);
         chosen_slot->buffer = buffer_result.release_value();
         chosen_slot->allocated_buffer_id++;
         new (chosen_slot->buffer.data<void>()) SlotHeader;
@@ -151,6 +149,7 @@ ErrorOr<NonnullRefPtr<PooledVideoFrameSlot>> VideoFramePool::try_adopt_acquired_
 
 void VideoFrameEntryLedger::publish_acquisition_while_locked(Slot& slot)
 {
+    m_shed_storage_on_release = false;
     slot.hold_count = 1;
     slot.last_slot_acquisition_id++;
     slot_header(slot.buffer).slot_acquisition_id.store(slot.last_slot_acquisition_id);
@@ -187,7 +186,7 @@ u32 VideoFrameEntryLedger::held_slot_count_while_locked() const
     return held_count;
 }
 
-void VideoFramePool::drop_slot_buffer_while_locked(Slot& slot)
+void VideoFramePool::drop_slot_storage_while_locked(Slot& slot)
 {
     if (!slot.buffer.is_valid())
         return;
@@ -207,7 +206,17 @@ void VideoFramePool::free_excess_buffers_while_locked()
         }
         if (largest_free_slot == nullptr)
             return;
-        drop_slot_buffer_while_locked(*largest_free_slot);
+        drop_slot_storage_while_locked(*largest_free_slot);
+    }
+}
+
+void VideoFrameEntryLedger::shed_storage()
+{
+    Sync::MutexLocker locker { m_mutex };
+    m_shed_storage_on_release = true;
+    for (auto& slot : m_slots) {
+        if (slot.hold_count == 0)
+            drop_slot_storage_while_locked(slot);
     }
 }
 
@@ -226,27 +235,12 @@ void VideoFrameEntryLedger::release_hold(u32 slot_index)
         VERIFY(slot.hold_count > 0);
         if (--slot.hold_count > 0)
             return;
-        slot_freed_while_locked(slot);
+        if (m_shed_storage_on_release)
+            drop_slot_storage_while_locked(slot);
     }
 
     if (m_slot_freed_callback)
         m_slot_freed_callback();
-}
-
-void VideoFramePool::slot_freed_while_locked(Slot& slot)
-{
-    if (m_shed_buffers_on_release)
-        drop_slot_buffer_while_locked(slot);
-}
-
-void VideoFramePool::shed_buffers()
-{
-    Sync::MutexLocker locker { m_mutex };
-    m_shed_buffers_on_release = true;
-    for (auto& slot : m_slots) {
-        if (slot.hold_count == 0)
-            drop_slot_buffer_while_locked(slot);
-    }
 }
 
 Core::AnonymousBuffer VideoFrameEntryLedger::slot_buffer(u32 slot_index) const
@@ -303,8 +297,7 @@ Optional<VideoFrameSurfacePool::AcquiredSlot> VideoFrameSurfacePool::try_acquire
             return {};
 
         auto& unused_slot = m_slots[*unused_slot_index];
-        if (unused_slot.surface != nullptr)
-            m_slot_indices_by_surface_id.remove(unused_slot.surface->id());
+        drop_slot_storage_while_locked(unused_slot);
         unused_slot.buffer = buffer_result.release_value();
         new (unused_slot.buffer.data<void>()) SlotHeader;
         unused_slot.surface = surface;
@@ -321,6 +314,14 @@ Optional<VideoFrameSurfacePool::AcquiredSlot> VideoFrameSurfacePool::try_acquire
         .slot_acquisition_id = slot.last_slot_acquisition_id,
         .allocated_buffer_id = slot.allocated_buffer_id,
     };
+}
+
+void VideoFrameSurfacePool::drop_slot_storage_while_locked(Slot& slot)
+{
+    if (slot.surface == nullptr)
+        return;
+    m_slot_indices_by_surface_id.remove(slot.surface->id());
+    slot.surface = nullptr;
 }
 
 ErrorOr<NonnullRefPtr<PooledVideoFrameSlot>> VideoFrameSurfacePool::try_adopt_acquired_slot(AcquiredSlot const& acquired_slot)
@@ -404,6 +405,11 @@ void VideoFrameSlotDirectory::notify_slot_announced(VideoFramePoolID pool_id, u3
 void VideoFrameSlotDirectory::notify_pool_retired(VideoFramePoolID pool_id)
 {
     m_slots_by_pool_id.remove(pool_id);
+}
+
+void VideoFrameSlotDirectory::notify_all_pools_retired()
+{
+    m_slots_by_pool_id.clear();
 }
 
 RefPtr<VideoFrame> VideoFrameSlotDirectory::resolve_frame(VideoFrameHandle const& handle, Function<void()> on_release) const

--- a/Libraries/LibMedia/VideoFramePool.h
+++ b/Libraries/LibMedia/VideoFramePool.h
@@ -39,6 +39,10 @@ public:
     void add_hold(u32 slot_index);
     void release_hold(u32 slot_index);
 
+    // Marks each slot's storage for freeing when its hold count drops to zero. This marker is cleared upon the
+    // next acquire.
+    void shed_storage();
+
     // The buffer backing a held slot, for lending to consumer processes.
     Core::AnonymousBuffer slot_buffer(u32 slot_index) const;
 
@@ -61,7 +65,7 @@ protected:
     // Appends a slot with no payload, for a pool that has no free slot to reuse.
     Optional<u32> try_grow_while_locked();
 
-    virtual void slot_freed_while_locked(Slot&) { }
+    virtual void drop_slot_storage_while_locked(Slot&) = 0;
 
     u32 held_slot_count_while_locked() const;
     void publish_acquisition_while_locked(Slot&);
@@ -72,6 +76,7 @@ protected:
 private:
     VideoFramePoolID const m_id;
     Function<void()> m_slot_freed_callback;
+    bool m_shed_storage_on_release { false };
 };
 
 // A pool of shared-memory framebuffers that are allocated on demand up to a limited budget. Each slot's buffer fd must
@@ -95,22 +100,17 @@ public:
     Optional<AcquiredSlot> try_acquire(size_t byte_count);
     ErrorOr<NonnullRefPtr<PooledVideoFrameSlot>> try_adopt_acquired_slot(AcquiredSlot const&);
 
-    // Marks the buffers for freeing when their hold count drops to zero. This marker is cleared upon the next acquire.
-    void shed_buffers();
-
     size_t allocated_byte_count() const;
 
 private:
     explicit VideoFramePool(size_t byte_budget);
 
-    void slot_freed_while_locked(Slot&) override;
+    void drop_slot_storage_while_locked(Slot&) override;
 
-    void drop_slot_buffer_while_locked(Slot&);
     void free_excess_buffers_while_locked();
 
     size_t const m_byte_budget { 0 };
     size_t m_allocated_bytes { 0 };
-    bool m_shed_buffers_on_release { false };
 };
 
 // A pool of surfaces produced by a hardware decoder. The decoder allocates and recycles them, so this pool tracks
@@ -133,6 +133,8 @@ public:
 
 private:
     VideoFrameSurfacePool() = default;
+
+    void drop_slot_storage_while_locked(Slot&) override;
 
     HashMap<u32, u32> m_slot_indices_by_surface_id;
 };
@@ -207,6 +209,7 @@ public:
 
     void notify_slot_announced(VideoFramePoolID, u32 slot_index, Core::AnonymousBuffer slot_buffer, RefPtr<VideoSurface> surface);
     void notify_pool_retired(VideoFramePoolID);
+    void notify_all_pools_retired();
 
     RefPtr<VideoFrame> resolve_frame(VideoFrameHandle const&, Function<void()> on_release) const;
 

--- a/Libraries/LibMedia/VideoFramePool.h
+++ b/Libraries/LibMedia/VideoFramePool.h
@@ -16,12 +16,12 @@
 #include <LibGfx/YUVData.h>
 #include <LibMedia/Export.h>
 #include <LibMedia/VideoFrameHandle.h>
+#include <LibMedia/VideoSurface.h>
 #include <LibSync/Mutex.h>
 
 namespace Media {
 
 class PooledVideoFrameSlot;
-class VideoSurface;
 
 // The identity and lifetime bookkeeping shared by every kind of frame pool. Each slot owns a shared-memory buffer
 // beginning with the acquisition ID that a remote consumer validates its handle against; what follows the ID is the
@@ -56,7 +56,10 @@ protected:
 
     struct Slot {
         Core::AnonymousBuffer buffer;
+        // A slot keeps its surface once it has one, so that the decoder handing the same one back is recognized.
+        // Only the use says the pixels are live, and only a held slot has one.
         RefPtr<VideoSurface> surface;
+        VideoSurfaceUse surface_use;
         u64 last_slot_acquisition_id { 0 };
         u64 allocated_buffer_id { 0 };
         u32 hold_count { 0 };
@@ -184,6 +187,7 @@ public:
 private:
     Core::AnonymousBuffer m_slot_buffer;
     RefPtr<VideoSurface> m_surface;
+    VideoSurfaceUse m_surface_use;
     VideoFramePoolID m_pool_id { 0 };
     u32 m_slot_index { 0 };
     u64 m_slot_acquisition_id { 0 };

--- a/Libraries/LibMedia/VideoSurface.cpp
+++ b/Libraries/LibMedia/VideoSurface.cpp
@@ -12,9 +12,25 @@ namespace Media {
 
 #ifdef AK_OS_MACOS
 
-VideoSurface::~VideoSurface()
+VideoSurface::~VideoSurface() = default;
+
+bool VideoSurface::is_in_use() const
 {
-    m_io_surface.decrement_use_count();
+    return m_io_surface.is_in_use();
+}
+
+VideoSurfaceUse::VideoSurfaceUse(VideoSurface& surface)
+    : m_surface(surface)
+{
+    m_surface->m_io_surface.increment_use_count();
+}
+
+void VideoSurfaceUse::release()
+{
+    if (m_surface == nullptr)
+        return;
+    m_surface->m_io_surface.decrement_use_count();
+    m_surface = nullptr;
 }
 
 ErrorOr<NonnullRefPtr<VideoSurface>> VideoSurface::create(Core::IOSurfaceHandle io_surface)
@@ -32,7 +48,46 @@ ErrorOr<NonnullRefPtr<VideoSurface>> VideoSurface::create_from_mach_port(Core::M
 
 VideoSurface::~VideoSurface() = default;
 
+bool VideoSurface::is_in_use() const
+{
+    return false;
+}
+
+VideoSurfaceUse::VideoSurfaceUse(VideoSurface& surface)
+    : m_surface(surface)
+{
+}
+
+void VideoSurfaceUse::release()
+{
+    m_surface = nullptr;
+}
+
 #endif
+
+VideoSurfaceUse VideoSurface::begin_use()
+{
+    return VideoSurfaceUse { *this };
+}
+
+VideoSurfaceUse::VideoSurfaceUse(VideoSurfaceUse&& other)
+    : m_surface(move(other.m_surface))
+{
+}
+
+VideoSurfaceUse& VideoSurfaceUse::operator=(VideoSurfaceUse&& other)
+{
+    if (this != &other) {
+        release();
+        m_surface = move(other.m_surface);
+    }
+    return *this;
+}
+
+VideoSurfaceUse::~VideoSurfaceUse()
+{
+    release();
+}
 
 }
 

--- a/Libraries/LibMedia/VideoSurface.h
+++ b/Libraries/LibMedia/VideoSurface.h
@@ -19,13 +19,20 @@
 
 namespace Media {
 
+class VideoSurfaceUse;
+
 // A frame's pixels in memory that a GPU can sample without a copy. Hardware decoders allocate these and recycle a
-// bounded set of them, so each carries the identity its recycling can be recognized by.
+// bounded set of them, so each carries the identity its recycling can be recognized by. Holding one keeps it alive
+// and keeps that identity unambiguous, which is what lets a recycled surface be recognized as the one it was;
+// begin_use() is what says its pixels are being read or written.
 class MEDIA_API VideoSurface : public AtomicRefCounted<VideoSurface> {
 public:
     ~VideoSurface();
 
     u32 id() const { return m_id; }
+
+    [[nodiscard]] VideoSurfaceUse begin_use();
+    bool is_in_use() const;
 
 #ifdef AK_OS_MACOS
     static ErrorOr<NonnullRefPtr<VideoSurface>> create(Core::IOSurfaceHandle);
@@ -35,18 +42,39 @@ public:
 #endif
 
 private:
+    friend class VideoSurfaceUse;
+
 #ifdef AK_OS_MACOS
     VideoSurface(Core::IOSurfaceHandle io_surface, u32 id)
         : m_io_surface(move(io_surface))
         , m_id(id)
     {
-        m_io_surface.increment_use_count();
     }
 
     Core::IOSurfaceHandle m_io_surface;
 #endif
 
     u32 m_id { 0 };
+};
+
+// Says that a surface's pixels are being read or written for as long as it exists. The decoder that allocated the
+// surface will not decode into it again while any of these are alive.
+class MEDIA_API VideoSurfaceUse {
+    AK_MAKE_NONCOPYABLE(VideoSurfaceUse);
+
+public:
+    VideoSurfaceUse() = default;
+    VideoSurfaceUse(VideoSurfaceUse&&);
+    VideoSurfaceUse& operator=(VideoSurfaceUse&&);
+    ~VideoSurfaceUse();
+
+private:
+    friend class VideoSurface;
+
+    explicit VideoSurfaceUse(VideoSurface&);
+    void release();
+
+    RefPtr<VideoSurface> m_surface;
 };
 
 }

--- a/Libraries/LibMedia/VideoToolbox/VideoToolboxVideoDecoder.h
+++ b/Libraries/LibMedia/VideoToolbox/VideoToolboxVideoDecoder.h
@@ -46,6 +46,9 @@ private:
     struct Session;
     struct DecodedOutput {
         NonnullRefPtr<VideoSurface> surface;
+        // An output waiting on the reorder window is not in a slot yet, so this is what keeps the media engine from
+        // decoding over it before it is.
+        VideoSurfaceUse surface_use;
         AK::Duration timestamp;
         AK::Duration duration;
         Gfx::IntSize size;

--- a/Libraries/LibMedia/VideoToolbox/VideoToolboxVideoDecoder.mm
+++ b/Libraries/LibMedia/VideoToolbox/VideoToolboxVideoDecoder.mm
@@ -648,6 +648,8 @@ VideoToolboxVideoDecoder::~VideoToolboxVideoDecoder()
     // Tearing down the session hands the media engine's remaining frames to the output callback, which touches
     // members that would otherwise already be gone by the time the session is destroyed.
     m_session.clear();
+
+    m_surface_pool->shed_storage();
 }
 
 DecoderErrorOr<void> VideoToolboxVideoDecoder::ensure_session_for_frame(CodedFrame const& coded_frame)

--- a/Libraries/LibMedia/VideoToolbox/VideoToolboxVideoDecoder.mm
+++ b/Libraries/LibMedia/VideoToolbox/VideoToolboxVideoDecoder.mm
@@ -767,8 +767,12 @@ void VideoToolboxVideoDecoder::enqueue_decoded_output_while_locked(CodingIndepen
     if (m_decode_failure.has_value())
         return;
 
+    auto surface = surface_or_error.release_value();
+    auto surface_use = surface->begin_use();
+
     DecodedOutput output {
-        .surface = surface_or_error.release_value(),
+        .surface = move(surface),
+        .surface_use = move(surface_use),
         .timestamp = timestamp,
         .duration = duration,
         .size = { static_cast<int>(CVPixelBufferGetWidth(pixel_buffer)), static_cast<int>(CVPixelBufferGetHeight(pixel_buffer)) },

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -342,6 +342,8 @@ Optional<Gfx::DecodedImageFrame> HTMLVideoElement::current_decoded_image_frame()
         dbgln("Could not convert video frame to bitmap: {}", bitmap_or_error.release_error());
         return {};
     }
+    if (!current_frame->revalidate_backing())
+        return {};
     auto bitmap = bitmap_or_error.release_value();
     auto color_space = Gfx::ColorSpace {};
     if (auto color_space_result = Gfx::ColorSpace::from_cicp(current_frame->cicp()); !color_space_result.is_error())

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -118,6 +118,9 @@ struct DisplayListCachedVideoSinkImageResource {
     // A surface-backed image samples the surface where it lies, so it stays valid for every frame decoded into
     // that surface rather than only for the one acquisition.
     u32 surface_id { 0 };
+    // Drawing is recorded here but read by the GPU afterwards, so the surface stays in use until a different one
+    // is drawn in its place.
+    Media::VideoSurfaceUse surface_use;
     RefPtr<Gfx::SkiaBackendContext> skia_backend_context;
     sk_sp<SkImage> image;
 };
@@ -393,6 +396,7 @@ sk_sp<SkImage> DisplayListResourceStorage::skia_image_for_video_sink(VideoSinkRe
     cached_image_storage.slot_index = handle.slot_index;
     cached_image_storage.slot_acquisition_id = handle.slot_acquisition_id;
     cached_image_storage.surface_id = surface_id;
+    cached_image_storage.surface_use = surface ? surface->begin_use() : Media::VideoSurfaceUse {};
     cached_image_storage.skia_backend_context = skia_backend_context;
     cached_image_storage.image = image;
     return image;

--- a/Tests/LibMedia/TestRemoteVideoNode.cpp
+++ b/Tests/LibMedia/TestRemoteVideoNode.cpp
@@ -594,3 +594,35 @@ TEST_CASE(current_frame_ignores_handles_whose_lend_was_released)
     sink->release_slot(handles[1].pool_id, handles[1].slot_index);
     EXPECT(sink->current_frame() == nullptr);
 }
+
+TEST_CASE(consumer_forgets_announced_slots_on_suspension)
+{
+    auto producer_edge = MUST(VideoEdgeQueue::create());
+    auto ring_fd = MUST(Core::System::dup(producer_edge.ring_fd()));
+    auto consumer_edge = MUST(VideoEdgeQueue::create(ring_fd, producer_edge.header_buffer()));
+
+    auto pool = MUST(VideoFramePool::create());
+    auto frame = create_pooled_frame(*pool, AK::Duration::from_milliseconds(1000));
+    auto handle = VideoFrameHandle::for_frame(*frame);
+
+    auto directory = VideoFrameSlotDirectory::create();
+    directory->notify_slot_announced(pool->id(), handle.slot_index, pool->slot_buffer(handle.slot_index), nullptr);
+
+    RemoteVideoProducer::Delegates delegates;
+    delegates.request_start = [] { };
+    delegates.request_seek = [](AK::Duration) { };
+    delegates.release_slot = [](VideoFramePoolID, u32) { };
+    delegates.notify_space_available = [] { };
+    auto consumer = RemoteVideoProducer::create(move(consumer_edge), directory, move(delegates));
+
+    auto resolved_before_suspension = directory->resolve_frame(handle, [] { });
+    EXPECT(resolved_before_suspension != nullptr);
+
+    producer_edge.set_status(PipelineStatus::Suspended, 0);
+    consumer->notify_data_available();
+
+    // The decoder that announced this slot is gone, so nothing more resolves against it, while the frame that
+    // already did keeps reading what it holds.
+    EXPECT(directory->resolve_frame(handle, [] { }) == nullptr);
+    EXPECT(resolved_before_suspension->revalidate_backing());
+}

--- a/Tests/LibMedia/TestVideoFramePool.cpp
+++ b/Tests/LibMedia/TestVideoFramePool.cpp
@@ -198,7 +198,7 @@ TEST_CASE(excess_free_buffers_are_dropped_to_fit_the_budget)
     EXPECT(pool->allocated_byte_count() <= slot_buffer_size * Media::VideoFramePool::MIN_SLOT_COUNT);
 }
 
-TEST_CASE(shed_buffers_frees_all_but_held_slots)
+TEST_CASE(shed_storage_frees_all_but_held_slots)
 {
     auto pool = make_pool();
     auto held = pool->try_acquire(resolved_frame_byte_count()).release_value();
@@ -209,7 +209,7 @@ TEST_CASE(shed_buffers_frees_all_but_held_slots)
     auto released = pool->try_acquire(FRAME_BYTE_COUNT).release_value();
     pool->release_hold(released.index);
 
-    pool->shed_buffers();
+    pool->shed_storage();
 
     // Only the held slot's buffer remains, and it still resolves.
     EXPECT_EQ(pool->allocated_byte_count(), measured_slot_buffer_size(resolved_frame_byte_count()));
@@ -234,7 +234,7 @@ TEST_CASE(acquisition_ends_shedding_of_held_buffers)
     auto pool = make_pool();
     auto held = pool->try_acquire(FRAME_BYTE_COUNT).release_value();
 
-    pool->shed_buffers();
+    pool->shed_storage();
 
     // An acquisition returns the pool to service, so the buffer held through the shed is
     // recycled rather than freed when its hold releases.
@@ -588,6 +588,30 @@ TEST_CASE(surface_pool_keeps_a_recycled_surface_on_its_slot)
     EXPECT_EQ(second.index, first.index);
     EXPECT_EQ(second.allocated_buffer_id, first.allocated_buffer_id);
     EXPECT_NE(second.slot_acquisition_id, first.slot_acquisition_id);
+}
+
+TEST_CASE(shed_storage_releases_surfaces_as_their_holds_run_out)
+{
+    auto pool = MUST(Media::VideoFrameSurfacePool::create());
+    auto held_surface = make_surface();
+    auto free_surface = make_surface();
+
+    auto held = pool->try_acquire(held_surface).value();
+    auto freed = pool->try_acquire(free_surface).value();
+    pool->release_hold(freed.index);
+
+    pool->shed_storage();
+
+    // Nothing but this test and the pool refers to either surface, so what the pool has let go of shows in the count.
+    EXPECT_EQ(free_surface->ref_count(), 1u);
+    EXPECT_EQ(held_surface->ref_count(), 2u);
+
+    pool->release_hold(held.index);
+    EXPECT_EQ(held_surface->ref_count(), 1u);
+
+    // The identities went with them, so a surface the pool held through the shed is a stranger to it again.
+    auto reacquired = pool->try_acquire(held_surface).value();
+    EXPECT_NE(reacquired.allocated_buffer_id, held.allocated_buffer_id);
 }
 
 TEST_CASE(surface_pool_gives_distinct_surfaces_distinct_slots)

--- a/Tests/LibMedia/TestVideoFramePool.cpp
+++ b/Tests/LibMedia/TestVideoFramePool.cpp
@@ -590,6 +590,57 @@ TEST_CASE(surface_pool_keeps_a_recycled_surface_on_its_slot)
     EXPECT_NE(second.slot_acquisition_id, first.slot_acquisition_id);
 }
 
+TEST_CASE(surface_pool_stops_using_a_surface_once_its_holds_run_out)
+{
+    auto pool = MUST(Media::VideoFrameSurfacePool::create());
+    auto surface = make_surface();
+
+    auto first = pool->try_acquire(surface).value();
+    EXPECT(surface->is_in_use());
+
+    pool->release_hold(first.index);
+
+    // The decoder is free to decode into it again, which it can only be recognized for having done because the
+    // slot kept hold of the surface through it.
+    EXPECT(!surface->is_in_use());
+
+    auto second = pool->try_acquire(surface).value();
+    EXPECT(surface->is_in_use());
+    EXPECT_EQ(second.index, first.index);
+    EXPECT_EQ(second.allocated_buffer_id, first.allocated_buffer_id);
+}
+
+TEST_CASE(a_resolved_frame_keeps_using_a_surface_its_slot_has_released)
+{
+    auto pool = MUST(Media::VideoFrameSurfacePool::create());
+    auto surface = make_surface();
+    auto acquired = pool->try_acquire(surface).value();
+
+    auto directory = Media::VideoFrameSlotDirectory::create();
+    directory->notify_slot_announced(pool->id(), acquired.index, pool->slot_buffer(acquired.index), pool->slot_surface(acquired.index));
+
+    auto handle = Media::VideoFrameHandle {
+        .pool_id = pool->id(),
+        .slot_index = acquired.index,
+        .slot_acquisition_id = acquired.slot_acquisition_id,
+        .timestamp = AK::Duration::from_milliseconds(40),
+        .duration = AK::Duration::from_milliseconds(20),
+        .size = { 16, 16 },
+        .bit_depth = 8,
+        .subsampling = Media::Subsampling(true, true),
+        .cicp = {},
+    };
+    auto frame = directory->resolve_frame(handle, [] { });
+    EXPECT(frame != nullptr);
+
+    // A lend can be released from under a frame, so the frame is what has to say it is still reading the pixels.
+    pool->release_hold(acquired.index);
+    EXPECT(surface->is_in_use());
+
+    frame = nullptr;
+    EXPECT(!surface->is_in_use());
+}
+
 TEST_CASE(shed_storage_releases_surfaces_as_their_holds_run_out)
 {
     auto pool = MUST(Media::VideoFrameSurfacePool::create());
@@ -602,12 +653,13 @@ TEST_CASE(shed_storage_releases_surfaces_as_their_holds_run_out)
 
     pool->shed_storage();
 
-    // Nothing but this test and the pool refers to either surface, so what the pool has let go of shows in the count.
+    // Nothing but this test refers to a surface the pool has let go of, while the held one is still being read.
     EXPECT_EQ(free_surface->ref_count(), 1u);
-    EXPECT_EQ(held_surface->ref_count(), 2u);
+    EXPECT(held_surface->is_in_use());
 
     pool->release_hold(held.index);
     EXPECT_EQ(held_surface->ref_count(), 1u);
+    EXPECT(!held_surface->is_in_use());
 
     // The identities went with them, so a surface the pool held through the shed is a stranger to it again.
     auto reacquired = pool->try_acquire(held_surface).value();

--- a/Tests/LibMedia/TestVideoToolboxDecode.cpp
+++ b/Tests/LibMedia/TestVideoToolboxDecode.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <LibMedia/CodecParameters.h>
 #include <LibMedia/Codecs/AV1.h>
@@ -136,6 +137,39 @@ TEST_CASE(surfaces_are_not_reused_while_their_frames_are_held)
         held_surface_ids.set(surface->id());
         held_frames.append(move(frame));
     }
+}
+
+TEST_CASE(a_recycled_surface_does_not_cost_a_fresh_announcement)
+{
+    auto decoding = open_decoding("./vp9_in_webm.webm"sv, Media::CodecID::VP9);
+
+    // A consumer is told about a slot whenever its buffer generation moves, so this counts what it would hear.
+    HashTable<u32> distinct_surface_ids;
+    HashMap<u32, u64> announced_buffer_id_by_slot;
+    size_t announcements = 0;
+    size_t frame_count = 0;
+
+    while (frame_count < 24) {
+        auto frame_result = decoding.next_frame();
+        if (frame_result.is_error() && hardware_decoding_is_unavailable(frame_result.error()))
+            return;
+        auto frame = TRY_OR_FAIL(move(frame_result));
+        auto const* slot = frame->pool_slot();
+        EXPECT_NE(slot, nullptr);
+
+        auto announced = announced_buffer_id_by_slot.get(slot->slot_index());
+        if (!announced.has_value() || *announced != slot->allocated_buffer_id()) {
+            announcements++;
+            announced_buffer_id_by_slot.set(slot->slot_index(), slot->allocated_buffer_id());
+        }
+        distinct_surface_ids.set(frame->surface()->id());
+        frame_count++;
+    }
+
+    // Releasing a frame lets the media engine decode into its surface again, and the slot that kept hold of that
+    // surface recognizes it, so a surface costs one announcement however many frames it carries.
+    EXPECT(distinct_surface_ids.size() < frame_count);
+    EXPECT(announcements <= distinct_surface_ids.size());
 }
 
 TEST_CASE(storage_runs_out_while_every_frame_is_held)


### PR DESCRIPTION
- Ensure that a displayed frame hasn't been recycled before capturing it in WebContent
- Actually free memory when a decoder gets suspended
- Reuse video surface slot announcements instead of announcing every frame