### PR TITLE
LibWeb: Share image style resources between elements with the same computed image

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -106,6 +106,22 @@ void ImageStyleValueResource::notify_image_style_values_did_update()
         registration.key->notify_clients_did_update();
 }
 
+static HashMap<StyleValueFFI::StyleValueData const*, ImageStyleValue const*>& facades_by_rust_style_value_data()
+{
+    static auto& facades = *new HashMap<StyleValueFFI::StyleValueData const*, ImageStyleValue const*>;
+    return facades;
+}
+
+ValueComparingNonnullRefPtr<ImageStyleValue const> ImageStyleValue::adopt_rust_style_value_data(StyleValueFFI::StyleValueData const* data)
+{
+    if (auto facade = facades_by_rust_style_value_data().get(data); facade.has_value()) {
+        // The transferred reference duplicates the one the shared facade already holds.
+        StyleValueFFI::rust_style_value_release(data);
+        return **facade;
+    }
+    return adopt_ref(*new (nothrow) ImageStyleValue(data));
+}
+
 ValueComparingNonnullRefPtr<ImageStyleValue const> ImageStyleValue::create(URL const& url)
 {
     return adopt_ref(*new (nothrow) ImageStyleValue(url));
@@ -127,21 +143,27 @@ ImageStyleValue::ImageStyleValue(URL const& url, Optional<::URL::URL> style_reso
     , m_parent_style_sheet_origin_clean(parent_style_sheet_origin_clean)
     , m_should_absolutize_url_for_computed_value(should_absolutize_url_for_computed_value)
 {
+    facades_by_rust_style_value_data().set(m_value.data(), this);
 }
 
 ImageStyleValue::ImageStyleValue(StyleValueFFI::StyleValueData const* data)
     : AbstractImageStyleValue(Type::Image, data)
 {
     auto const& context = data->image.resource_context;
-    if (context.has_base_url) {
+    if (context.has_base_url)
         m_style_resource_base_url = DOMURL::parse(url_text_from_rust_data(context.base_url));
-    }
     if (context.has_parent_style_sheet_origin_clean)
         m_parent_style_sheet_origin_clean = context.parent_style_sheet_origin_clean;
     m_should_absolutize_url_for_computed_value = context.should_absolutize_url_for_computed_value;
+    facades_by_rust_style_value_data().set(m_value.data(), this);
 }
 
-ImageStyleValue::~ImageStyleValue() = default;
+ImageStyleValue::~ImageStyleValue()
+{
+    auto& facades = facades_by_rust_style_value_data();
+    if (auto it = facades.find(m_value.data()); it != facades.end() && it->value == this)
+        facades.remove(it);
+}
 
 GC::Ptr<HTML::SharedResourceRequest> ImageStyleValue::fetch_image(DOM::Document& document) const
 {
@@ -162,8 +184,8 @@ void ImageStyleValue::load_any_resources(DOM::Document& document)
 
 void ImageStyleValue::set_style_sheet(StyleSheetState* style_sheet)
 {
-
     m_style_resource_base_url.clear();
+    m_resolved_url.clear();
     m_parent_style_sheet_origin_clean.clear();
     m_should_absolutize_url_for_computed_value = false;
 
@@ -176,6 +198,7 @@ void ImageStyleValue::set_style_sheet(StyleSheetState* style_sheet)
 void ImageStyleValue::update_style_sheet_resource_context(StyleSheetState const& style_sheet)
 {
     m_style_resource_base_url = style_sheet.style_resource_base_url();
+    m_resolved_url.clear();
     m_parent_style_sheet_origin_clean = style_sheet.is_origin_clean();
     m_should_absolutize_url_for_computed_value = true;
 }
@@ -271,11 +294,18 @@ void ImageStyleValue::notify_clients_did_update() const
 
 Optional<::URL::URL> ImageStyleValue::resolved_url(DOM::Document const& document) const
 {
+    if (m_resolved_url.has_value())
+        return m_resolved_url;
+
     auto url = url_text_from_rust_data(m_value->image.url);
     if (url.is_empty())
         return {};
 
-    return DOMURL::parse(url, style_resource_base_url(document));
+    auto resolved_url = DOMURL::parse(url, style_resource_base_url(document));
+    // A value without a base URL of its own follows the document's base URL as that changes.
+    if (m_style_resource_base_url.has_value())
+        m_resolved_url = resolved_url;
+    return resolved_url;
 }
 
 ::URL::URL ImageStyleValue::style_resource_base_url(DOM::Document const& document) const

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -179,7 +179,20 @@ GC::Ptr<HTML::SharedResourceRequest> ImageStyleValue::fetch_image(DOM::Document&
 
 void ImageStyleValue::load_any_resources(DOM::Document& document)
 {
+    if (resource_registered_by_clients(document))
+        return;
+    if (auto resolved_url = this->resolved_url(document); resolved_url.has_value() && document.css_image_resource(*resolved_url))
+        return;
     fetch_image(document);
+}
+
+ImageStyleValueResource* ImageStyleValue::resource_registered_by_clients(DOM::Document const& document) const
+{
+    for (auto const* client : m_clients) {
+        if (client->m_resource && client->document().ptr() == &document)
+            return client->m_resource;
+    }
+    return nullptr;
 }
 
 void ImageStyleValue::set_style_sheet(StyleSheetState* style_sheet)
@@ -248,19 +261,22 @@ void ImageStyleValue::register_client(Client& client) const
     if (!document)
         return;
 
-    auto resolved_url = this->resolved_url(*document);
-    if (!resolved_url.has_value())
-        return;
-
-    ImageStyleValueResource* resource = document->css_image_resource(*resolved_url);
+    auto* resource = resource_registered_by_clients(*document);
     if (!resource) {
-        auto resource_request = fetch_image(*document);
+        auto resolved_url = this->resolved_url(*document);
+        if (!resolved_url.has_value())
+            return;
 
-        // NB: This can only fail if the URL is invalid or ResourceLoader is not initialized, neither of which should be
-        //     the case here.
-        VERIFY(resource_request);
+        resource = document->css_image_resource(*resolved_url);
+        if (!resource) {
+            auto resource_request = fetch_image(*document);
 
-        resource = &document->create_css_image_resource(*resource_request);
+            // NB: This can only fail if the URL is invalid or ResourceLoader is not initialized, neither of which should be
+            //     the case here.
+            VERIFY(resource_request);
+
+            resource = &document->create_css_image_resource(*resource_request);
+        }
     }
 
     resource->register_image_style_value(*this);
@@ -281,9 +297,9 @@ void ImageStyleValue::unregister_client(Client& client) const
     if (!document)
         return;
 
-    auto url = resource->url();
     resource->unregister_image_style_value(*this);
-    document->remove_css_image_resource_if_unused(url);
+    if (resource->can_be_removed())
+        document->remove_css_image_resource_if_unused(resource->url());
 }
 
 void ImageStyleValue::notify_clients_did_update() const

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -100,6 +100,7 @@ private:
     GC::Ptr<HTML::SharedResourceRequest> fetch_image(DOM::Document&) const;
     Optional<::URL::URL> resolved_url(DOM::Document const&) const;
     ::URL::URL style_resource_base_url(DOM::Document const&) const;
+    ImageStyleValueResource* resource_registered_by_clients(DOM::Document const&) const;
 
     // NB: StyleValue dispatches operations by type tag, so it may call private impls.
     friend class StyleValue;

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -79,6 +79,7 @@ public:
     static ValueComparingNonnullRefPtr<ImageStyleValue const> create(URL const&);
     static ValueComparingNonnullRefPtr<ImageStyleValue const> create(URL const&, Optional<::URL::URL> style_resource_base_url);
     static ValueComparingNonnullRefPtr<ImageStyleValue const> create(::URL::URL const&);
+    static ValueComparingNonnullRefPtr<ImageStyleValue const> adopt_rust_style_value_data(StyleValueFFI::StyleValueData const*);
     virtual ~ImageStyleValue() override;
 
     virtual void load_any_resources(DOM::Document&) override;
@@ -114,6 +115,7 @@ private:
     Optional<::URL::URL> m_style_resource_base_url;
     Optional<bool> m_parent_style_sheet_origin_clean;
     bool m_should_absolutize_url_for_computed_value { false };
+    mutable Optional<::URL::URL> m_resolved_url;
 
     mutable HashTable<Client*> m_clients;
 };

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -207,7 +207,7 @@ ValueComparingNonnullRefPtr<StyleValue const> StyleValue::adopt_rust_style_value
     case StyleValueFFI::StyleValueData::Tag::Integer:
         return adopt_ref(*new (nothrow) IntegerStyleValue(data));
     case StyleValueFFI::StyleValueData::Tag::Image:
-        return adopt_ref(*new (nothrow) ImageStyleValue(data));
+        return ImageStyleValue::adopt_rust_style_value_data(data);
     case StyleValueFFI::StyleValueData::Tag::ImageSet:
         return adopt_ref(*new (nothrow) ImageSetStyleValue(data));
     case StyleValueFFI::StyleValueData::Tag::LightDark:

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -291,6 +291,7 @@ Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list
         m_color_scheme = color_scheme;
         m_cached_rendered_frames.clear();
         m_cached_rendered_surfaces.clear();
+        m_natural_size.clear();
         m_document->set_svg_image_color_scheme(color_scheme);
         m_document->style_scope().invalidate_style_cache();
         m_document->record_style_environment_change();
@@ -367,53 +368,55 @@ Optional<Gfx::DecodedImageFrame> SVGDecodedImageData::default_frame(Gfx::IntSize
     return current_frame(size);
 }
 
+// https://svgwg.org/svg2-draft/coords.html#SizingSVGInCSS
+CSS::SizeWithAspectRatio const& SVGDecodedImageData::natural_size() const
+{
+    if (m_natural_size.has_value())
+        return *m_natural_size;
+
+    CSS::SizeWithAspectRatio natural_size;
+    {
+        ScopedSVGImageDocument scoped_document { *m_page_client, *m_document, ScopedSVGImageDocument::FrameRequests::RouteToCurrentImage, const_cast<SVGDecodedImageData&>(*this) };
+        m_document->update_style();
+        auto const* sizing_values = m_root_element->style_group<CSS::ComputedValues::SizingValues>();
+        VERIFY(sizing_values);
+        auto absolute_length = [](auto const& size_handle) -> Optional<CSSPixels> {
+            auto const& size = CSS::Size::view(size_handle);
+            if (size.is_length() && size.length().is_absolute())
+                return size.length().absolute_length_to_px();
+            return {};
+        };
+        natural_size.width = absolute_length(sizing_values->width);
+        natural_size.height = absolute_length(sizing_values->height);
+    }
+
+    if (natural_size.width.has_value() && natural_size.height.has_value() && *natural_size.width > 0 && *natural_size.height > 0) {
+        natural_size.aspect_ratio = *natural_size.width / *natural_size.height;
+    } else if (auto const& viewbox = m_root_element->view_box(); viewbox.has_value()) {
+        auto viewbox_width = CSSPixels::nearest_value_for(viewbox->width);
+        auto viewbox_height = CSSPixels::nearest_value_for(viewbox->height);
+        if (viewbox_width != 0 && viewbox_height != 0)
+            natural_size.aspect_ratio = viewbox_width / viewbox_height;
+    }
+
+    // The style flush above may clear this cache through a frame request, so the result is stored only after it.
+    m_natural_size = natural_size;
+    return *m_natural_size;
+}
+
 Optional<CSSPixels> SVGDecodedImageData::intrinsic_width() const
 {
-    // https://www.w3.org/TR/SVG2/coords.html#SizingSVGInCSS
-    ScopedSVGImageDocument scoped_document { *m_page_client, *m_document, ScopedSVGImageDocument::FrameRequests::RouteToCurrentImage, const_cast<SVGDecodedImageData&>(*this) };
-    m_document->update_style();
-    auto const* sizing_values = m_root_element->style_group<CSS::ComputedValues::SizingValues>();
-    VERIFY(sizing_values);
-    auto const& width_value = CSS::Size::view(sizing_values->width);
-    if (width_value.is_length() && width_value.length().is_absolute())
-        return width_value.length().absolute_length_to_px();
-    return {};
+    return natural_size().width;
 }
 
 Optional<CSSPixels> SVGDecodedImageData::intrinsic_height() const
 {
-    // https://www.w3.org/TR/SVG2/coords.html#SizingSVGInCSS
-    ScopedSVGImageDocument scoped_document { *m_page_client, *m_document, ScopedSVGImageDocument::FrameRequests::RouteToCurrentImage, const_cast<SVGDecodedImageData&>(*this) };
-    m_document->update_style();
-    auto const* sizing_values = m_root_element->style_group<CSS::ComputedValues::SizingValues>();
-    VERIFY(sizing_values);
-    auto const& height_value = CSS::Size::view(sizing_values->height);
-    if (height_value.is_length() && height_value.length().is_absolute())
-        return height_value.length().absolute_length_to_px();
-    return {};
+    return natural_size().height;
 }
 
 Optional<CSSPixelFraction> SVGDecodedImageData::intrinsic_aspect_ratio() const
 {
-    // https://www.w3.org/TR/SVG2/coords.html#SizingSVGInCSS
-    auto width = intrinsic_width();
-    auto height = intrinsic_height();
-    if (width.has_value() && height.has_value() && *width > 0 && *height > 0)
-        return *width / *height;
-
-    if (auto const& viewbox = m_root_element->view_box(); viewbox.has_value()) {
-        auto viewbox_width = CSSPixels::nearest_value_for(viewbox->width);
-
-        if (viewbox_width == 0)
-            return {};
-
-        auto viewbox_height = CSSPixels::nearest_value_for(viewbox->height);
-        if (viewbox_height == 0)
-            return {};
-
-        return viewbox_width / viewbox_height;
-    }
-    return {};
+    return natural_size().aspect_ratio;
 }
 
 void SVGDecodedImageData::SVGPageClient::visit_edges(Visitor& visitor)
@@ -514,6 +517,7 @@ void SVGDecodedImageData::did_request_frame()
 void SVGDecodedImageData::invalidate_cached_rendering()
 {
     m_vector_content_identity = next_vector_content_identity();
+    m_natural_size.clear();
     m_cached_rendered_frames.clear();
     m_cached_rendered_surfaces.clear();
     m_cached_display_lists.clear();

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <LibGC/Heap.h>
 #include <LibGfx/DecodedImageFrame.h>
+#include <LibWeb/CSS/Sizing.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayList.h>
@@ -56,6 +57,7 @@ public:
 private:
     SVGDecodedImageData(GC::Ref<Page>, GC::Ref<SVGPageClient>, GC::Ref<DOM::Document>, GC::Ref<SVG::SVGSVGElement>);
 
+    CSS::SizeWithAspectRatio const& natural_size() const;
     RefPtr<Gfx::PaintingSurface> render_to_surface(Gfx::IntSize) const;
     void prune_cached_display_list_resources() const;
     void append_cached_display_list_resources(Painting::DisplayListResourceSet&) const;
@@ -94,6 +96,7 @@ private:
         static bool equals(RenderKey const& a, RenderKey const& b) { return a == b; }
     };
     mutable HashMap<RenderKey, CachedDisplayList, RenderKeyTraits> m_cached_display_lists;
+    mutable Optional<CSS::SizeWithAspectRatio> m_natural_size;
 
     GC::Ref<Page> m_page;
     GC::Ref<SVGPageClient> m_page_client;


### PR DESCRIPTION
Elements styled with the same image now share one image style value, its loaded resource, and the natural size of an SVG image, instead of resolving and querying them once per element on every restyle. 

See the individual commits for details.

Increases the performance of the Speedometer `TodoMVC/CompletingAllItems` suites:
| Benchmark | Old score | New score | Score change | Old time (s) | New time (s) | Speedup |
|---|---|---|---|---|---|---|
| Speedometer2 | 85.23 ± 0.31 | 86.58 ± 0.27 | +1.59% | 6.195 ± 0.013 | 6.165 ± 0.011 | 1.005× |
| Speedometer3 | 5.50 ± 0.02 | 5.59 ± 0.02 | +1.72% | 4.609 ± 0.016 | 4.565 ± 0.018 | 1.010× |
| StyleBench | 161.47 ± 0.60 | 162.11 ± 0.62 | +0.39% | 1.538 ± 0.005 | 1.532 ± 0.006 | 1.004× |