### PR TITLE
LibWeb: Keep WebWorkers alive while they are running

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5715,7 +5715,9 @@ void Document::destroy()
         page().navigable_document_destroyed({}, *navigable);
     }
 
-    // FIXME: 10. Remove document from the owner set of each WorkerGlobalScope object whose set contains document.
+    // 10. Remove document from the owner set of each WorkerGlobalScope object whose set contains document.
+    HTML::relevant_settings_object(*this).release_owned_worker_agents();
+
     // FIXME: 11. For each workletGlobalScope in document's worklet global scopes, terminate workletGlobalScope.
 }
 

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -78,7 +78,7 @@ void EnvironmentSettingsObject::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_lock_manager);
     visitor.visit(m_service_worker_registration_object_map);
     visitor.visit(m_service_worker_object_map);
-    visitor.visit(m_worker_agents_to_keep_alive_while_starting);
+    visitor.visit(m_owned_worker_agents);
 }
 
 void EnvironmentSettingsObject::discard_environment()
@@ -90,16 +90,23 @@ void EnvironmentSettingsObject::discard_environment()
     set_discarded(true);
 }
 
-void EnvironmentSettingsObject::keep_worker_agent_alive_while_starting(WorkerAgentParent& worker_agent)
+void EnvironmentSettingsObject::add_owned_worker_agent(WorkerAgentParent& worker_agent)
 {
-    m_worker_agents_to_keep_alive_while_starting.append(worker_agent);
+    m_owned_worker_agents.append(worker_agent);
 }
 
-void EnvironmentSettingsObject::release_worker_agent_from_startup_keep_alive(WorkerAgentParent& worker_agent)
+void EnvironmentSettingsObject::remove_owned_worker_agent(WorkerAgentParent& worker_agent)
 {
-    m_worker_agents_to_keep_alive_while_starting.remove_first_matching([&](auto& agent) {
+    m_owned_worker_agents.remove_first_matching([&](auto& agent) {
         return agent.ptr() == &worker_agent;
     });
+}
+
+void EnvironmentSettingsObject::release_owned_worker_agents()
+{
+    auto owned_worker_agents = move(m_owned_worker_agents);
+    for (auto& worker_agent : owned_worker_agents)
+        worker_agent->terminate();
 }
 
 JS::ExecutionContext& EnvironmentSettingsObject::realm_execution_context()

--- a/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -147,8 +147,9 @@ public:
 
     virtual void discard_environment() override;
 
-    void keep_worker_agent_alive_while_starting(WorkerAgentParent&);
-    void release_worker_agent_from_startup_keep_alive(WorkerAgentParent&);
+    void add_owned_worker_agent(WorkerAgentParent&);
+    void remove_owned_worker_agent(WorkerAgentParent&);
+    void release_owned_worker_agents();
 
     // FIXME: This method below is from HighResolutionTime spec in section 3. Section for Specification Authors.
     // The following other methods are currently not supported:
@@ -205,7 +206,7 @@ private:
     // A service worker client has an associated discarded flag. It is initially unset.
     bool m_discarded { false };
 
-    Vector<GC::Ref<WorkerAgentParent>> m_worker_agents_to_keep_alive_while_starting;
+    Vector<GC::Ref<WorkerAgentParent>> m_owned_worker_agents;
 };
 
 RunScriptDecision can_run_script(EnvironmentSettingsObject const&);

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
@@ -152,6 +152,15 @@ void WorkerAgentParent::did_close_worker(WorkerAgentOwnerToken owner_token)
     parent->value->release_startup_keep_alive();
 }
 
+void WorkerAgentParent::did_worker_agent_die(WorkerAgentOwnerToken owner_token)
+{
+    auto parent = worker_agent_parents().find(owner_token);
+    if (parent == worker_agent_parents().end())
+        return;
+    parent->value->dispatch_error_event();
+    parent->value->release_startup_keep_alive();
+}
+
 void WorkerAgentParent::terminate()
 {
     if (m_agent_id == 0)

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
@@ -68,7 +68,7 @@ WorkerAgentParent::WorkerAgentParent(URL::URL url, WorkerOptions const& options,
 void WorkerAgentParent::start()
 {
     auto& realm = m_outside_settings->realm();
-    m_outside_settings->keep_worker_agent_alive_while_starting(*this);
+    m_outside_settings->add_owned_worker_agent(*this);
 
     auto* global_scope = window_or_worker_global_scope_from_global_object(realm.global_object());
     VERIFY(global_scope);
@@ -119,21 +119,13 @@ void WorkerAgentParent::start()
     m_agent_id = Bindings::principal_host_defined_page(realm).client().start_worker_agent(move(request));
 }
 
-void WorkerAgentParent::did_finish_loading_worker_script(WorkerAgentOwnerToken owner_token)
-{
-    auto parent = worker_agent_parents().find(owner_token);
-    if (parent == worker_agent_parents().end())
-        return;
-    parent->value->release_startup_keep_alive();
-}
-
 void WorkerAgentParent::did_fail_loading_worker_script(WorkerAgentOwnerToken owner_token)
 {
     auto parent = worker_agent_parents().find(owner_token);
     if (parent == worker_agent_parents().end())
         return;
     parent->value->dispatch_error_event();
-    parent->value->release_startup_keep_alive();
+    parent->value->forget_agent();
 }
 
 void WorkerAgentParent::did_report_worker_exception(WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno)
@@ -149,7 +141,7 @@ void WorkerAgentParent::did_close_worker(WorkerAgentOwnerToken owner_token)
     auto parent = worker_agent_parents().find(owner_token);
     if (parent == worker_agent_parents().end())
         return;
-    parent->value->release_startup_keep_alive();
+    parent->value->forget_agent();
 }
 
 void WorkerAgentParent::did_worker_agent_die(WorkerAgentOwnerToken owner_token)
@@ -158,7 +150,7 @@ void WorkerAgentParent::did_worker_agent_die(WorkerAgentOwnerToken owner_token)
     if (parent == worker_agent_parents().end())
         return;
     parent->value->dispatch_error_event();
-    parent->value->release_startup_keep_alive();
+    parent->value->forget_agent();
 }
 
 void WorkerAgentParent::terminate()
@@ -167,15 +159,16 @@ void WorkerAgentParent::terminate()
         return;
 
     worker_agent_parents().remove(m_owner_token);
-    release_startup_keep_alive();
 
-    auto agent_id = exchange(m_agent_id, 0);
+    auto agent_id = m_agent_id;
+    forget_agent();
     Bindings::principal_host_defined_page(m_outside_settings->realm()).client().close_worker_agent(agent_id, m_owner_token);
 }
 
-void WorkerAgentParent::release_startup_keep_alive()
+void WorkerAgentParent::forget_agent()
 {
-    m_outside_settings->release_worker_agent_from_startup_keep_alive(*this);
+    m_agent_id = 0;
+    m_outside_settings->remove_owned_worker_agent(*this);
 }
 
 void WorkerAgentParent::dispatch_error_event()
@@ -232,8 +225,8 @@ void WorkerAgentParent::finalize()
 
     worker_agent_parents().remove(m_owner_token);
 
-    if (m_agent_id != 0)
-        Bindings::principal_host_defined_page(m_outside_settings->realm()).client().close_worker_agent(m_agent_id, m_owner_token);
+    if (!heap().is_collecting_everything())
+        VERIFY(m_agent_id == 0);
 }
 
 void WorkerAgentParent::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
@@ -124,8 +124,9 @@ void WorkerAgentParent::did_fail_loading_worker_script(WorkerAgentOwnerToken own
     auto parent = worker_agent_parents().find(owner_token);
     if (parent == worker_agent_parents().end())
         return;
-    parent->value->dispatch_error_event();
-    parent->value->forget_agent();
+    auto agent_parent = parent->value;
+    agent_parent->dispatch_error_event();
+    agent_parent->forget_agent();
 }
 
 void WorkerAgentParent::did_report_worker_exception(WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno)
@@ -149,16 +150,15 @@ void WorkerAgentParent::did_worker_agent_die(WorkerAgentOwnerToken owner_token)
     auto parent = worker_agent_parents().find(owner_token);
     if (parent == worker_agent_parents().end())
         return;
-    parent->value->dispatch_error_event();
-    parent->value->forget_agent();
+    auto agent_parent = parent->value;
+    agent_parent->dispatch_error_event();
+    agent_parent->forget_agent();
 }
 
 void WorkerAgentParent::terminate()
 {
     if (m_agent_id == 0)
         return;
-
-    worker_agent_parents().remove(m_owner_token);
 
     auto agent_id = m_agent_id;
     forget_agent();
@@ -168,6 +168,7 @@ void WorkerAgentParent::terminate()
 void WorkerAgentParent::forget_agent()
 {
     m_agent_id = 0;
+    worker_agent_parents().remove(m_owner_token);
     m_outside_settings->remove_owned_worker_agent(*this);
 }
 

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.h
@@ -25,7 +25,6 @@ public:
         GC::Ptr<MessagePort> outside_port, GC::Ref<EnvironmentSettingsObject> outside_settings,
         GC::Ref<DOM::EventTarget> worker_event_target, AgentType);
 
-    static WEB_API void did_finish_loading_worker_script(WorkerAgentOwnerToken);
     static WEB_API void did_fail_loading_worker_script(WorkerAgentOwnerToken);
     static WEB_API void did_report_worker_exception(WorkerAgentOwnerToken, Utf16String message, Utf16String filename, u32 lineno, u32 colno);
     static WEB_API void did_close_worker(WorkerAgentOwnerToken);
@@ -43,7 +42,7 @@ private:
         AgentType);
 
     void start();
-    void release_startup_keep_alive();
+    void forget_agent();
     void dispatch_error_event();
     void dispatch_worker_exception(Utf16String message, Utf16String filename, u32 lineno, u32 colno);
 

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.h
@@ -29,6 +29,7 @@ public:
     static WEB_API void did_fail_loading_worker_script(WorkerAgentOwnerToken);
     static WEB_API void did_report_worker_exception(WorkerAgentOwnerToken, Utf16String message, Utf16String filename, u32 lineno, u32 colno);
     static WEB_API void did_close_worker(WorkerAgentOwnerToken);
+    static WEB_API void did_worker_agent_die(WorkerAgentOwnerToken);
 
     void terminate();
 

--- a/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -33,7 +33,6 @@ endpoint WebWorkerServer {
 
     close_worker() =|
 
-    did_worker_agent_finish_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) =|
     did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) =|
     did_worker_agent_report_exception(Web::HTML::WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno) =|
     did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) =|

--- a/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -37,6 +37,7 @@ endpoint WebWorkerServer {
     did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) =|
     did_worker_agent_report_exception(Web::HTML::WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno) =|
     did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) =|
+    did_worker_agent_die(Web::HTML::WorkerAgentOwnerToken owner_token) =|
 
     broadcast_channel_message(Web::HTML::BroadcastChannelMessage message) =|
 

--- a/Libraries/LibWebView/WorkerProcessManager.cpp
+++ b/Libraries/LibWebView/WorkerProcessManager.cpp
@@ -332,6 +332,18 @@ void WorkerProcessManager::notify_worker_close(Owner const& owner)
         });
 }
 
+void WorkerProcessManager::notify_worker_death(Owner const& owner)
+{
+    owner.client.visit(
+        [&](WebContentOwner const& web_content_owner) {
+            if (web_content_owner.client)
+                web_content_owner.client->async_did_worker_agent_die(owner.token);
+        },
+        [&](WebWorkerOwner const& web_worker_owner) {
+            web_worker_owner.client->async_did_worker_agent_die(owner.token);
+        });
+}
+
 void WorkerProcessManager::worker_did_finish_loading_script(Web::HTML::WorkerAgentId agent_id, bool worker_is_secure_context)
 {
     auto maybe_agent = m_agents.find(agent_id);
@@ -397,7 +409,25 @@ void WorkerProcessManager::worker_did_close(Web::HTML::WorkerAgentId agent_id)
 
 void WorkerProcessManager::worker_did_die(Web::HTML::WorkerAgentId agent_id)
 {
-    worker_did_close(agent_id);
+    auto maybe_agent = m_agents.find(agent_id);
+    if (maybe_agent == m_agents.end())
+        return;
+
+    // A close we initiated is expected to drop the connection; any other loss must not look like a clean close.
+    auto& agent = maybe_agent->value;
+    if (agent.closing) {
+        worker_did_close(agent_id);
+        return;
+    }
+
+    agent.closing = true;
+    auto owners = agent.owners;
+    for (auto const& owner : owners)
+        notify_worker_death(owner);
+
+    Core::deferred_invoke([this, agent_id] {
+        remove_agent(agent_id);
+    });
 }
 
 void WorkerProcessManager::worker_did_request_file(Web::HTML::WorkerAgentId agent_id, ByteString path, i32 request_id)

--- a/Libraries/LibWebView/WorkerProcessManager.cpp
+++ b/Libraries/LibWebView/WorkerProcessManager.cpp
@@ -102,7 +102,6 @@ Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(Owner owner, W
                     //         handles steps 11.5.5-11.5.7).
                     agent.owners.append(owner);
                     agent.client->async_connect_shared_worker(move(request.outside_port), request.outside_settings);
-                    notify_worker_script_load_success(owner);
                     return agent.id;
                 }
             }
@@ -208,7 +207,7 @@ void WorkerProcessManager::remove_web_content_owner(WebContentClient& client)
     }
 
     for (auto agent_id : agents_to_close)
-        remove_agent(agent_id);
+        remove_agent(agent_id, AgentRemovalCause::OwnerSetEmptied);
 }
 
 void WorkerProcessManager::remove_web_worker_owner(WebWorkerClient& client)
@@ -225,7 +224,7 @@ void WorkerProcessManager::remove_web_worker_owner(WebWorkerClient& client)
     }
 
     for (auto agent_id : agents_to_close)
-        remove_agent(agent_id);
+        remove_agent(agent_id, AgentRemovalCause::OwnerSetEmptied);
 }
 
 void WorkerProcessManager::broadcast_channel_message_from_web_content(Web::HTML::BroadcastChannelMessage const& message, IsPrivate is_private)
@@ -284,18 +283,6 @@ ErrorOr<void> WorkerProcessManager::simulate_request_server_connection_loss_for_
     return {};
 }
 
-void WorkerProcessManager::notify_worker_script_load_success(Owner const& owner)
-{
-    owner.client.visit(
-        [&](WebContentOwner const& web_content_owner) {
-            if (web_content_owner.client)
-                web_content_owner.client->async_did_worker_agent_finish_loading_script(owner.token);
-        },
-        [&](WebWorkerOwner const& web_worker_owner) {
-            web_worker_owner.client->async_did_worker_agent_finish_loading_script(owner.token);
-        });
-}
-
 void WorkerProcessManager::notify_worker_script_load_failure(Owner const& owner)
 {
     owner.client.visit(
@@ -352,9 +339,6 @@ void WorkerProcessManager::worker_did_finish_loading_script(Web::HTML::WorkerAge
 
     auto& agent = maybe_agent->value;
     agent.worker_is_secure_context = worker_is_secure_context;
-
-    for (auto const& owner : agent.owners)
-        notify_worker_script_load_success(owner);
 }
 
 void WorkerProcessManager::worker_did_fail_loading_script(Web::HTML::WorkerAgentId agent_id)
@@ -373,7 +357,7 @@ void WorkerProcessManager::worker_did_fail_loading_script(Web::HTML::WorkerAgent
         notify_worker_script_load_failure(owner);
 
     Core::deferred_invoke([this, agent_id] {
-        remove_agent(agent_id);
+        remove_agent(agent_id, AgentRemovalCause::AgentTerminated);
     });
 }
 
@@ -403,7 +387,7 @@ void WorkerProcessManager::worker_did_close(Web::HTML::WorkerAgentId agent_id)
         notify_worker_close(owner);
 
     Core::deferred_invoke([this, agent_id] {
-        remove_agent(agent_id);
+        remove_agent(agent_id, AgentRemovalCause::AgentTerminated);
     });
 }
 
@@ -426,7 +410,7 @@ void WorkerProcessManager::worker_did_die(Web::HTML::WorkerAgentId agent_id)
         notify_worker_death(owner);
 
     Core::deferred_invoke([this, agent_id] {
-        remove_agent(agent_id);
+        remove_agent(agent_id, AgentRemovalCause::AgentTerminated);
     });
 }
 
@@ -471,11 +455,16 @@ void WorkerProcessManager::worker_did_post_broadcast_channel_message(Web::HTML::
     }
 }
 
-void WorkerProcessManager::remove_agent(Web::HTML::WorkerAgentId agent_id)
+void WorkerProcessManager::remove_agent(Web::HTML::WorkerAgentId agent_id, AgentRemovalCause cause)
 {
     auto maybe_agent = m_agents.find(agent_id);
     if (maybe_agent == m_agents.end())
         return;
+
+    // A worker still reachable from an owner is actively needed, and closing it here would be the
+    // wrapper-lifetime bug this ownership model exists to prevent.
+    if (cause == AgentRemovalCause::OwnerSetEmptied)
+        VERIFY(maybe_agent->value.owners.is_empty());
 
     auto agent = move(maybe_agent->value);
     m_agents.remove(agent_id);
@@ -513,8 +502,10 @@ void WorkerProcessManager::remove_owner(Web::HTML::WorkerAgentId agent_id, Owner
     if (!agent_owned_by_specified_owner)
         return;
 
-    if (agent.agent_type == Web::HTML::AgentType::DedicatedWorker || agent.owners.is_empty())
-        remove_agent(agent_id);
+    if (agent.owners.is_empty())
+        remove_agent(agent_id, AgentRemovalCause::OwnerSetEmptied);
+    else if (agent.agent_type == Web::HTML::AgentType::DedicatedWorker)
+        remove_agent(agent_id, AgentRemovalCause::AgentTerminated);
 }
 
 Optional<u64> WorkerProcessManager::exclusive_performance_owner(pid_t pid) const

--- a/Libraries/LibWebView/WorkerProcessManager.h
+++ b/Libraries/LibWebView/WorkerProcessManager.h
@@ -87,6 +87,7 @@ private:
     void notify_worker_script_load_failure(Owner const&);
     void notify_worker_exception(Owner const&, Utf16String const& message, Utf16String const& filename, u32 lineno, u32 colno);
     void notify_worker_close(Owner const&);
+    void notify_worker_death(Owner const&);
 
     void worker_did_finish_loading_script(Web::HTML::WorkerAgentId, bool worker_is_secure_context);
     void worker_did_fail_loading_script(Web::HTML::WorkerAgentId);

--- a/Libraries/LibWebView/WorkerProcessManager.h
+++ b/Libraries/LibWebView/WorkerProcessManager.h
@@ -83,7 +83,6 @@ private:
 
     Web::HTML::WorkerAgentId start_worker_agent(Owner, Web::HTML::WorkerAgentStartRequest, IsPrivate);
 
-    void notify_worker_script_load_success(Owner const&);
     void notify_worker_script_load_failure(Owner const&);
     void notify_worker_exception(Owner const&, Utf16String const& message, Utf16String const& filename, u32 lineno, u32 colno);
     void notify_worker_close(Owner const&);
@@ -97,7 +96,11 @@ private:
     void worker_did_request_file(Web::HTML::WorkerAgentId, ByteString path, i32 request_id);
     void worker_did_post_broadcast_channel_message(Web::HTML::WorkerAgentId, Web::HTML::BroadcastChannelMessage);
 
-    void remove_agent(Web::HTML::WorkerAgentId);
+    enum class AgentRemovalCause {
+        OwnerSetEmptied,
+        AgentTerminated,
+    };
+    void remove_agent(Web::HTML::WorkerAgentId, AgentRemovalCause);
     void remove_owner(Web::HTML::WorkerAgentId, Owner const& identity);
 
     struct WorkerAgent {

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2807,11 +2807,6 @@ void ConnectionFromClient::broadcast_channel_message(Web::HTML::BroadcastChannel
     Web::HTML::BroadcastChannel::deliver_message_locally(message);
 }
 
-void ConnectionFromClient::did_worker_agent_finish_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token)
-{
-    Web::HTML::WorkerAgentParent::did_finish_loading_worker_script(owner_token);
-}
-
 void ConnectionFromClient::did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token)
 {
     Web::HTML::WorkerAgentParent::did_fail_loading_worker_script(owner_token);

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2827,6 +2827,11 @@ void ConnectionFromClient::did_worker_agent_close(Web::HTML::WorkerAgentOwnerTok
     Web::HTML::WorkerAgentParent::did_close_worker(owner_token);
 }
 
+void ConnectionFromClient::did_worker_agent_die(Web::HTML::WorkerAgentOwnerToken owner_token)
+{
+    Web::HTML::WorkerAgentParent::did_worker_agent_die(owner_token);
+}
+
 // https://html.spec.whatwg.org/multipage/speculative-loading.html#nav-traversal-ui:close-a-top-level-traversable
 void ConnectionFromClient::request_close(u64 page_id)
 {

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -267,7 +267,6 @@ private:
     virtual void set_document_cookie_version_index(u64 page_id, i64 document_id, Core::SharedVersionIndex document_index) override;
     virtual void cookies_changed(u64 page_id, Vector<HTTP::Cookie::Cookie>) override;
     virtual void broadcast_channel_message(Web::HTML::BroadcastChannelMessage message) override;
-    virtual void did_worker_agent_finish_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) override;
     virtual void did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) override;
     virtual void did_worker_agent_report_exception(Web::HTML::WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno) override;
     virtual void did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) override;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -271,6 +271,7 @@ private:
     virtual void did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) override;
     virtual void did_worker_agent_report_exception(Web::HTML::WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno) override;
     virtual void did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) override;
+    virtual void did_worker_agent_die(Web::HTML::WorkerAgentOwnerToken owner_token) override;
 
     virtual void request_close(u64 page_id) override;
     virtual void force_close(u64 page_id) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -247,6 +247,7 @@ endpoint WebContentServer
     did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) =|
     did_worker_agent_report_exception(Web::HTML::WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno) =|
     did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) =|
+    did_worker_agent_die(Web::HTML::WorkerAgentOwnerToken owner_token) =|
 
     request_close(u64 page_id) =|
     force_close(u64 page_id) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -243,7 +243,6 @@ endpoint WebContentServer
     cookies_changed(u64 page_id, Vector<HTTP::Cookie::Cookie> cookies) =|
     broadcast_channel_message(Web::HTML::BroadcastChannelMessage message) =|
 
-    did_worker_agent_finish_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) =|
     did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) =|
     did_worker_agent_report_exception(Web::HTML::WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno) =|
     did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) =|

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -264,6 +264,11 @@ void ConnectionFromClient::did_worker_agent_close(Web::HTML::WorkerAgentOwnerTok
     Web::HTML::WorkerAgentParent::did_close_worker(owner_token);
 }
 
+void ConnectionFromClient::did_worker_agent_die(Web::HTML::WorkerAgentOwnerToken owner_token)
+{
+    Web::HTML::WorkerAgentParent::did_worker_agent_die(owner_token);
+}
+
 void ConnectionFromClient::broadcast_channel_message(Web::HTML::BroadcastChannelMessage message)
 {
     Web::HTML::BroadcastChannel::deliver_message_locally(message);

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -244,11 +244,6 @@ void ConnectionFromClient::handle_file_return(i32 error, Optional<IPC::File> fil
     file_request.value().on_file_request_finish(error != 0 ? Error::from_errno(error) : ErrorOr<i32> { file->take_fd() });
 }
 
-void ConnectionFromClient::did_worker_agent_finish_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token)
-{
-    Web::HTML::WorkerAgentParent::did_finish_loading_worker_script(owner_token);
-}
-
 void ConnectionFromClient::did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token)
 {
     Web::HTML::WorkerAgentParent::did_fail_loading_worker_script(owner_token);

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -76,6 +76,7 @@ private:
     virtual void did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) override;
     virtual void did_worker_agent_report_exception(Web::HTML::WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno) override;
     virtual void did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) override;
+    virtual void did_worker_agent_die(Web::HTML::WorkerAgentOwnerToken owner_token) override;
     virtual void broadcast_channel_message(Web::HTML::BroadcastChannelMessage message) override;
 
     GC::Root<PageHost> m_page_host;

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -72,7 +72,6 @@ private:
     virtual void connect_shared_worker(Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject) override;
     virtual void handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id) override;
     virtual void blob_url_entry_removed(Utf16String url) override;
-    virtual void did_worker_agent_finish_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) override;
     virtual void did_worker_agent_fail_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) override;
     virtual void did_worker_agent_report_exception(Web::HTML::WorkerAgentOwnerToken owner_token, Utf16String message, Utf16String filename, u32 lineno, u32 colno) override;
     virtual void did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) override;

--- a/Tests/LibWeb/Text/expected/Worker/SharedWorker-survives-gc.txt
+++ b/Tests/LibWeb/Text/expected/Worker/SharedWorker-survives-gc.txt
@@ -1,0 +1,1 @@
+echo: ping

--- a/Tests/LibWeb/Text/input/Worker/SharedWorker-survives-gc.html
+++ b/Tests/LibWeb/Text/input/Worker/SharedWorker-survives-gc.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // https://html.spec.whatwg.org/multipage/workers.html#active-needed-worker
+    // A SharedWorkerGlobalScope whose owner set contains a fully active Document is actively needed,
+    // so collecting the SharedWorker object must not tear the worker down while its port is in use.
+    asyncTest(async done => {
+        const source = new Blob(["onconnect = event => { const port = event.ports[0]; port.postMessage('ready'); port.onmessage = e => port.postMessage('echo: ' + e.data); };"], { type: "text/javascript" });
+        const port = (() => {
+            const worker = new SharedWorker(URL.createObjectURL(source), "shared-worker-survives-gc");
+            return worker.port;
+        })();
+
+        // Wait until the worker is running, so that it is held by nothing but its owner set.
+        await new Promise(resolve => {
+            port.onmessage = () => resolve();
+            port.start();
+        });
+        await internals.gcAsync();
+        await internals.gcAsync();
+
+        port.onmessage = event => {
+            println(event.data);
+            done();
+        };
+        port.postMessage("ping");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Worker/Worker-requestAnimationFrame-supported.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-requestAnimationFrame-supported.html
@@ -6,14 +6,29 @@
     // Document: a worker nested inside a page-owned dedicated worker is supported, while a worker
     // nested inside a shared worker is not and must throw "NotSupportedError".
     asyncTest(done => {
+        let finished = false;
+        function finish() {
+            if (finished)
+                return;
+            finished = true;
+            done();
+        }
+        function reportFailure(message) {
+            println(message);
+            finish();
+        }
+
         function testNestedInDedicatedWorker(next) {
             const parentScript = `
                 const nestedScript = 'try { requestAnimationFrame(() => postMessage("raf callback ran")); } catch (e) { postMessage("raf threw: " + e.name); }';
                 const nested = new Worker(URL.createObjectURL(new Blob([nestedScript], { type: "application/javascript" })));
+                nested.onerror = e => postMessage("nested worker error: " + e.message);
                 nested.onmessage = evt => postMessage(evt.data);
             `;
             const blob = new Blob([parentScript], { type: "application/javascript" });
             const worker = new Worker(URL.createObjectURL(blob));
+            worker.onerror = event => reportFailure("nested in dedicated worker: worker error: " + event.message);
+            worker.onmessageerror = () => reportFailure("nested in dedicated worker: message deserialization failed");
             worker.onmessage = evt => {
                 println("nested in dedicated worker: " + evt.data);
                 next();
@@ -26,11 +41,14 @@
                     const port = event.ports[0];
                     const nestedScript = 'let result; try { requestAnimationFrame(() => {}); result = "raf did not throw"; } catch (e) { result = "raf threw: " + e.name; } try { cancelAnimationFrame(1); result += ", caf did not throw"; } catch (e) { result += ", caf threw: " + e.name; } postMessage(result);';
                     const nested = new Worker(URL.createObjectURL(new Blob([nestedScript], { type: "application/javascript" })));
+                    nested.onerror = e => port.postMessage("nested worker error: " + e.message);
                     nested.onmessage = evt => port.postMessage(evt.data);
                 };
             `;
             const blob = new Blob([sharedScript], { type: "application/javascript" });
             const worker = new SharedWorker(URL.createObjectURL(blob), "raf-supported-test");
+            worker.onerror = event => reportFailure("nested in shared worker: worker error: " + event.message);
+            worker.port.onmessageerror = () => reportFailure("nested in shared worker: message deserialization failed");
             worker.port.onmessage = evt => {
                 println("nested in shared worker: " + evt.data);
                 next();
@@ -38,6 +56,6 @@
             worker.port.start();
         }
 
-        testNestedInDedicatedWorker(() => testNestedInSharedWorker(done));
+        testNestedInDedicatedWorker(() => testNestedInSharedWorker(finish));
     });
 </script>


### PR DESCRIPTION
This fixes a timeout in Worker-requestAnimationFrame-supported.html since it relied on GC not reclaiming a worker that was expected to report back to the test.