### PR TITLE
Tests/LibWeb: Update WPT's scroll-to-anchored-fixed tests

### DIFF
--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-001-ref.html
@@ -55,6 +55,7 @@ function raf() {
   return new Promise(resolve => requestAnimationFrame(resolve));
 }
 async function runTest() {
+  await document.fonts.ready;
   await raf();
   document.getElementById('test').focus();
   await raf();

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-005-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-005-ref.html
@@ -55,6 +55,7 @@ function raf() {
   return new Promise(resolve => requestAnimationFrame(resolve));
 }
 async function runTest() {
+  await document.fonts.ready;
   await raf();
   document.getElementById('test').focus();
   await raf();

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-001.html
@@ -58,6 +58,7 @@ function raf() {
   return new Promise(resolve => requestAnimationFrame(resolve));
 }
 async function runTest() {
+  await document.fonts.ready;
   await raf();
   document.getElementById('test').focus();
   await raf();

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-005.html
@@ -58,6 +58,7 @@ function raf() {
   return new Promise(resolve => requestAnimationFrame(resolve));
 }
 async function runTest() {
+  await document.fonts.ready;
   await raf();
   document.getElementById('test').focus();
   await raf();


### PR DESCRIPTION
These were updated upstream to wait for fonts to load, which fixes a flake that has been plaguing our CI.