### PR TITLE
LibWebView: Fix visual glitches during cross-site navigation

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1086,7 +1086,11 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(
         initial_document_state_id = cross_process_id_allocator.allocate();
 
     auto client = TRY(WebView::launch_web_content_process(is_private, initial_page_id, root_navigable_id));
-    auto system_visibility_state = view.has_value() ? view->traversable().system_visibility_state() : Web::HTML::VisibilityState::Hidden;
+    // NB: A replacement process's bootstrap about:blank is not the displayed document. Keep it hidden so it
+    //     cannot paint over the outgoing page; activation supplies the destination's actual visibility state.
+    auto system_visibility_state = view.has_value() && !navigable_to_adopt.has_value()
+        ? view->traversable().system_visibility_state()
+        : Web::HTML::VisibilityState::Hidden;
 
     // A process replacing another adopts the view's traversable, so this entry only bootstraps its about:blank:
     // the entry's identity is never observed, and the canonical entry it will host arrives with the traversal.

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -2828,6 +2828,9 @@ void CanonicalTraversable::did_receive_changing_navigable_continuation_applied(W
                 if (navigable_id == id()) {
                     if (auto view = ViewImplementation::find_view_for_traversable(*this); view.has_value()) {
                         view->m_client_state.hosts_committed_entry = true;
+                        // NB: The address bar can already show a pending navigation's URL while the old document
+                        //     is still visible. Only apply the destination's zoom after its document is activated.
+                        view->apply_zoom_for_current_host();
                         view->m_external_url_request_policy.clear_page_request_allowance();
                         if (view->on_top_level_navigation_commit)
                             view->on_top_level_navigation_commit();

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -55,6 +55,13 @@ void CanonicalTraversable::set_system_visibility_state(Web::HTML::VisibilityStat
         if (!endpoint.client)
             return IterationDecision::Continue;
 
+        // NB: Tab visibility changes must not expose a replacement process's bootstrap document.
+        //     The destination receives the latest system visibility state when it is activated.
+        if (navigable.is_top_level_traversable()) {
+            if (auto view = ViewImplementation::find_view_for_traversable(*this); view.has_value() && !view->m_client_state.hosts_committed_entry)
+                return IterationDecision::Continue;
+        }
+
         // 2. Queue a global task on the user interaction task source given document's relevant global object
         //    to update the visibility state of document with newState.
         endpoint.client->async_update_visibility_state(endpoint.page_id, navigable.id(), visibility_state);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2159,7 +2159,8 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client, Op
     client().async_set_zoom_level(m_client_state.page_index, m_zoom_level);
     client().async_set_viewport(m_client_state.page_index, viewport_size(), m_device_pixel_ratio, m_is_fullscreen);
     client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
-    client().async_update_visibility_state(m_client_state.page_index, m_top_level_traversable.id(), m_top_level_traversable.system_visibility_state());
+    if (m_client_state.hosts_committed_entry)
+        client().async_update_visibility_state(m_client_state.page_index, m_top_level_traversable.id(), m_top_level_traversable.system_visibility_state());
     auto compositor_context_id = client().compositor_context_id_for_page(m_client_state.page_index);
     Application::the().update_compositor_viewport(compositor_context_id, viewport_size().to_type<int>());
     Application::the().update_compositor_context_visibility(compositor_context_id, m_top_level_traversable.system_visibility_state());

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2110,8 +2110,12 @@ void ViewImplementation::handle_resize()
 
 void ViewImplementation::initialize_client(CreateNewClient create_new_client, Optional<Web::HTML::CrossProcessId> initial_document_state_id)
 {
-    if (create_new_client == CreateNewClient::Yes)
+    if (create_new_client == CreateNewClient::Yes) {
         fail_pending_debugger_requests();
+        // NB: The replacement process has no hovered link and cannot clear the outgoing page's status label.
+        if (on_link_unhover)
+            on_link_unhover();
+    }
     if (m_debugger_paused) {
         set_debugger_paused(false);
         if (on_debugger_resumed)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -168,12 +168,8 @@ void ViewImplementation::set_url(URL::URL url)
     if (m_url == url)
         return;
 
-    auto previous_host = current_host();
     m_url = move(url);
     update_bookmark_action();
-
-    if (current_host() != previous_host)
-        apply_zoom_for_current_host();
 
     if (on_url_change)
         on_url_change(m_url);
@@ -2080,9 +2076,10 @@ void ViewImplementation::update_zoom()
 
 String ViewImplementation::current_host() const
 {
-    if (!m_url.host().has_value())
+    auto const& state = m_top_level_traversable.replicated_state();
+    if (!state.has_value() || !state->active_document_url.host().has_value())
         return {};
-    return m_url.serialized_host();
+    return state->active_document_url.serialized_host();
 }
 
 void ViewImplementation::apply_zoom_for_current_host()

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -152,6 +152,12 @@ if (BUILD_TESTING AND NOT WIN32)
     set_tests_properties(TestWebDriverSessionHistory PROPERTIES TIMEOUT 120 ENVIRONMENT "XDG_DATA_HOME=${CMAKE_CURRENT_BINARY_DIR}/session-history-data")
 
     add_test(
+        NAME TestWebDriverSiteZoom
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-webdriver-site-zoom.py $<TARGET_FILE:WebDriver>
+    )
+    set_tests_properties(TestWebDriverSiteZoom PROPERTIES TIMEOUT 120)
+
+    add_test(
         NAME TestWebDriverErrorKeepAlive
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-webdriver-error-keep-alive.py $<TARGET_FILE:WebDriver>
     )

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -158,6 +158,12 @@ if (BUILD_TESTING AND NOT WIN32)
     set_tests_properties(TestWebDriverSiteZoom PROPERTIES TIMEOUT 120)
 
     add_test(
+        NAME TestWebDriverSiteZoomWithSiteIsolation
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-webdriver-site-zoom.py $<TARGET_FILE:WebDriver>
+    )
+    set_tests_properties(TestWebDriverSiteZoomWithSiteIsolation PROPERTIES TIMEOUT 120 ENVIRONMENT "LADYBIRD_WEBDRIVER_ENABLE_SITE_ISOLATION=1")
+
+    add_test(
         NAME TestWebDriverErrorKeepAlive
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-webdriver-error-keep-alive.py $<TARGET_FILE:WebDriver>
     )

--- a/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
+++ b/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
@@ -237,9 +237,23 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Core::EventLoop::current().spin_until([&] { return restored_view_loads_finished >= 1 && restored_view->url() == closed_tab_url; });
     VERIFY(restored_view->traversable().session_history().current_entry()->url == closed_tab_url);
 
+    // The new process has no hovered link, so it cannot send an unhover notification for the outgoing page.
+    bool link_is_hovered = false;
+    restored_view->on_link_hover = [&](auto const&) { link_is_hovered = true; };
+    restored_view->on_link_unhover = [&] { link_is_hovered = false; };
+    restored_view->run_javascript("document.body.innerHTML = '<a href=\"https://example.com/\" style=\"position:fixed;inset:0\">Link</a>'"_string);
+    restored_view->enqueue_input_event(Web::MouseEvent {
+        .type = Web::MouseEvent::Type::MouseMove,
+        .position = { 20, 20 },
+        .screen_position = { 20, 20 },
+        .browser_data = nullptr,
+    });
+    Core::EventLoop::current().spin_until([&] { return link_is_hovered; });
+    restored_view->replace_web_content_process_for_history_traversal(restored_view->traversable().session_history().current_entry()->document_state.id);
+    VERIFY(!link_is_hovered);
+
     // A replacement process's bootstrap document must stay hidden until the destination is activated.
     // Otherwise it can paint over the outgoing page while the destination is still being prepared.
-    restored_view->replace_web_content_process_for_history_traversal(restored_view->traversable().session_history().current_entry()->document_state.id);
     auto document_is_hidden = [&] {
         Optional<bool> hidden;
         restored_view->on_request_alert = [&](Utf16String const& value) {

--- a/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
+++ b/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
@@ -237,6 +237,30 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Core::EventLoop::current().spin_until([&] { return restored_view_loads_finished >= 1 && restored_view->url() == closed_tab_url; });
     VERIFY(restored_view->traversable().session_history().current_entry()->url == closed_tab_url);
 
+    // A replacement process's bootstrap document must stay hidden until the destination is activated.
+    // Otherwise it can paint over the outgoing page while the destination is still being prepared.
+    restored_view->replace_web_content_process_for_history_traversal(restored_view->traversable().session_history().current_entry()->document_state.id);
+    auto document_is_hidden = [&] {
+        Optional<bool> hidden;
+        restored_view->on_request_alert = [&](Utf16String const& value) {
+            hidden = value == "hidden"_utf16;
+            restored_view->alert_closed();
+        };
+        restored_view->run_javascript("alert(document.visibilityState)"_string);
+        Core::EventLoop::current().spin_until([&] { return hidden.has_value(); });
+        restored_view->on_request_alert = nullptr;
+        return *hidden;
+    };
+    VERIFY(document_is_hidden());
+    restored_view->set_system_visibility_state(Web::HTML::VisibilityState::Hidden);
+    restored_view->set_system_visibility_state(Web::HTML::VisibilityState::Visible);
+    VERIFY(document_is_hidden());
+    auto loads_before_replacement_reload = restored_view_loads_finished;
+    restored_view->reload();
+    Core::EventLoop::current().spin_until([&] { return restored_view_loads_finished > loads_before_replacement_reload; });
+    VERIFY(!document_is_hidden());
+    VERIFY(restored_view->url() == closed_tab_url);
+
     outln("PASS: browser history traversal");
     return 0;
 }

--- a/Tests/LibWebView/test-webdriver-site-zoom.py
+++ b/Tests/LibWebView/test-webdriver-site-zoom.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026-present, the Ladybird developers.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import http.server
+import json
+import runpy
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+from pathlib import Path
+
+helpers = runpy.run_path(str(Path(__file__).with_name("test-webdriver-delete-session.py")))
+requested = threading.Event()
+release_response = threading.Event()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/blocked":
+            requested.set()
+            if not release_response.wait(timeout=30):
+                self.send_error(500)
+                return
+        if self.path == "/favicon.ico":
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(b"<!doctype html><title>Zoom test</title><body>Zoom test")
+
+    def log_message(self, format, *args):
+        pass
+
+
+with tempfile.TemporaryDirectory() as directory:
+    config = Path(directory) / "config"
+    config.mkdir()
+    (config / "Settings.json").write_text(json.dumps({"zoomPerHost": {"127.0.0.1": 1.8}}))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    port = helpers["unused_port"]()
+    process = subprocess.Popen(
+        [sys.argv[1], "--headless", "-l", "127.0.0.1", "-p", str(port), "--profile-path", directory]
+    )
+    session = None
+    try:
+        helpers["wait_for_port"](port)
+        session = helpers["create_session"](port)
+
+        def command(path, body):
+            status, payload, raw = helpers["request"](port, "POST", f"/session/{session}/{path}", body)
+            assert status == 200, raw
+            return payload["value"]
+
+        def script(source, *args):
+            return command("execute/sync", {"script": source, "args": list(args)})
+
+        def wait_for_page(url, pixel_ratio):
+            deadline = time.monotonic() + 30
+            state = None
+            while time.monotonic() < deadline:
+                state = script("return [location.href, document.readyState, devicePixelRatio]")
+                if state == [url, "complete", pixel_ratio]:
+                    return
+                time.sleep(0.01)
+            raise AssertionError(f"Expected {url} at scale {pixel_ratio}, got {state}")
+
+        # Measure the platform's unzoomed ratio rather than assuming a particular display density.
+        baseline_ratio = script("return devicePixelRatio")
+        source_url = f"http://127.0.0.1:{server.server_port}/source"
+        target_url = f"http://localhost:{server.server_port}/blocked"
+        command("url", {"url": source_url})
+        wait_for_page(source_url, baseline_ratio * 1.8)
+
+        # Hold the response until the old document has been inspected. No delay determines whether
+        # navigation has started or whether it is allowed to commit.
+        script(
+            "const a = document.createElement('a'); a.href = arguments[0]; document.body.append(a); a.click();",
+            target_url,
+        )
+        assert requested.wait(timeout=30), "Destination request did not arrive"
+        state = script("return [location.href, devicePixelRatio]")
+        assert state == [source_url, baseline_ratio * 1.8], f"Pending navigation changed the old page's zoom: {state}"
+        release_response.set()
+        wait_for_page(target_url, baseline_ratio)
+
+        command("back", {})
+        wait_for_page(source_url, baseline_ratio * 1.8)
+
+        # A canceled navigation must also leave the source document at its saved zoom.
+        requested.clear()
+        release_response.clear()
+        script("location.href = arguments[0]", target_url)
+        assert requested.wait(timeout=30), "Canceled destination request did not arrive"
+        script("window.stop()")
+        state = script("return [location.href, devicePixelRatio]")
+        assert state == [source_url, baseline_ratio * 1.8], f"Canceled navigation changed zoom: {state}"
+        release_response.set()
+        print("PASS: site zoom follows the committed document")
+    finally:
+        release_response.set()
+        if session is not None:
+            helpers["request"](port, "DELETE", f"/session/{session}")
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+        server.shutdown()
+        server.server_close()

--- a/Tests/LibWebView/test-webdriver-site-zoom.py
+++ b/Tests/LibWebView/test-webdriver-site-zoom.py
@@ -67,7 +67,19 @@ with tempfile.TemporaryDirectory() as directory:
             deadline = time.monotonic() + 30
             state = None
             while time.monotonic() < deadline:
-                state = script("return [location.href, document.readyState, devicePixelRatio]")
+                status, payload, raw = helpers["request"](
+                    port,
+                    "POST",
+                    f"/session/{session}/execute/sync",
+                    {"script": "return [location.href, document.readyState, devicePixelRatio]", "args": []},
+                )
+                if (
+                    status == 500
+                    and payload["value"]["message"] == "WebContent was replaced while executing the command"
+                ):
+                    continue
+                assert status == 200, raw
+                state = payload["value"]
                 if state == [url, "complete", pixel_ratio]:
                     return
                 time.sleep(0.01)


### PR DESCRIPTION
Apply saved site zoom when the destination document is activated, so the outgoing page keeps its scale while navigation is pending. Keep the replacement process’s startup `about:blank` hidden to avoid a blank flash, and clear the outgoing page’s hovered-link status so its URL doesn’t linger after navigation.
