### PR TITLE
Fix style verification and timing-dependent web test failures

### DIFF
--- a/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -21,6 +21,16 @@
 
 namespace Gfx {
 
+RefPtr<Typeface> SystemFontProvider::get_typeface_by_local_name(String const&)
+{
+    return {};
+}
+
+RefPtr<Typeface> FontDatabase::get_typeface_by_local_name(String const& name)
+{
+    return m_system_font_provider->get_typeface_by_local_name(name);
+}
+
 // Key function for SystemFontProvider to emit the vtable here
 SystemFontProvider::~SystemFontProvider() = default;
 

--- a/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Libraries/LibGfx/Font/FontDatabase.h
@@ -24,6 +24,7 @@ public:
     virtual RefPtr<Gfx::Font> get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings = {}, Optional<Gfx::ShapeFeatures> const& shape_features = {}) = 0;
     virtual void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>) = 0;
     virtual RefPtr<Typeface> get_typeface_by_id(u64 generation, u64 face_id);
+    virtual RefPtr<Typeface> get_typeface_by_local_name(String const&);
     virtual RefPtr<Gfx::Font> get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope, bool prefer_color_emoji);
     virtual Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope);
 };
@@ -36,6 +37,7 @@ public:
     RefPtr<Gfx::Font> get(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings = {}, Optional<Gfx::ShapeFeatures> const& shape_features = {});
     RefPtr<Gfx::Font> get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope, bool prefer_color_emoji);
     RefPtr<Typeface> get_typeface_by_id(u64 generation, u64 face_id);
+    RefPtr<Typeface> get_typeface_by_local_name(String const&);
     Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope);
     void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>);
     [[nodiscard]] StringView system_font_provider_name() const;

--- a/Libraries/LibGfx/Font/SharedFontProvider.cpp
+++ b/Libraries/LibGfx/Font/SharedFontProvider.cpp
@@ -12,6 +12,13 @@
 
 namespace Gfx {
 
+RefPtr<Typeface> SharedFontProvider::get_typeface_by_local_name(String const& name)
+{
+    if (!m_callbacks.match_local_font)
+        return {};
+    return load_brokered_font(m_callbacks.match_local_font(name));
+}
+
 ErrorOr<NonnullOwnPtr<SharedFontProvider>> SharedFontProvider::create(NonnullOwnPtr<Core::MappedFile> mapping, u64 generation, SharedFontProviderCallbacks&& callbacks)
 {
     auto catalog = TRY(FontCatalog::parse(mapping->bytes(), generation));

--- a/Libraries/LibGfx/Font/SharedFontProvider.h
+++ b/Libraries/LibGfx/Font/SharedFontProvider.h
@@ -28,6 +28,7 @@ struct BrokeredFont {
 
 struct SharedFontProviderCallbacks {
     Function<BrokeredFont(u64 generation, u64 face_id)> open_font;
+    Function<BrokeredFont(String const& name)> match_local_font;
     Function<BrokeredFont(String const& family, u16 weight, u16 width, u8 slope)> match_font;
     Function<BrokeredFont(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)> match_font_for_code_point;
     Function<Optional<FlyString>(String const& family, u16 weight, u8 slope)> resolve_generic_family;
@@ -49,6 +50,7 @@ public:
     virtual RefPtr<Gfx::Font> get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& = {}, Optional<Gfx::ShapeFeatures> const& = {}) override;
     virtual void for_each_typeface_with_family_name(FlyString const&, Function<void(Typeface const&)>) override;
     virtual RefPtr<Typeface> get_typeface_by_id(u64 generation, u64 face_id) override;
+    virtual RefPtr<Typeface> get_typeface_by_local_name(String const&) override;
     virtual RefPtr<Gfx::Font> get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) override;
     virtual Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope) override;
     virtual StringView name() const LIFETIME_BOUND override { return "Shared"sv; }

--- a/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Libraries/LibGfx/Font/Typeface.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <harfbuzz/hb-ot.h>
 #include <harfbuzz/hb.h>
 
 #include <LibGfx/Font/Font.h>
@@ -15,6 +16,41 @@
 #include <LibIPC/Encoder.h>
 
 namespace Gfx {
+
+ErrorOr<Vector<String>> Typeface::local_font_names() const
+{
+    // https://drafts.csswg.org/css-fonts-4/#local-font-fallback
+    // NB: local() identifies a face by its full name or PostScript name, never by its family.
+    //     Prefer US English names, or the first available localization if English is absent.
+    auto* face = harfbuzz_typeface();
+    unsigned entry_count = 0;
+    auto const* entries = hb_ot_name_list_names(face, &entry_count);
+    Vector<String> names;
+    for (auto name_id : { HB_OT_NAME_ID_FULL_NAME, HB_OT_NAME_ID_POSTSCRIPT_NAME }) {
+        hb_language_t language = HB_LANGUAGE_INVALID;
+        for (unsigned index = 0; index < entry_count; ++index) {
+            auto const& entry = entries[index];
+            if (entry.name_id != name_id)
+                continue;
+            if (language == HB_LANGUAGE_INVALID)
+                language = entry.language;
+            if (entry.language == hb_language_from_string("en", -1) || entry.language == hb_language_from_string("en-us", -1)) {
+                language = entry.language;
+                break;
+            }
+        }
+        if (language == HB_LANGUAGE_INVALID)
+            continue;
+        auto length = hb_ot_name_get_utf8(face, name_id, language, nullptr, nullptr);
+        if (length == 0 || length == NumericLimits<unsigned>::max())
+            continue;
+        auto bytes = TRY(ByteBuffer::create_uninitialized(static_cast<size_t>(length) + 1));
+        auto capacity = length + 1;
+        hb_ot_name_get_utf8(face, name_id, language, &capacity, reinterpret_cast<char*>(bytes.data()));
+        names.append(TRY(String::from_utf8({ reinterpret_cast<char const*>(bytes.data()), capacity })));
+    }
+    return names;
+}
 
 ErrorOr<NonnullRefPtr<Typeface>> Typeface::try_load_from_resource(Core::Resource const& resource, u32 ttc_index)
 {

--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -84,6 +84,7 @@ public:
     Optional<SystemFontIdentifier> system_font_identifier() const { return m_system_font_identifier; }
 
     hb_face_t* harfbuzz_typeface() const;
+    ErrorOr<Vector<String>> local_font_names() const;
 
     // Union of all glyph bounding boxes as recorded in the `head` table, in font units with y pointing up.
     // is_empty() when the face has no usable `head` table (e.g. bitmap-only fonts).

--- a/Libraries/LibGfx/FontCascadeList.cpp
+++ b/Libraries/LibGfx/FontCascadeList.cpp
@@ -51,7 +51,7 @@ void FontCascadeList::add(NonnullRefPtr<Font const> font, Vector<UnicodeRange> u
         } });
 }
 
-void FontCascadeList::add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<PendingFontState()> resolve)
+void FontCascadeList::add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<PendingFontState()> resolve, Function<RefPtr<Font const>()> resolved_font)
 {
     m_ascii_cache.fill(nullptr);
     if (unicode_ranges.is_empty())
@@ -64,7 +64,7 @@ void FontCascadeList::add_pending_face(Vector<UnicodeRange> unicode_ranges, Func
         highest_code_point = max(highest_code_point, range.max_code_point());
     }
 
-    m_pending_faces.append({ m_fonts.size(), adopt_ref(*new PendingFace(UnicodeRange { lowest_code_point, highest_code_point }, move(unicode_ranges), move(resolve))) });
+    m_pending_faces.append({ m_fonts.size(), adopt_ref(*new PendingFace(UnicodeRange { lowest_code_point, highest_code_point }, move(unicode_ranges), move(resolve), move(resolved_font))) });
 }
 
 void FontCascadeList::extend(FontCascadeList const& other)
@@ -84,7 +84,7 @@ void FontCascadeList::extend_fallback(FontCascadeList const& other)
 // https://drafts.csswg.org/css-fonts/#first-available-font
 Gfx::Font const& FontCascadeList::first_available_font() const
 {
-    if (m_first_available_font_cache)
+    if (m_first_available_font_cache && m_pending_faces.is_empty())
         return *m_first_available_font_cache;
 
     // The first available font, used for example in the definition of font-relative lengths such as ex or in the
@@ -93,7 +93,26 @@ Gfx::Font const& FontCascadeList::first_available_font() const
     // font if none are available).
     static constexpr u32 space_code_point = 0x20;
 
-    for (auto const& entry : m_fonts) {
+    size_t pending_index = 0;
+    auto resolve_pending_faces = [&](size_t font_index) -> Font const* {
+        while (pending_index < m_pending_faces.size()
+            && m_pending_faces[pending_index].font_index <= font_index) {
+            auto const& pending = m_pending_faces[pending_index++].face;
+            if (!pending->covers(space_code_point))
+                continue;
+            // NB: Metric probes can use resident faces, but must not initiate font loads.
+            if (auto* font = pending->resolved_font())
+                return font;
+        }
+        return nullptr;
+    };
+
+    for (size_t font_index = 0; font_index < m_fonts.size(); ++font_index) {
+        if (auto* font = resolve_pending_faces(font_index)) {
+            m_first_available_font_cache = font;
+            return *font;
+        }
+        auto const& entry = m_fonts[font_index];
         if (!entry.range_data.has_value()) {
             m_first_available_font_cache = entry.font.ptr();
             return *m_first_available_font_cache;
@@ -107,6 +126,11 @@ Gfx::Font const& FontCascadeList::first_available_font() const
                 return *m_first_available_font_cache;
             }
         }
+    }
+
+    if (auto* font = resolve_pending_faces(m_fonts.size())) {
+        m_first_available_font_cache = font;
+        return *font;
     }
 
     m_first_available_font_cache = m_last_resort_font.ptr();
@@ -153,7 +177,8 @@ Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, EmojiPrese
 
     size_t pending_index = 0;
     bool rendering_with_fallback = false;
-    auto resolve_pending_faces = [&](size_t font_index) {
+    Font const* author_glyph_match = nullptr;
+    auto resolve_pending_faces = [&](size_t font_index) -> Font const* {
         while (!rendering_with_fallback && pending_index < m_pending_faces.size()
             && m_pending_faces[pending_index].font_index <= font_index) {
             auto const& pending = m_pending_faces[pending_index++].face;
@@ -162,16 +187,28 @@ Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, EmojiPrese
             auto state = pending->resolve();
             if (state == PendingFontState::Failed)
                 continue;
+            // NB: A local face can become available during resolution. Use its glyphs on
+            //     this first measurement without starting any unused fallback font loads.
+            if (auto* font = pending->resolved_font()) {
+                if (!font->contains_glyph(code_point))
+                    continue;
+                if (emoji_presentation.forced == ForcedPresentation::No || presentation_matches(*font))
+                    return font;
+                if (!author_glyph_match)
+                    author_glyph_match = font;
+                continue;
+            }
             invisible = state == PendingFontState::Invisible;
             // https://drafts.csswg.org/css-fonts-4/#font-display-timeline
             // Doing this must not trigger loads of any of the fallback fonts.
             rendering_with_fallback = true;
         }
+        return nullptr;
     };
 
-    Font const* author_glyph_match = nullptr;
     for (size_t font_index = 0; font_index < m_fonts.size(); ++font_index) {
-        resolve_pending_faces(font_index);
+        if (auto* font = resolve_pending_faces(font_index))
+            return cache_and_return(*font);
         auto const& entry = m_fonts[font_index];
         if (!entry_contains_glyph(entry))
             continue;
@@ -181,7 +218,8 @@ Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, EmojiPrese
             author_glyph_match = entry.font.ptr();
     }
 
-    resolve_pending_faces(m_fonts.size());
+    if (auto* font = resolve_pending_faces(m_fonts.size()))
+        return cache_and_return(*font);
 
     Font const* fallback_glyph_match = nullptr;
     for (auto const& entry : m_fallback_fonts) {

--- a/Libraries/LibGfx/FontCascadeList.h
+++ b/Libraries/LibGfx/FontCascadeList.h
@@ -62,7 +62,7 @@ public:
     void add(NonnullRefPtr<Font const> font, Vector<UnicodeRange> unicode_ranges);
 
     // Resolve a pending face only when it is selected for a rendered code point.
-    void add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<PendingFontState()> resolve);
+    void add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<PendingFontState()> resolve, Function<RefPtr<Font const>()> resolved_font = {});
 
     void extend(FontCascadeList const& other);
 
@@ -86,10 +86,11 @@ public:
 
     class PendingFace : public RefCounted<PendingFace> {
     public:
-        PendingFace(UnicodeRange enclosing, Vector<UnicodeRange> ranges, Function<PendingFontState()> resolve)
+        PendingFace(UnicodeRange enclosing, Vector<UnicodeRange> ranges, Function<PendingFontState()> resolve, Function<RefPtr<Font const>()> resolved_font)
             : m_enclosing_range(enclosing)
             , m_unicode_ranges(move(ranges))
             , m_resolve(move(resolve))
+            , m_resolved_font(move(resolved_font))
         {
         }
 
@@ -105,11 +106,19 @@ public:
         }
 
         PendingFontState resolve() const { return m_resolve(); }
+        Font const* resolved_font() const
+        {
+            if (!m_font && m_resolved_font)
+                m_font = m_resolved_font();
+            return m_font.ptr();
+        }
 
     private:
         UnicodeRange m_enclosing_range;
         Vector<UnicodeRange> m_unicode_ranges;
         Function<PendingFontState()> m_resolve;
+        Function<RefPtr<Font const>()> m_resolved_font;
+        mutable RefPtr<Font const> m_font;
     };
 
     void set_last_resort_font(NonnullRefPtr<Font> font)

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -86,10 +86,10 @@ FontComputer::FontComputer(DOM::Document& document)
 
 FontComputer::~FontComputer() = default;
 
-FontLoader::FontLoader(FontComputer& font_computer, RuleOrDeclaration rule_or_declaration, Vector<URL> urls, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load)
+FontLoader::FontLoader(FontComputer& font_computer, RuleOrDeclaration rule_or_declaration, Vector<Source> sources, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load)
     : m_font_computer(font_computer)
     , m_rule_or_declaration(rule_or_declaration)
-    , m_urls(move(urls))
+    , m_sources(move(sources))
 {
     if (on_load)
         m_subscribers.append(*on_load);
@@ -142,70 +142,82 @@ void FontLoader::did_request_for_rendering()
         m_document_load_event_delayer.emplace(m_font_computer->document());
 }
 
-void FontLoader::start_loading_next_url()
+void FontLoader::start_loading_next_source()
 {
-    // A loader that has settled must not consume another URL: its typeface is final, and fetching a
+    // A loader that has settled must not consume another source: its typeface is final, and fetching a
     // further src would replace it after subscribers already saw the settled one. load_font_face()
-    // hands back an existing loader for a shared first URL, so a second FontFace can reach here after
+    // hands back an existing loader for a shared source list, so a second FontFace can reach here after
     // the first one finished.
     if (m_has_completed)
         return;
 
-    // FIXME: Load local() fonts somehow.
     if (m_fetch_controller && m_fetch_controller->state() == Fetch::Infrastructure::FetchController::State::Ongoing)
         return;
-    if (m_urls.is_empty())
-        return;
 
-    // https://drafts.csswg.org/css-fonts-4/#fetch-a-font
-    // To fetch a font given a selected <url> url for @font-face rule, fetch url, with ruleOrDeclaration being rule,
-    // destination "font", CORS mode "cors", and processResponse being the following steps given response res and null,
-    // failure or a byte stream stream:
-    m_has_received_font_data = false;
-    m_fetch_controller = fetch_a_style_resource(m_urls.take_first(), m_rule_or_declaration, Fetch::Infrastructure::Request::Destination::Font, CorsMode::Cors,
-        [loader = this](auto response, auto stream) {
-            // 1. If stream is null, return.
-            // 2. Load a font from stream according to its type.
-
-            auto* immutable_bytes = stream.template get_pointer<Core::ImmutableBytes>();
-            if (!immutable_bytes) {
-                if (loader->m_urls.is_empty()) {
-                    loader->font_did_load_or_fail(nullptr);
-                } else {
-                    loader->m_fetch_controller = nullptr;
-                    loader->start_loading_next_url();
-                }
+    while (true) {
+        // https://drafts.csswg.org/css-fonts-4/#src-desc
+        // NB: Try local names and URLs in source order, continuing after an unavailable face.
+        while (!m_sources.is_empty() && m_sources.first().has<Utf16FlyString>()) {
+            auto name = MUST(m_sources.take_first().get<Utf16FlyString>().view().to_utf8());
+            if (auto typeface = Gfx::FontDatabase::the().get_typeface_by_local_name(name)) {
+                font_did_load_or_fail(move(typeface));
                 return;
             }
-            loader->m_has_received_font_data = true;
-            auto bytes = immutable_bytes->copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
+        }
+        if (m_sources.is_empty()) {
+            font_did_load_or_fail(nullptr);
+            return;
+        }
 
-            auto mime_type_essence = loader->try_load_font_mime_type_essence(response, bytes);
-            if (!requires_off_thread_vector_font_preparation(bytes, mime_type_essence)) {
-                auto maybe_typeface = try_load_vector_font(bytes, mime_type_essence);
-                if (maybe_typeface.is_error()) {
-                    if (loader->m_urls.is_empty()) {
+        // https://drafts.csswg.org/css-fonts-4/#fetch-a-font
+        // To fetch a font given a selected <url> url for @font-face rule, fetch url, with ruleOrDeclaration being rule,
+        // destination "font", CORS mode "cors", and processResponse being the following steps given response res and null,
+        // failure or a byte stream stream:
+        m_has_received_font_data = false;
+        m_fetch_controller = fetch_a_style_resource(m_sources.take_first().get<URL>(), m_rule_or_declaration, Fetch::Infrastructure::Request::Destination::Font, CorsMode::Cors,
+            [loader = this](auto response, auto stream) {
+                // 1. If stream is null, return.
+                // 2. Load a font from stream according to its type.
+
+                auto* immutable_bytes = stream.template get_pointer<Core::ImmutableBytes>();
+                if (!immutable_bytes) {
+                    if (loader->m_sources.is_empty()) {
                         loader->font_did_load_or_fail(nullptr);
                     } else {
                         loader->m_fetch_controller = nullptr;
-                        loader->start_loading_next_url();
+                        loader->start_loading_next_source();
                     }
                     return;
                 }
+                loader->m_has_received_font_data = true;
+                auto bytes = immutable_bytes->copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
 
-                loader->font_did_load_or_fail(maybe_typeface.release_value());
-                return;
-            }
+                auto mime_type_essence = loader->try_load_font_mime_type_essence(response, bytes);
+                if (!requires_off_thread_vector_font_preparation(bytes, mime_type_essence)) {
+                    auto maybe_typeface = try_load_vector_font(bytes, mime_type_essence);
+                    if (maybe_typeface.is_error()) {
+                        if (loader->m_sources.is_empty()) {
+                            loader->font_did_load_or_fail(nullptr);
+                        } else {
+                            loader->m_fetch_controller = nullptr;
+                            loader->start_loading_next_source();
+                        }
+                        return;
+                    }
 
-            auto loader_handle = GC::make_root(GC::Ref(*loader));
-            prepare_vector_font_data_off_thread(move(bytes), [loader = move(loader_handle)](auto prepared_font_data) mutable {
+                    loader->font_did_load_or_fail(maybe_typeface.release_value());
+                    return;
+                }
+
+                auto loader_handle = GC::make_root(GC::Ref(*loader));
+                prepare_vector_font_data_off_thread(move(bytes), [loader = move(loader_handle)](auto prepared_font_data) mutable {
                 if (prepared_font_data.is_error()) {
                     // NB: If we have other sources available, try the next one.
-                    if (loader->m_urls.is_empty()) {
+                    if (loader->m_sources.is_empty()) {
                         loader->font_did_load_or_fail(nullptr);
                     } else {
                         loader->m_fetch_controller = nullptr;
-                        loader->start_loading_next_url();
+                        loader->start_loading_next_source();
                     }
                     return;
                 }
@@ -213,20 +225,21 @@ void FontLoader::start_loading_next_url()
                 auto prepared = prepared_font_data.release_value();
                 auto maybe_typeface = Gfx::Typeface::try_load_from_anonymous_buffer(move(prepared));
                 if (maybe_typeface.is_error()) {
-                    if (loader->m_urls.is_empty()) {
+                    if (loader->m_sources.is_empty()) {
                         loader->font_did_load_or_fail(nullptr);
                     } else {
                         loader->m_fetch_controller = nullptr;
-                        loader->start_loading_next_url();
+                        loader->start_loading_next_source();
                     }
                     return;
                 }
 
                 loader->font_did_load_or_fail(maybe_typeface.release_value()); });
-        });
+            });
 
-    if (!m_fetch_controller)
-        font_did_load_or_fail(nullptr);
+        if (m_fetch_controller || m_has_completed)
+            return;
+    }
 }
 
 void FontLoader::font_did_load_or_fail(RefPtr<Gfx::Typeface const> typeface)
@@ -362,7 +375,7 @@ void FontComputer::visit_edges(Visitor& visitor)
     visitor.visit(m_document);
     for (auto& [_, faces] : m_font_faces)
         visitor.visit(faces);
-    for (auto& [_, loader] : m_loaders_by_url)
+    for (auto& [_, loader] : m_loaders_by_source)
         visitor.visit(loader);
 }
 
@@ -1046,17 +1059,14 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
         return {};
     }
 
-    // FIXME: Handle local() font sources.
-    Vector<URL> urls;
+    Vector<FontLoader::Source> sources;
+    StringBuilder key_builder;
     for (auto const& source : font_face.sources()) {
-        if (source.local_or_url.has<URL>())
-            urls.append(source.local_or_url.get<URL>());
-    }
-
-    if (urls.is_empty()) {
-        if (on_load)
-            on_load->function()({});
-        return {};
+        sources.append(source.local_or_url);
+        auto value = source.local_or_url.has<URL>()
+            ? source.local_or_url.get<URL>().to_string()
+            : MUST(source.local_or_url.get<Utf16FlyString>().view().to_utf8());
+        key_builder.appendff("{}{}:{}", source.local_or_url.has<URL>() ? 'u' : 'l', value.bytes_as_string_view().length(), value);
     }
 
     RuleOrDeclaration rule_or_declaration {
@@ -1068,15 +1078,15 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
         .parent_style_sheet_origin_clean = {},
     };
 
-    auto key = urls.first().to_string();
-    if (auto it = m_loaders_by_url.find(key); it != m_loaders_by_url.end()) {
+    auto key = MUST(key_builder.to_string());
+    if (auto it = m_loaders_by_source.find(key); it != m_loaders_by_source.end()) {
         if (on_load)
             it->value->subscribe(*on_load);
         return it->value;
     }
 
-    auto loader = GC::Heap::the().allocate<FontLoader>(*this, rule_or_declaration, move(urls), move(on_load));
-    m_loaders_by_url.set(move(key), loader);
+    auto loader = GC::Heap::the().allocate<FontLoader>(*this, rule_or_declaration, move(sources), move(on_load));
+    m_loaders_by_source.set(move(key), loader);
     return loader;
 }
 

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -18,6 +18,7 @@
 #include <LibWeb/CSS/FontFeatureData.h>
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
+#include <LibWeb/CSS/URL.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -80,11 +81,12 @@ class FontLoader final : public GC::Cell {
     GC_DECLARE_ALLOCATOR(FontLoader);
 
 public:
-    FontLoader(FontComputer&, RuleOrDeclaration, Vector<URL> urls, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load = {});
+    using Source = Variant<Utf16FlyString, URL>;
+    FontLoader(FontComputer&, RuleOrDeclaration, Vector<Source> sources, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load = {});
 
     virtual ~FontLoader();
 
-    void start_loading_next_url();
+    void start_loading_next_source();
 
     bool is_loading() const;
     void did_request_for_rendering();
@@ -104,7 +106,7 @@ private:
     GC::Ref<FontComputer> m_font_computer;
     RuleOrDeclaration m_rule_or_declaration;
     RefPtr<Gfx::Typeface const> m_typeface;
-    Vector<URL> m_urls;
+    Vector<Source> m_sources;
     GC::Ptr<Fetch::Infrastructure::FetchController> m_fetch_controller;
     Vector<GC::Ref<GC::Function<void(RefPtr<Gfx::Typeface const>)>>> m_subscribers;
     Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer;
@@ -164,7 +166,7 @@ private:
     GC::Ref<DOM::Document> m_document;
 
     HashMap<FontFaceKey, Vector<NonnullRefPtr<FontFaceState>>> m_font_faces;
-    HashMap<String, GC::Ref<FontLoader>> m_loaders_by_url;
+    HashMap<String, GC::Ref<FontLoader>> m_loaders_by_source;
 
     mutable HashMap<ComputedFontCacheKey, NonnullRefPtr<Gfx::FontCascadeList const>> m_computed_font_cache;
     mutable HashMap<Utf16FlyString, HashMap<FontFeatureValueKey, Vector<u32>>> m_font_feature_values_cache;

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -519,8 +519,10 @@ RefPtr<Gfx::FontCascadeList const> FontFaceState::font_with_point_size(float poi
         font_list->add_pending_face(m_unicode_ranges, [weak_face = make_weak_ptr()] {
             if (weak_face)
                 return weak_face->resolve_for_rendering();
-            return Gfx::PendingFontState::Failed;
-        });
+            return Gfx::PendingFontState::Failed; }, [weak_face = make_weak_ptr(), point_size, variations, shape_features]() -> RefPtr<Gfx::Font const> {
+            if (weak_face && weak_face->m_parsed_font && !weak_face->m_font_display_failed)
+                return weak_face->m_parsed_font->font(point_size, variations, shape_features);
+            return {}; });
     }
     if (font_list->is_empty())
         return {};
@@ -1027,6 +1029,14 @@ void FontFaceState::load_for_style()
     // 5. When the load operation completes, successfully or not, queue a task to run the following steps synchronously:
     auto on_load = GC::create_function(GC::Heap::the(), [font_root = keep_alive_during_load()](RefPtr<Gfx::Typeface const> maybe_typeface) {
         auto& font = *font_root->elements().first();
+        // NB: A resident typeface is available to synchronous layout immediately. Keep the
+        //     observable load status, promise settlement, and FontFaceSet notifications in
+        //     the queued font-loading task.
+        font.update_font_display_period();
+        font.m_font_download_completed = true;
+        if (font.m_font_download_timer)
+            font.m_font_download_timer->stop();
+        font.m_parsed_font = maybe_typeface;
         HTML::queue_global_task(HTML::Task::Source::FontLoading, font.task_global_object(), GC::create_function(GC::Heap::the(), [font_root, maybe_typeface] {
             font_root->elements().first()->did_load(maybe_typeface);
         }));
@@ -1038,7 +1048,7 @@ void FontFaceState::load_for_style()
 
         if (auto loader = font_computer.load_font_face(parsed_font_face(), m_source_style_sheet, move(on_load))) {
             m_font_loader = loader;
-            loader->start_loading_next_url();
+            loader->start_loading_next_source();
         }
     } else {
         // FIXME: Don't know how to load fonts in workers! They don't have a StyleComputer
@@ -1048,10 +1058,6 @@ void FontFaceState::load_for_style()
 
 void FontFaceState::did_load(RefPtr<Gfx::Typeface const> maybe_typeface)
 {
-    update_font_display_period();
-    m_font_download_completed = true;
-    if (m_font_download_timer)
-        m_font_download_timer->stop();
     HTML::TemporaryExecutionContext context(*m_environment, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
     // 1. If the attempt to load fails, reject font face’s [[FontStatusPromise]] with a DOMException whose name
     //    is "NetworkError" and set font face’s status attribute to "error".

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -657,6 +657,7 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
                         auto pseudo_element = static_cast<PseudoElement>(kind);
                         if (is_synthetic_pseudo_element(pseudo_element)
                             && pseudo_element != PseudoElement::Backdrop
+                            && !is_highlight_pseudo_element(pseudo_element)
                             && !pseudo_element_records[kind].has_value())
                             element->set_computed_style(pseudo_element, *previous_pseudo_element_records[kind]);
                     }

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -4224,6 +4224,12 @@ impl ElementFactStore {
         &self.rows
     }
 
+    /// Published answers belong to the committed transaction, even when applying its styles
+    /// has already staged inputs for the next one. Verify them against those committed facts.
+    pub(super) fn committed_for_verification(&self) -> &StyleNodeFacts {
+        &self.rows
+    }
+
     pub(super) fn primary_view(&mut self) -> MatchingFactBatch {
         assert!(
             !self.has_dirty_staging(),

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -3934,9 +3934,14 @@ impl StyleEngine {
         matches: &mut Vec<exact_matcher::ExactRuleMatch>,
     ) -> Result<(), Incomplete> {
         let shadow_root = self.scope_root(scope);
-        let mut matcher = ExactMatcher::new(&self.tree, self.facts.primary(), &self.programs, &self.program)
-            .in_scope(scope)
-            .with_context(context);
+        let mut matcher = ExactMatcher::new(
+            &self.tree,
+            self.facts.committed_for_verification(),
+            &self.programs,
+            &self.program,
+        )
+        .in_scope(scope)
+        .with_context(context);
         if let Some(shadow_root) = shadow_root {
             matcher = matcher.in_shadow_tree(shadow_root);
         }

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -7161,6 +7161,34 @@ fn unobserved_inputs_do_not_seed_prefix_convergence() {
 }
 
 #[test]
+fn cold_answer_verification_uses_committed_facts_with_pending_inputs() {
+    let (mut engine, nodes) = linear_document();
+    for &node in &nodes {
+        engine.facts.ensure_row(node);
+    }
+    let target = StyleAtomID(200);
+    add_target_rule(&mut engine, StyleSheetObjectID(1), target);
+    discard_transaction(&mut engine);
+
+    let before = engine.exact_match_answer_for_verification(nodes[1]).unwrap();
+    assert!(before.is_empty());
+    add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(target));
+    assert!(engine.facts.has_dirty_staging());
+    assert_eq!(engine.exact_match_answer_for_verification(nodes[1]).unwrap(), before);
+    assert!(
+        engine
+            .exact_cascade_answer_for_verification(nodes[1])
+            .unwrap()
+            .0
+            .is_empty()
+    );
+    assert!(engine.facts.has_dirty_staging());
+
+    discard_transaction(&mut engine);
+    assert_eq!(engine.exact_match_answer_for_verification(nodes[1]).unwrap().len(), 1);
+}
+
+#[test]
 fn state_input_commits_after_its_old_row_is_snapshotted() {
     let (mut engine, nodes) = linear_document();
     let class = StyleAtomID(200);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -714,7 +714,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 
     create_platform_options(m_browser_options, m_request_server_options, m_web_content_options);
 
-    m_font_service = FontService::create();
+    m_font_service = FontService::create(m_browser_options.additional_font_directories);
 
     // Test mode implies experimental interfaces and internals object are exposed and the Skia CPU backend is used.
     if (m_web_content_options.is_test_mode == IsTestMode::Yes) {

--- a/Libraries/LibWebView/FontService.cpp
+++ b/Libraries/LibWebView/FontService.cpp
@@ -15,16 +15,18 @@
 
 namespace WebView {
 
-NonnullOwnPtr<FontService> FontService::create()
+NonnullOwnPtr<FontService> FontService::create(Vector<String> additional_font_directories)
 {
-    return adopt_own(*new FontService);
+    return adopt_own(*new FontService(move(additional_font_directories)));
 }
 
-FontService::FontService()
-    : m_worker(Threading::Thread::construct("Font catalog"sv, [this] {
+FontService::FontService(Vector<String> additional_font_directories)
+    : m_additional_font_directories(move(additional_font_directories))
+    , m_worker(Threading::Thread::construct("Font catalog"sv, [this] {
         if (auto result = build_catalog(); result.is_error()) {
             dbgln("Unable to discover system fonts: {}. Using an empty catalog.", result.error());
             m_font_sources.clear();
+            m_local_font_names.clear();
             if (auto fallback_result = build_empty_catalog(); fallback_result.is_error())
                 m_build_error = MUST(String::formatted("{}", fallback_result.error()));
         }
@@ -71,12 +73,26 @@ ErrorOr<void> FontService::build_catalog()
     u64 next_face_id = 1;
 
     auto directories = TRY(Gfx::FontDatabase::font_directories());
+    directories.extend(m_additional_font_directories);
     for (auto const& directory : directories) {
         auto uri = TRY(String::formatted("file://{}", directory));
         Gfx::PathFontProvider::for_each_typeface_in_uri(uri, loaded_paths, [&](String const& path, u32 ttc_index, Gfx::FontFileFormat format, NonnullRefPtr<Gfx::Typeface> typeface) {
             if (callback_error.has_value())
                 return;
             auto face_id = next_face_id++;
+            auto names = typeface->local_font_names();
+            if (names.is_error()) {
+                callback_error = names.release_error();
+                return;
+            }
+            for (auto const& name : names.value()) {
+                auto folded_name = name.to_casefold();
+                if (folded_name.is_error()) {
+                    callback_error = folded_name.release_error();
+                    return;
+                }
+                m_local_font_names.set(folded_name.release_value(), face_id, AK::HashSetExistingEntryBehavior::Keep);
+            }
             auto result = builder->add_face({
                 .family = typeface->family().bytes_as_string_view(),
                 .face_id = face_id,
@@ -189,6 +205,22 @@ Gfx::BrokeredFont FontService::materialize_typeface(NonnullRefPtr<Gfx::TypefaceS
                                        });
     m_dynamic_match_cache.set(move(cache_key), face_id);
     return open_font_without_lock(m_generation, face_id);
+}
+
+Gfx::BrokeredFont FontService::match_local_font(String const& name)
+{
+    Sync::MutexLocker locker(m_mutex);
+    if (wait_until_ready().is_error())
+        return {};
+    auto folded_name = name.to_casefold();
+    if (folded_name.is_error())
+        return {};
+    auto face_id = m_local_font_names.get(folded_name.value());
+    if (!face_id.has_value())
+        return {};
+    // https://drafts.csswg.org/css-fonts-4/#local-font-fallback
+    // Platform substitutions for a given font name must not be used.
+    return open_font_without_lock(m_generation, *face_id);
 }
 
 Gfx::BrokeredFont FontService::match_font(String const& family, u16 weight, u16 width, u8 slope)

--- a/Libraries/LibWebView/FontService.h
+++ b/Libraries/LibWebView/FontService.h
@@ -29,17 +29,18 @@ class WEBVIEW_API FontService {
     AK_MAKE_NONMOVABLE(FontService);
 
 public:
-    static NonnullOwnPtr<FontService> create();
+    static NonnullOwnPtr<FontService> create(Vector<String> additional_font_directories = {});
     ~FontService();
 
     ErrorOr<FontCatalogDescriptor> clone_catalog();
     Gfx::BrokeredFont open_font(u64 generation, u64 face_id);
+    Gfx::BrokeredFont match_local_font(String const& name);
     Gfx::BrokeredFont match_font(String const& family, u16 weight, u16 width, u8 slope);
     Gfx::BrokeredFont match_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji);
     Optional<FlyString> resolve_generic_family(String const& family, u16 weight, u8 slope);
 
 private:
-    FontService();
+    explicit FontService(Vector<String> additional_font_directories);
 
     struct FontSource {
         String path;
@@ -60,6 +61,8 @@ private:
     Gfx::BrokeredFont materialize_typeface(NonnullRefPtr<Gfx::TypefaceSkia>, String cache_key);
     Gfx::BrokeredFont open_font_without_lock(u64 generation, u64 face_id);
 
+    Vector<String> m_additional_font_directories;
+    HashMap<String, u64> m_local_font_names;
     NonnullRefPtr<Threading::Thread> m_worker;
     Optional<String> m_build_error;
     IPC::File m_catalog_file;

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -81,6 +81,7 @@ enum class ProfileTool {
 };
 
 struct BrowserOptions {
+    Vector<String> additional_font_directories {};
     Vector<URL::URL> urls;
     Vector<ByteString> raw_urls;
     Optional<HeadlessMode> headless_mode;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -46,6 +46,12 @@ Messages::WebContentClient::OpenSystemFontResponse WebContentClient::open_system
     return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
 }
 
+Messages::WebContentClient::MatchLocalFontResponse WebContentClient::match_local_font(String name)
+{
+    auto font = Application::font_service().match_local_font(name);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
 Messages::WebContentClient::MatchSystemFontResponse WebContentClient::match_system_font(String family, u16 weight, u16 width, u8 slope)
 {
     auto font = Application::font_service().match_font(family, weight, width, slope);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -75,6 +75,7 @@ public:
 
     virtual Messages::WebContentClient::OpenSystemFontResponse open_system_font(u64 generation, u64 face_id) override;
     virtual Messages::WebContentClient::MatchSystemFontResponse match_system_font(String family, u16 weight, u16 width, u8 slope) override;
+    virtual Messages::WebContentClient::MatchLocalFontResponse match_local_font(String name) override;
     virtual Messages::WebContentClient::MatchSystemFontForCodePointResponse match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) override;
     virtual Messages::WebContentClient::ResolveGenericFontResponse resolve_generic_font(String family, u16 weight, u8 slope) override;
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -142,6 +142,17 @@ void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 genera
     }
 
     Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.match_local_font = [this](String const& name) {
+        auto response = send_sync_but_allow_failure<Messages::WebContentClient::MatchLocalFont>(name);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
     callbacks.open_font = [this](u64 requested_generation, u64 face_id) {
         auto response = send_sync_but_allow_failure<Messages::WebContentClient::OpenSystemFont>(requested_generation, face_id);
         if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -536,6 +536,13 @@ void PageClient::request_rendering_opportunity_if_needed()
     if (Web::HTML::main_thread_event_loop().rendering_task_queued_or_running())
         return;
 
+    // NB: Headless tests have no display clock to follow. Schedule their frames locally so
+    //     compositor IPC latency cannot let document timers overtake a requested frame.
+    if (is_headless() && Web::HTML::Window::in_test_mode()) {
+        schedule_local_rendering_opportunity();
+        return;
+    }
+
     if (page().has_local_root_navigable()) {
         auto& local_root_navigable = *page().local_root_navigable();
         if (local_root_navigable.has_compositor_context() && local_root_navigable.compositor_context().request_rendering_opportunity(m_maximum_frames_per_second)) {

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -61,6 +61,7 @@ endpoint WebContentClient
 {
     open_system_font(u64 generation, u64 face_id) => (u64 matched_face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
     match_system_font(String family, u16 weight, u16 width, u8 slope) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    match_local_font(String name) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
     match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
     resolve_generic_font(String family, u16 weight, u8 slope) => (Optional<String> resolved_family)
 

--- a/Tests/LibGfx/TestFont.cpp
+++ b/Tests/LibGfx/TestFont.cpp
@@ -198,6 +198,61 @@ TEST_CASE(pending_font_does_not_load_fallback_fonts)
     EXPECT_EQ(fallback_loads, 0u);
 }
 
+TEST_CASE(pending_font_can_resolve_synchronously_without_loading_fallbacks)
+{
+    auto local_font = load_text_font(24);
+    auto fallback_font = load_text_font(16);
+    auto cascade = Gfx::FontCascadeList::create();
+    u32 local_loads = 0;
+    u32 fallback_loads = 0;
+    cascade->add_pending_face({ { 'a', 'a' } }, [&] {
+        ++local_loads;
+        return Gfx::PendingFontState::Invisible; }, [local_font] { return local_font; });
+    cascade->add_pending_face({ { 'a', 'a' } }, [&] {
+        ++fallback_loads;
+        return Gfx::PendingFontState::Invisible;
+    });
+    cascade->add(fallback_font);
+    cascade->set_last_resort_font(fallback_font);
+    EXPECT_EQ(&cascade->font_for_code_point('b'), fallback_font.ptr());
+    EXPECT_EQ(local_loads, 0u);
+    EXPECT_EQ(&cascade->font_for_code_point('a'), local_font.ptr());
+    EXPECT_EQ(&cascade->font_for_code_point('a'), local_font.ptr());
+    EXPECT_EQ(local_loads, 1u);
+    EXPECT_EQ(fallback_loads, 0u);
+}
+
+TEST_CASE(first_available_font_resolves_resident_faces_in_cascade_order)
+{
+    auto local_font = load_text_font(24);
+    auto fallback_font = load_text_font(16);
+    auto cascade = Gfx::FontCascadeList::create();
+    bool resident = false;
+    u32 excluded_loads = 0;
+    u32 fallback_loads = 0;
+    cascade->add_pending_face({ { 'a', 'a' } }, [&] {
+        ++excluded_loads;
+        return Gfx::PendingFontState::Invisible;
+    });
+    cascade->add_pending_face({ { ' ', ' ' } }, [] { return Gfx::PendingFontState::Invisible; }, [&]() -> RefPtr<Gfx::Font const> { return resident ? local_font.ptr() : nullptr; });
+    cascade->add_pending_face({ { 0, 0x10FFFF } }, [&] {
+        ++fallback_loads;
+        return Gfx::PendingFontState::Visible;
+    });
+    cascade->add(fallback_font);
+    cascade->set_last_resort_font(fallback_font);
+    EXPECT_EQ(&cascade->first_available_font(), fallback_font.ptr());
+    resident = true;
+    EXPECT_EQ(&cascade->first_available_font(), local_font.ptr());
+    EXPECT_EQ(excluded_loads, 0u);
+    EXPECT_EQ(fallback_loads, 0u);
+
+    auto preferred = Gfx::FontCascadeList::create();
+    preferred->add(fallback_font);
+    preferred->extend(*cascade);
+    EXPECT_EQ(&preferred->first_available_font(), fallback_font.ptr());
+}
+
 TEST_CASE(loaded_font_precedes_pending_font_after_extending_cascade)
 {
     auto font = load_text_font(16);

--- a/Tests/LibGfx/TestSharedFontProvider.cpp
+++ b/Tests/LibGfx/TestSharedFontProvider.cpp
@@ -71,6 +71,28 @@ static Gfx::BrokeredFont open_test_font(u64 face_id)
 
 }
 
+TEST_CASE(local_font_lookup_preserves_face_names_and_missing_results)
+{
+    auto catalog = make_catalog();
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.match_local_font = [](String const& name) {
+        if (name == "Lato Bold"sv || name == "Lato-Bold"sv)
+            return open_test_font(17);
+        return Gfx::BrokeredFont {};
+    };
+    auto provider = MUST(Gfx::SharedFontProvider::create(map_bytes(catalog.bytes()), 9, move(callbacks)));
+    auto full_name_face = provider->get_typeface_by_local_name("Lato Bold"_string);
+    auto postscript_name_face = provider->get_typeface_by_local_name("Lato-Bold"_string);
+    EXPECT(full_name_face);
+    EXPECT_EQ(full_name_face.ptr(), postscript_name_face.ptr());
+    EXPECT(!provider->get_typeface_by_local_name("Lato"_string));
+    EXPECT(!provider->get_typeface_by_local_name("Missing"_string));
+    auto names = MUST(full_name_face->local_font_names());
+    EXPECT_EQ(names.size(), 2u);
+    EXPECT_EQ(names[0], "Lato Bold"sv);
+    EXPECT_EQ(names[1], "Lato-Bold"sv);
+}
+
 TEST_CASE(opens_catalog_faces_lazily_and_caches_them)
 {
     auto catalog = make_catalog();

--- a/Tests/LibWeb/Text/expected/css/local-font-sources.txt
+++ b/Tests/LibWeb/Text/expected/css/local-font-sources.txt
@@ -1,0 +1,20 @@
+Local metrics are immediately available: true
+Load notification remains asynchronous: true
+Resident local font remains usable after its deadline: true
+Local ch metrics precede load notification: true
+Local font-relative metrics remain unchanged: true
+Excluded character leaves local subset unloaded: true
+Local subset metrics are immediately available: true
+Local face: true
+Case-insensitive name: true
+Unknown face: true
+No family-style substitution: true
+No generic substitution: true
+Second local source: true
+Local before URL: true
+Unused URL was not requested: true
+Invalid URL before local: true
+Invalid URL before URL: true
+URL before local: true
+Different fallback after shared URL: true
+Missing local before URL: true

--- a/Tests/LibWeb/Text/input/css/local-font-sources.html
+++ b/Tests/LibWeb/Text/input/css/local-font-sources.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const context = document.createElement("canvas").getContext("2d");
+        const immediateFont = new FontFace("ImmediateLocalAhem", "local('Ahem')", { display: "optional" });
+        document.fonts.add(immediateFont);
+        context.font = "10px ImmediateLocalAhem";
+        println(`Local metrics are immediately available: ${context.measureText("abc").width === 30}`);
+        println(`Load notification remains asynchronous: ${immediateFont.status === "loading"}`);
+        internals.setFontDisplayTime(immediateFont, 10000);
+        await immediateFont.loaded;
+        println(`Resident local font remains usable after its deadline: ${context.measureText("abc").width === 30}`);
+        document.fonts.delete(immediateFont);
+
+        const metricFont = new FontFace("LocalMetrics", "local('Ahem')");
+        document.fonts.add(metricFont);
+        metricFont.load();
+        const element = document.createElement("div");
+        element.style.cssText = "font: 20px LocalMetrics; width: 1ch; height: 1ex";
+        document.body.append(element);
+        const before = element.getBoundingClientRect();
+        println(`Local ch metrics precede load notification: ${before.width === 20 && metricFont.status === "loading"}`);
+        await metricFont.loaded;
+        const after = element.getBoundingClientRect();
+        println(`Local font-relative metrics remain unchanged: ${before.width === after.width && before.height === after.height}`);
+        element.remove();
+        document.fonts.delete(metricFont);
+
+        const subsetFont = new FontFace("SubsetLocalAhem", "local('Ahem')", { unicodeRange: "U+61" });
+        document.fonts.add(subsetFont);
+        context.font = "10px SubsetLocalAhem";
+        context.measureText("b");
+        println(`Excluded character leaves local subset unloaded: ${subsetFont.status === "unloaded"}`);
+        println(`Local subset metrics are immediately available: ${context.measureText("a").width === 10}`);
+        await subsetFont.loaded;
+        document.fonts.delete(subsetFont);
+
+        async function check(label, source, shouldLoad) {
+            const font = new FontFace("LocalAhem", source);
+            try {
+                await font.load();
+                document.fonts.add(font);
+                context.font = "10px LocalAhem";
+                println(`${label}: ${shouldLoad && font.status === "loaded" && context.measureText("abc").width === 30}`);
+                document.fonts.delete(font);
+            } catch (error) {
+                println(`${label}: ${!shouldLoad && error.name === "NetworkError"}`);
+            }
+        }
+
+        await check("Local face", "local('Ahem')", true);
+        await check("Case-insensitive name", "local('aHeM')", true);
+        await check("Unknown face", "local('LadybirdMissingFont')", false);
+        await check("No family-style substitution", "local('Ahem Regular')", false);
+        await check("No generic substitution", "local('serif')", false);
+        await check("Second local source", "local('LadybirdMissingFont'), local('Ahem')", true);
+        await check("Local before URL", "local('Ahem'), url('unused-local-font-fallback.ttf')", true);
+        println(`Unused URL was not requested: ${!performance.getEntriesByType("resource").some(entry => entry.name.endsWith("unused-local-font-fallback.ttf"))}`);
+        await check("Invalid URL before local", "url('http://['), local('Ahem')", true);
+        await check("Invalid URL before URL", "url('http://['), url('../../../Ref/data/fonts/Ahem.ttf')", true);
+        await check("URL before local", "url('data:font/ttf,invalid'), local('Ahem')", true);
+        await check("Different fallback after shared URL", "url('data:font/ttf,invalid'), local('LadybirdMissingFont')", false);
+        await check("Missing local before URL", "local('LadybirdMissingFont'), url('../../../Ref/data/fonts/Ahem.ttf')", true);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/flex-intrinsic-axis-measurements.html
+++ b/Tests/LibWeb/Text/input/flex-intrinsic-axis-measurements.html
@@ -15,10 +15,15 @@
         overflow-wrap: break-word;
     }
 </style>
-<div id="outer"><div id="inner"><div id="item">AAAAAAAAAAAAAAAAAAAAAAAAAAAA</div></div></div>
+<template id="fixture">
+    <div id="outer"><div id="inner"><div id="item">AAAAAAAAAAAAAAAAAAAAAAAAAAAA</div></div></div>
+</template>
 <script>
     test(() => {
+        // Flush the initial layout before inserting the fixture so its measurements are always counted.
+        document.body.offsetWidth;
         const measurementsBefore = internals.intrinsicMeasurementCount();
+        document.body.appendChild(document.getElementById("fixture").content.cloneNode(true));
         document.getElementById("outer").offsetWidth;
         println(`intrinsic measurements: ${internals.intrinsicMeasurementCount() - measurementsBefore}`);
     });

--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -109,6 +109,10 @@ void Application::create_platform_options(WebView::BrowserOptions& browser_optio
 
     // Ensure consistent font rendering between operating systems.
     web_content_options.force_fontconfig = WebView::ForceFontconfig::Yes;
+    // NB: WPT's Ahem stylesheet prefers local('Ahem'). Make the test font available before
+    //     navigation so its metrics do not depend on an asynchronous font download.
+    auto font_directory = LexicalPath::join(test_root_path, "Ref/input/wpt-import/fonts"sv).string();
+    browser_options.additional_font_directories.append(MUST(String::from_byte_string(LexicalPath::absolute_path(MUST(Core::System::getcwd()), font_directory))));
 
     // Ensure tests are resilient to minor changes to the viewport scrollbar.
     web_content_options.paint_viewport_scrollbars = WebView::PaintViewportScrollbars::No;


### PR DESCRIPTION
Preserve selection highlights during style verification and check retained selector matches against committed facts, fixing selection rendering failures and the crash when switching focus between text controls.

Implement CSS `local()` font lookup by full and PostScript names, preserve source order, and make local metrics available immediately while keeping unused fallback fonts unloaded. Provide Ahem through the test font catalog so the anchored-scroll tests work with their original upstream sources.

Schedule headless test frames locally to avoid compositor IPC delays racing document timers, and make the flex intrinsic-measurement fixture deterministic.
