### PR TITLE
Make the Grafana dashboard reliable and its links clickable

### DIFF
--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -184,7 +184,9 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_skia_typeface(sk_sp<Sk
 
 ErrorOr<NonnullRefPtr<TypefaceSkia>> TypefaceSkia::load_from_buffer(AK::ReadonlyBytes buffer, u32 ttc_index)
 {
-    auto data = SkData::MakeWithoutCopy(buffer.data(), buffer.size());
+    // NB: Skia can retain the typeface in text blobs and glyph caches after our Typeface is destroyed.
+    //     Its stream must own the font bytes independently of our font data backing.
+    auto data = SkData::MakeWithCopy(buffer.data(), buffer.size());
 
     // https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header
     // TrueType Collection files bundle multiple fonts (often different weights of the same

--- a/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -21,7 +21,10 @@
 #include <LibWeb/DOM/Slottable.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/DOM/Utils.h>
+#include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/HTMLAnchorElement.h>
+#include <LibWeb/HTML/HTMLButtonElement.h>
 #include <LibWeb/HTML/HTMLSlotElement.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
@@ -394,6 +397,43 @@ bool EventDispatcher::dispatch(GC::Ref<EventTarget> target, Event& event, bool l
 
             // 3. Invoke with struct, event, "bubbling", and legacyOutputDidListenersThrowFlag if given.
             invoke(entry, event, Event::Phase::BubblingPhase, legacy_output_did_listeners_throw);
+        }
+    }
+
+    // INTEROP: Plain buttons inside links allow the link's default action. Check after event listeners
+    //          have run, since a click listener can give the button a submit, reset, command, or popover action.
+    if (auto* button = as_if<HTML::HTMLButtonElement>(activation_target.ptr()); button && event.bubbles() && button->enabled()
+        && button->type_state() == HTML::HTMLButtonElement::TypeAttributeState::Button
+        && !button->get_the_attribute_associated_element(HTML::AttributeNames::commandfor, button->command_for_element())
+        && !HTML::PopoverTargetAttributes::get_the_popover_target_element(*button)) {
+        bool passed_button = false;
+        GC::Ptr<EventTarget> intervening_activation_target;
+        for (auto const& entry : event.path()) {
+            if (entry.invocation_target.ptr() == button) {
+                passed_button = true;
+                continue;
+            }
+            if (!passed_button)
+                continue;
+
+            // INTEROP: An intervening form-associated submit or reset button consumes activation
+            //          before it can reach the link, even when its form action is canceled.
+            if (auto* ancestor_button = as_if<HTML::HTMLButtonElement>(entry.invocation_target.ptr()); ancestor_button
+                && ancestor_button->enabled() && ancestor_button->form()
+                && (ancestor_button->is_submit_button() || ancestor_button->type_state() == HTML::HTMLButtonElement::TypeAttributeState::Reset)) {
+                if (!intervening_activation_target)
+                    intervening_activation_target = ancestor_button;
+                continue;
+            }
+            if (is<HTML::HTMLAnchorElement>(*entry.invocation_target) && entry.invocation_target->has_activation_behavior()) {
+                activation_target = intervening_activation_target ? intervening_activation_target : entry.invocation_target;
+                break;
+            }
+
+            // NB: Keep other intervening activation behaviors, such as labels, as boundaries.
+            //     The link fallback must not bypass them just because the clicked button is plain.
+            if (entry.invocation_target->has_activation_behavior())
+                break;
         }
     }
 

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -20,7 +20,7 @@ endforeach()
 target_link_libraries(BenchmarkJPEGLoader PRIVATE LibImageDecoders)
 target_link_libraries(TestImageDecoder PRIVATE LibImageDecoders)
 target_link_libraries(TestImageWriter PRIVATE LibImageDecoders)
-target_link_libraries(TestFont PRIVATE harfbuzz LibIPC)
+target_link_libraries(TestFont PRIVATE harfbuzz LibIPC skia)
 target_link_libraries(TestSharedFontProvider PRIVATE LibIPC)
 target_compile_definitions(TestSharedFontProvider PRIVATE LADYBIRD_SOURCE_DIR="${LADYBIRD_SOURCE_DIR}")
 

--- a/Tests/LibGfx/TestFont.cpp
+++ b/Tests/LibGfx/TestFont.cpp
@@ -17,6 +17,7 @@
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 #include <LibTest/TestCase.h>
+#include <core/SkTypeface.h>
 #include <harfbuzz/hb.h>
 
 #define TEST_INPUT(x) ("test-inputs/" x)
@@ -58,6 +59,24 @@ TEST_CASE(monochrome_emoji_font_is_not_emoji_font)
 TEST_CASE(text_font_is_not_emoji_font)
 {
     EXPECT(!font_is_emoji(TEST_INPUT("fonts/text.ttf"sv)));
+}
+
+TEST_CASE(skia_typeface_retains_font_data_after_ladybird_typeface_is_destroyed)
+{
+    sk_sp<SkTypeface const> skia_typeface;
+    ByteBuffer expected_table;
+    constexpr auto cmap_tag = SkSetFourByteTag('c', 'm', 'a', 'p');
+    {
+        auto file = MUST(Core::MappedFile::map(TEST_INPUT("fonts/text.ttf"sv)));
+        auto typeface = MUST(Gfx::Typeface::try_load_from_temporary_memory(file->bytes()));
+        skia_typeface = sk_ref_sp(static_cast<Gfx::TypefaceSkia const&>(*typeface).sk_typeface());
+        expected_table = MUST(ByteBuffer::create_uninitialized(skia_typeface->getTableSize(cmap_tag)));
+        EXPECT(!expected_table.is_empty());
+        EXPECT_EQ(skia_typeface->getTableData(cmap_tag, 0, expected_table.size(), expected_table.data()), expected_table.size());
+    }
+    auto actual_table = MUST(ByteBuffer::create_uninitialized(expected_table.size()));
+    EXPECT_EQ(skia_typeface->getTableData(cmap_tag, 0, actual_table.size(), actual_table.data()), actual_table.size());
+    EXPECT_EQ(actual_table, expected_table);
 }
 
 static NonnullRefPtr<Gfx::Font> load_text_font(float point_size)

--- a/Tests/LibWeb/Text/expected/button-inside-anchor.txt
+++ b/Tests/LibWeb/Text/expected/button-inside-anchor.txt
@@ -1,0 +1,12 @@
+Nested button: type=submit, shadow=false, activated=submit
+Nested button: type=submit, shadow=true, activated=submit
+Nested button: type=reset, shadow=false, activated=reset
+Nested button: type=reset, shadow=true, activated=reset
+Button changed to submit during click: true
+Button changed to reset during click: true
+Command target added during click: true
+Popover target added during click: true
+Link activated: in form=false, descendant=false
+Link activated: in form=false, descendant=true
+Link activated: in form=true, descendant=false
+Link activated: in form=true, descendant=true

--- a/Tests/LibWeb/Text/input/button-inside-anchor.html
+++ b/Tests/LibWeb/Text/input/button-inside-anchor.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+promiseTest(async () => {
+    for (const type of ["submit", "reset"]) {
+        for (const shadow of [false, true]) {
+            const form = document.createElement("form");
+            form.innerHTML = `<a href="javascript:window.nestedActivation('link')"><button type="${type}"></button></a>`;
+            document.body.append(form);
+            const outerButton = form.querySelector("button");
+            let parent = outerButton;
+            if (shadow) {
+                const host = document.createElement("div");
+                outerButton.append(host);
+                parent = host.attachShadow({ mode: "open" });
+            }
+            const innerButton = document.createElement("button");
+            innerButton.type = "button";
+            parent.append(innerButton);
+            const activated = new Promise(resolve => {
+                window.nestedActivation = resolve;
+                form.addEventListener(type, event => {
+                    event.preventDefault();
+                    resolve(type);
+                });
+            });
+            innerButton.click();
+            println(`Nested button: type=${type}, shadow=${shadow}, activated=${await activated}`);
+            form.remove();
+        }
+    }
+
+    for (const type of ["submit", "reset"]) {
+        const form = document.createElement("form");
+        form.innerHTML = '<a href="#unexpected"><button type="button">Commit</button></a>';
+        document.body.append(form);
+        const button = form.querySelector("button");
+        button.onclick = () => button.type = type;
+        let activated = false;
+        form.addEventListener(type, event => {
+            event.preventDefault();
+            activated = true;
+        });
+        button.click();
+        println(`Button changed to ${type} during click: ${activated}`);
+        form.remove();
+    }
+
+    const container = document.createElement("div");
+    container.innerHTML = '<a href="#unexpected"><button type="button">Commit</button></a><div id="command-target"></div><div id="popover-target" popover>Popover</div>';
+    document.body.append(container);
+    const button = container.querySelector("button");
+    let commandActivated = false;
+    container.querySelector("#command-target").addEventListener("command", () => commandActivated = true);
+    button.onclick = () => {
+        button.setAttribute("commandfor", "command-target");
+        button.setAttribute("command", "--test");
+    };
+    button.click();
+    println(`Command target added during click: ${commandActivated}`);
+    button.removeAttribute("commandfor");
+    button.removeAttribute("command");
+    button.onclick = () => button.setAttribute("popovertarget", "popover-target");
+    button.click();
+    println(`Popover target added during click: ${container.querySelector("#popover-target").matches(":popover-open")}`);
+    container.remove();
+
+    for (const inForm of [false, true]) {
+        for (const descendant of [false, true]) {
+            const container = document.createElement(inForm ? "form" : "div");
+            container.innerHTML = '<a href="javascript:window.linkActivated()"><button type="button"><span>Commit</span></button></a>';
+            document.body.append(container);
+            const activated = new Promise(resolve => window.linkActivated = resolve);
+            container.querySelector(descendant ? "span" : "button").click();
+            await activated;
+            println(`Link activated: in form=${inForm}, descendant=${descendant}`);
+            container.remove();
+        }
+    }
+});
+</script>


### PR DESCRIPTION
Fix two issues with our Grafana dashboard: compositor crashes while loading or scrolling, and the tooltip’s “Commit” link doing nothing when clicked.

Keep font data alive for Skia’s cached typefaces, and let plain buttons inside links activate the enclosing link while respecting intervening form controls and actions added by click handlers.
