### PR TITLE
LibWeb: Use assigned flex container sizes when aligning flex lines

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -407,6 +407,16 @@ impl<'pass> FlexFormattingContext<'pass> {
         self.select_cross(used.has_definite_inline_size(), used.has_definite_block_size())
     }
 
+    fn container_cross_size_is_known_for_layout(&self) -> bool {
+        self.has_definite_cross_size_used(&self.container_used())
+            || (self.layout_input.unwrap().participation == ParticipationInParentFormattingContext::Item
+                && !self
+                    .available_space_for_items
+                    .unwrap()
+                    .cross
+                    .is_intrinsic_sizing_constraint())
+    }
+
     fn has_definite_main_size(&self, index: usize) -> bool {
         self.has_definite_main_size_used(&self.item_used(index))
     }
@@ -1740,7 +1750,11 @@ impl<'pass> FlexFormattingContext<'pass> {
     // https://www.w3.org/TR/css-flexbox-1/#algo-cross-line
     fn calculate_cross_size_of_each_flex_line(&mut self) {
         // If the flex container is single-line and has a definite cross size, the cross size of the flex line is the flex container’s inner cross size.
-        if self.is_single_line() && self.has_definite_cross_size_used(&self.container_used()) {
+        // https://drafts.csswg.org/css-flexbox-1/#flex-lines
+        // In a single-line flex container, the cross size of the line is the cross size of the flex container,
+        // and align-content has no effect.
+        // NB: A parent formatting context can assign a used size that is still indefinite for resolving percentages.
+        if self.is_single_line() && self.container_cross_size_is_known_for_layout() {
             self.flex_lines[0].cross_size = self.inner_cross_size_used(&self.container_used());
             return;
         }
@@ -1791,7 +1805,7 @@ impl<'pass> FlexFormattingContext<'pass> {
     fn handle_align_content_stretch(&mut self) {
         // If the flex container has a definite cross size, or its automatic
         // cross size is increased by a minimum cross size,
-        if (!self.has_definite_cross_size_used(&self.container_used())
+        if (!self.container_cross_size_is_known_for_layout()
             && self.computed_cross_min_size(self.flex_container).0.is_auto())
             // align-content is stretch,
             || !matches!(

--- a/Tests/LibWeb/Text/expected/flex-item-indefinite-used-cross-size.txt
+++ b/Tests/LibWeb/Text/expected/flex-item-indefinite-used-cross-size.txt
@@ -1,0 +1,8 @@
+center: container height=100; top=40, height=20
+button: container height=100; top=40, height=20
+single line ignores align-content: container height=100; top=40, height=20
+stretch: container height=100; top=0, height=100
+multiple stretched lines: container height=100; top=15, height=20; top=65, height=20
+multiple unstretched lines: container height=100; top=0, height=20; top=20, height=20
+indefinite percentage height: container height=100; top=40, height=20
+definite percentage height: container height=100; top=25, height=50

--- a/Tests/LibWeb/Text/input/flex-item-indefinite-used-cross-size.html
+++ b/Tests/LibWeb/Text/input/flex-item-indefinite-used-cross-size.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    .outer {
+        display: flex;
+        flex-direction: column;
+        width: 100px;
+        min-height: 100px;
+        padding: 0;
+        border: 0;
+    }
+    .inner {
+        display: flex;
+        flex-grow: 1;
+        align-items: center;
+    }
+    .item {
+        flex: none;
+        width: 60px;
+    }
+    .content {
+        height: 20px;
+    }
+</style>
+<script>
+    test(() => {
+        function check(label, { button = false, wrap = false, alignContent = "normal", alignItems = "center", percentage = false, definite = false } = {}) {
+            const outer = document.createElement(button ? "button" : "div");
+            outer.className = "outer";
+            if (definite)
+                outer.style.height = "100px";
+            outer.innerHTML = '<div class="inner"><div class="item"><div class="content"></div></div></div>';
+            const inner = outer.firstElementChild;
+            inner.style.flexWrap = wrap ? "wrap" : "nowrap";
+            inner.style.alignContent = alignContent;
+            inner.style.alignItems = alignItems;
+            if (percentage)
+                inner.firstElementChild.style.height = "50%";
+            if (wrap)
+                inner.append(inner.firstElementChild.cloneNode(true));
+            document.body.append(outer);
+
+            const innerRect = inner.getBoundingClientRect();
+            const items = Array.from(inner.children, item => {
+                const rect = item.getBoundingClientRect();
+                return `top=${rect.top - innerRect.top}, height=${rect.height}`;
+            });
+            println(`${label}: container height=${innerRect.height}; ${items.join("; ")}`);
+            outer.remove();
+        }
+
+        check("center");
+        check("button", { button: true });
+        check("single line ignores align-content", { alignContent: "flex-start" });
+        check("stretch", { alignItems: "stretch" });
+        check("multiple stretched lines", { wrap: true });
+        check("multiple unstretched lines", { wrap: true, alignContent: "flex-start" });
+        check("indefinite percentage height", { percentage: true });
+        check("definite percentage height", { percentage: true, definite: true });
+    });
+</script>


### PR DESCRIPTION
A nested flex container can grow to fill a parent’s minimum height while remaining indefinite for percentage resolution. Use its assigned size when sizing and stretching flex lines so children align within the full container.

This fixes the raised notification bell on X profiles and matches other browsers while preserving percentage-height behavior.

Before:
<img width="842" height="588" alt="Screenshot 2026-09-12 at 16 04 21" src="https://github.com/user-attachments/assets/6352ae21-88f6-4947-aaa3-0287ac1296db" />

After:
<img width="842" height="588" alt="Screenshot 2026-09-12 at 16 06 37" src="https://github.com/user-attachments/assets/3be8e2de-a4e9-40b3-b657-5db7e236bd04" />
