### PR TITLE
UI/Qt: Keep Ctrl+touchpad scrolling from triggering zoom

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -40,6 +40,7 @@
 #include <QCursor>
 #include <QGuiApplication>
 #include <QHBoxLayout>
+#include <QInputDevice>
 #include <QInputDialog>
 #include <QMenuBar>
 #include <QMessageBox>
@@ -1644,6 +1645,9 @@ void BrowserWindow::moveEvent(QMoveEvent* event)
 void BrowserWindow::wheelEvent(QWheelEvent* event)
 {
     if (!m_current_tab)
+        return;
+
+    if (event->phase() != Qt::NoScrollPhase || event->device()->type() == QInputDevice::DeviceType::TouchPad)
         return;
 
     if ((event->modifiers() & Qt::ControlModifier) != 0) {

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -682,7 +682,7 @@ void WebContentView::wheelEvent(QWheelEvent* event)
         return;
     }
 
-    if (event->modifiers().testFlag(Qt::ControlModifier)) {
+    if (event->modifiers().testFlag(Qt::ControlModifier) && !wheel_event_scrolls_continuously(*event)) {
         event->ignore();
         return;
     }


### PR DESCRIPTION
Only forward discrete Ctrl+wheel events to the window zoom handler. Ignore continuous scroll events in that handler as well, preserving Ctrl+mouse-wheel zoom while letting touchpad events scroll the page.