### PR TITLE
LibGC+LibWeb: Make the conservative scan a little less conservative

### DIFF
--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -552,8 +552,21 @@ private:
     FlatPtr m_heap_region_end;
 };
 
-AK::JsonObject Heap::dump_graph()
+NO_SANITIZE_ADDRESS AK::JsonObject Heap::dump_graph()
 {
+    jmp_buf registers;
+    setjmp(registers);
+    ReadonlySpan<FlatPtr> captured_registers { reinterpret_cast<FlatPtr const*>(registers), sizeof(jmp_buf) / (sizeof(FlatPtr)) };
+    return build_graph(captured_registers);
+}
+
+AK::JsonObject Heap::build_graph(ReadonlySpan<FlatPtr> callee_saved_registers)
+{
+    ConservativeScanOrigin origin {
+        .stack_floor = bit_cast<FlatPtr>(__builtin_frame_address(0)),
+        .callee_saved_registers = callee_saved_registers,
+    };
+
     // An in-progress incremental sweep would leave parts of the heap as freelist
     // entries while the conservative scan in gather_roots() can still pick up
     // not-yet-swept (but unreachable) cells whose internal pointers lead to
@@ -562,7 +575,7 @@ AK::JsonObject Heap::dump_graph()
 
     HashMap<Cell*, HeapRoot> roots;
     Vector<StackFrameInfo> stack_frames;
-    gather_roots(roots, &stack_frames);
+    gather_roots(origin, roots, &stack_frames);
     GraphConstructorVisitor visitor(*this, roots);
     visitor.visit_all_cells();
     auto graph = visitor.dump();
@@ -615,8 +628,21 @@ void Heap::run_post_mark_phases(bool report)
     }
 }
 
-void Heap::collect_garbage(CollectionType collection_type, bool print_report)
+NO_SANITIZE_ADDRESS void Heap::collect_garbage(CollectionType collection_type, bool print_report)
 {
+    jmp_buf registers;
+    setjmp(registers);
+    ReadonlySpan<FlatPtr> captured_registers { reinterpret_cast<FlatPtr const*>(registers), sizeof(jmp_buf) / (sizeof(FlatPtr)) };
+    run_collection(captured_registers, collection_type, print_report);
+}
+
+void Heap::run_collection(ReadonlySpan<FlatPtr> callee_saved_registers, CollectionType collection_type, bool print_report)
+{
+    ConservativeScanOrigin origin {
+        .stack_floor = bit_cast<FlatPtr>(__builtin_frame_address(0)),
+        .callee_saved_registers = callee_saved_registers,
+    };
+
     VERIFY(!m_collecting_garbage);
 
     finish_pending_incremental_sweep();
@@ -648,7 +674,7 @@ void Heap::collect_garbage(CollectionType collection_type, bool print_report)
             HashMap<Cell*, HeapRoot> roots;
             {
                 ScopedPhaseTimer timer { report, g_phase_timings.gather_roots_us };
-                gather_roots(roots);
+                gather_roots(origin, roots);
             }
             {
                 ScopedPhaseTimer timer { report, g_phase_timings.mark_live_cells_us };
@@ -780,7 +806,7 @@ void Heap::register_sweep_callback(AK::Function<void()> callback)
     m_sweep_callbacks.append(move(callback));
 }
 
-void Heap::gather_roots(HashMap<Cell*, HeapRoot>& roots, Vector<StackFrameInfo>* out_stack_frames, IncludeIncomingCrossHeapMembers include_incoming_cross_heap_members)
+void Heap::gather_roots(ConservativeScanOrigin const& origin, HashMap<Cell*, HeapRoot>& roots, Vector<StackFrameInfo>* out_stack_frames, IncludeIncomingCrossHeapMembers include_incoming_cross_heap_members)
 {
     // Cross-heap members targeting this heap act as roots for local collections (as the foreign holder is invisible to a local mark).
     if (include_incoming_cross_heap_members == IncludeIncomingCrossHeapMembers::Yes) {
@@ -796,7 +822,7 @@ void Heap::gather_roots(HashMap<Cell*, HeapRoot>& roots, Vector<StackFrameInfo>*
     }
     {
         ScopedPhaseTimer timer { g_recording_phase_timings, g_phase_timings.gather_conservative_roots_us };
-        gather_conservative_roots(roots, out_stack_frames);
+        gather_conservative_roots(origin, roots, out_stack_frames);
     }
 
     {
@@ -850,30 +876,34 @@ void Heap::gather_asan_fake_stack_roots(HashMap<FlatPtr, HeapRoot>&, FlatPtr, Fl
 }
 #endif
 
-NO_SANITIZE_ADDRESS void Heap::gather_conservative_roots(HashMap<Cell*, HeapRoot>& roots, Vector<StackFrameInfo>* out_stack_frames)
+NO_SANITIZE_ADDRESS void Heap::gather_conservative_roots(ConservativeScanOrigin const& origin, HashMap<Cell*, HeapRoot>& roots, Vector<StackFrameInfo>* out_stack_frames)
 {
-    FlatPtr dummy;
-
     dbgln_if(HEAP_DEBUG, "gather_conservative_roots:");
 
-    jmp_buf buf;
-    setjmp(buf);
-
     HashMap<FlatPtr, HeapRoot> possible_pointers;
-
-    auto* raw_jmp_buf = reinterpret_cast<FlatPtr const*>(buf);
 
     auto heap_region_start = BlockAllocator::heap_region_start();
     auto heap_region_end = BlockAllocator::heap_region_end();
 
+    // The scan covers the entry point's frame and its callers; the collection's own frames below the floor are left out.
+    FlatPtr own_frame;
+    auto stack_reference = origin.stack_floor;
+    auto stack_top = m_stack_info.top();
+    VERIFY(stack_reference > bit_cast<FlatPtr>(&own_frame) && stack_reference < stack_top);
+
+    // The captured registers are a buffer in the entry point's frame, so they fall inside the range scanned below.
+    auto captured_registers_start = bit_cast<FlatPtr>(origin.callee_saved_registers.data());
+    auto captured_registers_end = captured_registers_start + origin.callee_saved_registers.size() * sizeof(FlatPtr);
+    VERIFY(captured_registers_start % sizeof(FlatPtr) == 0);
+    VERIFY(captured_registers_start >= stack_reference && captured_registers_end <= stack_top);
+
     {
         ScopedPhaseTimer timer { g_recording_phase_timings, g_phase_timings.conservative_register_scan_us };
-        for (size_t i = 0; i < ((size_t)sizeof(buf)) / sizeof(FlatPtr); ++i)
-            add_possible_value(possible_pointers, raw_jmp_buf[i], HeapRoot { .type = HeapRoot::Type::RegisterPointer }, heap_region_start, heap_region_end);
+        for (auto register_value : origin.callee_saved_registers) {
+            add_possible_value(possible_pointers, register_value, HeapRoot { .type = HeapRoot::Type::RegisterPointer }, heap_region_start, heap_region_end);
+            gather_asan_fake_stack_roots(possible_pointers, register_value, heap_region_start, heap_region_end, stack_reference, stack_top);
+        }
     }
-
-    auto stack_reference = bit_cast<FlatPtr>(&dummy);
-    auto stack_top = m_stack_info.top();
 
     // Build frame boundary map for annotation if requested.
     // Each entry maps a frame pointer address to the stack frame index in out_stack_frames.
@@ -968,6 +998,11 @@ NO_SANITIZE_ADDRESS void Heap::gather_conservative_roots(HashMap<Cell*, HeapRoot
     {
         ScopedPhaseTimer timer { g_recording_phase_timings, g_phase_timings.conservative_stack_scan_us };
         for (FlatPtr stack_address = stack_reference; stack_address < stack_top; stack_address += sizeof(FlatPtr)) {
+            // Stepping over the captured registers keeps roots that live only in a register attributed as RegisterPointer.
+            if (stack_address == captured_registers_start) {
+                stack_address = captured_registers_end - sizeof(FlatPtr);
+                continue;
+            }
             auto data = *reinterpret_cast<FlatPtr*>(stack_address);
             add_possible_value(possible_pointers, data, HeapRoot { .type = HeapRoot::Type::StackPointer, .stack_frame_index = frame_index_for_stack_address(stack_address) }, heap_region_start, heap_region_end);
             gather_asan_fake_stack_roots(possible_pointers, data, heap_region_start, heap_region_end, stack_reference, stack_top);

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -82,8 +82,11 @@ public:
         CollectEverything,
     };
 
-    void collect_garbage(CollectionType = CollectionType::CollectGarbage, bool print_report = false);
-    AK::JsonObject dump_graph();
+    // NB: NEVER_INLINE so that each entry point keeps a frame of its own: setjmp() only captures the registers as
+    //     they are in the frame it runs in, and the frames below become the scan's floor. The definitions are
+    //     NO_SANITIZE_ADDRESS so that the capture buffer stays on the real stack rather than ASan's fake one.
+    NEVER_INLINE void collect_garbage(CollectionType = CollectionType::CollectGarbage, bool print_report = false);
+    NEVER_INLINE AK::JsonObject dump_graph();
 
     bool should_collect_on_every_allocation() const { return m_should_collect_on_every_allocation; }
     // This is true for any CollectEverything cycle, not only heap teardown.
@@ -168,10 +171,24 @@ private:
         No,
         Yes,
     };
-    void gather_roots(HashMap<Cell*, HeapRoot>&, Vector<StackFrameInfo>* out_stack_frames = nullptr, IncludeIncomingCrossHeapMembers = IncludeIncomingCrossHeapMembers::Yes);
+    // Where the conservative scan starts: every frame from stack_floor up, plus the callee-saved registers as captured
+    // at the entry point. The floor lands just below the entry point's frame, so the caller's registers that its
+    // prologue spilled are covered by the stack scan and the ones it left alone by the capture.
+    struct ConservativeScanOrigin {
+        FlatPtr stack_floor { 0 };
+        ReadonlySpan<FlatPtr> callee_saved_registers;
+    };
+
+    // NB: NEVER_INLINE so that these stay below their entry point's frame, and so that __builtin_frame_address(0)
+    //     yields a floor that leaves out their own frames -- which is what keeps the collection's large locals from
+    //     being scanned.
+    NEVER_INLINE void run_collection(ReadonlySpan<FlatPtr> callee_saved_registers, CollectionType, bool print_report);
+    NEVER_INLINE AK::JsonObject build_graph(ReadonlySpan<FlatPtr> callee_saved_registers);
+
+    void gather_roots(ConservativeScanOrigin const&, HashMap<Cell*, HeapRoot>&, Vector<StackFrameInfo>* out_stack_frames = nullptr, IncludeIncomingCrossHeapMembers = IncludeIncomingCrossHeapMembers::Yes);
     static void mark_live_cells_across(ReadonlySpan<Heap* const>, HashMap<Cell*, HeapRoot> const& roots);
     void run_post_mark_phases(bool report);
-    void gather_conservative_roots(HashMap<Cell*, HeapRoot>&, Vector<StackFrameInfo>* out_stack_frames = nullptr);
+    void gather_conservative_roots(ConservativeScanOrigin const&, HashMap<Cell*, HeapRoot>&, Vector<StackFrameInfo>* out_stack_frames = nullptr);
     void gather_asan_fake_stack_roots(HashMap<FlatPtr, HeapRoot>&, FlatPtr, FlatPtr heap_region_start, FlatPtr heap_region_end, FlatPtr stack_reference, FlatPtr stack_top);
     void mark_live_cells(HashMap<Cell*, HeapRoot> const& live_cells);
     void finalize_unmarked_cells();

--- a/Libraries/LibGC/HeapGroup.cpp
+++ b/Libraries/LibGC/HeapGroup.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/ElapsedTimer.h>
 #include <LibGC/Heap.h>
 #include <LibGC/HeapGroup.h>
+#include <setjmp.h>
 
 namespace GC {
 
@@ -31,8 +32,21 @@ void HeapGroup::remove(Heap& heap)
     m_heaps.remove_first_matching([&](auto* entry) { return entry == &heap; });
 }
 
-void HeapGroup::collect_garbage(bool print_report)
+NO_SANITIZE_ADDRESS void HeapGroup::collect_garbage(bool print_report)
 {
+    jmp_buf registers;
+    setjmp(registers);
+    ReadonlySpan<FlatPtr> captured_registers { reinterpret_cast<FlatPtr const*>(registers), sizeof(jmp_buf) / (sizeof(FlatPtr)) };
+    run_collection(captured_registers, print_report);
+}
+
+void HeapGroup::run_collection(ReadonlySpan<FlatPtr> callee_saved_registers, bool print_report)
+{
+    Heap::ConservativeScanOrigin origin {
+        .stack_floor = bit_cast<FlatPtr>(__builtin_frame_address(0)),
+        .callee_saved_registers = callee_saved_registers,
+    };
+
     // Defer all member heaps' collections until the last one, so that cross-heap edges are visible to the mark phase.
     for (auto* heap : m_heaps) {
         VERIFY(!heap->m_collecting_garbage);
@@ -53,7 +67,7 @@ void HeapGroup::collect_garbage(bool print_report)
 
     HashMap<Cell*, HeapRoot> roots;
     for (auto* heap : m_heaps)
-        heap->gather_roots(roots, nullptr, Heap::IncludeIncomingCrossHeapMembers::No);
+        heap->gather_roots(origin, roots, nullptr, Heap::IncludeIncomingCrossHeapMembers::No);
 
     Heap::mark_live_cells_across(m_heaps, roots);
 

--- a/Libraries/LibGC/HeapGroup.h
+++ b/Libraries/LibGC/HeapGroup.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+#include <AK/Span.h>
+#include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibGC/Forward.h>
 
@@ -23,9 +26,11 @@ public:
     void add(Heap&);
     void remove(Heap&);
 
-    void collect_garbage(bool print_report = false);
+    NEVER_INLINE void collect_garbage(bool print_report = false);
 
 private:
+    NEVER_INLINE void run_collection(ReadonlySpan<FlatPtr> callee_saved_registers, bool print_report);
+
     Vector<Heap*> m_heaps;
 };
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -345,14 +345,14 @@ void Internals::gc()
 
 void Internals::gc_async(GC::Ref<WebIDL::Promise> promise)
 {
-    auto& realm = window().principal_realm();
-
-    // Queue a task so that the collection runs outside the JS execution context.
-    HTML::queue_a_task(HTML::Task::Source::Unspecified, nullptr, nullptr, GC::create_function(GC::Heap::the(), [&realm, promise] {
+    // Queue a LibCore event to run the collection, so that it runs outside the JS execution context with as small a
+    // stack as possible.
+    Core::deferred_invoke([promise = GC::make_root(promise)] {
+        auto& realm = WebIDL::promise_realm(*promise);
         HTML::TemporaryExecutionContext execution_context { realm };
         realm.vm().heap().collect_garbage();
-        WebIDL::resolve_promise(promise);
-    }));
+        WebIDL::resolve_promise(*promise);
+    });
 }
 
 WebIDL::ExceptionOr<void> Internals::mark_as_garbage(Utf16String const& variable_name)

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -2,6 +2,7 @@
 Crash/DOM/shared-resource-request-finalize-while-in-flight.html
 Text/input/css/font-cache-first-paint.html
 Text/input/css/font-display-timeline.html
+Text/input/css/unused-font-document-collectable.html
 Text/input/css/canvas-font-display.html
 Ref/input/font-display-periods.html
 Ref/expected/font-display-periods-ref.html

--- a/Tests/LibWeb/Text/expected/css/unused-font-document-collectable.txt
+++ b/Tests/LibWeb/Text/expected/css/unused-font-document-collectable.txt
@@ -1,0 +1,3 @@
+unused face status: unloaded
+removed document collected: true
+unused face collected: true

--- a/Tests/LibWeb/Text/input/css/unused-font-document-collectable.html
+++ b/Tests/LibWeb/Text/input/css/unused-font-document-collectable.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+promiseTest(async () => {
+    const fontBytes = await (await fetch("../../../Assets/HashSans.woff")).arrayBuffer();
+    async function makeRemovedDocument() {
+        const iframe = document.createElement("iframe");
+        const loaded = new Promise(resolve => iframe.onload = resolve);
+        iframe.srcdoc = `<!DOCTYPE html>
+            <style>
+                @font-face { font-family: Unused; src: url("data:font/woff;base64,AA=="); }
+                body { font: 20px monospace; }
+            </style>
+            <body>AAAA`;
+        document.body.append(iframe);
+        await loaded;
+        iframe.onload = null;
+        const preferred = new iframe.contentWindow.FontFace("Preferred", fontBytes);
+        await preferred.load();
+        iframe.contentDocument.fonts.add(preferred);
+        iframe.contentDocument.body.style.fontFamily = "Preferred, Unused, monospace";
+        // Populate the document-owned cascade while the first family covers every character.
+        iframe.contentDocument.body.getBoundingClientRect();
+        const face = [...iframe.contentDocument.fonts][0];
+        println(`unused face status: ${face.status}`);
+        // Preserve the wrappers so collection checks the native objects, not just disposable JS wrappers.
+        iframe.contentDocument.gcSentinel = true;
+        face.gcSentinel = true;
+        const weakDocument = new WeakRef(iframe.contentDocument);
+        const weakFace = new WeakRef(face);
+        iframe.remove();
+        // Release the parent's layout references to the removed iframe before collecting it.
+        document.body.getBoundingClientRect();
+        return { weakDocument, weakFace };
+    }
+    const { weakDocument, weakFace } = await makeRemovedDocument();
+    // Collect outside the creating JS job, after its locals and WeakRef kept-alive objects are released.
+    const maximumGcRoundsWhileIframeTeardownTasksDrain = 100;
+    for (let round = 0; round < maximumGcRoundsWhileIframeTeardownTasksDrain; ++round) {
+        await timeout(0);
+        await internals.gcAsync();
+        if (weakDocument.deref() === undefined && weakFace.deref() === undefined)
+            break;
+    }
+    println(`removed document collected: ${weakDocument.deref() === undefined}`);
+    println(`unused face collected: ${weakFace.deref() === undefined}`);
+});
+</script>


### PR DESCRIPTION
The main change here is to avoid including the stack space that the collection algorithms use in the GC's conservative stack scan. In addition, `internals.gcAsync()` posts a `deferred_invoke()` to the LibCore event loop instead of a task to the HTML event queue, which gets the stack size much lower for the conservative scan.

These changes combined gets all the tests involving `WeakRef` and `gcAsync()` to pass 100% on my Linux machine, tested with Clang and GCC, as well as on my MacBook.