### PR TITLE
LibWeb: Simplify partial relayout inputs and entry points

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1875,20 +1875,6 @@ void Document::end_style_stabilization_epoch()
     m_animations_created_in_stabilization_epoch.clear();
 }
 
-static void relayout_subtree(Layout::Box& subtree_root)
-{
-    Layout::LayoutRustBridge bridge;
-    // Absolutely positioned boundaries re-resolve their own size and position by replaying
-    // their layout from saved inputs; SVG root boundaries keep the frozen geometry saved at
-    // the previous commit. The commit sink resolves the committed row to splice out in either
-    // path.
-    if (subtree_root.is_absolutely_positioned()) {
-        bridge.replay_saved_abspos_layout(subtree_root);
-    } else {
-        bridge.compute_subtree_layout(subtree_root);
-    }
-}
-
 // Refreshes every structure derived from committed layout results, shared by the partial and
 // full layout paths so neither can forget one.
 void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, LayoutCommitScope layout_commit_scope)
@@ -2152,8 +2138,9 @@ Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::Ru
     }
 
     layout_node_arena().sync_enrolled_content_for_layout();
+    Layout::LayoutRustBridge bridge;
     for (auto* root : partial_relayout_roots)
-        relayout_subtree(*root);
+        bridge.compute_subtree_layout(*root);
 
     ++m_partial_layout_count;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1883,7 +1883,6 @@ static void relayout_subtree(Layout::Box& subtree_root)
     // the previous commit. The commit sink resolves the committed row to splice out in either
     // path.
     if (subtree_root.is_absolutely_positioned()) {
-        VERIFY(subtree_root.has_saved_abspos_layout_inputs());
         bridge.replay_saved_abspos_layout(subtree_root);
     } else {
         bridge.compute_subtree_layout(subtree_root);

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -46,7 +46,6 @@ public:
     virtual ~Box() override;
 
     void notify_content_navigable_of_committed_viewport();
-    bool has_saved_abspos_layout_inputs() const { return has_flag(RustFFI::NodeFlag::HasSavedAbsposLayoutInputs); }
 
     Box(DOM::Document&, GC::Ptr<DOM::Node>, CSS::LayoutStyle, RustFFI::NodeKind = RustFFI::NodeKind::Box);
     Box(DOM::Document&, BindToPreparedArenaSlot, RustFFI::NodeSlotId, RustFFI::NodeKind);

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -503,22 +503,6 @@ void LayoutRustBridge::compute_subtree_layout(Box& root)
     }
 }
 
-void LayoutRustBridge::replay_saved_abspos_layout(Box& box)
-{
-    VERIFY(!m_commit_root);
-    m_commit_root = &box;
-    ScopeGuard clear_commit_root = [&] {
-        m_commit_root = nullptr;
-    };
-
-    auto callbacks = formatting_context_callbacks();
-    auto sink = commit_sink();
-    {
-        ActiveLayoutPassScope active_pass;
-        RustFFI::rust_layout_replay_saved_abspos_layout(Node::slot_id(&box), &callbacks, &sink);
-    }
-}
-
 static void invalidate_descendant_styles_for_container_query_size_change(GC::Ptr<DOM::Node> node)
 {
     auto* element = as_if<DOM::Element>(node.ptr());

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -37,7 +37,6 @@ public:
 
     void run_root_layout(Box& viewport, CSSPixels viewport_inline_size, CSSPixels viewport_block_size, bool should_collect_devtools_layout_data);
     void compute_subtree_layout(Box&);
-    void replay_saved_abspos_layout(Box&);
 
 private:
     [[nodiscard]] RustFFI::FfiLayoutFcCallbacks formatting_context_callbacks();

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -2009,10 +2009,10 @@ impl<'pass> AbsposEngine<'pass> {
     }
 
     pub(super) fn replay(&self, run: &FormattingContextRun<'pass>, node: Node) {
-        let saved_inputs = self.callbacks.saved_abspos_layout_inputs(node);
-        let found = saved_inputs.is_some();
-        assert!(found);
-        let mut inputs = saved_inputs.unwrap();
+        let mut inputs = self
+            .callbacks
+            .saved_abspos_layout_inputs(node)
+            .expect("abspos relayout root must have committed layout inputs");
         if !inputs.containing_block_info.derives_from_own_computed_values {
             let (inline, block) = axis_modes(
                 self.style(node)

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -50,13 +50,6 @@ fn commit_subtree(
     let entry = links_by_slot.get(&slot_index).copied();
     let reuses_committed_subtree = pass_fragments.subtree_was_reused(slot_index);
     debug_assert!(!reuses_committed_subtree || entry.is_some());
-    if let Some(link) = entry {
-        let arena = paintables.arena();
-        let data = arena.data(node);
-        if node_facts::kind_is_box(data.kind.get()) {
-            arena.set_saved_abspos_layout_inputs(data, link.abspos_layout_inputs);
-        }
-    }
     let prepared = paintables.prepare_node(
         node,
         entry.is_some(),

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -2180,16 +2180,6 @@ unsafe fn commit_entry_pass<'a>(
     arena
 }
 
-/// The subtree commit reset the root's descendant rows, and the subtree's new size may change
-/// ancestor scrollable overflow; scheduling the root covers both.
-fn schedule_scrollable_overflow_recalculation_for_relaid_out_root(arena: &LayoutNodeArena, root: NodeSlotId) {
-    // A partial relayout root is an SVG viewport or an absolutely positioned box, never an SVG
-    // content box, so the host's rule of re-laying out SVG content instead of scheduling does not
-    // apply here.
-    debug_assert!(!node_facts::kind_is_svg_box(arena.data(root).kind.get()));
-    arena.schedule_scrollable_overflow_recalculation(root);
-}
-
 /// # Safety
 ///
 /// The callback table and commit sink must remain valid for the duration of the call.
@@ -2218,15 +2208,22 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
     // the incremental tree build created; refresh the containing blocks of the whole subtree.
     arena.recompute_containing_blocks_in_subtree(root, host.inline_containing_block_lookup);
 
-    let pass_fragments = RunRecords::with_unrooted(arena, root, |entry_records| {
-        let root_used = used_values::used_values_from_committed_fragment_link(&callbacks, root)
-            .expect("partial relayout root must have committed geometry");
-        entry_records.register(root, root_used.clone());
-        let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(root));
+    // Abspos boundaries recompute their size and position in their containing block's space.
+    // In-flow SVG boundaries keep their committed geometry and lay out only their contents.
+    let root_is_absolutely_positioned = NodeFacts::new(&callbacks, root).is_absolutely_positioned();
+    let entry_root = if root_is_absolutely_positioned {
+        let containing_block = callbacks.containing_block(root);
+        assert!(!containing_block.is_invalid());
+        containing_block
+    } else {
+        root
+    };
+    let pass_fragments = RunRecords::with_unrooted(arena, entry_root, |entry_records| {
+        let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(entry_root));
         let entry_run = FormattingContextRun {
             purpose: LayoutPurpose::Commit,
             records: entry_records,
-            box_: root,
+            box_: entry_root,
             layout_mode: LayoutMode::Normal,
             callbacks,
             should_collect_devtools_layout_data: false,
@@ -2234,108 +2231,92 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             fragments: Some(entry_fragments.clone()),
             previous_line_data: None,
         };
-        if !viewport.is_invalid() && viewport != root {
-            let viewport_inline_size = CssPixels::from_raw(viewport_inline_size_raw);
-            let viewport_block_size = CssPixels::from_raw(viewport_block_size_raw);
-            let viewport_constraints = ContainingBlockConstraints {
-                percentage_basis_inline_size: Some(viewport_inline_size),
-                percentage_basis_block_size: Some(viewport_block_size),
-                ..ContainingBlockConstraints::default()
-            };
-            let viewport_used = entry_records.create_used_values(&callbacks, viewport, viewport_constraints);
-            viewport_used.set_content_inline_size(viewport_inline_size);
-            viewport_used.set_content_block_size(viewport_block_size);
-            place_child(&entry_run, viewport, FfiCssPixelPoint::default(), None);
+        if root_is_absolutely_positioned {
+            abspos_engine::AbsposEngine::for_run(&entry_run).replay(&entry_run, root);
+        } else {
+            layout_subtree_with_frozen_root_geometry(
+                &entry_run,
+                viewport,
+                CssPixels::from_raw(viewport_inline_size_raw),
+                CssPixels::from_raw(viewport_block_size_raw),
+            );
         }
-        let input = LayoutInput::new(
-            AvailableSpace {
-                inline_size: AvailableSize::definite(root_used.content_inline_size.get()),
-                block_size: AvailableSize::definite(root_used.content_block_size.get()),
-            },
-            // The subtree root has definite sizes in both axes, so boxes
-            // below it do not need inherited percentage constraints.
-            ContainingBlockConstraints::default(),
-            ParticipationInParentFormattingContext::Root,
-        );
-
-        let facts = NodeFacts::new(&callbacks, root);
-        let fc_type = formatting_context_type_created_by_box(facts)
-            .expect("partial relayout root must establish an independent formatting context");
-        run_formatting_context(
-            LayoutPurpose::Commit,
-            Some(&entry_fragments),
-            &root_used,
-            root,
-            None,
-            fc_type,
-            LayoutMode::Normal,
-            false,
-            callbacks,
-            input,
-            None,
-            None,
-        );
-        entry_fragments.normalize_arrivals_for_placement(root);
-        entry_fragments.build_fragment_for_placed_box(
-            &callbacks,
-            root,
-            None,
-            &root_used,
-            false,
-            None,
-            root_used.content_offset.get(),
-            None,
-        );
         finish_entry_pass(entry_records, &entry_fragments, &callbacks, false)
     });
     // SAFETY: Computation has finished and its input borrows are no longer used.
     let arena = unsafe { commit_entry_pass(host, root, &pass_fragments, sink) };
-    schedule_scrollable_overflow_recalculation_for_relaid_out_root(arena, root);
+    // Commit reset the subtree's rows, and its new size may affect ancestor scrollable overflow.
+    // Partial relayout roots are SVG viewports or abspos boxes, never SVG content boxes that
+    // would require a new layout instead of an overflow update.
+    debug_assert!(!node_facts::kind_is_svg_box(arena.data(root).kind.get()));
+    arena.schedule_scrollable_overflow_recalculation(root);
 }
 
-/// # Safety
-///
-/// The callback table and commit sink must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
-    box_: NodeSlotId,
-    callbacks: *const FfiLayoutFcCallbacks,
-    sink: *const commit::FfiCommitSink,
+fn layout_subtree_with_frozen_root_geometry(
+    run: &FormattingContextRun<'_>,
+    viewport: Node,
+    viewport_inline_size: CssPixels,
+    viewport_block_size: CssPixels,
 ) {
-    assert!(!box_.is_invalid());
-    assert!(!callbacks.is_null());
-    assert!(!sink.is_null());
-    // SAFETY: The C++ pass host keeps both callback tables live for this
-    // synchronous entry.
-    let host = unsafe { &*callbacks };
-    // SAFETY: The host keeps the document's layout inputs alive and unchanged
-    // while computing fragments. Nested measurements only mutate side caches.
-    let arena = unsafe { LayoutNodeArena::from_handle(host.arena) };
-    let callbacks = LayoutPass::new(arena, host);
-    let sink = unsafe { &*sink };
-    // As for a subtree layout: the replayed box's own subtree is what is about to be laid out.
-    arena.recompute_containing_blocks_in_subtree(box_, host.inline_containing_block_lookup);
-    let containing_block = callbacks.containing_block(box_);
-    assert!(!containing_block.is_invalid());
-    let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(
-        containing_block,
-    ));
-    let pass_fragments = RunRecords::with_unrooted(arena, containing_block, |entry_records| {
-        let run = FormattingContextRun {
-            purpose: LayoutPurpose::Commit,
-            records: entry_records,
-            box_: containing_block,
-            layout_mode: LayoutMode::Normal,
-            callbacks,
-            should_collect_devtools_layout_data: false,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
-            fragments: Some(entry_fragments.clone()),
-            previous_line_data: None,
+    let root = run.box_;
+    let callbacks = &run.callbacks;
+    let root_used = used_values::used_values_from_committed_fragment_link(callbacks, root)
+        .expect("partial relayout root must have committed geometry");
+    run.records.register(root, root_used.clone());
+    let fragments = run.fragments.as_deref().expect("partial relayout must build fragments");
+    if !viewport.is_invalid() && viewport != root {
+        let viewport_constraints = ContainingBlockConstraints {
+            percentage_basis_inline_size: Some(viewport_inline_size),
+            percentage_basis_block_size: Some(viewport_block_size),
+            ..ContainingBlockConstraints::default()
         };
-        abspos_engine::AbsposEngine::for_run(&run).replay(&run, box_);
-        finish_entry_pass(entry_records, &entry_fragments, &callbacks, false)
-    });
-    // SAFETY: Computation has finished and its input borrows are no longer used.
-    let arena = unsafe { commit_entry_pass(host, box_, &pass_fragments, sink) };
-    schedule_scrollable_overflow_recalculation_for_relaid_out_root(arena, box_);
+        let viewport_used = run
+            .records
+            .create_used_values(callbacks, viewport, viewport_constraints);
+        viewport_used.set_content_inline_size(viewport_inline_size);
+        viewport_used.set_content_block_size(viewport_block_size);
+        place_child(run, viewport, FfiCssPixelPoint::default(), None);
+    }
+    let input = LayoutInput::new(
+        AvailableSpace {
+            inline_size: AvailableSize::definite(root_used.content_inline_size.get()),
+            block_size: AvailableSize::definite(root_used.content_block_size.get()),
+        },
+        // The subtree root has definite sizes in both axes, so boxes
+        // below it do not need inherited percentage constraints.
+        ContainingBlockConstraints::default(),
+        ParticipationInParentFormattingContext::Root,
+    );
+
+    let facts = NodeFacts::new(callbacks, root);
+    debug_assert!(facts.is_svg_svg_box());
+    let fc_type = formatting_context_type_created_by_box(facts)
+        .expect("partial relayout root must establish an independent formatting context");
+    run_formatting_context(
+        run.purpose,
+        Some(fragments),
+        &root_used,
+        root,
+        None,
+        fc_type,
+        run.layout_mode,
+        run.should_collect_devtools_layout_data,
+        *callbacks,
+        input,
+        None,
+        None,
+    );
+    // The retained offset already includes relative positioning. Publish it directly instead
+    // of applying placement adjustments a second time.
+    fragments.normalize_arrivals_for_placement(root);
+    fragments.build_fragment_for_placed_box(
+        callbacks,
+        root,
+        None,
+        &root_used,
+        false,
+        None,
+        root_used.content_offset.get(),
+        None,
+    );
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -308,12 +308,6 @@ struct IntrinsicSizeCacheSlot {
     sizes: Option<Box<IntrinsicSizeMaps>>,
 }
 
-#[derive(Default)]
-struct SavedAbsposLayoutInputsSlot {
-    generation: u8,
-    inputs: Option<Box<AbsposLayoutInputs>>,
-}
-
 #[derive(Clone, Copy, Default)]
 struct DefaultScrollShiftAnchorSlot {
     generation: u8,
@@ -540,7 +534,6 @@ pub(crate) struct LayoutNodeArena {
     intrinsic_size_caches: RefCell<Vec<IntrinsicSizeCacheSlot>>,
     table_cell_measurement_cache_misses: Cell<u64>,
     intrinsic_measurements: Cell<u64>,
-    saved_abspos_layout_inputs: RefCell<Vec<SavedAbsposLayoutInputsSlot>>,
     default_scroll_shift_anchors: RefCell<Vec<DefaultScrollShiftAnchorSlot>>,
     any_default_scroll_shift_anchor_ever_stored: Cell<bool>,
     text_nodes: Vec<TextNodeSlot>,
@@ -592,7 +585,6 @@ impl LayoutNodeArena {
             intrinsic_size_caches: RefCell::new(Vec::new()),
             table_cell_measurement_cache_misses: Cell::new(0),
             intrinsic_measurements: Cell::new(0),
-            saved_abspos_layout_inputs: RefCell::new(Vec::new()),
             default_scroll_shift_anchors: RefCell::new(Vec::new()),
             any_default_scroll_shift_anchor_ever_stored: Cell::new(false),
             text_nodes: Vec::new(),
@@ -868,9 +860,6 @@ impl LayoutNodeArena {
 
         if let Some(slot) = self.intrinsic_size_caches.get_mut().get_mut(index as usize) {
             *slot = IntrinsicSizeCacheSlot::default();
-        }
-        if let Some(slot) = self.saved_abspos_layout_inputs.get_mut().get_mut(index as usize) {
-            *slot = SavedAbsposLayoutInputsSlot::default();
         }
         if let Some(slot) = self.default_scroll_shift_anchors.get_mut().get_mut(index as usize) {
             *slot = DefaultScrollShiftAnchorSlot::default();
@@ -1969,68 +1958,10 @@ impl LayoutNodeArena {
 
     pub(crate) fn saved_abspos_layout_inputs(&self, data: &NodeData) -> Option<AbsposLayoutInputs> {
         let (index, metadata) = self.slot_for_data(data);
-        let slots = self.saved_abspos_layout_inputs.borrow();
-        let inputs = slots
-            .get(index as usize)
-            .filter(|slot| slot.generation == metadata.generation)
-            .and_then(|slot| slot.inputs.as_deref().copied());
-
-        let flags = data.flags.get();
-        assert_eq!(
-            flags & NodeFlag::HasSavedAbsposLayoutInputs as u32 != 0,
-            inputs.is_some(),
-            "saved abspos input presence flag disagrees with the arena side table"
-        );
-        assert_eq!(
-            flags & NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues as u32 != 0,
-            inputs.is_some_and(|inputs| inputs.containing_block_info.derives_from_own_computed_values),
-            "saved abspos containing-block flag disagrees with the arena side table"
-        );
-        assert_eq!(
-            flags & NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues as u32 != 0,
-            inputs.is_some_and(|inputs| { inputs.static_position_rect.alignment_derives_from_own_computed_values }),
-            "saved abspos alignment flag disagrees with the arena side table"
-        );
-        inputs
-    }
-
-    pub(crate) fn set_saved_abspos_layout_inputs(&self, data: &NodeData, inputs: Option<AbsposLayoutInputs>) {
-        let (index, metadata) = self.slot_for_data(data);
-        let mut slots = self.saved_abspos_layout_inputs.borrow_mut();
-        if slots.len() <= index as usize {
-            slots.resize_with(index as usize + 1, SavedAbsposLayoutInputsSlot::default);
-        }
-        let slot = &mut slots[index as usize];
-        if slot.generation != metadata.generation {
-            *slot = SavedAbsposLayoutInputsSlot {
-                generation: metadata.generation,
-                inputs: inputs.map(Box::new),
-            };
-        } else if let Some(inputs) = inputs {
-            if let Some(saved_inputs) = &mut slot.inputs {
-                **saved_inputs = inputs;
-            } else {
-                slot.inputs = Some(Box::new(inputs));
-            }
-        } else {
-            slot.inputs = None;
-        }
-        drop(slots);
-
-        let saved_abspos_flags = NodeFlag::HasSavedAbsposLayoutInputs as u32
-            | NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues as u32
-            | NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues as u32;
-        let mut value = data.flags.get() & !saved_abspos_flags;
-        if let Some(inputs) = inputs {
-            value |= NodeFlag::HasSavedAbsposLayoutInputs as u32;
-            if inputs.containing_block_info.derives_from_own_computed_values {
-                value |= NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues as u32;
-            }
-            if inputs.static_position_rect.alignment_derives_from_own_computed_values {
-                value |= NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues as u32;
-            }
-        }
-        data.flags.set(value);
+        self.paintable_rows
+            .with_committed_fragment_link(index, metadata.generation, |link| {
+                link.and_then(|link| link.abspos_layout_inputs)
+            })
     }
 
     pub(crate) fn set_default_scroll_shift(
@@ -3273,6 +3204,9 @@ pub unsafe extern "C" fn layout_arena_set_table_spans(
 mod tests {
     use std::cell::Cell;
 
+    use crate::layout::abspos_inputs::{
+        AbsposAxisMode, AbsposContainingBlockInfo, AbsposLayoutInputs, StaticPositionAlignment, StaticPositionRect,
+    };
     use crate::layout::layout_node_arena::{
         Chunk, FfiDerivedStyleRecord, IntrinsicBlockSizeMeasurement, IntrinsicInlineSizeMeasurement,
         IntrinsicSizeCacheKey, IntrinsicSizeCacheKind, LayoutNodeArena, SLOTS_PER_CHUNK, TableCellMeasurement,
@@ -3609,12 +3543,39 @@ mod tests {
         arena.free_subtree(second.slot).destroy_shells_and_invoke_callbacks();
     }
 
+    fn test_abspos_layout_inputs() -> AbsposLayoutInputs {
+        AbsposLayoutInputs {
+            static_position_rect: StaticPositionRect {
+                rect: Default::default(),
+                inline_alignment: StaticPositionAlignment::Center,
+                block_alignment: StaticPositionAlignment::End,
+                alignment_derives_from_own_computed_values: true,
+            },
+            containing_block_info: AbsposContainingBlockInfo {
+                rect: Default::default(),
+                inline_axis_mode: AbsposAxisMode::StaticPosition,
+                block_axis_mode: AbsposAxisMode::InsetFromRect,
+                inline_alignment: None,
+                block_alignment: None,
+                derives_from_own_computed_values: true,
+            },
+            resolved_anchor_insets: None,
+        }
+    }
+
     #[test]
-    fn clearing_a_committed_box_evicts_its_fragment_link() {
+    fn clearing_a_committed_box_evicts_its_fragment_link_and_abspos_inputs() {
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate_for_test();
-        arena.set_committed_fragment_link(arena.data(allocation.slot), test_fragment_link(allocation.slot));
+        let inputs = test_abspos_layout_inputs();
+        let mut link = test_fragment_link(allocation.slot);
+        link.abspos_layout_inputs = Some(inputs);
+        arena.set_committed_fragment_link(arena.data(allocation.slot), link);
         assert!(arena.committed_fragment_link(arena.data(allocation.slot)).is_some());
+        assert_eq!(
+            arena.saved_abspos_layout_inputs(arena.data(allocation.slot)),
+            Some(inputs)
+        );
 
         // SAFETY: arena is a live handle on this thread, and allocation names
         // a live slot in it.
@@ -3626,17 +3587,20 @@ mod tests {
         }
 
         assert!(arena.committed_fragment_link(arena.data(allocation.slot)).is_none());
+        assert_eq!(arena.saved_abspos_layout_inputs(arena.data(allocation.slot)), None);
         arena
             .free_subtree(allocation.slot)
             .destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
-    fn committed_fragment_links_move_between_slots() {
+    fn committed_fragment_links_move_abspos_inputs_between_slots() {
         let mut arena = LayoutNodeArena::new();
         let old = arena.allocate_for_test();
         let new = arena.allocate_for_test();
-        let link = test_fragment_link(old.slot);
+        let inputs = test_abspos_layout_inputs();
+        let mut link = test_fragment_link(old.slot);
+        link.abspos_layout_inputs = Some(inputs);
         let retained_fragment = link.fragment.clone();
         arena.set_committed_fragment_link(arena.data(old.slot), link);
 
@@ -3647,10 +3611,14 @@ mod tests {
         arena.set_committed_fragment_link(arena.data(new.slot), moved);
 
         assert!(arena.committed_fragment_link(arena.data(old.slot)).is_none());
+        assert_eq!(arena.saved_abspos_layout_inputs(arena.data(old.slot)), None);
+        assert_eq!(arena.saved_abspos_layout_inputs(arena.data(new.slot)), Some(inputs));
         let moved = arena
             .committed_fragment_link(arena.data(new.slot))
             .expect("new slot must receive the committed fragment");
         assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
+        arena.set_committed_fragment_link(arena.data(new.slot), test_fragment_link(new.slot));
+        assert_eq!(arena.saved_abspos_layout_inputs(arena.data(new.slot)), None);
         arena.free_subtree(old.slot).destroy_shells_and_invoke_callbacks();
         arena.free_subtree(new.slot).destroy_shells_and_invoke_callbacks();
     }

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -158,9 +158,6 @@ pub enum NodeFlag {
     UsesButtonLayout = 1 << 16,
     IsEditingHost = 1 << 17,
     ReplacedBoxCanHaveChildren = 1 << 18,
-    HasSavedAbsposLayoutInputs = 1 << 19,
-    SavedAbsposCbDerivesFromOwnComputedValues = 1 << 20,
-    SavedAbsposAlignmentDerivesFromOwnComputedValues = 1 << 21,
     ProducesLineBoxFragmentWhenEmpty = 1 << 22,
     ListMarkerIsInside = 1 << 23,
     HasAnchorNames = 1 << 24,
@@ -301,17 +298,6 @@ mod tests {
         assert_eq!(id.slot_index(), MAX_NODE_SLOT_COUNT - 1);
         assert_eq!(id.generation(), u8::MAX);
         assert_ne!(id, NodeSlotId::INVALID);
-    }
-
-    #[test]
-    fn saved_abspos_flags_use_previously_unassigned_bits() {
-        assert_eq!(NodeFlag::IsReplacedElement as u32, 1 << 12);
-        assert_eq!(NodeFlag::HasSavedAbsposLayoutInputs as u32, 1 << 19);
-        assert_eq!(NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues as u32, 1 << 20);
-        assert_eq!(
-            NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues as u32,
-            1 << 21
-        );
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -121,7 +121,7 @@ impl LayoutNodeArena {
         if node_facts::has_flag(data, NodeFlag::IsDocumentElement) {
             return false;
         }
-        if !node_facts::has_flag(data, NodeFlag::HasSavedAbsposLayoutInputs) {
+        if self.saved_abspos_layout_inputs(data).is_none() {
             return false;
         }
 
@@ -333,7 +333,10 @@ impl LayoutNodeArena {
             return false;
         }
 
-        if node_facts::has_flag(data, NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues) {
+        let Some(inputs) = self.saved_abspos_layout_inputs(data) else {
+            return false;
+        };
+        if inputs.containing_block_info.derives_from_own_computed_values {
             return false;
         }
 
@@ -343,9 +346,7 @@ impl LayoutNodeArena {
         let inset = &style.surround().inset;
         let uses_static_position =
             (inset.left.is_auto() && inset.right.is_auto()) || (inset.top.is_auto() && inset.bottom.is_auto());
-        if uses_static_position
-            && node_facts::has_flag(data, NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues)
-        {
+        if uses_static_position && inputs.static_position_rect.alignment_derives_from_own_computed_values {
             return false;
         }
 

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -1633,12 +1633,6 @@ fn update_principal_node_after_entry(
                 let new_data = arena.data(layout_node);
                 if node_kind_is_box(old_data.kind.get())
                     && node_kind_is_box(new_data.kind.get())
-                    && let Some(inputs) = arena.saved_abspos_layout_inputs(old_data)
-                {
-                    arena.set_saved_abspos_layout_inputs(new_data, Some(inputs));
-                }
-                if node_kind_is_box(old_data.kind.get())
-                    && node_kind_is_box(new_data.kind.get())
                     && let Some(link) = arena.take_committed_fragment_link(old_data)
                 {
                     arena.set_committed_fragment_link(new_data, link);


### PR DESCRIPTION
Read saved abspos inputs directly from retained fragment links, removing the duplicate arena table, mirrored flags, and separate copying during box replacement.

Route SVG and abspos partial relayout through one entry point, sharing pass setup, commit, and overflow updates. Preserve SVG’s committed size and offset while continuing to recompute abspos sizing and placement.