### PR TITLE
LibWeb: Keep scrollable overflow maintenance in Rust

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -977,14 +977,6 @@ AnimationUpdateContext::~AnimationUpdateContext()
                 element.document().schedule_accumulated_visual_context_update(target, scope);
             }
         }
-        if (invalidation.needs_scrollable_overflow_recalculation()) {
-            if (element.pseudo_element().has_value()) {
-                if (auto pseudo_element_node = target->pseudo_element_unsafe_layout_node(element.pseudo_element().value()))
-                    element.document().schedule_scrollable_overflow_recalculation(*pseudo_element_node);
-            } else {
-                element.document().schedule_scrollable_overflow_recalculation(target);
-            }
-        }
 
         auto* repaint_layout_node = element.pseudo_element().has_value()
             ? target->pseudo_element_unsafe_layout_node(*element.pseudo_element())

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -22,8 +22,6 @@ RequiredInvalidationAfterStyleChange decode_style_invalidation(u32 packed)
         result.set_layout_tree_rebuild_root(static_cast<LayoutTreeRebuildRoot>((packed >> to_underlying(RebuildRootShift)) & to_underlying(LevelMask)));
     if (packed & to_underlying(RebuildStackingContext))
         result.set_needs_stacking_context_tree_rebuild();
-    if (packed & to_underlying(RecalculateScrollableOverflow))
-        result.set_needs_scrollable_overflow_recalculation();
     result.needs_scroll_container_resnap = packed & to_underlying(ResnapScrollContainer);
     result.recompute_descendant_styles = packed & to_underlying(RecomputeDescendants);
     auto inherited_groups = static_cast<u8>((packed >> to_underlying(InheritedGroupsShift)) & to_underlying(InheritedGroupsMask));

--- a/Libraries/LibWeb/CSS/StyleInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.h
@@ -50,10 +50,6 @@ struct RequiredInvalidationAfterStyleChange {
         ensure_at_least(InvalidationLevel::Repaint);
     }
 
-    // NB: Deliberately does not imply repaint: whether anything needs repainting is only known
-    //     after the overflow has actually been re-measured and turned out to have changed.
-    void set_needs_scrollable_overflow_recalculation() { m_needs_scrollable_overflow_recalculation = true; }
-
     [[nodiscard]] bool needs_repaint() const { return m_level >= InvalidationLevel::Repaint; }
     [[nodiscard]] bool needs_relayout() const { return m_level >= InvalidationLevel::Relayout; }
     [[nodiscard]] bool needs_layout_tree_rebuild() const { return m_level >= InvalidationLevel::RebuildLayoutTree; }
@@ -68,9 +64,6 @@ struct RequiredInvalidationAfterStyleChange {
         m_layout_tree_rebuild_root = rebuild_root;
     }
     [[nodiscard]] bool needs_stacking_context_tree_rebuild() const { return m_rebuild_stacking_context_tree; }
-    // NB: A pending relayout re-measures all scrollable overflow anyway, so this reports true only
-    //     when the recalculation has to run as a separate step.
-    [[nodiscard]] bool needs_scrollable_overflow_recalculation() const { return m_needs_scrollable_overflow_recalculation && !needs_relayout(); }
     [[nodiscard]] AccumulatedVisualContextInvalidation accumulated_visual_contexts() const { return m_accumulated_visual_contexts; }
     [[nodiscard]] bool invalidates_hit_test_display_list() const
     {
@@ -116,7 +109,6 @@ struct RequiredInvalidationAfterStyleChange {
         m_level = max(m_level, other.m_level);
         m_accumulated_visual_contexts = max(m_accumulated_visual_contexts, other.m_accumulated_visual_contexts);
         m_rebuild_stacking_context_tree |= other.m_rebuild_stacking_context_tree;
-        m_needs_scrollable_overflow_recalculation |= other.m_needs_scrollable_overflow_recalculation;
         needs_scroll_container_resnap |= other.needs_scroll_container_resnap;
         recompute_descendant_styles |= other.recompute_descendant_styles;
         m_inherited_style_groups_changed |= other.m_inherited_style_groups_changed;
@@ -131,7 +123,6 @@ struct RequiredInvalidationAfterStyleChange {
     {
         return m_level == InvalidationLevel::None
             && m_accumulated_visual_contexts == AccumulatedVisualContextInvalidation::None
-            && !m_needs_scrollable_overflow_recalculation
             && !needs_scroll_container_resnap
             && !recompute_descendant_styles
             && !inherited_style_changed()
@@ -164,7 +155,6 @@ private:
     AccumulatedVisualContextInvalidation m_accumulated_visual_contexts { AccumulatedVisualContextInvalidation::None };
     LayoutTreeRebuildRoot m_layout_tree_rebuild_root { LayoutTreeRebuildRoot::Parent };
     bool m_rebuild_stacking_context_tree : 1 { false };
-    bool m_needs_scrollable_overflow_recalculation : 1 { false };
     u8 m_inherited_style_groups_changed { 0 };
 };
 

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -53,9 +53,6 @@ static void apply_element_style_invalidation_after_style_change(DOM::Element& el
     else if (invalidation.accumulated_visual_contexts() == AccumulatedVisualContextInvalidation::Rebuild)
         element.document().schedule_accumulated_visual_context_update(element, DOM::Document::AccumulatedVisualContextUpdateScope::Structure);
 
-    if (invalidation.needs_scrollable_overflow_recalculation())
-        element.document().schedule_scrollable_overflow_recalculation(element);
-
     if (invalidation.needs_scroll_container_resnap)
         element.document().schedule_scroll_container_resnap();
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -10379,28 +10379,6 @@ void Document::schedule_accumulated_visual_context_update(Element& element, Accu
     }
 }
 
-void Document::schedule_scrollable_overflow_recalculation(Layout::Node const& layout_node)
-{
-    // SVG layout consumes transforms when computing geometry, so a transform change on SVG content
-    // has to perform layout, matching the behavior of the transform presentation attribute.
-    if (layout_node.is_svg_box()) {
-        const_cast<Layout::Node&>(layout_node).set_needs_layout_update(DOM::SetNeedsLayoutReason::StyleChange);
-        return;
-    }
-
-    Layout::RustFFI::layout_arena_schedule_scrollable_overflow_recalculation(layout_node.arena_handle(), Layout::Node::slot_id(&layout_node));
-}
-
-void Document::schedule_scrollable_overflow_recalculation(Element& element)
-{
-    if (auto* layout_node = element.unsafe_layout_node())
-        schedule_scrollable_overflow_recalculation(*layout_node);
-    element.for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement const& pseudo_element) {
-        if (auto* pseudo_element_layout_node = pseudo_element.unsafe_layout_node())
-            schedule_scrollable_overflow_recalculation(*pseudo_element_layout_node);
-    });
-}
-
 Painting::SnappedAreas const& Document::snapped_areas_of_scroll_container(Compositor::AsyncScrollNodeStableID const& stable_node_id) const
 {
     static NeverDestroyed<Painting::SnappedAreas const> no_snapped_areas;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -707,6 +707,8 @@ Layout::NodeArena& Document::layout_node_arena()
 void Document::reset_style_invalidation_counters() const
 {
     m_style_invalidation_counters = {};
+    if (m_layout_node_arena)
+        Layout::RustFFI::layout_arena_scrollable_overflow_recalculation_count(m_layout_node_arena->handle(), true);
     CSS::reset_longhand_wrappers_minted();
 }
 
@@ -1526,8 +1528,6 @@ void Document::tear_down_layout_tree()
     if (auto* layout_root = exchange(m_layout_root, nullptr))
         layout_node_arena().free_subtree(Layout::Node::slot_id(layout_root));
     m_paint_state = nullptr;
-    if (m_layout_node_arena)
-        Layout::RustFFI::layout_arena_clear_scrollable_overflow_contained_boxes(m_layout_node_arena->handle());
     m_needs_full_layout_tree_update = true;
 }
 
@@ -1877,24 +1877,15 @@ void Document::end_style_stabilization_epoch()
 
 // Refreshes every structure derived from committed layout results, shared by the partial and
 // full layout paths so neither can forget one.
-void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, LayoutCommitScope layout_commit_scope)
+void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed)
 {
     // NB: Called during layout update.
     m_layout_root->invalidate_text_blocks_cache();
 
     set_needs_to_record_display_list();
 
-    // A commit that changed the tree can have replaced boxes referenced by the cached
-    // contained-boxes index; refresh it before overflow measurement follows them. A pending full
-    // recalculation rebuilds the index inside its own measurement traversal instead.
-    if (layout_tree_changed == LayoutTreeChanged::Yes && !Layout::RustFFI::layout_arena_needs_full_scrollable_overflow_recalculation(layout_node_arena().handle()))
-        Layout::RustFFI::layout_arena_rebuild_scrollable_overflow_contained_boxes(layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root));
-    if (layout_commit_scope == LayoutCommitScope::Full)
-        update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates::HandledByFullLayoutCommit);
-    else
-        update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates::HandledByAfterLayoutCommit);
-
     set_needs_accumulated_visual_contexts_update(true);
+    prepare_for_rendering();
 
     // A tree update can replace layout nodes referenced by selection state.
     if (auto range = get_selection()->range())
@@ -2144,7 +2135,7 @@ Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::Ru
 
     ++m_partial_layout_count;
 
-    after_layout_commit(layout_tree_was_built_in_partial_branch ? LayoutTreeChanged::Yes : LayoutTreeChanged::No, LayoutCommitScope::Subtree);
+    after_layout_commit(layout_tree_was_built_in_partial_branch ? LayoutTreeChanged::Yes : LayoutTreeChanged::No);
     if (needs_style_update_after_layout() || !layout_is_up_to_date())
         return PartialRelayoutResult::NeedsAnotherLayoutPass;
     return PartialRelayoutResult::Done;
@@ -2208,7 +2199,7 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
             && reason == UpdateLayoutReason::InspectDevToolsLayoutData;
 
         if (layout_is_up_to_date() && !force_devtools_layout_data_collection) {
-            update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates::UpdateAfterMeasure);
+            prepare_for_rendering();
             return;
         }
 
@@ -2266,7 +2257,7 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
         style_invalidation_counters().relayouts_performed++;
         ++m_full_layout_count;
 
-        after_layout_commit(LayoutTreeChanged::Yes, LayoutCommitScope::Full);
+        after_layout_commit(LayoutTreeChanged::Yes);
 
         if constexpr (UPDATE_LAYOUT_DEBUG) {
             dbgln("LAYOUT {} {} µs", to_string(reason), timer.elapsed_time().to_microseconds());
@@ -2619,7 +2610,7 @@ void Document::finish_animated_style_update()
         effect->request_observation_sample();
 }
 
-void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates derived_structure_updates)
+void Document::prepare_for_rendering()
 {
     if (!m_layout_node_arena)
         return;
@@ -2640,39 +2631,21 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
         });
     }
 
-    auto outcome = Painting::rust_update_scrollable_overflow(*this,
-        derived_structure_updates == ScrollableOverflowDerivedStructureUpdates::HandledByFullLayoutCommit);
-    if (!outcome.performed_recalculation)
-        return;
-
-    style_invalidation_counters().scrollable_overflow_recalculations++;
-
-    if (derived_structure_updates != ScrollableOverflowDerivedStructureUpdates::UpdateAfterMeasure)
-        return;
-
-    // Nothing derived from scrollable overflow needs updating. In particular, this keeps transform
-    // changes that ride the accumulated-visual-context value-update path free of display list
-    // re-recording when the overflow they produce is unchanged.
-    if (!outcome.any_overflow_changed)
-        return;
-
-    if (outcome.any_has_scrollable_overflow_flipped) {
+    auto outcome = Painting::rust_prepare_for_rendering(*this, m_needs_accumulated_visual_contexts_update);
+    if (outcome.requires_visual_context_update)
         set_needs_accumulated_visual_contexts_update(true);
-    } else if (!m_needs_accumulated_visual_contexts_update) {
-        // Sticky insets only depend on scrollport geometry and which ancestor is scrollable, neither of
-        // which changes without a flip; the constraints capture the scroll ancestor's scrollable
-        // overflow size though, so they have to be refreshed. When a full visual context rebuild is
-        // already pending it recaptures constraints anyway, and skipping the refresh then also avoids
-        // touching scroll nodes whose committed rows a subtree relayout may have replaced.
-        paint_state().refresh_sticky_constraints(*this);
+    if (outcome.visual_context_values_changed)
+        paint_state().did_update_visual_context_values();
+    if (outcome.requires_display_list_recording) {
+        set_needs_to_record_display_list();
+        m_document->set_needs_repaint();
     }
-    set_needs_to_record_display_list();
-    m_document->set_needs_repaint();
 }
 
 void Document::update_paint_and_hit_testing_properties_if_needed()
 {
     // NB: Called during paint property resolution.
+    prepare_for_rendering();
     if (m_needs_accumulated_visual_contexts_update) {
         m_needs_accumulated_visual_contexts_update = false;
         if (has_committed_viewport_box())

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1172,8 +1172,6 @@ public:
     bool can_compute_client_rects_without_accumulated_visual_contexts_update(Layout::Node const&) const;
     void schedule_accumulated_visual_context_update(Element&, AccumulatedVisualContextUpdateScope);
     void schedule_accumulated_visual_context_update(Layout::Node const&, AccumulatedVisualContextUpdateScope);
-    void schedule_scrollable_overflow_recalculation(Element&);
-    void schedule_scrollable_overflow_recalculation(Layout::Node const&);
 
     Painting::SnappedAreas const& snapped_areas_of_scroll_container(Compositor::AsyncScrollNodeStableID const&) const;
     void set_snapped_areas_of_scroll_container(Compositor::AsyncScrollNodeStableID const&, Painting::SnappedAreas);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -499,12 +499,7 @@ public:
     [[nodiscard]] u64 full_layout_count() const { return m_full_layout_count; }
     [[nodiscard]] bool layout_is_up_to_date() const;
     void clear_devtools_layout_inspection_data();
-    enum class ScrollableOverflowDerivedStructureUpdates : u8 {
-        UpdateAfterMeasure,
-        HandledByAfterLayoutCommit,
-        HandledByFullLayoutCommit,
-    };
-    void update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates);
+    void prepare_for_rendering();
     void update_paint_and_hit_testing_properties_if_needed();
     void sample_animation_effects_needing_style_update();
     void update_style_computer_viewport_rect();
@@ -1152,7 +1147,6 @@ public:
         u64 custom_property_cycle_participants { 0 };
         u64 style_cascade_microseconds { 0 };
         u64 style_values_microseconds { 0 };
-        u64 scrollable_overflow_recalculations { 0 };
     };
     StyleInvalidationCounters& style_invalidation_counters() const { return m_style_invalidation_counters; }
     void reset_style_invalidation_counters() const;
@@ -1515,11 +1509,7 @@ private:
         No,
         Yes,
     };
-    enum class LayoutCommitScope : u8 {
-        Subtree,
-        Full,
-    };
-    void after_layout_commit(LayoutTreeChanged, LayoutCommitScope);
+    void after_layout_commit(LayoutTreeChanged);
 
     void run_unloading_cleanup_steps();
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -2129,7 +2129,7 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("customPropertyCycleParticipants"_utf16_fly_string, JS::Value(counters.custom_property_cycle_participants), JS::default_attributes);
     object->define_direct_property("styleCascadeMicroseconds"_utf16_fly_string, JS::Value(counters.style_cascade_microseconds), JS::default_attributes);
     object->define_direct_property("styleValuesMicroseconds"_utf16_fly_string, JS::Value(counters.style_values_microseconds), JS::default_attributes);
-    object->define_direct_property("scrollableOverflowRecalculations"_utf16_fly_string, JS::Value(counters.scrollable_overflow_recalculations), JS::default_attributes);
+    object->define_direct_property("scrollableOverflowRecalculations"_utf16_fly_string, JS::Value(Layout::RustFFI::layout_arena_scrollable_overflow_recalculation_count(document.layout_node_arena().handle(), false)), JS::default_attributes);
     return object;
 }
 

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/TextNode.h>
+#include <LibWeb/Painting/PaintingRustBridge.h>
 
 namespace Web::Layout {
 
@@ -19,6 +20,7 @@ NodeArena::NodeArena()
     }))
 {
     VERIFY(m_handle);
+    Painting::register_geometry_host(*this);
 }
 
 NodeArena::~NodeArena()

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -150,13 +150,13 @@ CSSPixels border_box_height(Layout::Node const& node)
 
 bool has_scrollable_overflow(Layout::Node const& node)
 {
-    auto overflow = rust_scrollable_overflow(node);
+    auto overflow = Layout::RustFFI::layout_arena_paintable_scrollable_overflow(node.arena_handle(), committed_row_slot(node));
     return overflow.has_value && overflow.value.has_scrollable_overflow;
 }
 
 Optional<CSSPixelRect> scrollable_overflow_rect(Layout::Node const& node)
 {
-    auto overflow = rust_scrollable_overflow(node);
+    auto overflow = Layout::RustFFI::layout_arena_paintable_scrollable_overflow(node.arena_handle(), committed_row_slot(node));
     if (!overflow.has_value)
         return {};
     return overflow.value.rect;

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -148,39 +148,18 @@ CSSPixels border_box_height(Layout::Node const& node)
     return content_height(node) + border_box.top + border_box.bottom;
 }
 
-static bool overflow_is_valid(Layout::Node const& node)
-{
-    return Layout::RustFFI::layout_arena_paintable_overflow_is_valid(node.arena_handle(), committed_row_slot(node));
-}
-
-static void measure_scrollable_overflow_if_missing(Layout::Node const& node)
-{
-    if (overflow_is_valid(node))
-        return;
-    if (auto const* box = as_if<Layout::Box>(node))
-        rust_measure_scrollable_overflow(*box);
-}
-
 bool has_scrollable_overflow(Layout::Node const& node)
 {
-    auto const* row = committed_row(node);
-    if (!row)
-        return false;
-    measure_scrollable_overflow_if_missing(node);
-    return overflow_is_valid(node) && row->overflow_relative_to_padding_box.has_scrollable_overflow;
+    auto overflow = rust_scrollable_overflow(node);
+    return overflow.has_value && overflow.value.has_scrollable_overflow;
 }
 
 Optional<CSSPixelRect> scrollable_overflow_rect(Layout::Node const& node)
 {
-    auto const* row = committed_row(node);
-    if (!row)
+    auto overflow = rust_scrollable_overflow(node);
+    if (!overflow.has_value)
         return {};
-    measure_scrollable_overflow_if_missing(node);
-    if (!overflow_is_valid(node))
-        return {};
-    auto rect = row->overflow_relative_to_padding_box.rect;
-    rect.translate_by(absolute_padding_box_rect(node).location());
-    return rect;
+    return overflow.value.rect;
 }
 
 static bool layout_node_is_visible(Layout::NodeWithStyle const& layout_node)

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -79,12 +79,6 @@ void DocumentPaintState::viewport_row_was_reset()
     m_visual_context_tree_needs_compositor_update = false;
 }
 
-void DocumentPaintState::refresh_sticky_constraints(DOM::Document& document)
-{
-    if (mirror_rust_refresh_sticky_constraints(document))
-        m_visual_context_tree_needs_compositor_update = true;
-}
-
 void DocumentPaintState::invalidate_scroll_state(DOM::Document& document)
 {
     rust_invalidate_scroll_state(document);

--- a/Libraries/LibWeb/Painting/DocumentPaintState.h
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.h
@@ -34,7 +34,7 @@ public:
     // Called from Document::update_paint_and_hit_testing_properties_if_needed() once the visual
     // context tree is settled; every other consumer reaches the scroll state through that update.
     void refresh_scroll_state(DOM::Document&);
-    void refresh_sticky_constraints(DOM::Document&);
+    void did_update_visual_context_values() { m_visual_context_tree_needs_compositor_update = true; }
 
     void update_accumulated_visual_contexts(DOM::Document&);
     void update_visual_viewport_accumulated_visual_context(DOM::Document&);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -475,12 +475,12 @@ static Layout::RustFFI::FfiScrollableOverflowHostCallbacks scrollable_overflow_h
     };
 }
 
-void rust_measure_scrollable_overflow(Layout::Node const& box)
+Layout::RustFFI::FfiOptionalOverflowData rust_scrollable_overflow(Layout::Node const& box)
 {
     auto& document = const_cast<DOM::Document&>(box.document());
     if (!document.has_committed_viewport_box())
-        return;
-    Layout::RustFFI::layout_arena_measure_scrollable_overflow(box.arena_handle(), committed_row_slot(box), scrollable_overflow_host_callbacks());
+        return {};
+    return Layout::RustFFI::layout_arena_paintable_scrollable_overflow(box.arena_handle(), committed_row_slot(box), scrollable_overflow_host_callbacks());
 }
 
 Layout::RustFFI::FfiScrollableOverflowUpdateOutcome rust_update_scrollable_overflow(DOM::Document& document, bool handled_by_full_layout_commit)

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -457,10 +457,15 @@ Layout::RustFFI::FfiPhysicalOverflowDirections rust_physical_overflow_directions
     return Layout::RustFFI::layout_arena_physical_overflow_directions(box.arena_handle(), committed_row_slot(box));
 }
 
-static Layout::RustFFI::FfiScrollableOverflowHostCallbacks scrollable_overflow_host_callbacks()
+void register_geometry_host(Layout::NodeArena& arena)
 {
-    return {
+    Layout::RustFFI::FfiGeometryHostCallbacks callbacks {
         .context = nullptr,
+        .clamp_scroll_offset_if_nonzero = [](void*, void* layout_node_shell) {
+            auto& box = *static_cast<Layout::Node*>(layout_node_shell);
+            auto offset = scroll_offset(box);
+            if (!offset.is_zero())
+                set_scroll_offset(box, offset); },
         .layout_node_is_in_focused_text_control = [](void*, void* layout_node_shell) -> bool {
             auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
             auto const* dom_node = layout_node.dom_node();
@@ -473,32 +478,13 @@ static Layout::RustFFI::FfiScrollableOverflowHostCallbacks scrollable_overflow_h
                 && shadow_root->host()->is_focused();
         },
     };
+    Layout::RustFFI::layout_arena_set_geometry_host(arena.handle(), callbacks);
 }
 
-Layout::RustFFI::FfiOptionalOverflowData rust_scrollable_overflow(Layout::Node const& box)
+Layout::RustFFI::FfiRenderingPreparationOutcome rust_prepare_for_rendering(DOM::Document& document, bool visual_context_update_pending)
 {
-    auto& document = const_cast<DOM::Document&>(box.document());
-    if (!document.has_committed_viewport_box())
-        return {};
-    return Layout::RustFFI::layout_arena_paintable_scrollable_overflow(box.arena_handle(), committed_row_slot(box), scrollable_overflow_host_callbacks());
-}
-
-Layout::RustFFI::FfiScrollableOverflowUpdateOutcome rust_update_scrollable_overflow(DOM::Document& document, bool handled_by_full_layout_commit)
-{
-    // The scroll offset can become invalid if the scrollable overflow rectangle has changed. For
-    // example, if the scroll container has been scrolled to the very end and then its scrollable
-    // overflow rect becomes smaller, the scroll offset would be out of bounds. Re-applying the
-    // current offset clamps it against the new rect.
-    auto clamp_scroll_offset_if_nonzero = [](void*, void* layout_node_shell) {
-        auto& box = *static_cast<Layout::Node*>(layout_node_shell);
-        if (!scroll_offset(box).is_zero())
-            set_scroll_offset(box, scroll_offset(box));
-    };
-
-    return Layout::RustFFI::layout_arena_update_scrollable_overflow(
-        layout_arena_handle(document), viewport_row_slot(document), handled_by_full_layout_commit,
-        scrollable_overflow_host_callbacks(),
-        nullptr, clamp_scroll_offset_if_nonzero);
+    return Layout::RustFFI::layout_arena_prepare_for_rendering(
+        layout_arena_handle(document), visual_context_host_callbacks(document), visual_context_update_pending);
 }
 
 static CSS::PreferredColorScheme image_color_scheme(Layout::NodeWithStyle const& layout_node)
@@ -545,11 +531,6 @@ bool rust_refresh_scroll_state(DOM::Document& document, ScrollStateSnapshot& sna
         &snapshot, [](void* sink, Gfx::FloatPoint const* offsets, size_t count) {
             static_cast<ScrollStateSnapshot*>(sink)->assign_device_offsets({ offsets, count });
         });
-}
-
-bool mirror_rust_refresh_sticky_constraints(DOM::Document& document)
-{
-    return Layout::RustFFI::layout_arena_refresh_sticky_constraints(layout_arena_handle(document), visual_context_host_callbacks(document));
 }
 
 void rust_invalidate_scroll_state(DOM::Document& document)
@@ -661,9 +642,8 @@ static void dump_layout_tree(Layout::Node const& root, size_t initial_indent, bo
         .dump_nested_layout_tree = [](void*, void* layout_root_shell, size_t indent, bool interactive, void* output_sink) { dump_layout_tree(*static_cast<Layout::Node const*>(layout_root_shell), indent, interactive, output_sink, Layout::RustFFI::layout_arena_paint_push_bytes); },
         .append_text = append_text,
         .visual_context = visual_context_host_callbacks(document),
-        .scrollable_overflow = scrollable_overflow_host_callbacks(),
     };
-    Layout::RustFFI::layout_arena_dump_layout_tree(root.arena_handle(), Layout::Node::slot_id(&root), viewport_row_slot(document), initial_indent, interactive, callbacks);
+    Layout::RustFFI::layout_arena_dump_layout_tree(root.arena_handle(), Layout::Node::slot_id(&root), initial_indent, interactive, callbacks);
 }
 
 void dump_layout_tree(StringBuilder& builder, Layout::Node const& root, bool interactive)

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -33,8 +33,8 @@ WEB_API Vector<u32> rust_visual_animation_target_node_indices(Layout::Node const
 WEB_API bool rust_background_color_can_be_compositor_animated(Layout::Node const&);
 WEB_API void const* retain_rust_main_visual_context_tree(DOM::Document const&);
 WEB_API Layout::RustFFI::FfiPhysicalOverflowDirections rust_physical_overflow_directions(Layout::Node const&);
-WEB_API Layout::RustFFI::FfiOptionalOverflowData rust_scrollable_overflow(Layout::Node const&);
-WEB_API Layout::RustFFI::FfiScrollableOverflowUpdateOutcome rust_update_scrollable_overflow(DOM::Document&, bool handled_by_full_layout_commit);
+WEB_API void register_geometry_host(Layout::NodeArena&);
+WEB_API Layout::RustFFI::FfiRenderingPreparationOutcome rust_prepare_for_rendering(DOM::Document&, bool visual_context_update_pending);
 WEB_API void rust_update_visual_viewport_transform(DOM::Document&);
 enum class ForceScrollStateRefresh {
     No,
@@ -43,7 +43,6 @@ enum class ForceScrollStateRefresh {
 // Refreshes the snapshot from the Rust scroll state; false when nothing had invalidated it and
 // the refresh was not forced.
 WEB_API bool rust_refresh_scroll_state(DOM::Document&, ScrollStateSnapshot&, ForceScrollStateRefresh = ForceScrollStateRefresh::No);
-WEB_API bool mirror_rust_refresh_sticky_constraints(DOM::Document&);
 WEB_API void rust_invalidate_scroll_state(DOM::Document&);
 WEB_API void mirror_rust_invalidate_paint_cache(Layout::Node const&);
 WEB_API void rust_invalidate_propagated_text_decoration_caches(Layout::Node const&);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -33,7 +33,7 @@ WEB_API Vector<u32> rust_visual_animation_target_node_indices(Layout::Node const
 WEB_API bool rust_background_color_can_be_compositor_animated(Layout::Node const&);
 WEB_API void const* retain_rust_main_visual_context_tree(DOM::Document const&);
 WEB_API Layout::RustFFI::FfiPhysicalOverflowDirections rust_physical_overflow_directions(Layout::Node const&);
-WEB_API void rust_measure_scrollable_overflow(Layout::Node const&);
+WEB_API Layout::RustFFI::FfiOptionalOverflowData rust_scrollable_overflow(Layout::Node const&);
 WEB_API Layout::RustFFI::FfiScrollableOverflowUpdateOutcome rust_update_scrollable_overflow(DOM::Document&, bool handled_by_full_layout_commit);
 WEB_API void rust_update_visual_viewport_transform(DOM::Document&);
 enum class ForceScrollStateRefresh {

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -84,7 +84,6 @@ pub enum FfiStyleInvalidationField {
     VisualContextShift = 2,
     RebuildRootShift = 4,
     RebuildStackingContext = 1 << 6,
-    RecalculateScrollableOverflow = 1 << 7,
     ResnapScrollContainer = 1 << 8,
     RecomputeDescendants = 1 << 9,
     InheritedGroupsShift = 10,

--- a/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
@@ -31,7 +31,6 @@ struct StyleInvalidation {
     visual_context: u8,
     rebuild_root: u8,
     rebuild_stacking_context: bool,
-    recalculate_scrollable_overflow: bool,
     resnap_scroll_container: bool,
     recompute_descendants: bool,
     inherited_groups: u8,
@@ -82,7 +81,6 @@ impl StyleInvalidation {
         self.level = self.level.max(other.level);
         self.visual_context = self.visual_context.max(other.visual_context);
         self.rebuild_stacking_context |= other.rebuild_stacking_context;
-        self.recalculate_scrollable_overflow |= other.recalculate_scrollable_overflow;
         self.resnap_scroll_container |= other.resnap_scroll_container;
         self.recompute_descendants |= other.recompute_descendants;
         self.inherited_groups |= other.inherited_groups;
@@ -98,8 +96,6 @@ impl StyleInvalidation {
         packed |= u32::from(self.visual_context) << FfiStyleInvalidationField::VisualContextShift as u32;
         packed |= u32::from(self.rebuild_root) << FfiStyleInvalidationField::RebuildRootShift as u32;
         packed |= u32::from(self.rebuild_stacking_context) * FfiStyleInvalidationField::RebuildStackingContext as u32;
-        packed |= u32::from(self.recalculate_scrollable_overflow)
-            * FfiStyleInvalidationField::RecalculateScrollableOverflow as u32;
         packed |= u32::from(self.resnap_scroll_container) * FfiStyleInvalidationField::ResnapScrollContainer as u32;
         packed |= u32::from(self.recompute_descendants) * FfiStyleInvalidationField::RecomputeDescendants as u32;
         packed |= (u32::from(self.inherited_groups) & FfiStyleInvalidationField::InheritedGroupsMask as u32)
@@ -452,9 +448,6 @@ fn property_invalidation(property: u16, old: ComputedValuesView<'_>, new: Comput
         result.ensure_level(INVALIDATION_REPAINT);
     } else if property_metadata::property_affects_layout(property) {
         result.ensure_level(INVALIDATION_RELAYOUT);
-    }
-    if property_metadata::property_affects_scrollable_overflow(property) {
-        result.recalculate_scrollable_overflow = true;
     }
     if property_metadata::property_affects_scrollable_overflow(property)
         || matches!(

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -2122,10 +2122,7 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
     });
     // SAFETY: Computation has finished and its input borrows are no longer used.
     let arena = unsafe { commit_entry_pass(host, root, &pass_fragments, sink) };
-    // The full scrollable overflow update measures eagerly and returns without refilling the
-    // contained-boxes index, so the index is rebuilt here from the freshly committed rows.
-    arena.rebuild_scrollable_overflow_contained_boxes(root);
-    arena.set_needs_full_scrollable_overflow_recalculation();
+    arena.did_commit_full_layout(root);
 }
 
 fn finish_entry_pass(

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -948,6 +948,7 @@ impl LayoutNodeArena {
         self.assert_owner_thread();
         let data = self.data(id);
         data.style.set(payloads);
+        self.invalidate_overflow_after_style_change(id);
         self.update_anchor_positioning_dependency(id);
         self.style_records[id.slot_index() as usize].set(style_record);
         self.enroll_text_children_for_content_sync(id);
@@ -1218,6 +1219,7 @@ impl LayoutNodeArena {
         assert!(derived.record != 0 && !derived.payloads.is_null());
         let previous_style_record = self.style_records[slot.slot_index() as usize].replace(derived.record);
         self.data(slot).style.set(derived.payloads);
+        self.invalidate_overflow_after_style_change(slot);
         self.update_anchor_positioning_dependency(slot);
         self.enroll_text_children_for_content_sync(slot);
         self.enroll_node_for_replaced_content_facts_sync_if_eligible(slot);

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -552,6 +552,7 @@ pub(crate) struct LayoutNodeArena {
     fc_run_cache_store: super::fc_run_cache::FcRunCacheArenaStore,
     pub(crate) paintable_rows: crate::painting::paintable_rows::PaintableRowStore,
     paint_state: RefCell<crate::painting::paint_state::PaintState>,
+    pub(crate) scrollable_overflow: crate::painting::scrollable_overflow::ScrollableOverflowState,
     pub(crate) anchor_positioning_nodes: RefCell<HashSet<NodeSlotId>>,
     pub(crate) partial_relayout_boundary_roots: RefCell<Vec<NodeSlotId>>,
     /// Attribution of pending updates for partial relayout. Invariant: every update recorded
@@ -602,6 +603,7 @@ impl LayoutNodeArena {
             fc_run_cache_store: super::fc_run_cache::FcRunCacheArenaStore::default(),
             paintable_rows: crate::painting::paintable_rows::PaintableRowStore::default(),
             paint_state: RefCell::new(crate::painting::paint_state::PaintState::default()),
+            scrollable_overflow: Default::default(),
             anchor_positioning_nodes: RefCell::new(HashSet::default()),
             partial_relayout_boundary_roots: RefCell::new(Vec::new()),
             pending_updates_escape_partial_relayout: Cell::new(false),
@@ -765,6 +767,18 @@ impl LayoutNodeArena {
 
         assert!(!root.is_invalid(), "invalid layout node arena slot ID");
         self.assert_node_is_unlinked_from_parent(root);
+        self.scrollable_overflow.contained_boxes_dirty.set(true);
+        if self.scrollable_overflow.viewport.get() == Some(root) {
+            self.scrollable_overflow.viewport.set(None);
+            self.scrollable_overflow.non_child_boxes.borrow_mut().clear();
+            self.scrollable_overflow.full_layout_commit.set(false);
+            self.scrollable_overflow.geometry_changed.set(false);
+            self.scrollable_overflow.scrollability_changed.set(false);
+            self.boxes_needing_scrollable_overflow_recalculation
+                .borrow_mut()
+                .clear();
+            self.needs_full_scrollable_overflow_recalculation.set(false);
+        }
         let mut slots_in_pre_order = Vec::new();
         self.for_each_node_in_layout_subtree_in_pre_order(root, |slot| slots_in_pre_order.push(slot));
 
@@ -1495,6 +1509,7 @@ impl LayoutNodeArena {
         use crate::css::css_enums::positioning;
         use crate::painting::style_queries::establishes_positioning_containing_blocks;
 
+        self.scrollable_overflow.contained_boxes_dirty.set(true);
         let data = self.data(node);
         // Reset the inline containing block - we'll set it below if applicable.
         data.inline_containing_block.set(NodeSlotId::INVALID);
@@ -2341,6 +2356,7 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn note_structural_change_at_and_above(&self, node: NodeSlotId) {
+        self.scrollable_overflow.contained_boxes_dirty.set(true);
         self.invalidate_at_and_above(node, AncestorInvalidation::StructuralChange);
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -413,16 +413,6 @@ pub unsafe extern "C" fn layout_arena_node_has_css_transform(arena: *mut c_void,
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread, and
 /// `node` must name a live node in this arena.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_schedule_scrollable_overflow_recalculation(arena: *mut c_void, node: NodeSlotId) {
-    let arena = unsafe { arena_from_handle(arena) };
-    arena.schedule_scrollable_overflow_recalculation(node);
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread, and
-/// `node` must name a live node in this arena.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_invalidate_nearest_self_painting_inline_paint_cache(
     arena: *mut c_void,
     node: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -420,15 +420,6 @@ pub unsafe extern "C" fn layout_arena_schedule_scrollable_overflow_recalculation
 
 /// # Safety
 ///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_needs_full_scrollable_overflow_recalculation(arena: *mut c_void) -> bool {
-    let arena = unsafe { arena_from_handle(arena) };
-    arena.needs_full_scrollable_overflow_recalculation.get()
-}
-
-/// # Safety
-///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread, and
 /// `node` must name a live node in this arena.
 #[unsafe(no_mangle)]
@@ -681,34 +672,92 @@ pub struct FfiPhysicalOverflowDirections {
 
 /// # Safety
 ///
-/// `arena` must be a live handle used on the document thread. Callbacks must remain
-/// valid for the call and must not mutate layout geometry.
+/// `arena` must be a live arena on the document thread. The callbacks must remain
+/// valid until it is destroyed and must not mutate layout geometry.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_set_geometry_host(
+    arena: *mut c_void,
+    host: crate::painting::host::FfiGeometryHostCallbacks,
+) {
+    unsafe { arena_from_handle(arena) }
+        .scrollable_overflow
+        .host
+        .set(Some(host));
+}
+
+/// # Safety
+///
+/// `arena` must be a live arena used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_scrollable_overflow(
     arena: *mut c_void,
     slot: NodeSlotId,
-    overflow_callbacks: crate::painting::host::FfiScrollableOverflowHostCallbacks,
 ) -> FfiOptionalOverflowData {
     let arena = unsafe { arena_from_handle(arena) };
-    let rows = arena.paintable_rows();
-    if !rows.paintable_row_is_populated(slot) {
+    let Some(rect) = crate::painting::paintable_geometry::scrollable_overflow_rect(&arena.paintable_rows(), slot)
+    else {
         return FfiOptionalOverflowData::default();
-    }
-    if !crate::painting::paintable_geometry::overflow_is_valid(&rows, slot)
-        && arena
-            .node_kind_if_live(slot)
-            .is_some_and(crate::layout::node_facts::kind_is_box)
-    {
-        measure_scrollable_overflow_for_slot(arena, slot, &overflow_callbacks);
-    }
-    if !crate::painting::paintable_geometry::overflow_is_valid(&rows, slot) {
-        return FfiOptionalOverflowData::default();
-    }
+    };
     let mut value = arena.paintable_side_data(slot).overflow_relative_to_padding_box.get();
-    value.rect = crate::painting::paintable_geometry::scrollable_overflow_rect(&rows, slot)
-        .unwrap()
-        .into();
+    value.rect = rect.into();
     FfiOptionalOverflowData { has_value: true, value }
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct FfiRenderingPreparationOutcome {
+    pub requires_display_list_recording: bool,
+    pub requires_visual_context_update: bool,
+    pub visual_context_values_changed: bool,
+}
+
+/// # Safety
+///
+/// `arena` must be a live arena used on the document thread. Host callbacks must
+/// remain valid for this call and must not mutate layout geometry.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_prepare_for_rendering(
+    arena: *mut c_void,
+    callbacks: FfiVisualContextHostCallbacks,
+    visual_context_update_pending: bool,
+) -> FfiRenderingPreparationOutcome {
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::scrollable_overflow::update_scrollable_overflow(arena);
+    let changed = arena.scrollable_overflow.geometry_changed.replace(false);
+    let flipped = arena.scrollable_overflow.scrollability_changed.replace(false);
+    let mut visual_context_values_changed = false;
+    if changed && !flipped && !visual_context_update_pending {
+        let rows = arena.paintable_rows();
+        let mut state = arena.paint_state().borrow_mut();
+        let state = &mut state.visual_context;
+        if let Some(tree) = state.tree.as_mut() {
+            visual_context_values_changed = crate::painting::visual_context::refresh::refresh_sticky_constraints(
+                &rows,
+                &state.scroll_state,
+                tree,
+                &callbacks.tree_inputs(),
+            );
+        }
+        state.needs_to_refresh_scroll_state = true;
+    }
+    FfiRenderingPreparationOutcome {
+        requires_display_list_recording: changed,
+        requires_visual_context_update: flipped,
+        visual_context_values_changed,
+    }
+}
+
+/// # Safety
+///
+/// `arena` must be a live arena used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_scrollable_overflow_recalculation_count(arena: *mut c_void, reset: bool) -> u64 {
+    let state = &unsafe { arena_from_handle(arena) }.scrollable_overflow;
+    if reset {
+        state.recalculations.replace(0)
+    } else {
+        state.recalculations.get()
+    }
 }
 
 #[derive(Default)]
@@ -716,326 +765,6 @@ pub unsafe extern "C" fn layout_arena_paintable_scrollable_overflow(
 pub struct FfiOptionalOverflowData {
     pub has_value: bool,
     pub value: crate::painting::paintable_data::FfiOverflowData,
-}
-
-/// Whether a box is measured eagerly after a full commit rather than only when an ancestor's
-/// measurement reaches it: a scroll container, or a box whose element or pseudo-element stores a
-/// scroll offset that the new overflow may have to clamp. The offset lives on the DOM side, which
-/// sets `NodeFlag::HasScrollOffset` whenever it stores one and whenever a box becomes an element's
-/// or pseudo-element's box, so the answer is one style query and one flag read.
-fn box_holds_scroll_state(arena: &LayoutNodeArena, slot: NodeSlotId) -> bool {
-    crate::painting::style_queries::is_scroll_container(arena, slot)
-        || arena.node_flags_if_live(slot) & crate::layout::node_data::NodeFlag::HasScrollOffset as u32 != 0
-}
-
-fn measure_scrollable_overflow_for_slot(
-    arena: &LayoutNodeArena,
-    box_paintable: NodeSlotId,
-    overflow_callbacks: &crate::painting::host::FfiScrollableOverflowHostCallbacks,
-) {
-    let rows = arena.paintable_rows();
-    if !rows.paintable_row_is_populated(box_paintable) {
-        return;
-    }
-    let assignments = {
-        let paint_state = arena.paint_state().borrow();
-        crate::painting::scrollable_overflow::measure_scrollable_overflow(
-            &rows,
-            &paint_state.scrollable_overflow_non_child_boxes,
-            overflow_callbacks,
-            box_paintable,
-        )
-    };
-    for assignment in assignments {
-        assignment.apply(&rows);
-    }
-}
-
-/// Returns overflow for layout dumps, measuring missing data in Rust-owned cache storage.
-///
-/// # Safety
-///
-/// `arena_handle` must be a live handle from `layout_arena_create`, used on the document thread,
-/// with no outstanding borrows of the arena.
-pub(crate) unsafe fn scrollable_overflow_rect_measuring_if_missing(
-    arena_handle: *mut c_void,
-    slot: NodeSlotId,
-    viewport: NodeSlotId,
-    overflow_callbacks: &crate::painting::host::FfiScrollableOverflowHostCallbacks,
-) -> Option<crate::css::css_pixels::CssPixelRect> {
-    let needs_measurement = {
-        // SAFETY: Guaranteed by the caller; the borrow ends with this block.
-        let arena = unsafe { arena_from_handle(arena_handle) };
-        let rows = arena.paintable_rows();
-        if !rows.paintable_row_is_populated(slot) {
-            return None;
-        }
-        !crate::painting::paintable_geometry::overflow_is_valid(&rows, slot)
-            && arena
-                .node_kind_if_live(slot)
-                .is_some_and(crate::layout::node_facts::kind_is_box)
-            && rows.paintable_row_is_populated(viewport)
-    };
-    if needs_measurement {
-        // SAFETY: No arena borrow is alive here.
-        unsafe {
-            measure_scrollable_overflow_for_slot(arena_from_handle(arena_handle), slot, overflow_callbacks);
-        }
-    }
-    // SAFETY: The caller keeps the arena alive.
-    let arena = unsafe { arena_from_handle(arena_handle) };
-    let rows = arena.paintable_rows();
-    if !crate::painting::paintable_geometry::has_scrollable_overflow(&rows, slot) {
-        return None;
-    }
-    crate::painting::paintable_geometry::scrollable_overflow_rect(&rows, slot)
-}
-
-#[repr(C)]
-pub struct FfiScrollableOverflowUpdateOutcome {
-    pub performed_recalculation: bool,
-    pub any_overflow_changed: bool,
-    pub any_has_scrollable_overflow_flipped: bool,
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread. The
-/// callbacks receive live layout node shells and must not re-enter the arena.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_update_scrollable_overflow(
-    arena: *mut c_void,
-    viewport: NodeSlotId,
-    handled_by_full_layout_commit: bool,
-    overflow_callbacks: crate::painting::host::FfiScrollableOverflowHostCallbacks,
-    scroll_offset_context: *mut c_void,
-    clamp_scroll_offset_if_nonzero: unsafe extern "C" fn(*mut c_void, *mut c_void),
-) -> FfiScrollableOverflowUpdateOutcome {
-    let no_recalculation = FfiScrollableOverflowUpdateOutcome {
-        performed_recalculation: false,
-        any_overflow_changed: false,
-        any_has_scrollable_overflow_flipped: false,
-    };
-    let (pending_boxes, needs_full_recalculation) = {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call; every
-        // shared borrow below ends before the next exclusive re-derive.
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.take_scrollable_overflow_recalculation_state()
-    };
-    if pending_boxes.is_empty() && !needs_full_recalculation {
-        return no_recalculation;
-    }
-
-    let row_is_populated = |slot: NodeSlotId| {
-        // SAFETY: As above.
-        unsafe { arena_from_handle(arena) }
-            .paintable_rows()
-            .paintable_row_is_populated(slot)
-    };
-    if !row_is_populated(viewport) {
-        return no_recalculation;
-    }
-
-    let measure_and_clamp = |slot: NodeSlotId| {
-        // SAFETY: As above; the callback receives a live shell and does not re-enter.
-        unsafe {
-            measure_scrollable_overflow_for_slot(arena_from_handle(arena), slot, &overflow_callbacks);
-            let shell = arena_from_handle(arena).node_shell(slot);
-            clamp_scroll_offset_if_nonzero(scroll_offset_context, shell);
-        }
-    };
-
-    let performed = FfiScrollableOverflowUpdateOutcome {
-        performed_recalculation: true,
-        any_overflow_changed: false,
-        any_has_scrollable_overflow_flipped: false,
-    };
-    if handled_by_full_layout_commit {
-        assert!(needs_full_recalculation);
-        // A full-root commit reset every surviving row, including its overflow data and
-        // paint cache. There is therefore no old overflow to preserve or diff. Ordinary
-        // boxes are measured recursively when their overflow contributes to one of these
-        // roots, so they do not need separate eager measurement: only the viewport, scroll
-        // containers, and boxes holding a scroll offset are measured eagerly.
-        let mut eager_measurement_roots = Vec::new();
-        {
-            // SAFETY: As above.
-            let arena = unsafe { arena_from_handle(arena) };
-            arena.for_each_node_in_layout_subtree_in_pre_order(viewport, |slot| {
-                if !arena.paintable_rows().paintable_row_is_populated(slot) {
-                    return;
-                }
-                if slot == viewport || box_holds_scroll_state(arena, slot) {
-                    eager_measurement_roots.push(slot);
-                }
-            });
-        }
-        for slot in eager_measurement_roots {
-            measure_and_clamp(slot);
-        }
-        return performed;
-    }
-
-    // For every box that will be re-measured, the overflow data it had before, so the diff
-    // below can tell what actually changed; an empty entry means the box's committed row was
-    // reset by a subtree layout commit and the old data is unknown.
-    let mut old_overflow_data_by_box: crate::css::style::fast_hash::FastMap<
-        NodeSlotId,
-        Option<crate::painting::paintable_data::FfiOverflowData>,
-    > = Default::default();
-    let overflow_snapshot = |slot: NodeSlotId| {
-        // SAFETY: As above; callers established a populated row.
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        let data = paintable_rows.paintable_side_data(slot);
-        data.overflow_measured_this_commit
-            .get()
-            .then_some(data.overflow_relative_to_padding_box.get())
-    };
-    let mut record_and_clear_overflow_data = |slot: NodeSlotId| {
-        if !row_is_populated(slot) {
-            return true;
-        }
-        if old_overflow_data_by_box.contains_key(&slot) {
-            return false;
-        }
-        old_overflow_data_by_box.insert(slot, overflow_snapshot(slot));
-        // SAFETY: As above; the row was just established as populated.
-        unsafe { arena_from_handle(arena) }
-            .paintable_side_data(slot)
-            .overflow_measured_this_commit
-            .set(false);
-        true
-    };
-    let collect_box_subtree_slots = |root: NodeSlotId| {
-        let mut slots = Vec::new();
-        // SAFETY: As above; the traversal only reads tree links and kinds.
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.for_each_node_in_layout_subtree_in_pre_order(root, |slot| {
-            if crate::layout::node_facts::kind_is_box(
-                arena
-                    .node_kind_if_live(slot)
-                    .unwrap_or(crate::layout::node_data::NodeKind::Unset),
-            ) {
-                slots.push(slot);
-            }
-        });
-        slots
-    };
-
-    if needs_full_recalculation {
-        for slot in collect_box_subtree_slots(viewport) {
-            record_and_clear_overflow_data(slot);
-        }
-        {
-            // SAFETY: As above.
-            let arena = unsafe { arena_from_handle(arena) };
-            let paintable_rows = arena.paintable_rows();
-            let mut paint_state = arena.paint_state().borrow_mut();
-            crate::painting::scrollable_overflow::refill_contained_boxes_index(
-                &paintable_rows,
-                viewport,
-                &mut paint_state.scrollable_overflow_non_child_boxes,
-            );
-        }
-    } else {
-        for &pending_slot in &pending_boxes {
-            // SAFETY: As above.
-            let pending_is_box = row_is_populated(pending_slot)
-                && !unsafe { arena_from_handle(arena) }
-                    .shell_if_live(pending_slot)
-                    .is_null()
-                && crate::layout::node_facts::kind_is_box(
-                    unsafe { arena_from_handle(arena) }
-                        .node_kind_if_live(pending_slot)
-                        .unwrap_or(crate::layout::node_data::NodeKind::Unset),
-                );
-            if !pending_is_box {
-                continue;
-            }
-            let was_reset_by_subtree_layout_commit = overflow_snapshot(pending_slot).is_none();
-            if was_reset_by_subtree_layout_commit {
-                for slot in collect_box_subtree_slots(pending_slot) {
-                    record_and_clear_overflow_data(slot);
-                }
-            }
-            // SAFETY: As above; containing-block links only name live slots.
-            let mut containing_block = unsafe { arena_from_handle(arena) }.node_containing_block_if_live(pending_slot);
-            while let Some(block) = containing_block {
-                if row_is_populated(block) {
-                    // SAFETY: As above.
-                    unsafe { arena_from_handle(arena) }
-                        .paintable_rows()
-                        .clear_cached_overflow_data(block);
-                }
-                if !record_and_clear_overflow_data(block) {
-                    break;
-                }
-                // SAFETY: As above.
-                containing_block = unsafe { arena_from_handle(arena) }.node_containing_block_if_live(block);
-            }
-        }
-    }
-
-    if old_overflow_data_by_box.is_empty() {
-        return performed;
-    }
-
-    for (&slot, old_overflow_data) in &old_overflow_data_by_box {
-        if !row_is_populated(slot) {
-            continue;
-        }
-        // Boxes reset by a subtree commit have no previous overflow data. They will be
-        // measured recursively if an ancestor reaches them. Measuring each one here would
-        // repeatedly walk the same containing-block chains after a small subtree update.
-        if old_overflow_data.is_none() && slot != viewport {
-            // SAFETY: As above.
-            let arena = unsafe { arena_from_handle(arena) };
-            if !box_holds_scroll_state(arena, slot) {
-                continue;
-            }
-        }
-        measure_and_clamp(slot);
-    }
-
-    let mut any_overflow_changed = false;
-    let mut any_has_scrollable_overflow_flipped = false;
-    for (&slot, old_overflow_data) in &old_overflow_data_by_box {
-        if !row_is_populated(slot) {
-            continue;
-        }
-        let Some(new_overflow_data) = overflow_snapshot(slot) else {
-            continue;
-        };
-        // A box with no prior overflow data was just created or reset by the layout commit,
-        // so its paint cache is already clean.
-        let Some(old_overflow_data) = old_overflow_data else {
-            continue;
-        };
-        // Boxes that merely moved do not register here; everything derived below is
-        // translation-invariant, and movement-driven repaint belongs to the layout commit.
-        let rect_changed = old_overflow_data.rect != new_overflow_data.rect;
-        let has_scrollable_overflow_flipped =
-            old_overflow_data.has_scrollable_overflow != new_overflow_data.has_scrollable_overflow;
-        if !rect_changed && !has_scrollable_overflow_flipped {
-            continue;
-        }
-        // Cached paint commands and hit-test items capture scrollbar geometry and
-        // per-direction scrollability derived from the overflow rect, so they cannot be
-        // reused once it changes. This must also run for the after-layout-commit path: a
-        // subtree relayout re-measures a surviving ancestor's overflow without resetting
-        // the ancestor's committed row.
-        // SAFETY: As above.
-        unsafe { arena_from_handle(arena) }.invalidate_paint_cache(slot);
-        any_overflow_changed = true;
-        any_has_scrollable_overflow_flipped |= has_scrollable_overflow_flipped;
-    }
-
-    FfiScrollableOverflowUpdateOutcome {
-        performed_recalculation: true,
-        any_overflow_changed,
-        any_has_scrollable_overflow_flipped,
-    }
 }
 
 #[repr(C)]
@@ -1191,31 +920,6 @@ pub unsafe extern "C" fn layout_arena_paintable_absolute_border_box_rect(
         return FfiCssPixelRect::default();
     }
     crate::painting::paintable_geometry::absolute_border_box_rect(&paintable_rows, slot).into()
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_rebuild_scrollable_overflow_contained_boxes(
-    arena: *mut c_void,
-    root: NodeSlotId,
-) {
-    let arena = unsafe { arena_from_handle(arena) };
-    arena.rebuild_scrollable_overflow_contained_boxes(root);
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_clear_scrollable_overflow_contained_boxes(arena: *mut c_void) {
-    let arena = unsafe { arena_from_handle(arena) };
-    arena
-        .paint_state()
-        .borrow_mut()
-        .scrollable_overflow_non_child_boxes
-        .clear();
 }
 
 /// # Safety
@@ -1720,31 +1424,6 @@ pub unsafe extern "C" fn layout_arena_invalidate_scroll_state(arena: *mut c_void
         .borrow_mut()
         .visual_context
         .needs_to_refresh_scroll_state = true;
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
-    arena: *mut c_void,
-    callbacks: FfiVisualContextHostCallbacks,
-) -> bool {
-    let arena = unsafe { arena_from_handle(arena) };
-    let paintable_rows = arena.paintable_rows();
-    let mut paint_state = arena.paint_state().borrow_mut();
-    let state = &mut paint_state.visual_context;
-    let mut any_sticky_payload_changed = false;
-    if let Some(tree) = state.tree.as_mut() {
-        any_sticky_payload_changed = crate::painting::visual_context::refresh::refresh_sticky_constraints(
-            &paintable_rows,
-            &state.scroll_state,
-            tree,
-            &callbacks.tree_inputs(),
-        );
-    }
-    state.needs_to_refresh_scroll_state = true;
-    any_sticky_payload_changed
 }
 
 /// Re-reads the scroll containers' offsets when something invalidated them since the last

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -461,16 +461,6 @@ pub unsafe extern "C" fn layout_arena_paintable_row(arena: *mut c_void, slot: No
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_overflow_is_valid(arena: *mut c_void, slot: NodeSlotId) -> bool {
-    let arena = unsafe { arena_from_handle(arena) };
-    let rows = arena.paintable_rows();
-    rows.paintable_row_is_populated(slot) && crate::painting::paintable_geometry::overflow_is_valid(&rows, slot)
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_cleared_from_node(arena: *mut c_void, layout_node: NodeSlotId) {
     let reset = {
         let arena = unsafe { arena_from_handle(arena) };
@@ -691,17 +681,41 @@ pub struct FfiPhysicalOverflowDirections {
 
 /// # Safety
 ///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+/// `arena` must be a live handle used on the document thread. Callbacks must remain
+/// valid for the call and must not mutate layout geometry.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_measure_scrollable_overflow(
+pub unsafe extern "C" fn layout_arena_paintable_scrollable_overflow(
     arena: *mut c_void,
-    box_paintable: NodeSlotId,
+    slot: NodeSlotId,
     overflow_callbacks: crate::painting::host::FfiScrollableOverflowHostCallbacks,
-) {
-    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-    unsafe {
-        measure_scrollable_overflow_for_slot(arena, box_paintable, &overflow_callbacks);
-    };
+) -> FfiOptionalOverflowData {
+    let arena = unsafe { arena_from_handle(arena) };
+    let rows = arena.paintable_rows();
+    if !rows.paintable_row_is_populated(slot) {
+        return FfiOptionalOverflowData::default();
+    }
+    if !crate::painting::paintable_geometry::overflow_is_valid(&rows, slot)
+        && arena
+            .node_kind_if_live(slot)
+            .is_some_and(crate::layout::node_facts::kind_is_box)
+    {
+        measure_scrollable_overflow_for_slot(arena, slot, &overflow_callbacks);
+    }
+    if !crate::painting::paintable_geometry::overflow_is_valid(&rows, slot) {
+        return FfiOptionalOverflowData::default();
+    }
+    let mut value = arena.paintable_side_data(slot).overflow_relative_to_padding_box.get();
+    value.rect = crate::painting::paintable_geometry::scrollable_overflow_rect(&rows, slot)
+        .unwrap()
+        .into();
+    FfiOptionalOverflowData { has_value: true, value }
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct FfiOptionalOverflowData {
+    pub has_value: bool,
+    pub value: crate::painting::paintable_data::FfiOverflowData,
 }
 
 /// Whether a box is measured eagerly after a full commit rather than only when an ancestor's
@@ -714,41 +728,30 @@ fn box_holds_scroll_state(arena: &LayoutNodeArena, slot: NodeSlotId) -> bool {
         || arena.node_flags_if_live(slot) & crate::layout::node_data::NodeFlag::HasScrollOffset as u32 != 0
 }
 
-/// # Safety
-///
-/// `arena_handle` must be a live handle from `layout_arena_create`, used on the document
-/// thread, with no outstanding borrows of the arena.
-unsafe fn measure_scrollable_overflow_for_slot(
-    arena_handle: *mut c_void,
+fn measure_scrollable_overflow_for_slot(
+    arena: &LayoutNodeArena,
     box_paintable: NodeSlotId,
     overflow_callbacks: &crate::painting::host::FfiScrollableOverflowHostCallbacks,
 ) {
+    let rows = arena.paintable_rows();
+    if !rows.paintable_row_is_populated(box_paintable) {
+        return;
+    }
     let assignments = {
-        // SAFETY: Guaranteed by the caller.
-        let arena = unsafe { arena_from_handle(arena_handle) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(box_paintable) {
-            return;
-        }
         let paint_state = arena.paint_state().borrow();
         crate::painting::scrollable_overflow::measure_scrollable_overflow(
-            &paintable_rows,
+            &rows,
             &paint_state.scrollable_overflow_non_child_boxes,
             overflow_callbacks,
             box_paintable,
         )
     };
-    // SAFETY: The shared borrow above ended with its scope.
-    let arena = unsafe { arena_from_handle_mut(arena_handle) };
-    let mut paintable_rows = arena.paintable_rows_mut();
     for assignment in assignments {
-        assignment.apply(&mut paintable_rows);
+        assignment.apply(&rows);
     }
 }
 
-/// Mirrors the lazy measurement behind `Painting::has_scrollable_overflow`: a box whose overflow
-/// has not been measured since the last commit is measured on demand, which needs the arena
-/// exclusively, so no borrow may be alive across the call.
+/// Returns overflow for layout dumps, measuring missing data in Rust-owned cache storage.
 ///
 /// # Safety
 ///
@@ -776,10 +779,10 @@ pub(crate) unsafe fn scrollable_overflow_rect_measuring_if_missing(
     if needs_measurement {
         // SAFETY: No arena borrow is alive here.
         unsafe {
-            measure_scrollable_overflow_for_slot(arena_handle, slot, overflow_callbacks);
+            measure_scrollable_overflow_for_slot(arena_from_handle(arena_handle), slot, overflow_callbacks);
         }
     }
-    // SAFETY: The measurement's exclusive borrow ended with its call.
+    // SAFETY: The caller keeps the arena alive.
     let arena = unsafe { arena_from_handle(arena_handle) };
     let rows = arena.paintable_rows();
     if !crate::painting::paintable_geometry::has_scrollable_overflow(&rows, slot) {
@@ -836,7 +839,7 @@ pub unsafe extern "C" fn layout_arena_update_scrollable_overflow(
     let measure_and_clamp = |slot: NodeSlotId| {
         // SAFETY: As above; the callback receives a live shell and does not re-enter.
         unsafe {
-            measure_scrollable_overflow_for_slot(arena, slot, &overflow_callbacks);
+            measure_scrollable_overflow_for_slot(arena_from_handle(arena), slot, &overflow_callbacks);
             let shell = arena_from_handle(arena).node_shell(slot);
             clamp_scroll_offset_if_nonzero(scroll_offset_context, shell);
         }
@@ -884,9 +887,10 @@ pub unsafe extern "C" fn layout_arena_update_scrollable_overflow(
         // SAFETY: As above; callers established a populated row.
         let arena = unsafe { arena_from_handle(arena) };
         let paintable_rows = arena.paintable_rows();
-        let data = paintable_rows.paintable_data(slot);
+        let data = paintable_rows.paintable_side_data(slot);
         data.overflow_measured_this_commit
-            .then_some(data.overflow_relative_to_padding_box)
+            .get()
+            .then_some(data.overflow_relative_to_padding_box.get())
     };
     let mut record_and_clear_overflow_data = |slot: NodeSlotId| {
         if !row_is_populated(slot) {
@@ -897,10 +901,10 @@ pub unsafe extern "C" fn layout_arena_update_scrollable_overflow(
         }
         old_overflow_data_by_box.insert(slot, overflow_snapshot(slot));
         // SAFETY: As above; the row was just established as populated.
-        unsafe { arena_from_handle_mut(arena) }
-            .paintable_rows_mut()
-            .paintable_data_mut(slot)
-            .overflow_measured_this_commit = false;
+        unsafe { arena_from_handle(arena) }
+            .paintable_side_data(slot)
+            .overflow_measured_this_commit
+            .set(false);
         true
     };
     let collect_box_subtree_slots = |root: NodeSlotId| {

--- a/Libraries/LibWeb/Rust/src/painting/host/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/mod.rs
@@ -23,13 +23,14 @@ pub struct FfiRootBackgroundSource {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct FfiScrollableOverflowHostCallbacks {
+pub struct FfiGeometryHostCallbacks {
     pub context: *mut std::ffi::c_void,
+    pub clamp_scroll_offset_if_nonzero: unsafe extern "C" fn(*mut std::ffi::c_void, *mut std::ffi::c_void),
     pub layout_node_is_in_focused_text_control:
         unsafe extern "C" fn(*mut std::ffi::c_void, *mut std::ffi::c_void) -> bool,
 }
 
-impl FfiScrollableOverflowHostCallbacks {
+impl FfiGeometryHostCallbacks {
     pub(crate) fn layout_node_is_in_focused_text_control(&self, layout_node_shell: *mut std::ffi::c_void) -> bool {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe { (self.layout_node_is_in_focused_text_control)(self.context, layout_node_shell) }

--- a/Libraries/LibWeb/Rust/src/painting/layout_tree_dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/layout_tree_dump.rs
@@ -14,8 +14,7 @@ use crate::painting::dump::{
     Utf8Sink, dump_block_fragments, dump_inline_piece_fragments, format_float_like_ak, push_class_name,
     push_css_pixel_point, push_css_pixel_rect, push_css_pixels, push_indent,
 };
-use crate::painting::ffi::{arena_from_handle, scrollable_overflow_rect_measuring_if_missing};
-use crate::painting::host::FfiScrollableOverflowHostCallbacks;
+use crate::painting::ffi::arena_from_handle;
 use crate::painting::host::visual_context::FfiVisualContextHostCallbacks;
 use crate::painting::node_painting;
 use crate::painting::paintable_data::FfiPixelBox;
@@ -51,7 +50,6 @@ pub struct FfiLayoutTreeDumpCallbacks {
     ),
     pub append_text: unsafe extern "C" fn(context: *mut c_void, bytes: *const u8, byte_count: usize),
     pub visual_context: FfiVisualContextHostCallbacks,
-    pub scrollable_overflow: FfiScrollableOverflowHostCallbacks,
 }
 
 impl FfiLayoutTreeDumpCallbacks {
@@ -117,14 +115,12 @@ impl FfiLayoutTreeDumpCallbacks {
 pub unsafe extern "C" fn layout_arena_dump_layout_tree(
     arena: *mut c_void,
     root: NodeSlotId,
-    viewport: NodeSlotId,
     initial_indent: usize,
     interactive: bool,
     callbacks: FfiLayoutTreeDumpCallbacks,
 ) {
     let context = LayoutTreeDumpContext {
         arena_handle: arena,
-        viewport,
         interactive,
         palette: DumpPalette::new(interactive),
         callbacks: &callbacks,
@@ -139,7 +135,6 @@ pub unsafe extern "C" fn layout_arena_dump_layout_tree(
 
 struct LayoutTreeDumpContext<'a> {
     arena_handle: *mut c_void,
-    viewport: NodeSlotId,
     interactive: bool,
     palette: DumpPalette,
     callbacks: &'a FfiLayoutTreeDumpCallbacks,
@@ -458,18 +453,16 @@ unsafe fn dump_layout_node(output: &mut Vec<u8>, context: &LayoutTreeDumpContext
         }
     }
 
-    // SAFETY: No arena borrow is alive here.
-    let scrollable_overflow_rect = unsafe {
-        scrollable_overflow_rect_measuring_if_missing(
-            context.arena_handle,
-            slot,
-            context.viewport,
-            &context.callbacks.scrollable_overflow,
-        )
-    };
-    if let Some(rect) = scrollable_overflow_rect {
-        output.extend_from_slice(b" overflow: ");
-        push_css_pixel_rect(&mut Utf8Sink(output), rect);
+    {
+        // SAFETY: The dump's caller keeps the arena alive.
+        let arena = unsafe { arena_from_handle(context.arena_handle) };
+        let rows = arena.paintable_rows();
+        if paintable_geometry::has_scrollable_overflow(&rows, slot)
+            && let Some(rect) = paintable_geometry::scrollable_overflow_rect(&rows, slot)
+        {
+            output.extend_from_slice(b" overflow: ");
+            push_css_pixel_rect(&mut Utf8Sink(output), rect);
+        }
     }
     output.push(b'\n');
 

--- a/Libraries/LibWeb/Rust/src/painting/paint_state.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paint_state.rs
@@ -39,7 +39,6 @@ pub struct PaintState {
     pub(crate) selection: Option<crate::painting::selection::SelectionRange>,
     pub(crate) selection_pseudo_styles:
         std::collections::HashMap<NodeSlotId, Rc<crate::painting::record::paint::text::SelectionStyleAnswer>>,
-    pub(crate) scrollable_overflow_non_child_boxes: std::collections::HashMap<NodeSlotId, Vec<NodeSlotId>>,
     pub(crate) per_recording_memo_tables: RefCell<crate::painting::record::scratch::PerRecordingMemoTables>,
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -166,6 +166,7 @@ impl InlineBoxPieceRecord {
 pub struct PaintableSideData {
     // Invalidation also runs while paint geometry is borrowed. Keep this
     // mutable cache state out of the plain-data row shared with C++.
+    pub(crate) overflow_style: Option<crate::painting::scrollable_overflow::OverflowStyle>,
     pub(crate) overflow_valid_across_recommits: Cell<bool>,
     pub(crate) overflow_relative_to_padding_box: Cell<FfiOverflowData>,
     pub(crate) overflow_measured_this_commit: Cell<bool>,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -47,9 +47,6 @@ pub struct PaintableData {
     pub local_padding_box_union: used_values::FfiCssPixelRect,
     pub local_border_box_union: used_values::FfiCssPixelRect,
 
-    pub overflow_relative_to_padding_box: FfiOverflowData,
-    pub overflow_measured_this_commit: bool,
-
     pub establishes_stacking_context: bool,
 
     pub enclosing_scroll_node_index: SpatialNodeIndex,
@@ -74,8 +71,6 @@ impl Default for PaintableData {
             content_size: used_values::FfiCssPixelSize::default(),
             local_padding_box_union: used_values::FfiCssPixelRect::default(),
             local_border_box_union: used_values::FfiCssPixelRect::default(),
-            overflow_relative_to_padding_box: FfiOverflowData::default(),
-            overflow_measured_this_commit: false,
             establishes_stacking_context: false,
             enclosing_scroll_node_index: SpatialNodeIndex::default(),
             own_scroll_node_index: SpatialNodeIndex::default(),
@@ -172,6 +167,8 @@ pub struct PaintableSideData {
     // Invalidation also runs while paint geometry is borrowed. Keep this
     // mutable cache state out of the plain-data row shared with C++.
     pub(crate) overflow_valid_across_recommits: Cell<bool>,
+    pub(crate) overflow_relative_to_padding_box: Cell<FfiOverflowData>,
+    pub(crate) overflow_measured_this_commit: Cell<bool>,
     pub(crate) inline_content: Option<std::rc::Rc<crate::layout::inline_content::InlineContent>>,
     pub(crate) piece_indices: Vec<u32>,
     pub(crate) svg_filter_bounds: Cell<Option<used_values::FfiCssPixelRect>>,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -321,29 +321,25 @@ pub(crate) fn absolute_border_box_rect(arena: &impl PaintableRowsRead, slot: Nod
     )
 }
 
-pub(crate) fn overflow_is_valid(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
-    arena.paintable_side_data(slot).overflow_measured_this_commit.get()
-        || arena.paintable_side_data(slot).overflow_valid_across_recommits.get()
-}
-
 pub(crate) fn scrollable_overflow_rect(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> Option<CssPixelRect> {
-    if !overflow_is_valid(arena, slot) {
+    arena.ensure_scrollable_overflow(slot);
+    if !arena.paintable_row_is_populated(slot) {
+        return None;
+    }
+    let cache = arena.paintable_side_data(slot);
+    if !cache.overflow_valid_across_recommits.get() {
         return None;
     }
     Some(
-        CssPixelRect::from(
-            arena
-                .paintable_side_data(slot)
-                .overflow_relative_to_padding_box
-                .get()
-                .rect,
-        )
-        .translated_by(absolute_padding_box_rect(arena, slot).location()),
+        CssPixelRect::from(cache.overflow_relative_to_padding_box.get().rect)
+            .translated_by(absolute_padding_box_rect(arena, slot).location()),
     )
 }
 
 pub(crate) fn has_scrollable_overflow(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
-    overflow_is_valid(arena, slot)
+    arena.ensure_scrollable_overflow(slot);
+    arena.paintable_row_is_populated(slot)
+        && arena.paintable_side_data(slot).overflow_valid_across_recommits.get()
         && arena
             .paintable_side_data(slot)
             .overflow_relative_to_padding_box

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -322,7 +322,7 @@ pub(crate) fn absolute_border_box_rect(arena: &impl PaintableRowsRead, slot: Nod
 }
 
 pub(crate) fn overflow_is_valid(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
-    arena.paintable_data(slot).overflow_measured_this_commit
+    arena.paintable_side_data(slot).overflow_measured_this_commit.get()
         || arena.paintable_side_data(slot).overflow_valid_across_recommits.get()
 }
 
@@ -331,15 +331,22 @@ pub(crate) fn scrollable_overflow_rect(arena: &impl PaintableRowsRead, slot: Nod
         return None;
     }
     Some(
-        CssPixelRect::from(arena.paintable_data(slot).overflow_relative_to_padding_box.rect)
-            .translated_by(absolute_padding_box_rect(arena, slot).location()),
+        CssPixelRect::from(
+            arena
+                .paintable_side_data(slot)
+                .overflow_relative_to_padding_box
+                .get()
+                .rect,
+        )
+        .translated_by(absolute_padding_box_rect(arena, slot).location()),
     )
 }
 
 pub(crate) fn has_scrollable_overflow(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
     overflow_is_valid(arena, slot)
         && arena
-            .paintable_data(slot)
+            .paintable_side_data(slot)
             .overflow_relative_to_padding_box
+            .get()
             .has_scrollable_overflow
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -759,6 +759,9 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn populate_paintable_row(&mut self, layout_node: NodeSlotId) {
+        let overflow_style = self
+            .node_style_if_live(layout_node)
+            .map(crate::painting::scrollable_overflow::OverflowStyle::new);
         let store = &mut self.paintable_rows;
         let index = layout_node.slot_index() as usize;
         let chunks = &mut store.chunks;
@@ -782,7 +785,10 @@ impl LayoutNodeArena {
             slot_generation: layout_node.generation(),
             ..PaintableData::default()
         };
-        side_data[index] = PaintableSideData::default();
+        side_data[index] = PaintableSideData {
+            overflow_style,
+            ..Default::default()
+        };
         paint_caches[index].clear();
         absolute_rect_memo[index] = None;
         visual_context_records[index] = None;

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -35,10 +35,7 @@ mod tests {
             .paintable_side_data(node)
             .overflow_valid_across_recommits
             .set(true);
-        arena
-            .paintable_rows_mut()
-            .paintable_data_mut(node)
-            .overflow_measured_this_commit = true;
+        arena.paintable_side_data(node).overflow_measured_this_commit.set(true);
         arena.paintable_rows_mut().begin_paintable_row_recommit(node);
         assert!(arena.paintable_side_data(node).overflow_valid_across_recommits.get());
 
@@ -48,7 +45,7 @@ mod tests {
         rows.clear_cached_overflow_data(node);
         assert_eq!(*geometry, previous_geometry);
         assert!(!arena.paintable_side_data(node).overflow_valid_across_recommits.get());
-        assert!(!geometry.overflow_measured_this_commit);
+        assert!(!arena.paintable_side_data(node).overflow_measured_this_commit.get());
     }
 }
 
@@ -384,10 +381,13 @@ where
             let data = self.paintable_data_mut(id);
             data.offset = used_values::FfiCssPixelPoint::default();
             data.content_size = used_values::FfiCssPixelSize::default();
-            data.overflow_measured_this_commit = false;
             data.local_padding_box_union = used_values::FfiCssPixelRect::default();
             data.local_border_box_union = used_values::FfiCssPixelRect::default();
         }
+        self.arena
+            .paintable_side_data(id)
+            .overflow_measured_this_commit
+            .set(false);
         // The paint cache is deliberately kept; the commit diff marks rows whose committed
         // fragment identity or offset actually changed.
         self.arena.paintable_side_data_mut(id).clear_committed_records();

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -27,6 +27,76 @@ mod tests {
     use super::*;
 
     #[test]
+    fn overflow_queries_do_not_measure_ordinary_inline_fragments() {
+        use crate::css::css_pixels::{CssPixelRect, CssPixels};
+        use crate::layout::node_data::NodeKind;
+        use crate::painting::paintable_geometry;
+
+        let mut arena = LayoutNodeArena::new();
+        let node = arena.allocate_for_test().slot;
+        arena.data(node).kind.set(NodeKind::InlineNode);
+        arena.populate_paintable_row(node);
+        arena.scrollable_overflow.viewport.set(Some(node));
+        let rect = CssPixelRect::new(
+            CssPixels::from_integer(0),
+            CssPixels::from_integer(0),
+            CssPixels::from_integer(100),
+            CssPixels::from_integer(80),
+        );
+        arena
+            .paintable_rows_mut()
+            .paintable_data_mut(node)
+            .local_padding_box_union = rect.into();
+
+        let rows = arena.paintable_rows();
+        assert_eq!(paintable_geometry::scrollable_overflow_rect(&rows, node), None);
+        assert!(!paintable_geometry::has_scrollable_overflow(&rows, node));
+        assert!(!arena.paintable_side_data(node).overflow_measured_this_commit.get());
+    }
+
+    #[test]
+    fn overflow_queries_refresh_invalidated_data_while_geometry_is_borrowed() {
+        use crate::css::css_pixels::{CssPixelRect, CssPixels};
+        use crate::layout::node_data::NodeKind;
+        use crate::painting::paintable_geometry;
+
+        let mut arena = LayoutNodeArena::new();
+        let node = arena.allocate_for_test().slot;
+        arena.data(node).kind.set(NodeKind::InlineNode);
+        arena.set_node_flag(node, NodeFlag::HasScrollOffset, true);
+        arena.populate_paintable_row(node);
+        arena.scrollable_overflow.viewport.set(Some(node));
+        let rect = CssPixelRect::new(
+            CssPixels::from_integer(0),
+            CssPixels::from_integer(0),
+            CssPixels::from_integer(100),
+            CssPixels::from_integer(80),
+        );
+        arena
+            .paintable_rows_mut()
+            .paintable_data_mut(node)
+            .local_padding_box_union = rect.into();
+        let cache = arena.paintable_side_data(node);
+        cache.overflow_relative_to_padding_box.set(FfiOverflowData {
+            rect: CssPixelRect::new(rect.x, rect.y, CssPixels::from_integer(500), rect.height).into(),
+            has_scrollable_overflow: true,
+        });
+        cache.overflow_valid_across_recommits.set(true);
+        cache.overflow_measured_this_commit.set(true);
+        drop(cache);
+
+        let rows = arena.paintable_rows();
+        let geometry = rows.paintable_data(node);
+        let previous_geometry = *geometry;
+        rows.clear_cached_overflow_data(node);
+        assert_eq!(paintable_geometry::scrollable_overflow_rect(&rows, node), Some(rect));
+        assert!(!paintable_geometry::has_scrollable_overflow(&rows, node));
+        assert_eq!(*geometry, previous_geometry);
+        assert!(arena.scrollable_overflow.geometry_changed.get());
+        assert!(arena.scrollable_overflow.scrollability_changed.get());
+    }
+
+    #[test]
     fn overflow_cache_invalidation_is_independent_of_borrowed_geometry() {
         let mut arena = LayoutNodeArena::new();
         let node = arena.allocate_for_test().slot;
@@ -537,17 +607,6 @@ impl LayoutNodeArena {
 
     pub(crate) fn set_needs_full_scrollable_overflow_recalculation(&self) {
         self.needs_full_scrollable_overflow_recalculation.set(true);
-    }
-
-    /// Rebuilds the supplemental contained-boxes index from committed rows under `root`.
-    pub(crate) fn rebuild_scrollable_overflow_contained_boxes(&self, root: NodeSlotId) {
-        let paintable_rows = self.paintable_rows();
-        let mut paint_state = self.paint_state().borrow_mut();
-        crate::painting::scrollable_overflow::refill_contained_boxes_index(
-            &paintable_rows,
-            root,
-            &mut paint_state.scrollable_overflow_non_child_boxes,
-        );
     }
 
     pub(crate) fn take_scrollable_overflow_recalculation_state(&self) -> (Vec<NodeSlotId>, bool) {

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -880,3 +880,73 @@ pub(crate) fn update_scrollable_overflow(arena: &LayoutNodeArena) {
         }
     }
 }
+
+/// Retain the last published transform group so a style change can invalidate overflow
+/// even after the DOM or an animation has released its previous style record.
+pub(crate) struct OverflowStyle(std::ptr::NonNull<crate::css::computed_value_types::TransformValues>);
+
+impl OverflowStyle {
+    pub(crate) fn new(style: crate::css::computed_value_views::ComputedValuesView<'_>) -> Self {
+        let values = std::ptr::from_ref(style.transform());
+        crate::css::computed_values::retain_group_payload(
+            crate::css::computed_value_types::STYLE_GROUP_INDEX_TRANSFORM,
+            values.cast(),
+        );
+        Self(std::ptr::NonNull::from(style.transform()))
+    }
+
+    fn matches(&self, style: crate::css::computed_value_views::ComputedValuesView<'_>) -> bool {
+        let new = style.transform();
+        if std::ptr::eq(self.0.as_ptr(), new) {
+            return true;
+        }
+        // SAFETY: This snapshot retains the immutable group until it is replaced or dropped.
+        let old = unsafe { self.0.as_ref() };
+        old.transformations == new.transformations
+            && old.translate == new.translate
+            && old.rotate == new.rotate
+            && old.scale == new.scale
+            && old.transform_box == new.transform_box
+            && old.transform_origin_x == new.transform_origin_x
+            && old.transform_origin_y == new.transform_origin_y
+            && old.transform_origin_z == new.transform_origin_z
+    }
+}
+
+impl Drop for OverflowStyle {
+    fn drop(&mut self) {
+        crate::css::computed_values::release_group_payload(
+            crate::css::computed_value_types::STYLE_GROUP_INDEX_TRANSFORM,
+            self.0.as_ptr().cast(),
+        );
+    }
+}
+
+impl LayoutNodeArena {
+    pub(crate) fn invalidate_overflow_after_style_change(&self, slot: NodeSlotId) {
+        if !self.paintable_row_is_populated(slot) {
+            return;
+        }
+        let Some(style) = self.node_style_if_live(slot) else {
+            return;
+        };
+        let changed = {
+            let mut cache = self.paintable_side_data_mut(slot);
+            let changed = cache
+                .overflow_style
+                .as_ref()
+                .is_some_and(|previous| !previous.matches(style));
+            cache.overflow_style = Some(OverflowStyle::new(style));
+            changed
+        };
+        if !changed {
+            return;
+        }
+        if self.node_kind_if_live(slot).is_some_and(node_facts::kind_is_svg_box) {
+            // SVG consumes transforms during layout, unlike CSS box overflow measurement.
+            self.set_needs_layout_update(slot, true);
+        } else {
+            self.schedule_scrollable_overflow_recalculation(slot);
+        }
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -12,7 +12,7 @@ use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::node_facts;
 use crate::painting::host::FfiScrollableOverflowHostCallbacks;
 use crate::painting::paintable_data::FfiOverflowData;
-use crate::painting::paintable_rows::{PaintableRowsMut, PaintableRowsRead};
+use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
 use crate::painting::visual_context::node_values;
 use crate::painting::{paintable_geometry, style_queries, text_fragment};
@@ -288,19 +288,19 @@ pub(crate) struct OverflowAssignment {
 }
 
 impl OverflowAssignment {
-    pub(crate) fn apply(self, layout_arena: &mut PaintableRowsMut<'_>) {
+    pub(crate) fn apply(self, layout_arena: &impl PaintableRowsRead) {
         let (scroll_metadata_changed, scrollability_flipped) = {
-            let data = layout_arena.paintable_data_mut(self.box_paintable);
+            let data = layout_arena.paintable_side_data(self.box_paintable);
             let scroll_metadata_changed = self
                 .overflow_relative_to_padding_box
-                .is_some_and(|overflow| overflow != data.overflow_relative_to_padding_box);
+                .is_some_and(|overflow| overflow != data.overflow_relative_to_padding_box.get());
             let scrollability_flipped = self.overflow_relative_to_padding_box.is_some_and(|overflow| {
-                overflow.has_scrollable_overflow != data.overflow_relative_to_padding_box.has_scrollable_overflow
+                overflow.has_scrollable_overflow != data.overflow_relative_to_padding_box.get().has_scrollable_overflow
             });
             if let Some(overflow) = self.overflow_relative_to_padding_box {
-                data.overflow_relative_to_padding_box = overflow;
+                data.overflow_relative_to_padding_box.set(overflow);
             }
-            data.overflow_measured_this_commit = true;
+            data.overflow_measured_this_commit.set(true);
             (scroll_metadata_changed, scrollability_flipped)
         };
         if self.overflow_relative_to_padding_box.is_some() {
@@ -310,10 +310,14 @@ impl OverflowAssignment {
                 .set(true);
         }
         if scroll_metadata_changed {
-            layout_arena.mark_paint_cache_self_dirty(self.box_paintable);
+            layout_arena
+                .paintable_rows()
+                .mark_paint_cache_self_dirty(self.box_paintable);
         }
         if scrollability_flipped {
-            layout_arena.mark_descendant_subtree_caches_dirty_in_paint_subtree(self.box_paintable);
+            layout_arena
+                .paintable_rows()
+                .mark_descendant_subtree_caches_dirty_in_paint_subtree(self.box_paintable);
             layout_arena.note_visual_context_box_dirty(
                 self.box_paintable,
                 VisualContextBoxDirtyKind::ScrollableOverflowFlipped,
@@ -368,16 +372,16 @@ fn measure_scrollable_overflow_impl(
     assignments: &mut Vec<OverflowAssignment>,
 ) -> CssPixelRect {
     let still_valid_overflow = {
-        let data = layout_arena.paintable_data(box_paintable);
-        if data.overflow_measured_this_commit {
-            return CssPixelRect::from(data.overflow_relative_to_padding_box.rect)
+        let data = layout_arena.paintable_side_data(box_paintable);
+        if data.overflow_measured_this_commit.get() {
+            return CssPixelRect::from(data.overflow_relative_to_padding_box.get().rect)
                 .translated_by(paintable_geometry::absolute_padding_box_rect(layout_arena, box_paintable).location());
         }
         layout_arena
             .paintable_side_data(box_paintable)
             .overflow_valid_across_recommits
             .get()
-            .then_some(data.overflow_relative_to_padding_box)
+            .then_some(data.overflow_relative_to_padding_box.get())
     };
 
     let box_node = box_paintable;
@@ -503,7 +507,7 @@ fn measure_scrollable_overflow_impl(
         let child_display = child_style.map_or_else(FfiDisplay::block, |style| style.display());
 
         {
-            let child_data = layout_arena.paintable_data(child_node);
+            let child_data = layout_arena.paintable_side_data(child_node);
             if child_position == positioning::STATIC
                 && child_display.is_inline_outside()
                 && !child_is_floating
@@ -526,7 +530,7 @@ fn measure_scrollable_overflow_impl(
                     // The committed line fragment already contributes this content box. A box with no border whose
                     // cached overflow fits inside the content box cannot expand its containing block's overflow.
                     if content_box_relative_to_padding_box
-                        .contains_rect(child_data.overflow_relative_to_padding_box.rect.into())
+                        .contains_rect(child_data.overflow_relative_to_padding_box.get().rect.into())
                     {
                         continue;
                     }

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -10,13 +10,14 @@ use crate::css::display::FfiDisplay;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::node_facts;
-use crate::painting::host::FfiScrollableOverflowHostCallbacks;
+use crate::painting::host::FfiGeometryHostCallbacks;
 use crate::painting::paintable_data::FfiOverflowData;
 use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
 use crate::painting::visual_context::node_values;
 use crate::painting::{paintable_geometry, style_queries, text_fragment};
 use libgfx_rust::matrix::{AffineTransform, FloatMatrix4x4};
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
 /// Index boxes whose containing block differs from their layout parent. Direct children are
@@ -265,7 +266,7 @@ fn padding_inflated_scrollable_overflow(
 
 fn fragment_node_is_in_focused_text_control(
     layout_arena: &LayoutNodeArena,
-    overflow_callbacks: &FfiScrollableOverflowHostCallbacks,
+    overflow_callbacks: Option<&FfiGeometryHostCallbacks>,
     node: NodeSlotId,
 ) -> bool {
     let flags = layout_arena.node_flags_if_live(node);
@@ -277,7 +278,7 @@ fn fragment_node_is_in_focused_text_control(
     if shell.is_null() {
         return false;
     }
-    overflow_callbacks.layout_node_is_in_focused_text_control(shell)
+    overflow_callbacks.is_some_and(|callbacks| callbacks.layout_node_is_in_focused_text_control(shell))
 }
 
 #[derive(Clone, Copy)]
@@ -289,6 +290,10 @@ pub(crate) struct OverflowAssignment {
 
 impl OverflowAssignment {
     pub(crate) fn apply(self, layout_arena: &impl PaintableRowsRead) {
+        let previously_measured = layout_arena
+            .paintable_side_data(self.box_paintable)
+            .overflow_measured_this_commit
+            .get();
         let (scroll_metadata_changed, scrollability_flipped) = {
             let data = layout_arena.paintable_side_data(self.box_paintable);
             let scroll_metadata_changed = self
@@ -310,11 +315,17 @@ impl OverflowAssignment {
                 .set(true);
         }
         if scroll_metadata_changed {
+            if previously_measured {
+                layout_arena.scrollable_overflow.geometry_changed.set(true);
+            }
             layout_arena
                 .paintable_rows()
                 .mark_paint_cache_self_dirty(self.box_paintable);
         }
         if scrollability_flipped {
+            if previously_measured {
+                layout_arena.scrollable_overflow.scrollability_changed.set(true);
+            }
             layout_arena
                 .paintable_rows()
                 .mark_descendant_subtree_caches_dirty_in_paint_subtree(self.box_paintable);
@@ -348,7 +359,7 @@ fn store_overflow_data(
 pub(crate) fn measure_scrollable_overflow(
     layout_arena: &impl PaintableRowsRead,
     non_child_boxes_by_containing_block: &HashMap<NodeSlotId, Vec<NodeSlotId>>,
-    overflow_callbacks: &FfiScrollableOverflowHostCallbacks,
+    overflow_callbacks: Option<&FfiGeometryHostCallbacks>,
     box_paintable: NodeSlotId,
 ) -> Vec<OverflowAssignment> {
     // Each box occurs under only one containing block, so this traversal visits each box at most once and can stage
@@ -367,13 +378,13 @@ pub(crate) fn measure_scrollable_overflow(
 fn measure_scrollable_overflow_impl(
     layout_arena: &impl PaintableRowsRead,
     non_child_boxes_by_containing_block: &HashMap<NodeSlotId, Vec<NodeSlotId>>,
-    overflow_callbacks: &FfiScrollableOverflowHostCallbacks,
+    overflow_callbacks: Option<&FfiGeometryHostCallbacks>,
     box_paintable: NodeSlotId,
     assignments: &mut Vec<OverflowAssignment>,
 ) -> CssPixelRect {
     let still_valid_overflow = {
         let data = layout_arena.paintable_side_data(box_paintable);
-        if data.overflow_measured_this_commit.get() {
+        if data.overflow_measured_this_commit.get() && data.overflow_valid_across_recommits.get() {
             return CssPixelRect::from(data.overflow_relative_to_padding_box.get().rect)
                 .translated_by(paintable_geometry::absolute_padding_box_rect(layout_arena, box_paintable).location());
         }
@@ -712,4 +723,160 @@ fn measure_scrollable_overflow_impl(
     );
 
     scrollable_overflow_rect
+}
+
+/// Geometry caches and their pending effects belong to the arena, independently of the
+/// visual-context state temporarily borrowed or taken by painting traversals.
+#[derive(Default)]
+pub(crate) struct ScrollableOverflowState {
+    pub(crate) host: Cell<Option<FfiGeometryHostCallbacks>>,
+    pub(crate) viewport: Cell<Option<NodeSlotId>>,
+    pub(crate) full_layout_commit: Cell<bool>,
+    pub(crate) contained_boxes_dirty: Cell<bool>,
+    pub(crate) non_child_boxes: RefCell<HashMap<NodeSlotId, Vec<NodeSlotId>>>,
+    pub(crate) geometry_changed: Cell<bool>,
+    pub(crate) scrollability_changed: Cell<bool>,
+    pub(crate) recalculations: Cell<u64>,
+}
+
+impl LayoutNodeArena {
+    pub(crate) fn ensure_overflow_contained_boxes(&self) {
+        if !self.scrollable_overflow.contained_boxes_dirty.replace(false) {
+            return;
+        }
+        let mut index = self.scrollable_overflow.non_child_boxes.borrow_mut();
+        if let Some(viewport) = self.scrollable_overflow.viewport.get() {
+            refill_contained_boxes_index(&self.paintable_rows(), viewport, &mut index);
+        } else {
+            index.clear();
+        }
+    }
+
+    pub(crate) fn did_commit_full_layout(&self, viewport: NodeSlotId) {
+        self.scrollable_overflow.viewport.set(Some(viewport));
+        self.scrollable_overflow.full_layout_commit.set(true);
+        self.scrollable_overflow.contained_boxes_dirty.set(true);
+        self.set_needs_full_scrollable_overflow_recalculation();
+    }
+
+    pub(crate) fn ensure_scrollable_overflow(&self, slot: NodeSlotId) {
+        if !self.paintable_row_is_populated(slot)
+            || !self
+                .scrollable_overflow
+                .viewport
+                .get()
+                .is_some_and(|viewport| self.paintable_row_is_populated(viewport))
+        {
+            return;
+        }
+        {
+            let cache = self.paintable_side_data(slot);
+            if cache.overflow_valid_across_recommits.get() {
+                cache.overflow_measured_this_commit.set(true);
+                return;
+            }
+        }
+        // Ordinary inline fragments have paint geometry but no independently measured scrolling area.
+        // Rows holding scroll state still need measurement, as they do during rendering preparation.
+        if !self.node_kind_if_live(slot).is_some_and(node_facts::kind_is_box) && !box_holds_scroll_state(self, slot) {
+            return;
+        }
+        self.ensure_overflow_contained_boxes();
+        let rows = self.paintable_rows();
+        let assignments = measure_scrollable_overflow(
+            &rows,
+            &self.scrollable_overflow.non_child_boxes.borrow(),
+            self.scrollable_overflow.host.get().as_ref(),
+            slot,
+        );
+        for assignment in assignments {
+            assignment.apply(&rows);
+        }
+    }
+}
+
+/// Whether a box is measured eagerly after a full commit rather than only when an ancestor's
+/// measurement reaches it: a scroll container, or a box whose element or pseudo-element stores a
+/// scroll offset that the new overflow may have to clamp. The offset lives on the DOM side, which
+/// sets `NodeFlag::HasScrollOffset` whenever it stores one and whenever a box becomes an element's
+/// or pseudo-element's box, so the answer is one style query and one flag read.
+fn box_holds_scroll_state(arena: &LayoutNodeArena, slot: NodeSlotId) -> bool {
+    crate::painting::style_queries::is_scroll_container(arena, slot)
+        || arena.node_flags_if_live(slot) & crate::layout::node_data::NodeFlag::HasScrollOffset as u32 != 0
+}
+
+pub(crate) fn update_scrollable_overflow(arena: &LayoutNodeArena) {
+    let Some(viewport) = arena.scrollable_overflow.viewport.get() else {
+        return;
+    };
+    let full_layout_commit = arena.scrollable_overflow.full_layout_commit.replace(false);
+    let (pending_boxes, needs_full_recalculation) = arena.take_scrollable_overflow_recalculation_state();
+    if (pending_boxes.is_empty() && !needs_full_recalculation) || !arena.paintable_row_is_populated(viewport) {
+        return;
+    }
+    arena
+        .scrollable_overflow
+        .recalculations
+        .set(arena.scrollable_overflow.recalculations.get() + 1);
+    arena.ensure_overflow_contained_boxes();
+
+    // Ordinary boxes are measured when their contribution or geometry is queried. Settle
+    // scroll containers and stored offsets before DOM reads or painting observe them.
+    // Keep already measured ancestors in the set so changes invalidate their paint caches
+    // even when a cached recording would otherwise skip the subtree.
+    let mut roots = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut add = |slot: NodeSlotId| {
+        if arena.paintable_row_is_populated(slot) && seen.insert(slot) {
+            roots.push(slot);
+            true
+        } else {
+            false
+        }
+    };
+    if needs_full_recalculation {
+        arena.for_each_node_in_layout_subtree_in_pre_order(viewport, |slot| {
+            if arena.paintable_row_is_populated(slot)
+                && (slot == viewport
+                    || box_holds_scroll_state(arena, slot)
+                    || (!full_layout_commit && arena.paintable_side_data(slot).overflow_measured_this_commit.get()))
+            {
+                add(slot);
+            }
+        });
+    } else {
+        for slot in pending_boxes {
+            if !arena.slot_is_live(slot) || !arena.paintable_row_is_populated(slot) {
+                continue;
+            }
+            if !arena.paintable_side_data(slot).overflow_measured_this_commit.get() {
+                // A subtree commit can replace scroll containers whose overflow does not
+                // propagate through the relayout root (for example, overflow: hidden).
+                arena.for_each_node_in_layout_subtree_in_pre_order(slot, |child| {
+                    if arena.paintable_row_is_populated(child) && box_holds_scroll_state(arena, child) {
+                        add(child);
+                    }
+                });
+            }
+            add(slot);
+            let mut block = arena.node_containing_block_if_live(slot);
+            while let Some(slot) = block {
+                if !add(slot) {
+                    break;
+                }
+                block = arena.node_containing_block_if_live(slot);
+            }
+        }
+    }
+    for slot in roots {
+        arena.ensure_scrollable_overflow(slot);
+        if let Some(host) = arena.scrollable_overflow.host.get() {
+            let shell = arena.shell_if_live(slot);
+            if !shell.is_null() {
+                // SAFETY: The registered host receives a live shell. No mutable arena or
+                // cache borrow is held while it re-enters geometry queries to clamp the offset.
+                unsafe { (host.clamp_scroll_offset_if_nonzero)(host.context, shell) };
+            }
+        }
+    }
 }

--- a/Tests/LibWeb/Text/expected/query-scroll-size-of-inline-node.txt
+++ b/Tests/LibWeb/Text/expected/query-scroll-size-of-inline-node.txt
@@ -1,1 +1,4 @@
-Scroll Height: 0px, Scroll Width: 0px
+Empty inline: scrollHeight=0, scrollWidth=0
+Inline with text and padding: scrollHeight=0, scrollWidth=0
+Inline-block: scrollHeight=40, scrollWidth=60
+Changed to inline: scrollHeight=0, scrollWidth=0

--- a/Tests/LibWeb/Text/input/css/scrollable-overflow-recalc-scroll-offset-clamp.html
+++ b/Tests/LibWeb/Text/input/css/scrollable-overflow-recalc-scroll-offset-clamp.html
@@ -14,8 +14,9 @@
         const scrollTopAtMax = scroller.scrollTop;
         const countersBefore = internals.getStyleInvalidationCounters();
         child.style.transform = "translateY(150px)";
-        const heightAfterShrink = scroller.scrollHeight;
+        // Reading only the stored offset must settle the new scroll bounds too.
         const scrollTopAfterShrink = scroller.scrollTop;
+        const heightAfterShrink = scroller.scrollHeight;
         const countersAfter = internals.getStyleInvalidationCounters();
         println(`initial scrollHeight: ${initialHeight}`);
         println(`scrollTop clamped to: ${scrollTopAtMax}`);

--- a/Tests/LibWeb/Text/input/query-scroll-size-of-inline-node.html
+++ b/Tests/LibWeb/Text/input/query-scroll-size-of-inline-node.html
@@ -1,11 +1,20 @@
 <!DOCTYPE html>
 <span id="empty-span"></span>
+<span id="populated-span" style="padding: 10px">Text inside an inline</span>
+<span id="inline-block" style="display: inline-block; width: 60px; height: 40px"></span>
 <script src="include.js"></script>
 <script>
 test(() => {
-    const hiddenDiv = document.getElementById('empty-span');
-    const scrollHeight = hiddenDiv.scrollHeight;
-    const scrollWidth = hiddenDiv.scrollWidth;
-    println(`Scroll Height: ${scrollHeight}px, Scroll Width: ${scrollWidth}px`);
+    function report(label, element) {
+        println(`${label}: scrollHeight=${element.scrollHeight}, scrollWidth=${element.scrollWidth}`);
+    }
+
+    report("Empty inline", document.getElementById("empty-span"));
+    report("Inline with text and padding", document.getElementById("populated-span"));
+
+    const inlineBlock = document.getElementById("inline-block");
+    report("Inline-block", inlineBlock);
+    inlineBlock.style.display = "inline";
+    report("Changed to inline", inlineBlock);
 });
 </script>


### PR DESCRIPTION
C++ currently coordinates overflow cache checks, recalculation, and updates to dependent paint structures. Move that maintenance into Rust so geometry queries refresh missing or invalidated overflow without an explicit C++ measurement step.

Store overflow caches separately from shared geometry, allowing refreshes while geometry is borrowed. Rust now maintains the contained-box index and detects overflow-affecting style changes, including animation and pseudo-element updates. SVG transform changes continue to request layout.

Generic rendering preparation settles scroll offsets and determines whether sticky constraints, visual contexts, or recorded paint need updating. This preserves scroll-offset clamping even when a caller reads scrollTop without querying overflow dimensions.