### PR TITLE
LibWeb: Fix Netflix’s animation crash and throttle offscreen paint

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1069,6 +1069,10 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
 {
     if (m_is_compositor_driven || m_is_compositor_replaced)
         return true;
+    if (m_is_offscreen_throttled && all_of(target_properties(), [](auto const& property) {
+            return !first_is_one_of(property.id(), CSS::PropertyID::Transform, CSS::PropertyID::Translate, CSS::PropertyID::Rotate, CSS::PropertyID::Scale);
+        }))
+        return true;
 
     auto target = this->target();
     auto cache_result = [&](bool result) {
@@ -1182,10 +1186,11 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
     if (auto animation = associated_animation(); animation && !animation->is_css_animation())
         return true;
 
-    // An infinite effect cannot reach its natural end, so animationend listeners do not require a continuous tick.
+    // NB: Infinite effects cannot reach their natural end, and finite offscreen paint effects have an end timer.
+    //     Neither needs a continuous tick for animationend listeners.
     auto has_css_animation_event_listener_requiring_animation_tick = [this](DOM::EventTarget const& event_target) {
         // NB: Starting or cancelling an active animation requests an update independently of playback.
-        //     Only iteration events require future updates while a visually throttled infinite effect runs.
+        //     Only iteration events require future updates while a visually throttled effect runs.
         if (is_in_the_active_phase())
             return event_target.has_event_listener(HTML::EventNames::animationiteration)
                 || event_target.has_event_listener(HTML::EventNames::webkitAnimationIteration);

--- a/Libraries/LibWeb/Compositor/VisualAnimation.cpp
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.cpp
@@ -515,9 +515,12 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
 
 bool VisualAnimation::is_valid() const
 {
+    return !visual_context_node_indices.is_empty() && has_valid_animation_parameters();
+}
+
+bool VisualAnimation::has_valid_animation_parameters() const
+{
     if (!first_is_one_of(target_kind, TargetKind::Opacity, TargetKind::BackgroundColor, TargetKind::Filter, TargetKind::Transform))
-        return false;
-    if (visual_context_node_indices.is_empty())
         return false;
     if (!first_is_one_of(playback_direction,
             VisualAnimationPlaybackDirection::Normal,

--- a/Libraries/LibWeb/Compositor/VisualAnimation.h
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.h
@@ -151,6 +151,7 @@ struct VisualAnimation {
 
     WEB_API Optional<Sample> sample(AK::Duration elapsed_since_anchor) const;
     WEB_API bool is_valid() const;
+    WEB_API bool has_valid_animation_parameters() const;
     WEB_API bool has_same_animation_parameters(VisualAnimation const&) const;
     WEB_API bool has_same_parameters_except_anchor(VisualAnimation const&) const;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7906,11 +7906,11 @@ static Optional<double> next_throttled_animation_iteration_event_time(Animations
         || effect.iteration_duration().type != Animations::TimeValue::Type::Milliseconds
         || effect.iteration_duration().value <= 0 || !isfinite(effect.iteration_duration().value)
         || !effect.can_skip_per_frame_style_update()
-        || !isinf(effect.iteration_count()) || !effect.is_in_the_active_phase()
+        || !effect.is_in_the_active_phase()
         || effect.can_skip_per_frame_animation_tick())
         return {};
 
-    // NB: Observable infinite throttled animations need a rendering update at the next iteration boundary,
+    // NB: Observable throttled animations need a rendering update at the next iteration boundary,
     //     not at every display refresh. Seeking and cancellation already request their own updates.
     return effect.start_delay().value
         + (effect.previous_current_iteration() + 1 - effect.iteration_start()) * effect.iteration_duration().value;
@@ -7978,7 +7978,8 @@ void Document::service_compositor_animation_wakeup(double timestamp)
                 reached_wakeup = true;
             }
         }
-        if (!is_compositor_handled || isinf(effect.iteration_count()))
+        bool is_offscreen_handled = effect.is_offscreen_throttled() && effect.can_skip_per_frame_style_update();
+        if ((!is_compositor_handled && !is_offscreen_handled) || isinf(effect.iteration_count()))
             continue;
         auto active_end = effect.start_delay().value + effect.iteration_duration().value * effect.iteration_count();
         if (current_time->value < active_end) {
@@ -8152,6 +8153,100 @@ void Document::update_compositor_animations()
         return Layout::RustFFI::layout_arena_transform_subtree_is_clipped_outside(
             layout_node->arena_handle(), Layout::Node::slot_id(layout_node), root_bounds,
             Painting::rect_to_viewport_transform(*this, visual_context_tree));
+    };
+
+    auto paint_only_effect_is_offscreen = [&](Animations::KeyframeEffect const& effect, Element const& target) {
+        if (effect.pseudo_element_type().has_value() || target.namespace_uri() != Namespace::HTML
+            || target.is_document_element() || &target == body())
+            return false;
+
+        // NB: Only properties whose changes are confined to painting are eligible. In particular, color can
+        //     affect SVG stroke geometry, and filters and transforms can bring offscreen pixels into view.
+        bool paint_stays_within_border_box = true;
+        for (auto const& property : effect.target_properties()) {
+            switch (property.id()) {
+            case CSS::PropertyID::BackgroundColor:
+            case CSS::PropertyID::BackgroundPositionX:
+            case CSS::PropertyID::BackgroundPositionY:
+            case CSS::PropertyID::BackgroundSize:
+            case CSS::PropertyID::BackgroundRepeat:
+            case CSS::PropertyID::BackgroundOrigin:
+            case CSS::PropertyID::BackgroundClip:
+            case CSS::PropertyID::BackgroundBlendMode:
+            case CSS::PropertyID::BorderTopColor:
+            case CSS::PropertyID::BorderRightColor:
+            case CSS::PropertyID::BorderBottomColor:
+            case CSS::PropertyID::BorderLeftColor:
+                break;
+            case CSS::PropertyID::BoxShadow:
+            case CSS::PropertyID::OutlineColor:
+            case CSS::PropertyID::OutlineOffset:
+            case CSS::PropertyID::OutlineStyle:
+            case CSS::PropertyID::OutlineWidth:
+            case CSS::PropertyID::TextDecorationColor:
+            case CSS::PropertyID::TextDecorationStyle:
+            case CSS::PropertyID::TextDecorationThickness:
+                paint_stays_within_border_box = false;
+                break;
+            default:
+                return false;
+            }
+        }
+
+        auto const* layout_node = target.unsafe_layout_node();
+        if (!layout_node || !layout_node->is_box())
+            return false;
+
+        // NB: A descendant can explicitly inherit even a normally non-inherited paint property. Reject
+        //     content that can escape ancestor clips or be rendered elsewhere through SVG references.
+        bool subtree_can_escape = false;
+        layout_node->for_each_in_inclusive_subtree_of_type<Layout::NodeWithStyle>([&](auto const& descendant) {
+            if (descendant.is_svg_box() || descendant.is_fixed_position()
+                || (&descendant != layout_node && descendant.is_absolutely_positioned())) {
+                subtree_can_escape = true;
+                return TraversalDecision::Break;
+            }
+            return TraversalDecision::Continue;
+        });
+        if (subtree_can_escape)
+            return false;
+
+        auto viewport_bounds = CSSPixelRect { { 0, 0 }, viewport_rect().size() };
+        auto rect_to_viewport_transform = Painting::rect_to_viewport_transform(*this, visual_context_tree);
+        auto bounds_in_viewport = [&](Layout::Node const& node) -> CSSPixelRect {
+            return Layout::RustFFI::layout_arena_bounding_client_rect(
+                node.arena_handle(), Layout::Node::slot_id(&node), rect_to_viewport_transform);
+        };
+        for (auto const* ancestor = layout_node; ancestor; ancestor = ancestor->parent()) {
+            // NB: Compositor transforms and sticky positioning can move content without resampling its style.
+            //     Filters outside a clip can also expand otherwise clipped paint back into the viewport.
+            if (ancestor->has_css_transform() || ancestor->perspective().has_value() || ancestor->is_sticky_position()
+                || ancestor->filter().has_filters())
+                return false;
+            if (auto const* element = as_if<Element>(ancestor->dom_node())) {
+                if (in_effect_transform_effects_by_target.contains(element))
+                    return false;
+                if (auto effects = competing_effects.get(*element); effects.has_value() && effects->filter.winner)
+                    return false;
+            }
+        }
+        auto visible_bounds = viewport_bounds;
+        for (auto const* container = layout_node->containing_block(); container; container = container->containing_block()) {
+            if (container->overflow_x() == CSS::Overflow::Visible || container->overflow_y() == CSS::Overflow::Visible)
+                continue;
+            if (container->overflow_x() == CSS::Overflow::Clip || container->overflow_y() == CSS::Overflow::Clip) {
+                auto const& margin = container->style_group<CSS::ComputedValues::MiscResetValues>().overflow_clip_margin;
+                if (margin.top.offset != 0 || margin.right.offset != 0 || margin.bottom.offset != 0 || margin.left.offset != 0)
+                    continue;
+            }
+            visible_bounds = visible_bounds.intersected(bounds_in_viewport(*container));
+            if (visible_bounds.is_empty())
+                return true;
+        }
+
+        // NB: Otherwise, only a leaf box with bounded paint can be proven invisible from its own bounds.
+        return paint_stays_within_border_box && !layout_node->has_children()
+            && !bounds_in_viewport(*layout_node).intersects(visible_bounds);
     };
 
     auto observation_has_another_transform_animation = [&](Element const& animated_target, Element const& observation_target, Animations::KeyframeEffect const& current_effect) {
@@ -8370,6 +8465,20 @@ void Document::update_compositor_animations()
         if (animation.is_idle() || (!effect.is_in_effect() && !effect.is_in_the_before_phase()))
             continue;
         auto& target = abstract_target->element();
+
+        bool can_throttle_paint_only_effect = animation.play_state() == Bindings::AnimationPlayState::Running
+            && !animation.pending() && animation.playback_rate() > 0 && isfinite(animation.playback_rate())
+            && animation.timeline() && animation.timeline()->is_monotonically_increasing()
+            && effect.is_in_the_active_phase()
+            && effect.start_delay().type == Animations::TimeValue::Type::Milliseconds
+            && effect.iteration_duration().type == Animations::TimeValue::Type::Milliseconds
+            && effect.iteration_duration().value > 0 && isfinite(effect.iteration_duration().value)
+            && effect.end_delay().value == 0;
+        if (can_throttle_paint_only_effect && paint_only_effect_is_offscreen(effect, target)) {
+            effect.set_is_offscreen_throttled(true);
+            schedule_next_phase_wakeup(effect, animation);
+            continue;
+        }
 
         bool targets_opacity = effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity));
         bool targets_background_color = effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::BackgroundColor));

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7863,11 +7863,6 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
             VERIFY_NOT_REACHED();
         }();
         auto visual_context_node_indices = Painting::rust_visual_animation_target_node_indices(*layout_node, visual_context_tree, ffi_target_kind);
-        if (visual_context_node_indices.is_empty()) {
-            if (missing_visual_context_node)
-                *missing_visual_context_node = true;
-            return {};
-        }
 
         Compositor::VisualAnimation visual_animation {
             .target_kind = target_kind,
@@ -7886,8 +7881,15 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
             .easing = Compositor::VisualAnimationEasing::from_css(effect.timing_function()),
             .keyframes = move(keyframes),
         };
-        if (!visual_animation.is_valid())
+        // NB: Validate the animation before requesting a missing target node. Otherwise an unsupported
+        //     animation can repeatedly force and release that node while retrying compositor selection.
+        if (!visual_animation.has_valid_animation_parameters())
             return {};
+        if (visual_animation.visual_context_node_indices.is_empty()) {
+            if (missing_visual_context_node)
+                *missing_visual_context_node = true;
+            return {};
+        }
         return visual_animation;
     };
 

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-missing-endpoint.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-missing-endpoint.txt
@@ -1,0 +1,3 @@
+animations stay on the main thread: true
+complete keyframes use the compositor: true
+removing the endpoint returns to the main thread: true

--- a/Tests/LibWeb/Text/expected/css/offscreen-paint-only-animation-events.txt
+++ b/Tests/LibWeb/Text/expected/css/offscreen-paint-only-animation-events.txt
@@ -1,0 +1,11 @@
+finite and infinite offscreen paint animations build no overlays: true
+animation listeners do not keep the frame pump running: true
+offscreen paint animations publish no compositor descriptors: true
+animation event wake-up is armed: true
+early wake-up requests no frame: true
+finite and infinite offscreen animations dispatch iteration: true
+iteration needs no animated style overlays: true
+finite offscreen animations dispatch their end events: true
+finite offscreen animation finishes: true
+finite offscreen animation applies its final color: true
+offscreen animation dispatches cancellation: true

--- a/Tests/LibWeb/Text/expected/css/offscreen-paint-only-animation.txt
+++ b/Tests/LibWeb/Text/expected/css/offscreen-paint-only-animation.txt
@@ -1,0 +1,15 @@
+offscreen background builds no overlays: true
+offscreen background stops the frame pump: true
+computed style samples the current color: true
+scrolling into view samples the current color: true
+visible background resumes the frame pump: true
+scrolling out of view stops the frame pump again: true
+paint outside a nested scrollport stops the frame pump: true
+scrolling a nested scrollport resumes visible paint: true
+visible fixed descendant keeps inherited paint updating: true
+ancestor filter animation keeps paint updating even before it expands: true
+mixed layout and paint animation keeps updating: true
+offscreen clipped shadow stops the frame pump: true
+expanded overflow clip keeps potentially visible shadow updating: true
+horizontal clip does not hide vertical shadow overflow: true
+unclipped shadow that can reach the viewport keeps updating: true

--- a/Tests/LibWeb/Text/input/css/compositor-animation-forced-effects-frame-removal.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-forced-effects-frame-removal.html
@@ -23,6 +23,7 @@
         document.elementFromPoint(0, 0);
 
         const target = stale.children[stale.children.length - 2];
+        target.scrollIntoView();
         const staleChildren = [...stale.children].filter(child => child !== target && child !== dummy);
         const staleAnimations = staleChildren.map(child => child.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 100000 }));
         target.animate([{ backgroundColor: "rgb(255, 0, 0)" }, { backgroundColor: "rgb(0, 0, 255)" }], { duration: 100000 });

--- a/Tests/LibWeb/Text/input/css/compositor-animation-missing-endpoint.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-missing-endpoint.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes loading {
+        0%, 40%, 90% { background-color: rgb(35, 35, 35); }
+        70% { background-color: rgb(65, 65, 65); }
+    }
+    @keyframes filter-loading {
+        0%, 40%, 90% { filter: none; }
+        70% { filter: blur(1px); }
+    }
+    .target {
+        width: 20px;
+        height: 20px;
+    }
+    #target {
+        animation: loading 4s linear infinite;
+    }
+    #filter-target {
+        animation: filter-loading 4s linear infinite;
+    }
+</style>
+<div id="target" class="target"></div>
+<div id="filter-target" class="target"></div>
+<script>
+    asyncTest(async done => {
+        await Promise.all(document.getAnimations().map(animation => animation.ready));
+        internals.updateCompositorAnimations();
+        println(`animations stay on the main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 0}`);
+        const backgroundAnimation = document.getElementById("target").getAnimations()[0];
+        backgroundAnimation.effect.setKeyframes([
+            { backgroundColor: "rgb(35, 35, 35)", offset: 0 },
+            { backgroundColor: "rgb(65, 65, 65)", offset: 1 },
+        ]);
+        internals.updateCompositorAnimations();
+        println(`complete keyframes use the compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
+
+        backgroundAnimation.effect.setKeyframes([
+            { backgroundColor: "rgb(35, 35, 35)", offset: 0 },
+            { backgroundColor: "rgb(65, 65, 65)", offset: 0.7 },
+        ]);
+        internals.updateCompositorAnimations();
+        println(`removing the endpoint returns to the main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 0}`);
+        for (const animation of document.getAnimations())
+            animation.cancel();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/offscreen-paint-only-animation-events.html
+++ b/Tests/LibWeb/Text/input/css/offscreen-paint-only-animation-events.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes loading {
+        0%, 40%, 90% { background-color: rgb(35, 35, 35); }
+        70% { background-color: rgb(65, 65, 65); }
+    }
+    @keyframes finite-color {
+        from { background-color: rgb(0, 0, 0); }
+        to { background-color: rgb(200, 0, 0); }
+    }
+    .target { position: absolute; top: 200vh; width: 20px; height: 20px; }
+    #infinite { animation: loading 1s linear infinite; }
+    #finite { animation: finite-color 3s linear forwards; }
+    #repeated { animation: finite-color 1s linear 3 forwards; }
+</style>
+<div id="infinite" class="target"></div>
+<div id="finite" class="target"></div>
+<div id="repeated" class="target"></div>
+<script>
+    asyncTest(async done => {
+        const events = [];
+        document.addEventListener("animationiteration", event => events.push(`iteration ${event.elapsedTime}`));
+        document.addEventListener("animationend", event => events.push(`end ${event.elapsedTime}`));
+        document.addEventListener("animationcancel", () => events.push("cancel"));
+        const timeline = internals.createInternalAnimationTimeline();
+        const animations = document.getAnimations();
+        for (const animation of animations) {
+            animation.timeline = timeline;
+            animation.startTime = 0;
+        }
+        timeline.setTime(0);
+        timeline.setTimeForObservation(0);
+        const nextFrame = () => new Promise(requestAnimationFrame);
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        let counters = internals.getStyleInvalidationCounters();
+        println(`finite and infinite offscreen paint animations build no overlays: ${counters.animatedStyleOverlayBuilds === 0}`);
+        println(`animation listeners do not keep the frame pump running: ${counters.animationFramePumpRequests === 0}`);
+        println(`offscreen paint animations publish no compositor descriptors: ${counters.compositorVisualAnimations === 0}`);
+        println(`animation event wake-up is armed: ${counters.compositorAnimationWakeupTimerActive}`);
+
+        timeline.setTimeForObservation(999);
+        internals.fireCompositorAnimationWakeupForTesting(999);
+        println(`early wake-up requests no frame: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 0}`);
+        timeline.setTimeForObservation(1000);
+        internals.fireCompositorAnimationWakeupForTesting(1000);
+        timeline.setTime(1000);
+        await nextFrame();
+        println(`finite and infinite offscreen animations dispatch iteration: ${events.filter(event => event === "iteration 1").length === 2}`);
+        println(`iteration needs no animated style overlays: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
+
+        timeline.setTimeForObservation(3001);
+        internals.fireCompositorAnimationWakeupForTesting(3001);
+        timeline.setTime(3001);
+        await nextFrame();
+        println(`finite offscreen animations dispatch their end events: ${events.filter(event => event === "end 3").length === 2}`);
+        println(`finite offscreen animation finishes: ${finite.getAnimations()[0].playState === "finished"}`);
+        println(`finite offscreen animation applies its final color: ${getComputedStyle(finite).backgroundColor === "rgb(200, 0, 0)"}`);
+        for (const animation of animations)
+            animation.cancel();
+        await nextFrame();
+        println(`offscreen animation dispatches cancellation: ${events.includes("cancel")}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/offscreen-paint-only-animation.html
+++ b/Tests/LibWeb/Text/input/css/offscreen-paint-only-animation.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    .target { position: absolute; top: 200vh; width: 100px; height: 100px; }
+</style>
+<script>
+    asyncTest(async done => {
+        const nextFrame = () => new Promise(requestAnimationFrame);
+        async function settle() {
+            for (let i = 0; i < 4; ++i)
+                await nextFrame();
+        }
+        async function countersOverFrames() {
+            internals.resetStyleInvalidationCounters();
+            await settle();
+            return internals.getStyleInvalidationCounters();
+        }
+        const timeline = internals.createInternalAnimationTimeline();
+        timeline.setTime(0);
+        timeline.setTimeForObservation(0);
+        const target = document.createElement("div");
+        target.className = "target";
+        document.body.append(target);
+        const animation = new Animation(new KeyframeEffect(target, [
+            { backgroundColor: "rgb(0, 0, 0)", offset: 0 },
+            { backgroundColor: "rgb(200, 0, 0)", offset: 0.8 },
+        ], { duration: 1000, iterations: Infinity }), timeline);
+        animation.play();
+        animation.startTime = 0;
+        await settle();
+        let counters = await countersOverFrames();
+        println(`offscreen background builds no overlays: ${counters.animatedStyleOverlayBuilds === 0}`);
+        println(`offscreen background stops the frame pump: ${counters.animationFramePumpRequests === 0}`);
+
+        timeline.setTimeForObservation(400);
+        println(`computed style samples the current color: ${getComputedStyle(target).backgroundColor === "rgb(100, 0, 0)"}`);
+        timeline.setTime(600);
+        timeline.setTimeForObservation(600);
+        target.scrollIntoView();
+        await settle();
+        println(`scrolling into view samples the current color: ${getComputedStyle(target).backgroundColor === "rgb(150, 0, 0)"}`);
+        counters = await countersOverFrames();
+        println(`visible background resumes the frame pump: ${counters.animationFramePumpRequests > 0}`);
+
+        scrollTo(0, 0);
+        await settle();
+        counters = await countersOverFrames();
+        println(`scrolling out of view stops the frame pump again: ${counters.animationFramePumpRequests === 0}`);
+
+        const scroller = document.createElement("div");
+        scroller.style.cssText = "width: 100px; height: 20px; overflow: auto";
+        target.replaceWith(scroller);
+        scroller.append(target);
+        target.style.cssText = "position: relative; top: 40px";
+        await settle();
+        counters = await countersOverFrames();
+        println(`paint outside a nested scrollport stops the frame pump: ${counters.animationFramePumpRequests === 0}`);
+        scroller.scrollTop = 40;
+        await settle();
+        counters = await countersOverFrames();
+        println(`scrolling a nested scrollport resumes visible paint: ${counters.animationFramePumpRequests > 0}`);
+        scroller.replaceWith(target);
+        target.style.cssText = "";
+
+        const child = document.createElement("div");
+        child.style.cssText = "position: fixed; top: 0; width: 20px; height: 20px; background-color: inherit";
+        target.append(child);
+        await settle();
+        counters = await countersOverFrames();
+        println(`visible fixed descendant keeps inherited paint updating: ${counters.animationFramePumpRequests > 0}`);
+        child.remove();
+
+        const wrapper = document.createElement("div");
+        target.replaceWith(wrapper);
+        wrapper.append(target);
+        const filterAnimation = new Animation(new KeyframeEffect(wrapper, [
+            { filter: "none" },
+            { filter: "blur(100px)" },
+        ], { duration: 1000, iterations: Infinity }), timeline);
+        filterAnimation.play();
+        filterAnimation.startTime = 600;
+        await settle();
+        counters = await countersOverFrames();
+        println(`ancestor filter animation keeps paint updating even before it expands: ${counters.animationFramePumpRequests > 0}`);
+        filterAnimation.cancel();
+        wrapper.replaceWith(target);
+
+        animation.effect.setKeyframes([
+            { backgroundColor: "rgb(0, 0, 0)", width: "100px" },
+            { backgroundColor: "rgb(200, 0, 0)", width: "200px" },
+        ]);
+        await settle();
+        counters = await countersOverFrames();
+        println(`mixed layout and paint animation keeps updating: ${counters.animationFramePumpRequests > 0}`);
+        animation.cancel();
+        target.remove();
+
+        const clip = document.createElement("div");
+        clip.className = "target";
+        clip.style.overflow = "hidden";
+        const shadow = document.createElement("div");
+        shadow.style.cssText = "width: 20px; height: 20px";
+        clip.append(shadow);
+        document.body.append(clip);
+        const shadowAnimation = new Animation(new KeyframeEffect(shadow, [
+            { boxShadow: "0 0 0 0 red" },
+            { boxShadow: "0 -200vh 0 0 blue" },
+        ], { duration: 1000, iterations: Infinity }), timeline);
+        shadowAnimation.play();
+        shadowAnimation.startTime = 0;
+        await settle();
+        counters = await countersOverFrames();
+        println(`offscreen clipped shadow stops the frame pump: ${counters.animationFramePumpRequests === 0}`);
+        clip.style.cssText += "; overflow: clip; overflow-clip-margin: 300vh";
+        await settle();
+        counters = await countersOverFrames();
+        println(`expanded overflow clip keeps potentially visible shadow updating: ${counters.animationFramePumpRequests > 0}`);
+        clip.style.cssText += "; overflow-clip-margin: 0px; overflow-x: clip; overflow-y: visible";
+        await settle();
+        counters = await countersOverFrames();
+        println(`horizontal clip does not hide vertical shadow overflow: ${counters.animationFramePumpRequests > 0}`);
+        clip.style.overflow = "visible";
+        await settle();
+        counters = await countersOverFrames();
+        println(`unclipped shadow that can reach the viewport keeps updating: ${counters.animationFramePumpRequests > 0}`);
+        shadowAnimation.cancel();
+        clip.remove();
+        done();
+    });
+</script>


### PR DESCRIPTION
Netflix’s loading animations omit their final background-color keyframe, causing compositor selection to repeatedly create and remove target nodes until the stack overflows. Validate animation parameters before requesting those nodes.

Throttle eligible offscreen paint-only animations while preserving style observations, scrolling into view, and animation events. On Netflix, settled animation frame requests dropped from 120 to 5 over two seconds, with zero animated-style overlays built in that interval. The remaining requests deliver iteration events.
