### PR TITLE
Libweb: Improve performance of DOM node insertion and removal

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -350,6 +350,7 @@ set(SOURCES
     DOM/Slottable.cpp
     DOM/StaticNodeList.cpp
     DOM/StaticRange.cpp
+    DOM/SubtreeInsertionScope.cpp
     DOM/StyleElementBase.cpp
     DOM/Text.cpp
     DOM/TreeWalker.cpp

--- a/Libraries/LibWeb/CSS/Invalidation/FormControlInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/FormControlInvalidator.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/CSS/StyleEngineInput.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/SubtreeInsertionScope.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/HTMLFieldSetElement.h>
 #include <LibWeb/HTML/HTMLFormElement.h>
@@ -70,7 +71,13 @@ void invalidate_style_after_validity_change(DOM::Element& element)
         if (auto form = html_element->form())
             visit(*form);
     }
+    auto* subtree_insertion_scope = element.document().subtree_insertion_scope();
     for (auto ancestor = element.parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+        if (subtree_insertion_scope && ancestor.ptr() == &subtree_insertion_scope->parent()) {
+            for (auto const& fieldset : subtree_insertion_scope->inclusive_fieldset_ancestors_of_parent())
+                visit(fieldset);
+            return;
+        }
         if (is<HTML::HTMLFieldSetElement>(*ancestor))
             visit(*ancestor);
     }

--- a/Libraries/LibWeb/CSS/Invalidation/PseudoClassInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/PseudoClassInvalidator.cpp
@@ -90,6 +90,40 @@ void invalidate_style_after_pseudo_class_state_change(CSS::PseudoClass pseudo_cl
     walk_and_invalidate(new_state, old_chain, true);
 }
 
+struct PropagatingState {
+    CSS::PseudoClass pseudo_class;
+    GC::Ptr<DOM::Node> source;
+};
+
+static Array<PropagatingState, 2> propagating_states(DOM::Document& document)
+{
+    return { {
+        { CSS::PseudoClass::FocusWithin, document.focused_area() },
+        { CSS::PseudoClass::Hover, document.hovered_node() },
+    } };
+}
+
+static bool subtree_holds_propagating_state_source(DOM::Node const& subtree, CSS::PseudoClass pseudo_class, DOM::Node const& source)
+{
+    if (ancestor_traversal_for_pseudo_class(pseudo_class) == AncestorTraversal::FlatTree) {
+        for (auto const* node = &source; node; node = node->flat_tree_parent()) {
+            if (node == &subtree)
+                return true;
+        }
+        return false;
+    }
+    return subtree.is_shadow_including_inclusive_ancestor_of(source);
+}
+
+bool descendants_hold_a_propagating_state_source(DOM::Node& node)
+{
+    for (auto const& [pseudo_class, source] : propagating_states(node.document())) {
+        if (source && source.ptr() != &node && subtree_holds_propagating_state_source(node, pseudo_class, *source))
+            return true;
+    }
+    return false;
+}
+
 // A state that propagates to ancestors is a statement about the subtree below them, so moving a
 // subtree that holds one moves the state: the chain above where it was stops holding it and the
 // chain above where it landed starts, and no feature of any element in either chain moved to say
@@ -97,7 +131,6 @@ void invalidate_style_after_pseudo_class_state_change(CSS::PseudoClass pseudo_cl
 // than being told a transition.
 void invalidate_style_after_subtree_place_changed(DOM::Node& subtree, GC::Ptr<DOM::Node> old_parent)
 {
-    auto& document = subtree.document();
     auto republish = [](CSS::PseudoClass pseudo_class, GC::Ptr<DOM::Node> from) {
         if (!from)
             return;
@@ -111,30 +144,8 @@ void invalidate_style_after_subtree_place_changed(DOM::Node& subtree, GC::Ptr<DO
         });
     };
 
-    struct PropagatingState {
-        CSS::PseudoClass pseudo_class;
-        GC::Ptr<DOM::Node> source;
-    };
-    Array<PropagatingState, 2> const states { {
-        { CSS::PseudoClass::FocusWithin, document.focused_area() },
-        { CSS::PseudoClass::Hover, document.hovered_node() },
-    } };
-    for (auto const& [pseudo_class, source] : states) {
-        if (!source)
-            continue;
-        auto traversal = ancestor_traversal_for_pseudo_class(pseudo_class);
-        bool source_is_in_subtree = false;
-        if (traversal == AncestorTraversal::FlatTree) {
-            for (auto* node = source.ptr(); node; node = node->flat_tree_parent()) {
-                if (node == &subtree) {
-                    source_is_in_subtree = true;
-                    break;
-                }
-            }
-        } else {
-            source_is_in_subtree = subtree.is_shadow_including_inclusive_ancestor_of(*source);
-        }
-        if (!source_is_in_subtree)
+    for (auto const& [pseudo_class, source] : propagating_states(subtree.document())) {
+        if (!source || !subtree_holds_propagating_state_source(subtree, pseudo_class, *source))
             continue;
         republish(pseudo_class, source);
         republish(pseudo_class, old_parent);

--- a/Libraries/LibWeb/CSS/Invalidation/PseudoClassInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/PseudoClassInvalidator.h
@@ -14,5 +14,6 @@ namespace Web::CSS::Invalidation {
 
 void invalidate_style_after_pseudo_class_state_change(CSS::PseudoClass, GC::Ptr<DOM::Node> old_state, GC::Ptr<DOM::Node> new_state);
 void invalidate_style_after_subtree_place_changed(DOM::Node& subtree, GC::Ptr<DOM::Node> old_parent);
+bool descendants_hold_a_propagating_state_source(DOM::Node&);
 
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -452,7 +452,6 @@ void StyleComputer::unregister_style_node(StyleNodeID style_node_id)
 {
     if (style_node_id != 0 && style_node_id.value() < m_style_nodes.size()) {
         m_style_nodes[style_node_id.value()] = nullptr;
-        m_style_engine.cancel_preallocated_style_node(style_node_id);
         m_style_engine.consume_recorded_element_style_input_change(style_node_id);
     }
 }

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -73,9 +73,6 @@ public:
     [[nodiscard]] bool has_deferred_element_initial_features(StyleNodeID style_node) const { return m_nodes_with_pending_initial_features.contains(style_node); }
     HashTable<StyleNodeID> take_deferred_element_initial_features();
     HashTable<StyleNodeID> take_elements_awaiting_first_style_computation();
-    void mark_style_node_preallocated(StyleNodeID style_node, TreeScopeID tree_scope) { m_preallocated_style_nodes.set(style_node, tree_scope); }
-    Optional<TreeScopeID> consume_preallocated_style_node(StyleNodeID style_node) { return m_preallocated_style_nodes.take(style_node); }
-    void cancel_preallocated_style_node(StyleNodeID style_node) { m_preallocated_style_nodes.remove(style_node); }
 
     void set_element_parts(StyleNodeID node, ReadonlySpan<StyleAtomID> names, ReadonlySpan<StyleNodeID> hosts);
     void set_element_language(StyleNodeID node, StyleAtomID language, Utf16View tag);
@@ -300,7 +297,6 @@ private:
     u64 m_attribute_value_text_requirements_version { 0 };
     HashTable<StyleNodeID> m_nodes_with_pending_initial_features;
     HashTable<StyleNodeID> m_nodes_awaiting_first_style_computation;
-    HashMap<StyleNodeID, TreeScopeID> m_preallocated_style_nodes;
     size_t m_element_match_capacity { 64 };
 
     Vector<StyleEngineFFI::FfiTreeDelta> m_tree_deltas;

--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -181,39 +181,22 @@ static StyleEngineFFI::FfiTreeRelations detached_relations()
     };
 }
 
-void record_element_connected(DOM::Element& element)
+static void record_element_arrival_delta(DOM::Element& element, StyleEngine& style_engine, TreeScopeID tree_scope)
 {
-    auto* style_engine = style_engine_for(element);
-    if (!style_engine)
-        return;
-    Optional<TreeScopeID> preallocated_tree_scope;
-    if (element.style_node_id() == no_style_node) {
-        element.set_style_node_id(style_engine->allocate_style_node());
-        element.document().style_computer().register_style_node(element.style_node_id(), element);
-    } else {
-        preallocated_tree_scope = style_engine->consume_preallocated_style_node(element.style_node_id());
-        if (!preallocated_tree_scope.has_value()) {
-            // Already connected as far as the engine is concerned. Re-recording an insertion would
-            // double-link the element into its sibling sequence.
-            return;
-        }
-    }
     // A shadow root that took its identity before its host had one is still waiting to be linked to
     // it. A sheet adopted into a shadow tree names that root, so the root can be identified first,
     // and the link is what lets a `:host` or `::slotted()` rule in that tree reach the host instead
     // of the document.
     if (auto shadow_root = element.shadow_root(); shadow_root && shadow_root->style_node_id() != no_style_node)
-        style_engine->set_shadow_root(element.style_node_id(), shadow_root->style_node_id());
-    style_engine->record_tree_delta({
+        style_engine.set_shadow_root(element.style_node_id(), shadow_root->style_node_id());
+    style_engine.record_tree_delta({
         .node = element.style_node_id().value(),
         .old_connected = false,
         .new_connected = true,
         .old_relations = detached_relations(),
-        .new_relations = preallocated_tree_scope.has_value()
-            ? relations_of(element, *style_engine, *preallocated_tree_scope)
-            : relations_of(element, *style_engine),
+        .new_relations = relations_of(element, style_engine, tree_scope),
     });
-    style_engine->defer_element_initial_features(element.style_node_id());
+    style_engine.defer_element_initial_features(element.style_node_id());
 
     // A slot can take its identity after the nodes assigned to it took theirs - a shadow tree built
     // from markup assigns before the slot connects - and a slottable's assignment is published as
@@ -239,43 +222,63 @@ void publish_pending_element_features(StyleEngine& style_engine, StyleComputer& 
     }
 }
 
-void prepare_style_nodes_for_subtree(DOM::Node& root)
+void record_element_connected(DOM::Element& element)
+{
+    auto* style_engine = style_engine_for(element);
+    if (!style_engine || element.style_node_id() != no_style_node)
+        return;
+    element.set_style_node_id(style_engine->allocate_style_node());
+    element.document().style_computer().register_style_node(element.style_node_id(), element);
+    record_element_arrival_delta(element, *style_engine, tree_scope_of(element.root()));
+}
+
+void record_subtree_connecting(DOM::Node& root)
 {
     if (!root.parent() || !root.parent()->is_connected())
         return;
     auto& style_computer = root.document().style_computer();
     auto& style_engine = style_computer.style_engine();
-    Vector<GC::Ptr<DOM::Element>> elements;
-    Vector<TreeScopeID> element_tree_scopes;
-    Vector<GC::Ptr<DOM::ShadowRoot>> shadow_roots;
-    Vector<TreeScopeID> shadow_root_tree_scopes;
+    struct Arrival {
+        GC::Ref<DOM::Node> node;
+        TreeScopeID tree_scope;
+    };
+    Vector<Arrival, 64> arrivals;
+    size_t element_count = 0;
     auto collect = [&](DOM::Node& node, TreeScopeID tree_scope) {
         if (auto* element = as_if<DOM::Element>(node); element && element->style_node_id() == no_style_node) {
-            elements.append(element);
-            element_tree_scopes.append(tree_scope);
+            arrivals.append({ *element, tree_scope });
+            ++element_count;
         } else if (auto* shadow_root = as_if<DOM::ShadowRoot>(node); shadow_root && shadow_root->style_node_id() == no_style_node) {
-            shadow_roots.append(shadow_root);
-            shadow_root_tree_scopes.append(tree_scope);
+            arrivals.append({ *shadow_root, tree_scope });
         }
     };
-    auto root_tree_scope = tree_scope_of(root.root());
-    for_each_shadow_including_inclusive_descendant_with_scope(root, root_tree_scope, collect);
-    Vector<StyleNodeID> identities;
-    identities.resize(elements.size() + shadow_roots.size());
+    for_each_shadow_including_inclusive_descendant_with_scope(root, tree_scope_of(root.root()), collect);
+    if (arrivals.is_empty())
+        return;
+
+    Vector<StyleNodeID, 64> identities;
+    identities.resize(arrivals.size());
     style_engine.allocate_style_nodes(identities.span());
-    if (!identities.is_empty())
-        style_computer.ensure_style_node_slot(identities.last());
-    for (size_t index = 0; index < elements.size(); ++index) {
-        auto& element = *elements[index];
-        element.set_style_node_id(identities[index]);
-        style_computer.register_style_node(identities[index], element);
-        style_engine.mark_style_node_preallocated(element.style_node_id(), element_tree_scopes[index]);
+    style_computer.ensure_style_node_slot(identities.last());
+    size_t next_element_identity = 0;
+    size_t next_shadow_root_identity = element_count;
+    for (auto const& arrival : arrivals) {
+        if (auto* element = as_if<DOM::Element>(*arrival.node)) {
+            auto identity = identities[next_element_identity++];
+            element->set_style_node_id(identity);
+            style_computer.register_style_node(identity, *element);
+        } else {
+            auto identity = identities[next_shadow_root_identity++];
+            as<DOM::ShadowRoot>(*arrival.node).set_style_node_id(identity);
+            style_engine.set_tree_scope_root(arrival.tree_scope, identity);
+        }
     }
-    for (size_t index = 0; index < shadow_roots.size(); ++index) {
-        auto& shadow_root = *shadow_roots[index];
-        auto identity = identities[elements.size() + index];
-        shadow_root.set_style_node_id(identity);
-        style_engine.set_tree_scope_root(shadow_root_tree_scopes[index], identity);
+
+    // An arrival names the element's parent and siblings, so every identity in the subtree is
+    // assigned before the first arrival is recorded.
+    for (auto const& arrival : arrivals) {
+        if (auto* element = as_if<DOM::Element>(*arrival.node))
+            record_element_arrival_delta(*element, style_engine, arrival.tree_scope);
     }
 }
 

--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -1165,19 +1165,20 @@ void record_shadow_root_disconnecting(DOM::ShadowRoot& shadow_root)
 void record_subtree_disconnecting(DOM::Node& root)
 {
     auto root_tree_scope = tree_scope_of(root.root());
-    auto disconnect_element = [](DOM::Node& node, TreeScopeID tree_scope) {
-        if (auto* element = as_if<DOM::Element>(node))
+    Vector<GC::Ref<DOM::ShadowRoot>> shadow_roots;
+    auto disconnect_element = [&](DOM::Node& node, TreeScopeID tree_scope) {
+        if (auto* element = as_if<DOM::Element>(node)) {
             record_element_disconnecting(*element, tree_scope);
+        } else if (auto* shadow_root = as_if<DOM::ShadowRoot>(node)) {
+            shadow_roots.append(*shadow_root);
+        }
     };
     for_each_shadow_including_inclusive_descendant_with_scope(root, root_tree_scope, disconnect_element);
 
     // Only once no element still names a shadow root as its parent can the root give up its own
     // identity.
-    auto disconnect_shadow_root = [](DOM::Node& node, TreeScopeID) {
-        if (auto* shadow_root = as_if<DOM::ShadowRoot>(node))
-            record_shadow_root_disconnecting(*shadow_root);
-    };
-    for_each_shadow_including_inclusive_descendant_with_scope(root, root_tree_scope, disconnect_shadow_root);
+    for (auto const& shadow_root : shadow_roots)
+        record_shadow_root_disconnecting(shadow_root);
 }
 
 void record_shadow_root_connected(DOM::ShadowRoot& shadow_root)

--- a/Libraries/LibWeb/CSS/StyleEngineInput.h
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.h
@@ -28,10 +28,13 @@ WEB_API void flush_deferred_style_change_events_for_rule(CSSRule&);
 // node identity records nothing at all, which is what keeps disconnected and never-styled content
 // free.
 //
+// Called once a subtree has been linked into a connected tree. Allocates a style node identity for
+// every element and shadow root in it that has none yet, and records the arrival of each element.
+WEB_API void record_subtree_connecting(DOM::Node& root);
+
 // Called once a node has been linked into a connected tree. Allocates the element's style node
 // identity if it does not have one yet.
 WEB_API void record_element_connected(DOM::Element&);
-WEB_API void prepare_style_nodes_for_subtree(DOM::Node&);
 WEB_API void publish_pending_element_features(StyleEngine&, StyleComputer&);
 WEB_API void publish_required_attribute_value_texts(StyleEngine&, StyleComputer&);
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -622,6 +622,9 @@ public:
     bool has_form_or_fieldset_element() const { return m_has_form_or_fieldset_element; }
     void set_has_form_or_fieldset_element() { m_has_form_or_fieldset_element = true; }
 
+    SubtreeInsertionScope* subtree_insertion_scope() const { return m_subtree_insertion_scope; }
+    void set_subtree_insertion_scope(Badge<SubtreeInsertionScope>, SubtreeInsertionScope* scope) { m_subtree_insertion_scope = scope; }
+
     bool parser_cannot_change_the_mode() const { return m_parser_cannot_change_the_mode; }
     void set_parser_cannot_change_the_mode(bool parser_cannot_change_the_mode) { m_parser_cannot_change_the_mode = parser_cannot_change_the_mode; }
 
@@ -1641,6 +1644,7 @@ private:
     bool m_needs_mathml_and_svg_user_agent_style_sheets { false };
     bool m_has_element_with_auto_directionality { false };
     bool m_has_form_or_fieldset_element { false };
+    SubtreeInsertionScope* m_subtree_insertion_scope { nullptr };
 
     bool m_parser_cannot_change_the_mode { false };
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -694,7 +694,8 @@ bool Node::is_closed_shadow_hidden_from(Node const& b) const
 bool Node::is_browsing_context_connected() const
 {
     // A node is browsing-context connected when it is connected and its shadow-including root's browsing context is non-null.
-    return is_connected() && shadow_including_root().document().browsing_context();
+    // NB: A connected node's shadow-including root is its node document.
+    return is_connected() && document().browsing_context();
 }
 
 // https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1055,6 +1055,95 @@ void Node::insert_nodes_before(ReadonlySpan<GC::Root<Node>> nodes, GC::Ptr<Node>
     bump_dom_tree_version();
 }
 
+// https://dom.spec.whatwg.org/#concept-node-insert
+void Node::parser_insert_before(GC::Ref<Node> node, GC::Ptr<Node> child)
+{
+    // AD-HOC: The insertion of one node the parser has just created into a tree that is not connected. Script can
+    //         hold such a tree, so observers, live ranges and collection caches are served, but style, layout, custom
+    //         element reactions and the post-connection steps have nothing to do until the tree is connected.
+
+    VERIFY(!is_connected());
+
+    // 5. If child is non-null:
+    if (child) {
+        // 1. For each live range whose start node is parent and start offset is greater than child’s index:
+        //    increase its start offset by count.
+        // 2. For each live range whose end node is parent and end offset is greater than child’s index:
+        //    increase its end offset by count.
+        auto child_index = child->index();
+        for (auto& range : document().live_ranges()) {
+            if (range.start_container().ptr() == this && range.start_offset() > child_index)
+                range.increase_start_offset(1);
+            if (range.end_container().ptr() == this && range.end_offset() > child_index)
+                range.increase_end_offset(1);
+        }
+    }
+
+    // 6. Let previousSibling be child’s previous sibling or parent’s last child if child is null.
+    GC::Ptr<Node> previous_sibling = child ? child->previous_sibling() : last_child();
+
+    // 7. For each node in nodes, in tree order:
+    // 1. Adopt node into parent’s node document.
+    document().adopt_node_steps(*node);
+
+    // 2. If child is null, then append node to parent’s children.
+    // 3. Otherwise, insert node into parent’s children before child’s index.
+    insert_before_impl(node, child);
+
+    // 4. If parent is a shadow host whose shadow root’s slot assignment is "named" and node is a slottable, then
+    //    assign a slot for node.
+    if (auto* element = as_if<DOM::Element>(*this)) {
+        auto is_named_shadow_host = element->is_shadow_host()
+            && element->shadow_root()->slot_assignment() == SlotAssignmentMode::Named;
+
+        if (is_named_shadow_host && node->is_slottable())
+            assign_a_slot(node->as_slottable());
+    }
+
+    // 5. If parent’s root is a shadow root, and parent is a slot whose assigned nodes is the empty list, then run
+    //    signal a slot change for parent.
+    if (auto* this_slot_element = as_if<HTML::HTMLSlotElement>(*this); this_slot_element && root().is_shadow_root()) {
+        if (this_slot_element->assigned_nodes_internal().is_empty())
+            signal_a_slot_change(*this_slot_element);
+    }
+
+    // AD-HOC: Register any slot elements in the inserted subtree with the shadow root’s slot registry
+    //         before running assign_slottables_for_a_tree, so the registry is up-to-date.
+    if (auto* shadow_root = as_if<ShadowRoot>(node->root())) {
+        node->for_each_in_inclusive_subtree_of_type<HTML::HTMLSlotElement>([&](auto& slot) {
+            shadow_root->register_slot(slot);
+            return TraversalDecision::Continue;
+        });
+    }
+
+    // 6. Run assign slottables for a tree with node’s root.
+    assign_slottables_for_a_tree(node->root());
+
+    // 7. For each shadow-including inclusive descendant inclusiveDescendant of node, in shadow-including tree order:
+    //    1. Run the insertion steps with inclusiveDescendant.
+    //    2. If inclusiveDescendant is not connected, then continue.
+    node->for_each_shadow_including_inclusive_descendant([](Node& inclusive_descendant) {
+        inclusive_descendant.inserted();
+        return TraversalDecision::Continue;
+    });
+
+    // 8. If suppressObservers is false, then queue a tree mutation record for parent with nodes, « », previousSibling,
+    //    and child.
+    // OPTIMIZATION: Without an observer of tree mutations, the root the record needs is never allocated.
+    if (document().has_mutation_observers_of_type(MutationType::childList) || document().page().listen_for_dom_mutations()) {
+        auto single_node = GC::make_root(*node);
+        queue_tree_mutation_record({ &single_node, 1 }, {}, previous_sibling.ptr(), child.ptr());
+    }
+
+    // 9. Run the children changed steps for parent.
+    auto affects_elements = mutation_affects_elements(*node);
+    ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::Inserted, node, affects_elements };
+    children_changed(metadata);
+    invalidate_html_collection_caches_in_ancestors(affects_elements);
+
+    bump_dom_tree_version();
+}
+
 // https://dom.spec.whatwg.org/#concept-node-pre-insert
 WebIDL::ExceptionOr<GC::Ref<Node>> Node::pre_insert(GC::Ref<Node> node, GC::Ptr<Node> child)
 {

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1380,8 +1380,21 @@ public:
     {
         if (!was_connected)
             return;
-        pin_layout_style_records(node);
-        pin_dom_style_records_for_removing_steps(node);
+        node.for_each_shadow_including_inclusive_descendant([&](Node& inclusive_descendant) {
+            if (auto* layout_node = inclusive_descendant.unsafe_layout_node())
+                layout_node->pin_style_record_for_detachment();
+
+            if (auto* element = as_if<Element>(inclusive_descendant)) {
+                pin_dom_style_record(element->style_record_identity());
+                element->for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
+                    if (auto* layout_node = pseudo_element.unsafe_layout_node())
+                        layout_node->pin_style_record_for_detachment();
+                    pin_dom_style_record(pseudo_element.style_record_identity());
+                });
+            }
+
+            return TraversalDecision::Continue;
+        });
     }
 
     void pin_style_records_after_removal(Node& node, bool was_connected)
@@ -1390,11 +1403,6 @@ public:
             return;
         // Detached subtrees do not need DOM-held record pins, but layout nodes can still outlive removing steps and
         // keep their detachment pins.
-        pin_layout_style_records(node);
-    }
-
-    void pin_layout_style_records(Node& node)
-    {
         node.for_each_shadow_including_inclusive_descendant([](Node& inclusive_descendant) {
             if (auto* layout_node = inclusive_descendant.unsafe_layout_node())
                 layout_node->pin_style_record_for_detachment();
@@ -1403,20 +1411,6 @@ public:
                 element->for_each_synthetic_pseudo_element([](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
                     if (auto* layout_node = pseudo_element.unsafe_layout_node())
                         layout_node->pin_style_record_for_detachment();
-                });
-            }
-
-            return TraversalDecision::Continue;
-        });
-    }
-
-    void pin_dom_style_records_for_removing_steps(Node& node)
-    {
-        node.for_each_shadow_including_inclusive_descendant([&](Node& inclusive_descendant) {
-            if (auto* element = as_if<Element>(inclusive_descendant)) {
-                pin_dom_style_record(element->style_record_identity());
-                element->for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
-                    pin_dom_style_record(pseudo_element.style_record_identity());
                 });
             }
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1444,18 +1444,20 @@ private:
     Vector<CSS::StyleRecordID> m_dom_style_record_pins;
 };
 
-void Node::schedule_list_item_renumber_for_removal()
+bool Node::schedule_list_item_renumber_for_removal()
 {
     auto* element = as_if<Element>(*this);
     if (!element)
-        return;
+        return false;
     auto style = element->computed_style();
     // A removed list item can renumber the list-item counter for its list owner's whole list. Removing the final item
     // from a forward counter does not change any surviving counter value.
     if ((is_html_li_element() || (style && style->display().is_list_item()))
         && !final_direct_list_item_does_not_renumber_existing_content(*element)) {
         element->schedule_list_item_renumber_for_list_owner();
+        return true;
     }
+    return false;
 }
 
 void Node::report_removal_to_style_engine(Node& parent)
@@ -2828,6 +2830,8 @@ void Node::remove_all_children(bool suppress_observers)
     bool const track_affected_elements = document().has_valid_html_collection_caches();
     auto affects_elements = ChildrenChangedMetadata::AffectsElements::No;
     bool const a_child_holds_a_propagating_state_source = CSS::Invalidation::descendants_hold_a_propagating_state_source(*this);
+    // Every child has the same list owner, so the first child that renumbers it answers for all of them.
+    bool list_owner_renumber_scheduled = false;
 
     while (GC::Ptr<Node> child = first_child()) {
         // 4. For each NodeIterator object iterator whose root’s node document is node’s node document:
@@ -2843,7 +2847,8 @@ void Node::remove_all_children(bool suppress_observers)
         if (track_affected_elements && mutation_affects_elements(*child) == ChildrenChangedMetadata::AffectsElements::Yes)
             affects_elements = ChildrenChangedMetadata::AffectsElements::Yes;
 
-        child->schedule_list_item_renumber_for_removal();
+        if (!list_owner_renumber_scheduled)
+            list_owner_renumber_scheduled = child->schedule_list_item_renumber_for_removal();
 
         RemovalStyleRecordPins removal_style_record_pins { document().style_computer() };
         removal_style_record_pins.pin_style_records_before_removal(*child, was_connected);

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -944,7 +944,7 @@ void Node::insert_nodes_before(ReadonlySpan<GC::Root<Node>> nodes, GC::Ptr<Node>
         // the chain it lands under.
         CSS::Invalidation::invalidate_style_after_subtree_place_changed(*node_to_insert, nullptr);
 
-        CSS::prepare_style_nodes_for_subtree(*node_to_insert);
+        CSS::record_subtree_connecting(*node_to_insert);
 
         SubtreeInsertionScope subtree_insertion_scope { *this };
 
@@ -2564,11 +2564,11 @@ void Node::inserted()
     if (update_inside_blocking_wheel_event_handler_state())
         set_needs_repaint();
 
-    // The DOM insertion steps visit shadow-including inclusive descendants in tree order, so an
-    // element's parent and preceding siblings already have their identities by the time it records
-    // its own relations.
     if (auto* element = as_if<Element>(*this)) {
-        CSS::record_element_connected(*element);
+        // The content an element clones into its shadow tree from its own insertion steps lands under
+        // a root that connects only when this walk reaches it, so no subtree arrival covered it.
+        if (element->style_node_id() == 0)
+            CSS::record_element_connected(*element);
         if (is<HTML::HTMLSlotElement>(*element)) {
             if (auto parent = element->parent_element())
                 CSS::Invalidation::invalidate_style_after_text_change_under(*parent);

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2561,8 +2561,6 @@ void Node::inserted()
         m_is_connected = parent()->is_connected();
 
     recompute_editable_subtree_flag();
-    if (update_inside_blocking_wheel_event_handler_state())
-        set_needs_repaint();
 
     if (auto* element = as_if<Element>(*this)) {
         // The content an element clones into its shadow tree from its own insertion steps lands under
@@ -2614,7 +2612,6 @@ void Node::removed_from(IsSubtreeRoot, Node* old_parent, Node&)
 
     m_is_connected = false;
     m_in_editable_subtree = false;
-    m_inside_blocking_wheel_event_handler = false;
     if (m_layout_node)
         m_layout_node->pin_style_record_for_detachment();
     clear_committed_layout_box();
@@ -2636,8 +2633,6 @@ void Node::removed_from(IsSubtreeRoot, Node* old_parent, Node&)
 void Node::moved_from(IsSubtreeRoot, GC::Ptr<Node>)
 {
     recompute_editable_subtree_flag();
-    if (update_inside_blocking_wheel_event_handler_state())
-        set_needs_repaint();
 }
 
 static bool is_root_wheel_event_target(Node const& node)
@@ -2658,8 +2653,12 @@ bool Node::update_inside_blocking_wheel_event_handler_state()
 {
     bool const was_inside_blocking_wheel_event_handler = m_inside_blocking_wheel_event_handler;
     m_inside_blocking_wheel_event_handler = false;
-    if (auto* parent = parent_or_shadow_host_node())
+    if (auto* parent = parent_or_shadow_host()) {
+        // A shadow root has no layout box, so the layout tree builder never derives its state.
+        if (is<ShadowRoot>(*parent))
+            parent->update_inside_blocking_wheel_event_handler_state();
         m_inside_blocking_wheel_event_handler = parent->inside_blocking_wheel_event_handler();
+    }
 
     if (!m_inside_blocking_wheel_event_handler && !is_root_wheel_event_target(*this) && has_blocking_wheel_event_listener())
         m_inside_blocking_wheel_event_handler = true;

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -54,6 +54,7 @@
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/StaticNodeList.h>
+#include <LibWeb/DOM/SubtreeInsertionScope.h>
 #include <LibWeb/DOM/XMLDocument.h>
 #include <LibWeb/Editing/EditingHistory.h>
 #include <LibWeb/HTML/CustomElements/CustomElementReactionNames.h>
@@ -944,6 +945,8 @@ void Node::insert_nodes_before(ReadonlySpan<GC::Root<Node>> nodes, GC::Ptr<Node>
         CSS::Invalidation::invalidate_style_after_subtree_place_changed(*node_to_insert, nullptr);
 
         CSS::prepare_style_nodes_for_subtree(*node_to_insert);
+
+        SubtreeInsertionScope subtree_insertion_scope { *this };
 
         // 7. For each shadow-including inclusive descendant inclusiveDescendant of node, in shadow-including tree order:
         node_to_insert->for_each_shadow_including_inclusive_descendant([&](Node& inclusive_descendant) {

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1133,6 +1133,29 @@ void Node::live_range_pre_remove()
     }
 }
 
+void Node::live_range_pre_remove_all_children()
+{
+    for (auto& range : document().live_ranges()) {
+        if (range.start_container().ptr() == this) {
+            range.set_start_offset(0);
+        } else if (is_ancestor_of(range.start_container())) {
+            MUST(range.set_start(*this, 0));
+        }
+        if (range.end_container().ptr() == this) {
+            range.set_end_offset(0);
+        } else if (is_ancestor_of(range.end_container())) {
+            MUST(range.set_end(*this, 0));
+        }
+    }
+}
+
+void Node::run_node_iterator_pre_removing_steps()
+{
+    document().for_each_node_iterator([&](NodeIterator& node_iterator) {
+        node_iterator.run_pre_removing_steps(*this);
+    });
+}
+
 static bool node_contributes_to_layout_tree(Node const& node)
 {
     if (node.unsafe_layout_node())
@@ -1260,6 +1283,23 @@ public:
         release_dom_style_records();
     }
 
+    void pin_style_records_before_removal(Node& node, bool was_connected)
+    {
+        if (!was_connected)
+            return;
+        pin_layout_style_records(node);
+        pin_dom_style_records_for_removing_steps(node);
+    }
+
+    void pin_style_records_after_removal(Node& node, bool was_connected)
+    {
+        if (was_connected)
+            return;
+        // Detached subtrees do not need DOM-held record pins, but layout nodes can still outlive removing steps and
+        // keep their detachment pins.
+        pin_layout_style_records(node);
+    }
+
     void pin_layout_style_records(Node& node)
     {
         node.for_each_shadow_including_inclusive_descendant([](Node& inclusive_descendant) {
@@ -1311,111 +1351,77 @@ private:
     Vector<CSS::StyleRecordID> m_dom_style_record_pins;
 };
 
-// https://dom.spec.whatwg.org/#concept-node-remove
-void Node::remove(bool suppress_observers)
+void Node::schedule_list_item_renumber_for_removal()
 {
-    // NB: Mutations during a recorded editing command must go through the Editing proxy functions.
-    if (auto history = document().editing_history_if_exists())
-        history->notify_dom_mutation();
+    auto* element = as_if<Element>(*this);
+    if (!element)
+        return;
+    auto style = element->computed_style();
+    // A removed list item can renumber the list-item counter for its list owner's whole list. Removing the final item
+    // from a forward counter does not change any surviving counter value.
+    if ((is_html_li_element() || (style && style->display().is_list_item()))
+        && !final_direct_list_item_does_not_renumber_existing_content(*element)) {
+        element->schedule_list_item_renumber_for_list_owner();
+    }
+}
 
-    // 1. Let parent be node’s parent
-    auto* parent = this->parent();
-
-    // 2. Assert: parent is non-null.
-    VERIFY(parent);
-
-    document().flush_deferred_style_change_event();
-    bool const was_connected = is_connected();
-    RemovalStyleRecordPins removal_style_record_pins { document().style_computer() };
-
-    // 3. Run the live range pre-remove steps, given node.
-    live_range_pre_remove();
-
-    // 4. For each NodeIterator object iterator whose root’s node document is node’s node document:
-    //    run the NodeIterator pre-removing steps given node and iterator.
-    document().for_each_node_iterator([&](NodeIterator& node_iterator) {
-        node_iterator.run_pre_removing_steps(*this);
-    });
-
-    // 5. Let oldPreviousSibling be node’s previous sibling.
-    GC::Ptr<Node> old_previous_sibling = previous_sibling();
-
-    // 6. Let oldNextSibling be node’s next sibling.
-    GC::Ptr<Node> old_next_sibling = next_sibling();
-
-    // AD-HOC: A removed list item can renumber the list-item counter for its list owner's whole list.
-    //         Removing the final item from a forward counter does not change any surviving counter value.
-    if (is_element()) {
-        auto* this_element = static_cast<Element*>(this);
-        auto style = this_element->computed_style();
-        if ((is_html_li_element() || (style && style->display().is_list_item()))
-            && !final_direct_list_item_does_not_renumber_existing_content(*this_element)) {
-            this_element->schedule_list_item_renumber_for_list_owner();
+void Node::report_removal_to_style_engine(Node& parent)
+{
+    // A text or comment node leaving connects no element to record a delta from, but it can
+    // leave its parent empty, and `:empty` is about the parent.
+    if (!is<Element>(*this)) {
+        if (auto* parent_element = as_if<Element>(parent)) {
+            auto const* text = as_if<Text>(*this);
+            CSS::record_element_emptiness_changed(*parent_element, *this, text && !text->data().is_empty(), false);
         }
     }
 
-    if (was_connected) {
-        // NB: record_subtree_disconnecting() makes the style engine give up ownership of
-        //     disconnected records before removed_from() clears the DOM-held identities.
-        //     Preserve those identities only across the removing callback window.
-        removal_style_record_pins.pin_layout_style_records(*this);
-        removal_style_record_pins.pin_dom_style_records_for_removing_steps(*this);
+    // NB: Recorded here rather than in removed_from(), because StyleEngine's tree delta carries
+    //     the old relations and this is the last point at which they are still readable.
+    CSS::record_subtree_disconnecting(*this);
+}
 
-        // A text or comment node leaving connects no element to record a delta from, but it can
-        // leave its parent empty, and `:empty` is about the parent.
-        if (!is<Element>(*this)) {
-            if (auto* parent = as_if<Element>(parent_node())) {
-                auto const* text = as_if<Text>(*this);
-                CSS::record_element_emptiness_changed(*parent, *this, text && !text->data().is_empty(), false);
-            }
-        }
+void Node::update_layout_tree_for_removal(Node& parent, LayoutSubtreeRemoval removal, AncestorsMayHaveFirstLetter ancestors_may_have_first_letter)
+{
+    // A display: contents element has no principal layout node of its own, but removing it also removes
+    // all of its children's boxes from the parent's layout subtree.
+    if (!node_contributes_to_layout_tree(*this))
+        return;
 
-        // NB: Recorded here rather than in removed_from(), because StyleEngine's tree delta carries
-        //     the old relations and this is the last point at which they are still readable.
-        CSS::record_subtree_disconnecting(*this);
-
-        // A display: contents element has no principal layout node of its own, but removing it also removes
-        // all of its children's boxes from the parent's layout subtree.
-        // NB: Called during DOM removal, layout is not up to date.
-        if (node_contributes_to_layout_tree(*this)) {
-            // A suppressed-observer removal may be the first half of a compound mutation that immediately reinserts
-            // this node. Keep the old parent on the conservative rebuild path so the later insertion can relocate it.
-            if (auto* first_letter_owner = first_letter_owner_for_layout_subtree_from(*parent)) {
-                first_letter_owner->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeRemove);
-            } else if (!suppress_observers && can_detach_layout_subtree_for_removal(*this, *parent)) {
-                auto* layout_node = unsafe_layout_node();
-                layout_node->for_each_in_inclusive_subtree([](Layout::Node& node) {
-                    node.clear_committed_box();
-                    return TraversalDecision::Continue;
-                });
-                layout_node->prepare_subtree_for_detach_from_layout_tree();
-                VERIFY(Layout::destroy_layout_subtree(*layout_node));
-                if (auto* parent_layout_node = parent->unsafe_layout_node(); !parent_layout_node->has_children())
-                    parent_layout_node->set_children_are_inline(false);
-                parent->set_needs_layout_update(SetNeedsLayoutReason::LayoutTreeUpdate);
-            } else {
-                parent->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeRemove);
-            }
+    if (ancestors_may_have_first_letter == AncestorsMayHaveFirstLetter::Yes) {
+        if (auto* first_letter_owner = first_letter_owner_for_layout_subtree_from(parent)) {
+            first_letter_owner->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeRemove);
+            return;
         }
     }
 
-    // 7. Remove node from its parent’s children.
-    parent->remove_child_impl(*this);
+    if (removal == LayoutSubtreeRemoval::DetachInPlace && can_detach_layout_subtree_for_removal(*this, parent)) {
+        auto* layout_node = unsafe_layout_node();
+        layout_node->for_each_in_inclusive_subtree([](Layout::Node& node) {
+            node.clear_committed_box();
+            return TraversalDecision::Continue;
+        });
+        layout_node->prepare_subtree_for_detach_from_layout_tree();
+        VERIFY(Layout::destroy_layout_subtree(*layout_node));
+        if (auto* parent_layout_node = parent.unsafe_layout_node(); !parent_layout_node->has_children())
+            parent_layout_node->set_children_are_inline(false);
+        parent.set_needs_layout_update(SetNeedsLayoutReason::LayoutTreeUpdate);
+        return;
+    }
 
-    // 8. If node is assigned, then run assign slottables for node’s assigned slot.
+    parent.set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeRemove);
+}
+
+void Node::assign_slottables_after_removal(Node& parent, Node& parent_root)
+{
     if (auto assigned_slot = assigned_slot_for_node(*this))
         assign_slottables(*assigned_slot);
 
-    auto& parent_root = parent->root();
-
-    // 9. If parent’s root is a shadow root, and parent is a slot whose assigned nodes is the empty list, then run
-    //    signal a slot change for parent.
     if (auto* parent_slot_element = as_if<HTML::HTMLSlotElement>(parent); parent_slot_element && parent_root.is_shadow_root()) {
         if (parent_slot_element->assigned_nodes_internal().is_empty())
             signal_a_slot_change(*parent_slot_element);
     }
 
-    // 10. If node has an inclusive descendant that is a slot, then:
     if (auto* shadow_root = as_if<ShadowRoot>(parent_root)) {
         Vector<GC::Ref<HTML::HTMLSlotElement>> descendant_slots;
         for_each_in_inclusive_subtree_of_type<HTML::HTMLSlotElement>([&](auto& slot) {
@@ -1434,36 +1440,23 @@ void Node::remove(bool suppress_observers)
                 assign_slottables(slot);
         }
     }
+}
 
-    // NB: Detached subtrees do not need DOM-held record pins, but layout nodes can still outlive
-    //     removing steps and keep their detachment pins.
-    if (!was_connected)
-        removal_style_record_pins.pin_layout_style_records(*this);
-
-    // 11. Run the removing steps with node, true, and parent.
+void Node::run_removing_steps(Node& parent, Node& parent_root, bool was_connected)
+{
     if (was_connected) {
         if (auto* element = as_if<Element>(*this))
             element->cancel_css_animations_and_transitions();
     }
-    removed_from(IsSubtreeRoot::Yes, parent, parent_root);
+    removed_from(IsSubtreeRoot::Yes, &parent, parent_root);
 
-    // A subtree holding the focused or hovered node takes `:focus-within` and `:hover` out of the
-    // chain it hung off. Nothing about any element in that chain moved, so it has to be told.
-    CSS::Invalidation::invalidate_style_after_subtree_place_changed(*this, parent);
+    bool is_parent_connected = parent.is_connected();
 
-    // 12. Let isParentConnected be parent’s connected.
-    bool is_parent_connected = parent->is_connected();
-
-    // 13. If node is custom and isParentConnected is true, then enqueue a custom element callback reaction with node,
-    //     callback name "disconnectedCallback", and an empty argument list.
-    // Spec Note: It is intentional for now that custom elements do not get parent passed.
-    //            This might change in the future if there is a need.
     if (auto* element = as_if<DOM::Element>(*this)) {
         if (element->is_custom() && is_parent_connected)
             element->enqueue_a_custom_element_callback_reaction(HTML::CustomElementReactionNames::disconnectedCallback);
     }
 
-    // 14. For each shadow-including descendant descendant of node, in shadow-including tree order:
     for_each_shadow_including_descendant([&](Node& descendant) {
         if (was_connected) {
             if (auto* element = as_if<Element>(descendant))
@@ -1471,7 +1464,7 @@ void Node::remove(bool suppress_observers)
         }
 
         // 1. Run the removing steps with descendant, false, and parent.
-        descendant.removed_from(IsSubtreeRoot::No, parent, parent_root);
+        descendant.removed_from(IsSubtreeRoot::No, &parent, parent_root);
 
         // 2. If descendant is custom and isParentConnected is true, then enqueue a custom element callback reaction
         //    with descendant, callback name "disconnectedCallback", and « ».
@@ -1482,14 +1475,11 @@ void Node::remove(bool suppress_observers)
 
         return TraversalDecision::Continue;
     });
+}
 
-    removal_style_record_pins.release_dom_style_records();
-
-    // 15. For each inclusive ancestor inclusiveAncestor of parent, and then for each registered of inclusiveAncestor’s
-    //     registered observer list, if registered’s options["subtree"] is true, then append a new transient registered
-    //     observer whose observer is registered’s observer, options is registered’s options, and source is registered
-    //     to node’s registered observer list.
-    for (auto* inclusive_ancestor = parent; inclusive_ancestor; inclusive_ancestor = inclusive_ancestor->parent()) {
+void Node::add_transient_registered_observers_for_removal(Node& parent)
+{
+    for (auto* inclusive_ancestor = &parent; inclusive_ancestor; inclusive_ancestor = inclusive_ancestor->parent()) {
         auto* registered_observer_list = inclusive_ancestor->registered_observer_list();
         if (!registered_observer_list)
             continue;
@@ -1501,13 +1491,90 @@ void Node::remove(bool suppress_observers)
             }
         }
     }
+}
+
+void Node::queue_tree_mutation_record_for_removal(Node& parent, GC::Ptr<Node> old_previous_sibling, GC::Ptr<Node> old_next_sibling)
+{
+    auto removed_node = GC::make_root(*this);
+    parent.queue_tree_mutation_record({}, { &removed_node, 1 }, old_previous_sibling.ptr(), old_next_sibling.ptr());
+}
+
+// https://dom.spec.whatwg.org/#concept-node-remove
+void Node::remove(bool suppress_observers)
+{
+    // NB: Mutations during a recorded editing command must go through the Editing proxy functions.
+    if (auto history = document().editing_history_if_exists())
+        history->notify_dom_mutation();
+
+    // 1. Let parent be node’s parent
+    auto* parent = this->parent();
+
+    // 2. Assert: parent is non-null.
+    VERIFY(parent);
+
+    document().flush_deferred_style_change_event();
+    bool const was_connected = is_connected();
+
+    // 3. Run the live range pre-remove steps, given node.
+    live_range_pre_remove();
+
+    // 4. For each NodeIterator object iterator whose root’s node document is node’s node document:
+    //    run the NodeIterator pre-removing steps given node and iterator.
+    run_node_iterator_pre_removing_steps();
+
+    // 5. Let oldPreviousSibling be node’s previous sibling.
+    GC::Ptr<Node> old_previous_sibling = previous_sibling();
+
+    // 6. Let oldNextSibling be node’s next sibling.
+    GC::Ptr<Node> old_next_sibling = next_sibling();
+
+    schedule_list_item_renumber_for_removal();
+
+    RemovalStyleRecordPins removal_style_record_pins { document().style_computer() };
+    removal_style_record_pins.pin_style_records_before_removal(*this, was_connected);
+    if (was_connected) {
+        report_removal_to_style_engine(*parent);
+        // A suppressed-observer removal may be the first half of a compound mutation that immediately reinserts
+        // this node. Keep the old parent on the conservative rebuild path so the later insertion can relocate it.
+        auto layout_subtree_removal = suppress_observers ? LayoutSubtreeRemoval::RebuildParent : LayoutSubtreeRemoval::DetachInPlace;
+        update_layout_tree_for_removal(*parent, layout_subtree_removal, AncestorsMayHaveFirstLetter::Yes);
+    }
+
+    // 7. Remove node from its parent’s children.
+    parent->remove_child_impl(*this);
+
+    // 8. If node is assigned, then run assign slottables for node’s assigned slot.
+    // 9. If parent’s root is a shadow root, and parent is a slot whose assigned nodes is the empty list, then run
+    //    signal a slot change for parent.
+    // 10. If node has an inclusive descendant that is a slot, then:
+    auto& parent_root = parent->root();
+    assign_slottables_after_removal(*parent, parent_root);
+
+    removal_style_record_pins.pin_style_records_after_removal(*this, was_connected);
+
+    // 11. Run the removing steps with node, true, and parent.
+    // 12. Let isParentConnected be parent’s connected.
+    // 13. If node is custom and isParentConnected is true, then enqueue a custom element callback reaction with node,
+    //     callback name "disconnectedCallback", and an empty argument list.
+    // 14. For each shadow-including descendant descendant of node, in shadow-including tree order:
+    run_removing_steps(*parent, parent_root, was_connected);
+
+    removal_style_record_pins.release_dom_style_records();
+
+    // A subtree holding the focused or hovered node takes `:focus-within` and `:hover` out of the
+    // chain it hung off. Nothing about any element in that chain moved, so it has to be told.
+    CSS::Invalidation::invalidate_style_after_subtree_place_changed(*this, parent);
+
+    // 15. For each inclusive ancestor inclusiveAncestor of parent, and then for each registered of inclusiveAncestor’s
+    //     registered observer list, if registered’s options["subtree"] is true, then append a new transient registered
+    //     observer whose observer is registered’s observer, options is registered’s options, and source is registered
+    //     to node’s registered observer list.
+    add_transient_registered_observers_for_removal(*parent);
 
     // 16. If suppressObservers is false, then queue a tree mutation record for parent with « », « node »,
     //     oldPreviousSibling, and oldNextSibling.
-    if (!suppress_observers) {
-        auto removed_node = GC::make_root(*this);
-        parent->queue_tree_mutation_record({}, { &removed_node, 1 }, old_previous_sibling.ptr(), old_next_sibling.ptr());
-    }
+    if (!suppress_observers)
+        queue_tree_mutation_record_for_removal(*parent, old_previous_sibling, old_next_sibling);
 
     // 17. Run the children changed steps for parent.
     auto affects_elements = ChildrenChangedMetadata::AffectsElements::No;
@@ -2625,10 +2692,120 @@ Vector<GC::Root<Node>> Node::children_as_vector() const
     return nodes;
 }
 
+// https://dom.spec.whatwg.org/#concept-node-remove
 void Node::remove_all_children(bool suppress_observers)
 {
-    while (GC::Ptr<Node> child = first_child())
-        child->remove(suppress_observers);
+    // AD-HOC: The remove algorithm for each child in tree order. The steps that concern only the parent run once for
+    //         all of the children, as noted under each.
+
+    if (!has_children())
+        return;
+
+    // NB: Mutations during a recorded editing command must go through the Editing proxy functions.
+    if (auto history = document().editing_history_if_exists())
+        history->notify_dom_mutation();
+
+    document().flush_deferred_style_change_event();
+    bool const was_connected = is_connected();
+
+    // 1. Let parent be node’s parent
+    // NB: This node is the parent of every child removed here.
+
+    // 2. Assert: parent is non-null.
+    // NB: The parent is this node, so there is nothing to check.
+    auto& parent_root = root();
+
+    // 3. Run the live range pre-remove steps, given node.
+    // NB: Run once for all of the children before any is removed. Each child is the first child when its turn comes,
+    //     and the steps for every child together leave each boundary point that was in a child or on this node at
+    //     (this, 0). Nothing that runs between the removals can observe a live range.
+    live_range_pre_remove_all_children();
+
+    // Whether a removed box carries an ancestor's first letter is only a question when an ancestor has one.
+    auto ancestors_may_have_first_letter = AncestorsMayHaveFirstLetter::No;
+    if (was_connected) {
+        for (auto const* ancestor = this; ancestor; ancestor = ancestor->parent_or_shadow_host_node()) {
+            auto const* element = as_if<Element>(*ancestor);
+            if (element && element->has_style(CSS::PseudoElement::FirstLetter)) {
+                ancestors_may_have_first_letter = AncestorsMayHaveFirstLetter::Yes;
+                break;
+            }
+        }
+    }
+    bool const track_affected_elements = document().has_valid_html_collection_caches();
+    auto affects_elements = ChildrenChangedMetadata::AffectsElements::No;
+    bool const a_child_holds_a_propagating_state_source = CSS::Invalidation::descendants_hold_a_propagating_state_source(*this);
+
+    while (GC::Ptr<Node> child = first_child()) {
+        // 4. For each NodeIterator object iterator whose root’s node document is node’s node document:
+        //    run the NodeIterator pre-removing steps given node and iterator.
+        child->run_node_iterator_pre_removing_steps();
+
+        // 5. Let oldPreviousSibling be node’s previous sibling.
+        // NB: The child removed is always the first, so oldPreviousSibling is always null.
+
+        // 6. Let oldNextSibling be node’s next sibling.
+        GC::Ptr<Node> old_next_sibling = child->next_sibling();
+
+        if (track_affected_elements && mutation_affects_elements(*child) == ChildrenChangedMetadata::AffectsElements::Yes)
+            affects_elements = ChildrenChangedMetadata::AffectsElements::Yes;
+
+        child->schedule_list_item_renumber_for_removal();
+
+        RemovalStyleRecordPins removal_style_record_pins { document().style_computer() };
+        removal_style_record_pins.pin_style_records_before_removal(*child, was_connected);
+        if (was_connected) {
+            child->report_removal_to_style_engine(*this);
+            child->update_layout_tree_for_removal(*this, LayoutSubtreeRemoval::RebuildParent, ancestors_may_have_first_letter);
+        }
+
+        // 7. Remove node from its parent’s children.
+        remove_child_impl(*child);
+
+        // 8. If node is assigned, then run assign slottables for node’s assigned slot.
+        // 9. If parent’s root is a shadow root, and parent is a slot whose assigned nodes is the empty list, then run
+        //    signal a slot change for parent.
+        // 10. If node has an inclusive descendant that is a slot, then:
+        child->assign_slottables_after_removal(*this, parent_root);
+
+        removal_style_record_pins.pin_style_records_after_removal(*child, was_connected);
+
+        // 11. Run the removing steps with node, true, and parent.
+        // 12. Let isParentConnected be parent’s connected.
+        // 13. If node is custom and isParentConnected is true, then enqueue a custom element callback reaction with
+        //     node, callback name "disconnectedCallback", and an empty argument list.
+        // 14. For each shadow-including descendant descendant of node, in shadow-including tree order:
+        child->run_removing_steps(*this, parent_root, was_connected);
+
+        removal_style_record_pins.release_dom_style_records();
+
+        if (a_child_holds_a_propagating_state_source)
+            CSS::Invalidation::invalidate_style_after_subtree_place_changed(*child, this);
+
+        // 15. For each inclusive ancestor inclusiveAncestor of parent, and then for each registered of
+        //     inclusiveAncestor’s registered observer list, if registered’s options["subtree"] is true, then append a
+        //     new transient registered observer whose observer is registered’s observer, options is registered’s
+        //     options, and source is registered to node’s registered observer list.
+        child->add_transient_registered_observers_for_removal(*this);
+
+        // 16. If suppressObservers is false, then queue a tree mutation record for parent with « », « node »,
+        //     oldPreviousSibling, and oldNextSibling.
+        if (!suppress_observers)
+            child->queue_tree_mutation_record_for_removal(*this, nullptr, old_next_sibling);
+
+        // 17. Run the children changed steps for parent.
+        // NB: Run once after the last child has left. No script can run between two removals, so the runs in between
+        //     would only redo work on children that are about to leave.
+
+        child->bump_dom_tree_version();
+    }
+
+    // 17. Run the children changed steps for parent.
+    ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::AllChildrenRemoved, *this, affects_elements };
+    children_changed(metadata);
+    invalidate_html_collection_caches_in_ancestors(affects_elements);
+
+    bump_dom_tree_version();
 }
 
 // https://dom.spec.whatwg.org/#dom-node-comparedocumentposition

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -378,6 +378,7 @@ public:
         enum class Type {
             Inserted,
             Removal,
+            AllChildrenRemoved,
             Mutation,
         };
         enum class AffectsElements {
@@ -615,9 +616,28 @@ protected:
     ErrorOr<Utf16String> name_or_description(NameOrDescription, Document const&, HashTable<UniqueNodeID>&, IsDescendant = IsDescendant::No, ShouldComputeRole = ShouldComputeRole::Yes) const;
 
 private:
+    enum class LayoutSubtreeRemoval {
+        DetachInPlace,
+        RebuildParent,
+    };
+    enum class AncestorsMayHaveFirstLetter {
+        No,
+        Yes,
+    };
+
+    void run_node_iterator_pre_removing_steps();
+    void schedule_list_item_renumber_for_removal();
+    void report_removal_to_style_engine(Node& parent);
+    void update_layout_tree_for_removal(Node& parent, LayoutSubtreeRemoval, AncestorsMayHaveFirstLetter);
+    void assign_slottables_after_removal(Node& parent, Node& parent_root);
+    void run_removing_steps(Node& parent, Node& parent_root, bool was_connected);
+    void add_transient_registered_observers_for_removal(Node& parent);
+    void queue_tree_mutation_record_for_removal(Node& parent, GC::Ptr<Node> old_previous_sibling, GC::Ptr<Node> old_next_sibling);
+
     void queue_tree_mutation_record(ReadonlySpan<GC::Root<Node>> added_nodes, ReadonlySpan<GC::Root<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling);
 
     void live_range_pre_remove();
+    void live_range_pre_remove_all_children();
 
     void insert_before_impl(GC::Ref<Node>, GC::Ptr<Node> child);
     void insert_nodes_before(ReadonlySpan<GC::Root<Node>>, GC::Ptr<Node> child, bool suppress_observers, GC::Ref<Node> metadata_node, ChildrenChangedMetadata::AffectsElements);

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -628,7 +628,7 @@ private:
     };
 
     void run_node_iterator_pre_removing_steps();
-    void schedule_list_item_renumber_for_removal();
+    bool schedule_list_item_renumber_for_removal();
     void report_removal_to_style_engine(Node& parent);
     void update_layout_tree_for_removal(Node& parent, LayoutSubtreeRemoval, AncestorsMayHaveFirstLetter);
     void assign_slottables_after_removal(Node& parent, Node& parent_root);

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -266,6 +266,8 @@ public:
     WebIDL::ExceptionOr<GC::Ref<Node>> remove_child(GC::Ref<Node>);
 
     void insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_observers = false);
+    void parser_insert_before(GC::Ref<Node> node, GC::Ptr<Node> child);
+    void parser_append_child(GC::Ref<Node> node) { parser_insert_before(node, nullptr); }
     void remove(bool suppress_observers = false);
     void remove_all_children(bool suppress_observers = false);
 

--- a/Libraries/LibWeb/DOM/SubtreeInsertionScope.cpp
+++ b/Libraries/LibWeb/DOM/SubtreeInsertionScope.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/SubtreeInsertionScope.h>
+#include <LibWeb/HTML/HTMLFieldSetElement.h>
+#include <LibWeb/HTML/HTMLFormElement.h>
+
+namespace Web::DOM {
+
+SubtreeInsertionScope::SubtreeInsertionScope(Node& parent)
+    : m_parent(parent)
+    , m_document(parent.document())
+    , m_enclosing_scope(m_document->subtree_insertion_scope())
+{
+    m_document->set_subtree_insertion_scope({}, this);
+}
+
+SubtreeInsertionScope::~SubtreeInsertionScope()
+{
+    m_document->set_subtree_insertion_scope({}, m_enclosing_scope);
+}
+
+GC::Ptr<HTML::HTMLFormElement> SubtreeInsertionScope::nearest_inclusive_form_ancestor_of_parent()
+{
+    if (!m_nearest_inclusive_form_ancestor_of_parent.has_value()) {
+        GC::Ptr<HTML::HTMLFormElement> form;
+        for (auto* node = m_parent.ptr(); node; node = node->parent()) {
+            if (auto* form_element = as_if<HTML::HTMLFormElement>(*node)) {
+                form = form_element;
+                break;
+            }
+        }
+        m_nearest_inclusive_form_ancestor_of_parent = form;
+    }
+    return *m_nearest_inclusive_form_ancestor_of_parent;
+}
+
+ReadonlySpan<GC::Ref<Element>> SubtreeInsertionScope::inclusive_fieldset_ancestors_of_parent()
+{
+    if (!m_inclusive_fieldset_ancestors_of_parent.has_value()) {
+        Vector<GC::Ref<Element>> fieldsets;
+        for (GC::Ptr<Element> element = as_if<Element>(*m_parent); element; element = element->parent_element()) {
+            if (is<HTML::HTMLFieldSetElement>(*element))
+                fieldsets.append(*element);
+        }
+        m_inclusive_fieldset_ancestors_of_parent = move(fieldsets);
+    }
+    return *m_inclusive_fieldset_ancestors_of_parent;
+}
+
+}

--- a/Libraries/LibWeb/DOM/SubtreeInsertionScope.h
+++ b/Libraries/LibWeb/DOM/SubtreeInsertionScope.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/Optional.h>
+#include <AK/Vector.h>
+#include <LibGC/Ptr.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::DOM {
+
+class SubtreeInsertionScope {
+    AK_MAKE_NONCOPYABLE(SubtreeInsertionScope);
+    AK_MAKE_NONMOVABLE(SubtreeInsertionScope);
+
+public:
+    explicit SubtreeInsertionScope(Node& parent);
+    ~SubtreeInsertionScope();
+
+    Node& parent() const { return m_parent; }
+    GC::Ptr<HTML::HTMLFormElement> nearest_inclusive_form_ancestor_of_parent();
+    ReadonlySpan<GC::Ref<Element>> inclusive_fieldset_ancestors_of_parent();
+
+private:
+    GC::Ref<Node> m_parent;
+    GC::Ref<Document> m_document;
+    SubtreeInsertionScope* m_enclosing_scope { nullptr };
+    Optional<GC::Ptr<HTML::HTMLFormElement>> m_nearest_inclusive_form_ancestor_of_parent;
+    Optional<Vector<GC::Ref<Element>>> m_inclusive_fieldset_ancestors_of_parent;
+};
+
+}

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -578,6 +578,7 @@ class ShadowRoot;
 class SlotRegistry;
 class StaticNodeList;
 class StaticRange;
+class SubtreeInsertionScope;
 class SyntheticPseudoElement;
 class Text;
 class TreeWalker;

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -18,6 +18,7 @@
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/DOM/SelectionchangeEventDispatching.h>
+#include <LibWeb/DOM/SubtreeInsertionScope.h>
 #include <LibWeb/Editing/EditCommand.h>
 #include <LibWeb/Editing/EditingHistory.h>
 #include <LibWeb/HTML/CustomElements/CustomElementReactionNames.h>
@@ -353,6 +354,18 @@ void FormAssociatedElement::element_with_id_was_added_or_removed(Badge<DOM::Docu
     reset_form_owner();
 }
 
+static HTMLFormElement* nearest_form_ancestor(HTMLElement& element)
+{
+    auto* subtree_insertion_scope = element.document().subtree_insertion_scope();
+    for (auto* ancestor = element.parent(); ancestor; ancestor = ancestor->parent()) {
+        if (subtree_insertion_scope && ancestor == &subtree_insertion_scope->parent())
+            return subtree_insertion_scope->nearest_inclusive_form_ancestor_of_parent().ptr();
+        if (auto* form = as_if<HTMLFormElement>(*ancestor))
+            return form;
+    }
+    return nullptr;
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#reset-the-form-owner
 void FormAssociatedElement::reset_form_owner()
 {
@@ -370,7 +383,7 @@ void FormAssociatedElement::reset_form_owner()
     //    then do nothing, and return.
     if (auto* form = this->form(); form
         && (!is_listed() || !html_element.has_attribute(HTML::AttributeNames::form))
-        && html_element.first_ancestor_of_type<HTMLFormElement>() == form) {
+        && nearest_form_ancestor(html_element) == form) {
         if (is_submit_button())
             form->default_button_state_maybe_changed();
         return;
@@ -402,8 +415,7 @@ void FormAssociatedElement::reset_form_owner()
 
     // 5. Otherwise, if element has an ancestor form element, then associate element with the nearest such ancestor form element.
     else {
-        auto* form_ancestor = html_element.first_ancestor_of_type<HTMLFormElement>();
-        if (form_ancestor)
+        if (auto* form_ancestor = nearest_form_ancestor(html_element))
             set_form(form_ancestor);
     }
 

--- a/Libraries/LibWeb/HTML/HTMLOrSVGOrMathMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGOrMathMLElement.cpp
@@ -153,11 +153,12 @@ void HTMLOrSVGOrMathMLElement<ElementBase>::inserted()
     // "A node becomes browsing-context connected when the insertion steps are invoked with it as the argument
     // and it is now browsing-context connected."
     // https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-browsing-context-connected
-    if (!element.shadow_including_root().is_browsing_context_connected())
+    if (!element.is_browsing_context_connected())
         return;
 
     // 1. Let CSP list be element's shadow-including root's policy container's CSP list.
-    auto csp_list = element.shadow_including_root().document().policy_container()->csp_list;
+    // NB: A browsing-context connected element's shadow-including root is its node document.
+    auto csp_list = element.document().policy_container()->csp_list;
 
     // 2. If CSP list contains a header-delivered Content Security Policy, and element has a
     //    nonce content attribute whose value is not the empty string, then:

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1409,13 +1409,13 @@ GC::Ptr<DOM::DocumentFragment> HTMLParser::try_parse_html_fragment_fast(DOM::Ele
             auto& html_element = as<HTMLElement>(*element);
             if (html_element.is_form_associated_element() && html_element.is_resettable())
                 html_element.reset_algorithm();
-            MUST(parent.append_child(element));
+            parent.parser_append_child(element);
             if (!is_void)
                 parents.append(element);
         },
         [&] { parents.take_last(); },
         [&](StringView text) {
-            MUST(parents.last()->append_child(DOM::Text::create(context.document(), Utf16String::from_utf8_without_validation(text))));
+            parents.last()->parser_append_child(DOM::Text::create(context.document(), Utf16String::from_utf8_without_validation(text)));
         });
     VERIFY(success);
     return fragment;
@@ -2456,6 +2456,19 @@ struct NodeAndOffset {
     }
 };
 
+static void insert_node_for_parser(DOM::Node& parent, DOM::Node& node, DOM::Node* child)
+{
+    if (!parent.is_connected()) {
+        parent.parser_insert_before(node, child);
+        return;
+    }
+    if (child) {
+        parent.insert_before(node, child, false);
+    } else {
+        MUST(parent.append_child(node));
+    }
+}
+
 static u64 s_parser_non_append_insertions { 0 };
 
 u64 parser_non_append_insertions()
@@ -2528,14 +2541,8 @@ extern "C" void ladybird_html_parser_insert_text(size_t parent, size_t offset, u
         return;
     }
 
-    if (auto* before_node = insertion_location.child_at_offset()) {
-        auto text = DOM::Text::create(parent_node.document(), data);
-        parent_node.insert_before(*text, before_node);
-        return;
-    }
-
     auto text = DOM::Text::create(parent_node.document(), data);
-    MUST(parent_node.append_child(*text));
+    insert_node_for_parser(parent_node, *text, insertion_location.child_at_offset());
 }
 
 extern "C" void ladybird_html_parser_add_missing_attribute(size_t element, size_t local_name_raw, u16 const* value_ptr, size_t value_len)
@@ -2617,7 +2624,7 @@ extern "C" size_t ladybird_html_parser_create_element(void* parser, size_t inten
 
 extern "C" void ladybird_html_parser_append_child(size_t parent, size_t child)
 {
-    MUST(node_from_html_parser_ffi(parent).append_child(node_from_html_parser_ffi(child)));
+    insert_node_for_parser(node_from_html_parser_ffi(parent), node_from_html_parser_ffi(child), nullptr);
 }
 
 extern "C" void ladybird_html_parser_insert_node(size_t parent, size_t offset, size_t child, bool queue_custom_element_reactions)
@@ -2629,10 +2636,7 @@ extern "C" void ladybird_html_parser_insert_node(size_t parent, size_t offset, s
     if (queue_custom_element_reactions && child_element)
         relevant_similar_origin_window_agent(*child_element).custom_element_reactions_stack.element_queue_stack.append({});
 
-    if (auto* before_node = insertion_location.child_at_offset())
-        parent_node.insert_before(child_node, before_node, false);
-    else
-        MUST(parent_node.append_child(child_node));
+    insert_node_for_parser(parent_node, child_node, insertion_location.child_at_offset());
 
     if (queue_custom_element_reactions && child_element) {
         auto queue = relevant_similar_origin_window_agent(*child_element).custom_element_reactions_stack.element_queue_stack.take_last();

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1215,6 +1215,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(element_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
+            element.update_inside_blocking_wheel_event_handler_state();
             if (should_create_layout_node) {
                 LayoutTreeBuilderAccess::clear_synthetic_pseudo_element_layout_nodes(element);
                 update_style_if_needed_for_layout_tree_bypass_path(element);
@@ -1370,6 +1371,7 @@ static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element& ele
 
 static RustFFI::NodeSlotId create_layout_node_for_text(PrincipalNodeFrame& frame, DOM::Text& text_node)
 {
+    text_node.update_inside_blocking_wheel_event_handler_state();
     frame.layout_node = &allocate_layout_node<Layout::TextNode>(text_node.document(), text_node);
     return Node::slot_id(frame.layout_node);
 }

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -1328,6 +1328,9 @@ impl StyleEngine {
             InputValue::TreeRelations(old),
             InputValue::TreeRelations(new),
         );
+        if old.is_some() && new.is_none() {
+            self.counters.bump(Counter::TreeDepartureDeltas);
+        }
         self.tree_staging.stage_row(node, old_if_unstaged, new);
     }
 
@@ -1456,16 +1459,21 @@ impl StyleEngine {
                 self.tree.recompute_subtree_depth(node);
             }
         }
+        let live_animation_overlays_before = self.computed_group_sets.live_animation_overlay_records();
+        let mut retired_nodes: Vec<StyleNodeID> = Vec::new();
         for &(node, _, relations) in &staged_rows {
             if relations.is_some() || !self.tree.is_live(node) {
                 continue;
             }
             self.winner_groups.remove(node);
-            let live_animation_overlays_before = self.computed_group_sets.live_animation_overlay_records();
             self.computed_group_sets.remove(node);
             self.pending_element_style_computation_selections.remove(&node);
             self.pending_pseudo_style_computation_selections.remove(&node);
             self.nodes_with_substituted_records.remove(&node);
+            retired_nodes.push(node);
+        }
+        if !retired_nodes.is_empty() {
+            self.tree.retire_elements(&retired_nodes, &mut self.memory);
             let live_animation_overlays_after = self.computed_group_sets.live_animation_overlay_records();
             self.settle_computed_memory();
             self.counters.add(
@@ -1476,7 +1484,8 @@ impl StyleEngine {
                 Counter::LiveAnimationOverlayRecords,
                 live_animation_overlays_after as u64,
             );
-            self.tree.retire_element(node, &mut self.memory);
+            self.counters
+                .add(Counter::StyleNodesRetired, retired_nodes.len() as u64);
         }
         self.tree_staging.mark_applied();
         self.publish_budget_inputs();

--- a/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
@@ -39,6 +39,8 @@ define_counters! {
     // Typed input deltas, counted by kind. A generic version bump would hide exactly the
     // distinction that decides how much work a change causes.
     TreeDeltas => "treeDeltas",
+    TreeDepartureDeltas => "treeDepartureDeltas",
+    StyleNodesRetired => "styleNodesRetired",
     LocalFeatureDeltas => "localFeatureDeltas",
     StateDeltas => "stateDeltas",
     ElementDeclarationDeltas => "elementDeclarationDeltas",

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -378,6 +378,15 @@ impl StyleEngine {
         let old = relations(old);
         let new = relations(new);
 
+        // A node whose parent departed in the same transaction departed with it, so nothing that
+        // remains was its sibling or in its sequence.
+        if new.is_none()
+            && let Some(old) = old
+            && old.parent.is_some_and(|parent| !self.tree.is_live(parent))
+        {
+            return;
+        }
+
         if new.is_some()
             && (old.is_none()
                 || old.and_then(|relations| relations.parent) != new.and_then(|relations| relations.parent))

--- a/Libraries/LibWeb/Rust/src/css/style/tree.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tree.rs
@@ -592,25 +592,32 @@ impl StyleNodeTree {
     /// Retire an element identity. The slot stays reserved until [`Self::release_retired_identities`]
     /// runs at epoch retirement, so no reader can observe a reused identity.
     pub fn retire_element(&mut self, node: StyleNodeID, memory: &mut MemoryController) {
+        self.retire_elements(&[node], memory);
+    }
+
+    /// Retire a batch of element identities, accounting once for the capacity they release.
+    pub fn retire_elements(&mut self, nodes: &[StyleNodeID], memory: &mut MemoryController) {
         let before = self.retirement_capacity_bytes();
-        let index = node
-            .element_index()
-            .expect("retire_element requires an element identity");
-        assert!(
-            self.live.contains(index as usize),
-            "retiring an identity that is not live"
-        );
-        if let Some(shadow) = &mut self.shadow {
-            shadow.retire_node(node);
+        for &node in nodes {
+            let index = node
+                .element_index()
+                .expect("retire_element requires an element identity");
+            assert!(
+                self.live.contains(index as usize),
+                "retiring an identity that is not live"
+            );
+            if let Some(shadow) = &mut self.shadow {
+                shadow.retire_node(node);
+            }
+            self.live.set(index as usize, false);
+            self.parent[index as usize] = None;
+            self.first_element_child[index as usize] = None;
+            self.next_element_sibling[index as usize] = None;
+            self.previous_element_sibling[index as usize] = None;
+            self.depth[index as usize] = 0;
+            self.connected_element_count -= 1;
+            self.pending_reuse.push(index);
         }
-        self.live.set(index as usize, false);
-        self.parent[index as usize] = None;
-        self.first_element_child[index as usize] = None;
-        self.next_element_sibling[index as usize] = None;
-        self.previous_element_sibling[index as usize] = None;
-        self.depth[index as usize] = 0;
-        self.connected_element_count -= 1;
-        self.pending_reuse.push(index);
         let current = self.retirement_capacity_bytes();
         self.record_capacity_change(memory, before, current);
     }
@@ -794,6 +801,14 @@ impl StyleNodeTree {
     /// Slot assignment changes flat-tree identity even when the DOM parent does not move, which is
     /// why it is its own relation rather than a derived view of the DOM tree.
     pub fn set_assigned_slot(&mut self, node: StyleNodeID, slot: Option<StyleNodeID>, memory: &mut MemoryController) {
+        if slot.is_none()
+            && self
+                .shadow
+                .as_ref()
+                .is_none_or(|shadow| shadow.assigned_slot.get(node).is_none())
+        {
+            return;
+        }
         let before = self.shadow_capacity_bytes();
         let shadow = self.shadow_mut();
         if let Some(previous) = shadow.assigned_slot.remove(node)

--- a/Tests/LibWeb/Crash/DOM/subtree-insertion-scope-adopted-parent.html
+++ b/Tests/LibWeb/Crash/DOM/subtree-insertion-scope-adopted-parent.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<iframe id="frame"></iframe>
+<form id="form"><input id="input" form="form" required></form>
+<div id="anchor"></div>
+<script>
+    const anchorElement = document.getElementById("anchor");
+    const container = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const script = document.createElementNS("http://www.w3.org/2000/svg", "script");
+    script.textContent = "frame.contentDocument.body.appendChild(document.getElementById('anchor'));";
+    container.appendChild(script);
+    anchorElement.appendChild(container);
+    input.removeAttribute("form");
+    input.required = false;
+</script>

--- a/Tests/LibWeb/Text/expected/DOM/Node-remove-all-children.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Node-remove-all-children.txt
@@ -1,0 +1,15 @@
+Iterator reference before: two
+Color with focus inside: rgb(1, 2, 3)
+Range inside the children: list:0 - list:0
+Range on the parent: list:0 - after#text:1
+Range ending in a child: BODY:0 - list:0
+Unrelated range: after#text:0 - after#text:3
+Iterator reference after: list
+Color after removal: rgb(0, 0, 0)
+Children after removal: 0
+Range across an innerHTML replacement: list:0 - list:0
+Children after replacement: 1
+Caret on the parent, removing one at a time: 0, selection at list:0
+Caret on the parent, removing all at once: 0, selection at list:0
+Caret at the start of the parent, removing one at a time: 0, selection at list:0
+Caret at the start of the parent, removing all at once: 0, selection at list:0

--- a/Tests/LibWeb/Text/expected/HTML/parser-insertion-into-detached-subtree-is-observable.txt
+++ b/Tests/LibWeb/Text/expected/HTML/parser-insertion-into-detached-subtree-is-observable.txt
@@ -1,0 +1,4 @@
+Children of the detached parent: 3
+DIV#host gained DIV#a
+DIV#host gained DIV#b
+DIV#b gained SPAN#c

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-shadow-tree-and-move.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-shadow-tree-and-move.txt
@@ -1,0 +1,4 @@
+shadow child of a host inserted under a blocking listener: true
+descendant of a subtree before it moves: false
+descendant of a subtree moved under a blocking listener: true
+descendant of a subtree moved out from under a blocking listener: false

--- a/Tests/LibWeb/Text/input/DOM/Node-remove-all-children.html
+++ b/Tests/LibWeb/Text/input/DOM/Node-remove-all-children.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #list:focus-within {
+        color: rgb(1, 2, 3);
+    }
+</style>
+<ul id="list"><li id="one">one</li><li id="two">two<input></li><li id="three">three</li></ul>
+<span id="after">after</span>
+<script>
+    promiseTest(async () => {
+        const list = document.getElementById("list");
+        const [one, two, three] = list.children;
+        const after = document.getElementById("after");
+        const name = node => node.nodeType === Node.TEXT_NODE ? `${node.parentNode.id}#text` : node.id || node.nodeName;
+        const describe = range => `${name(range.startContainer)}:${range.startOffset} - ${name(range.endContainer)}:${range.endOffset}`;
+
+        const insideChildren = document.createRange();
+        insideChildren.setStart(one.firstChild, 1);
+        insideChildren.setEnd(three.firstChild, 2);
+        const onParent = document.createRange();
+        onParent.setStart(list, 2);
+        onParent.setEnd(after.firstChild, 1);
+        const intoChild = document.createRange();
+        intoChild.setStart(document.body, 0);
+        intoChild.setEnd(two.firstChild, 1);
+        const unrelated = document.createRange();
+        unrelated.setStart(after.firstChild, 0);
+        unrelated.setEnd(after.firstChild, 3);
+
+        const iterator = document.createNodeIterator(list, NodeFilter.SHOW_ELEMENT);
+        iterator.nextNode();
+        iterator.nextNode();
+        iterator.nextNode();
+        println(`Iterator reference before: ${name(iterator.referenceNode)}`);
+
+        two.querySelector("input").focus();
+        println(`Color with focus inside: ${getComputedStyle(list).color}`);
+
+        list.textContent = "";
+
+        println(`Range inside the children: ${describe(insideChildren)}`);
+        println(`Range on the parent: ${describe(onParent)}`);
+        println(`Range ending in a child: ${describe(intoChild)}`);
+        println(`Unrelated range: ${describe(unrelated)}`);
+        println(`Iterator reference after: ${name(iterator.referenceNode)}`);
+        println(`Color after removal: ${getComputedStyle(list).color}`);
+        println(`Children after removal: ${list.childNodes.length}`);
+
+        list.innerHTML = "<li id='four'>four</li><li id='five'>five</li>";
+        const replaced = document.createRange();
+        replaced.setStart(list.firstChild.firstChild, 1);
+        replaced.setEnd(list, 2);
+        list.innerHTML = "<li>six</li>";
+        println(`Range across an innerHTML replacement: ${describe(replaced)}`);
+        println(`Children after replacement: ${list.childNodes.length}`);
+
+        const selection = getSelection();
+        let selectionChanges = 0;
+        document.addEventListener("selectionchange", () => selectionChanges++);
+        const selectionChangesFromRemoval = async (offset, remove) => {
+            list.innerHTML = "<li>seven</li><li>eight</li>";
+            selection.collapse(list, offset);
+            await timeout(0);
+            selectionChanges = 0;
+            remove();
+            await timeout(0);
+            return `${selectionChanges}, selection at ${name(selection.anchorNode)}:${selection.anchorOffset}`;
+        };
+        const oneAtATime = () => {
+            while (list.firstChild)
+                list.firstChild.remove();
+        };
+        const allAtOnce = () => list.textContent = "";
+        println(`Caret on the parent, removing one at a time: ${await selectionChangesFromRemoval(2, oneAtATime)}`);
+        println(`Caret on the parent, removing all at once: ${await selectionChangesFromRemoval(2, allAtOnce)}`);
+        println(`Caret at the start of the parent, removing one at a time: ${await selectionChangesFromRemoval(0, oneAtATime)}`);
+        println(`Caret at the start of the parent, removing all at once: ${await selectionChangesFromRemoval(0, allAtOnce)}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/parser-insertion-into-detached-subtree-is-observable.html
+++ b/Tests/LibWeb/Text/input/HTML/parser-insertion-into-detached-subtree-is-observable.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="host"><script>
+    const host = document.getElementById("host");
+    host.remove();
+    const children = host.children;
+    children.length;
+    const records = [];
+    const observer = new MutationObserver(list => records.push(...list));
+    observer.observe(host, { childList: true, subtree: true });
+</script><div id="a"></div><div id="b"><span id="c"></span></div></div>
+<script>
+    test(() => {
+        records.push(...observer.takeRecords());
+        println(`Children of the detached parent: ${children.length}`);
+        for (const record of records) {
+            const added = Array.from(record.addedNodes, node => node.nodeType === Node.TEXT_NODE ? "#text" : `${node.nodeName}#${node.id}`);
+            println(`${record.target.nodeName}#${record.target.id} gained ${added.join(", ")}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/async-scrolling/blocking-wheel-event-region-shadow-tree-and-move.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/blocking-wheel-event-region-shadow-tree-and-move.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #blocking,
+    #plain {
+        position: absolute;
+        left: 0;
+        width: 100px;
+        height: 100px;
+    }
+
+    #blocking {
+        top: 0;
+    }
+
+    #plain {
+        top: 200px;
+    }
+
+    .probe {
+        margin-left: 200px;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div id="blocking"></div>
+<div id="plain"><div id="moved"><div class="probe"></div></div></div>
+<script>
+    test(() => {
+        blocking.addEventListener("wheel", () => {}, { passive: false });
+        const blocks = (label, y) => println(`${label}: ${internals.asyncScrollingStateBlocksWheelEventAt(250, y)}`);
+
+        const host = document.createElement("div");
+        const probe = document.createElement("div");
+        probe.style.cssText = "margin-left: 200px; width: 100px; height: 100px";
+        host.attachShadow({ mode: "open" }).append(probe);
+        blocking.append(host);
+        blocks("shadow child of a host inserted under a blocking listener", 50);
+        host.remove();
+
+        blocks("descendant of a subtree before it moves", 250);
+        blocking.moveBefore(moved, null);
+        blocks("descendant of a subtree moved under a blocking listener", 50);
+        plain.moveBefore(moved, null);
+        blocks("descendant of a subtree moved out from under a blocking listener", 250);
+    });
+</script>


### PR DESCRIPTION
This PR improves the performance of common DOM mutation operations by avoiding work which is unnecessary in various ways rather than following all steps of the relevant spec algorithms in all cases.

See individual commits for details.

Benchmark results:

| Benchmark | Old score | New score | Score change | Old time (s) | New time (s) | Speedup |
|---|---|---|---|---|---|---|
| Speedometer2 | 88.11 ± 0.31 | 89.61 ± 0.26 | +1.70% | 6.030 ± 0.014 | 5.966 ± 0.011 | 1.011× |
| Speedometer3 | 5.74 ± 0.02 | 5.79 ± 0.02 | +0.92% | 4.473 ± 0.010 | 4.421 ± 0.010 | 1.012× |
| StyleBench | 162.63 ± 0.73 | 162.81 ± 0.79 | +0.11% | 1.528 ± 0.007 | 1.524 ± 0.007 | 1.002× |