### PR TITLE
LibWeb: Stage paint capture metadata until recording publication

### DIFF
--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1490,7 +1490,7 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
             paint_state.recorded_canvas_color = Some(inputs.canvas_color);
         }
     }
-    let (output, resources, recording_from_scratch) = {
+    let (recording, recording_from_scratch) = {
         let paint_state = arena.paint_state().borrow();
         if !arena.paintable_row_is_populated(viewport) || arena.stacking_context_entries(viewport).is_none() {
             return false;
@@ -1509,7 +1509,7 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
             .then(|| paint_state.paint_command_cache_source.clone())
             .flatten();
         arena.set_paint_recording_in_progress(true);
-        let (output, resources) = crate::painting::record::traversal::record_display_list(
+        let recording = crate::painting::record::traversal::record_display_list(
             arena,
             &paint_state,
             viewport,
@@ -1520,11 +1520,15 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
             paint_state.trace_recordings || crate::painting::record::verify::enabled_by_environment(),
         );
         let recording_from_scratch = (crate::painting::record::verify::enabled_by_environment()
-            && output.capture_log_for_verification.as_ref().is_some_and(|log| {
-                log.command_byte_captures
-                    .iter()
-                    .any(|capture| capture.spliced_from_cache)
-            })
+            && recording
+                .output
+                .capture_log_for_verification
+                .as_ref()
+                .is_some_and(|log| {
+                    log.command_byte_captures
+                        .iter()
+                        .any(|capture| capture.spliced_from_cache)
+                })
             && !inputs.should_show_line_box_borders)
             .then(|| {
                 let mut inputs_for_recording_from_scratch = inputs;
@@ -1541,18 +1545,17 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
                 )
             });
         arena.set_paint_recording_in_progress(false);
-        (output, resources, recording_from_scratch)
+        (recording, recording_from_scratch)
     };
     let mut paint_state = arena.paint_state().borrow_mut();
-    if paint_state.trace_recordings && output.capture_log_for_verification.is_some() {
+    if paint_state.trace_recordings && recording.output.capture_log_for_verification.is_some() {
         paint_state.pending_recording_trace = Some(crate::painting::paint_state::PendingRecordingTrace {
             viewport,
             should_paint_overlay: inputs.should_paint_overlay,
         });
     }
     paint_state.pending_recording = Some(crate::painting::paint_state::PendingRecording {
-        output,
-        resources,
+        recording,
         recording_from_scratch,
         paint_command_cache_read_write: inputs.paint_command_cache_read_write,
     });

--- a/Libraries/LibWeb/Rust/src/painting/paint_state.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paint_state.rs
@@ -9,12 +9,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 pub(crate) struct PendingRecording {
-    pub(crate) output: crate::painting::record::RecordingOutput,
-    pub(crate) resources: crate::painting::record::resources::RecordingResourceManifest,
-    pub(crate) recording_from_scratch: Option<(
-        crate::painting::record::RecordingOutput,
-        crate::painting::record::resources::RecordingResourceManifest,
-    )>,
+    pub(crate) recording: crate::painting::record::RecordingResult,
+    pub(crate) recording_from_scratch: Option<crate::painting::record::RecordingResult>,
     pub(crate) paint_command_cache_read_write: bool,
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/record/cache.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/cache.rs
@@ -8,6 +8,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use crate::css::style::fast_hash::FastMap;
+use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::layout::used_values::FfiCssPixelPoint;
 use crate::painting::display_list::commands::ContextRef;
@@ -122,7 +123,7 @@ pub(crate) fn resolve_capture_address_in_source_tape(
 ) -> Option<SourceTapePosition> {
     debug_assert!(
         address.written_in_record_gen <= completed_record_gen,
-        "a capture site ran twice in one recording"
+        "source capture metadata must belong to a completed recording"
     );
     let Some(enclosing_capture) = address.enclosing_capture else {
         return (address.written_in_record_gen == completed_record_gen).then_some(SourceTapePosition {
@@ -160,16 +161,12 @@ fn resolve_enclosing_capture_start(
             },
             Some(anchor) => ResolvedEnclosingCapture {
                 gen_of_last_fresh_walk: anchor.gen_of_last_fresh_walk,
-                source_position: (anchor.address.written_in_record_gen <= completed_record_gen)
-                    .then(|| {
-                        resolve_capture_address_in_source_tape(
-                            completed_record_gen,
-                            anchor.address,
-                            lookup_enclosing_capture_anchor,
-                            memo,
-                        )
-                    })
-                    .flatten(),
+                source_position: resolve_capture_address_in_source_tape(
+                    completed_record_gen,
+                    anchor.address,
+                    lookup_enclosing_capture_anchor,
+                    memo,
+                ),
             },
         };
         memo.insert(site, resolved);
@@ -185,9 +182,8 @@ pub struct PaintCache {
     hit_test_items: [Cell<Option<CachedBoxPhaseHitTestItems>>; PaintPhase::COUNT],
     descendant_subtrees: [Cell<Option<CachedSubtreeCapture>>; StackingContextPaintPhase::COUNT],
     painted_as_stacking_context: Cell<Option<CachedSubtreeCapture>>,
-    // One captured position per row covers every entry: register_capture_position() drops the
-    // row's entries whenever a registration moves the stamp, so live entries are always captures
-    // taken at this position.
+    // Source entries and their position stay unchanged throughout recording. Publication drops
+    // the old entries if the staged captures were recorded at a different position.
     captured_absolute_position: Cell<FfiCssPixelPoint>,
     // Dirty while greater than the arena's completed-record generation; aged out by the bump
     // after a cache-writing recording, never cleared by walks.
@@ -218,27 +214,11 @@ impl PaintCache {
         self.hit_test_items[phase as usize].get()
     }
 
-    pub fn set_commands(&self, phase: PaintPhase, commands: CachedBoxPhaseCommands) {
-        self.commands[phase as usize].set(Some(commands));
-    }
-
-    pub fn set_hit_test_items(&self, phase: PaintPhase, hit_test_items: CachedBoxPhaseHitTestItems) {
-        self.hit_test_items[phase as usize].set(Some(hit_test_items));
-    }
-
     pub(crate) fn subtree_capture(&self, kind: CaptureKind) -> Option<CachedSubtreeCapture> {
         match kind {
             CaptureKind::BoxPhase(_) => None,
             CaptureKind::DescendantSubtreePhase(phase) => self.descendant_subtrees[phase as usize].get(),
             CaptureKind::PaintedAsStackingContext => self.painted_as_stacking_context.get(),
-        }
-    }
-
-    pub(crate) fn set_subtree_capture(&self, kind: CaptureKind, capture: CachedSubtreeCapture) {
-        match kind {
-            CaptureKind::BoxPhase(_) => unreachable!("a box phase capture is not a subtree capture"),
-            CaptureKind::DescendantSubtreePhase(phase) => self.descendant_subtrees[phase as usize].set(Some(capture)),
-            CaptureKind::PaintedAsStackingContext => self.painted_as_stacking_context.set(Some(capture)),
         }
     }
 
@@ -274,17 +254,30 @@ impl PaintCache {
         self.captured_absolute_position.get()
     }
 
-    /// The row keeps one captured position for all of its entries, which is only sound while
-    /// every live entry was captured at that position. A phase walk can re-register one entry
-    /// kind of a moved row (e.g. the always-empty descendant subtree of a positioned child)
-    /// while the row's other entries still hold output captured at the old position, so
-    /// registering at a new position must drop the remaining entries: a moved box can never
-    /// validly splice them again, and keeping them would let later position checks accept them
-    /// against the freshly moved stamp.
-    pub(crate) fn register_capture_position(&self, position: FfiCssPixelPoint) {
-        if self.captured_absolute_position.get() != position {
+    fn apply_update(&self, update: PaintCacheUpdate) {
+        if self.captured_absolute_position.get() != update.absolute_position {
             self.clear();
-            self.captured_absolute_position.set(position);
+            self.captured_absolute_position.set(update.absolute_position);
+        }
+        // Captures skipped by this recording remain available through their enclosing anchors.
+        // In particular, reusing an entire subtree only updates its root capture.
+        for (destination, source) in self.commands.iter().zip(update.commands) {
+            if let Some(entry) = source {
+                destination.set(Some(entry));
+            }
+        }
+        for (destination, source) in self.hit_test_items.iter().zip(update.hit_test_items) {
+            if let Some(entry) = source {
+                destination.set(Some(entry));
+            }
+        }
+        for (destination, source) in self.descendant_subtrees.iter().zip(update.descendant_subtrees) {
+            if let Some(entry) = source {
+                destination.set(Some(entry));
+            }
+        }
+        if let Some(entry) = update.painted_as_stacking_context {
+            self.painted_as_stacking_context.set(Some(entry));
         }
     }
 
@@ -305,6 +298,94 @@ impl PaintCache {
 
     pub(crate) fn has_dirty_descendants_since(&self, completed_record_gen: RecordGen) -> bool {
         self.descendant_dirty_gen.get() > u64::from(completed_record_gen)
+    }
+}
+
+#[derive(Default)]
+struct PaintCacheUpdate {
+    absolute_position: FfiCssPixelPoint,
+    commands: [Option<CachedBoxPhaseCommands>; PaintPhase::COUNT],
+    hit_test_items: [Option<CachedBoxPhaseHitTestItems>; PaintPhase::COUNT],
+    descendant_subtrees: [Option<CachedSubtreeCapture>; StackingContextPaintPhase::COUNT],
+    painted_as_stacking_context: Option<CachedSubtreeCapture>,
+}
+
+// Only rows that record or splice a capture get an update. The arena's caches remain the
+// immutable source until publication, including during the optional verification recording.
+#[derive(Default)]
+pub(crate) struct PendingPaintCacheUpdates {
+    rows: FastMap<NodeSlotId, PaintCacheUpdate>,
+}
+
+impl PendingPaintCacheUpdates {
+    fn for_paintable(&mut self, paintable: NodeSlotId, absolute_position: FfiCssPixelPoint) -> &mut PaintCacheUpdate {
+        let update = self.rows.entry(paintable).or_insert_with(|| PaintCacheUpdate {
+            absolute_position,
+            ..Default::default()
+        });
+        debug_assert_eq!(
+            update.absolute_position, absolute_position,
+            "a row moved during recording"
+        );
+        update
+    }
+
+    pub(crate) fn set_commands(
+        &mut self,
+        paintable: NodeSlotId,
+        position: FfiCssPixelPoint,
+        phase: PaintPhase,
+        commands: CachedBoxPhaseCommands,
+    ) {
+        let previous = self.for_paintable(paintable, position).commands[phase as usize].replace(commands);
+        debug_assert!(
+            previous.is_none(),
+            "a per-phase command capture site ran twice in one recording"
+        );
+    }
+
+    pub(crate) fn set_hit_test_items(
+        &mut self,
+        paintable: NodeSlotId,
+        position: FfiCssPixelPoint,
+        phase: PaintPhase,
+        items: CachedBoxPhaseHitTestItems,
+    ) {
+        let previous = self.for_paintable(paintable, position).hit_test_items[phase as usize].replace(items);
+        debug_assert!(
+            previous.is_none(),
+            "a per-phase hit-test capture site ran twice in one recording"
+        );
+    }
+
+    pub(crate) fn set_subtree_capture(
+        &mut self,
+        site: CaptureSite,
+        position: FfiCssPixelPoint,
+        capture: CachedSubtreeCapture,
+    ) {
+        let update = self.for_paintable(site.paintable, position);
+        let destination = match site.kind {
+            CaptureKind::BoxPhase(_) => unreachable!("a box phase capture is not a subtree capture"),
+            CaptureKind::DescendantSubtreePhase(phase) => &mut update.descendant_subtrees[phase as usize],
+            CaptureKind::PaintedAsStackingContext => &mut update.painted_as_stacking_context,
+        };
+        let previous = destination.replace(capture);
+        debug_assert!(previous.is_none(), "a capture site ran twice in one recording");
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub(crate) fn commit(self, arena: &LayoutNodeArena) {
+        for (paintable, update) in self.rows {
+            assert!(
+                arena.paintable_row_is_populated(paintable),
+                "a captured row was removed before publication"
+            );
+            arena.paintable_paint_cache(paintable).apply_update(update);
+        }
     }
 }
 
@@ -349,11 +430,11 @@ mod tests {
         }
     }
 
-    fn position(command_byte_offset: u32, hit_test_item_index: u32) -> Option<SourceTapePosition> {
-        Some(SourceTapePosition {
+    fn position(command_byte_offset: u32, hit_test_item_index: u32) -> SourceTapePosition {
+        SourceTapePosition {
             command_byte_offset,
             hit_test_item_index,
-        })
+        }
     }
 
     struct Anchors(HashMap<CaptureSite, EnclosingCaptureAnchor>);
@@ -379,7 +460,7 @@ mod tests {
         let mut memo = ResolvedEnclosingCaptureMemo::default();
         assert_eq!(
             resolve(7, address(None, 100, 4, 7), &anchors, &mut memo),
-            position(100, 4)
+            Some(position(100, 4))
         );
         assert_eq!(resolve(7, address(None, 100, 4, 6), &anchors, &mut memo), None);
     }
@@ -393,12 +474,12 @@ mod tests {
         let mut memo = ResolvedEnclosingCaptureMemo::default();
         assert_eq!(
             resolve(5, address(Some(subtree(2)), 40, 2, 3), &anchors, &mut memo),
-            position(1540, 17)
+            Some(position(1540, 17))
         );
         assert!(memo.get(&subtree(2)).is_some_and(|memo| memo.source_position.is_some()));
         assert_eq!(
             resolve(5, address(Some(subtree(2)), 8, 1, 3), &anchors, &mut memo),
-            position(1508, 16)
+            Some(position(1508, 16))
         );
     }
 
@@ -415,7 +496,7 @@ mod tests {
         );
         assert_eq!(
             resolve(4, address(Some(subtree(2)), 40, 2, 4), &anchors, &mut memo),
-            position(1540, 17)
+            Some(position(1540, 17))
         );
     }
 
@@ -441,29 +522,174 @@ mod tests {
         );
     }
 
-    #[test]
-    fn enclosing_capture_re_placed_by_the_current_recording_is_rejected_unless_memoized_first() {
-        let mut anchors = HashMap::new();
-        anchors.insert(subtree(1), anchor(address(None, 1000, 10, 5), 5));
-        anchors.insert(subtree(2), anchor(address(Some(subtree(1)), 500, 5, 5), 4));
-        let mut memo = ResolvedEnclosingCaptureMemo::default();
-        {
-            let anchors = Anchors(anchors.clone());
-            assert_eq!(
-                resolve(5, address(Some(subtree(2)), 40, 2, 4), &anchors, &mut memo),
-                position(1540, 17)
-            );
+    fn allocate_paintable(arena: &mut LayoutNodeArena) -> NodeSlotId {
+        let slot = arena.allocate_for_test().slot;
+        arena.populate_paintable_row(slot);
+        slot
+    }
+
+    fn capture(address: CaptureAddress, gen_of_last_fresh_walk: RecordGen) -> CachedSubtreeCapture {
+        CachedSubtreeCapture {
+            address,
+            gen_of_last_fresh_walk,
+            may_be_spliced_verbatim: true,
+            ..Default::default()
         }
-        anchors.insert(subtree(2), anchor(address(Some(subtree(1)), 900, 9, 6), 4));
-        let anchors = Anchors(anchors.clone());
-        assert_eq!(
-            resolve(5, address(Some(subtree(2)), 8, 1, 4), &anchors, &mut memo),
-            position(1508, 16)
+    }
+
+    fn resolve_in_arena(arena: &LayoutNodeArena, address: CaptureAddress) -> Option<SourceTapePosition> {
+        resolve_capture_address_in_source_tape(
+            narrow_record_gen(arena.paint_cache_completed_record_gen()),
+            address,
+            &|site| {
+                arena
+                    .paintable_paint_cache(site.paintable)
+                    .enclosing_capture_anchor(site.kind)
+            },
+            &mut ResolvedEnclosingCaptureMemo::default(),
+        )
+    }
+
+    #[test]
+    fn staging_enclosing_captures_in_either_order_preserves_unmemoized_source_addresses() {
+        let mut arena = LayoutNodeArena::new();
+        let root = CaptureSite {
+            paintable: allocate_paintable(&mut arena),
+            kind: CaptureKind::PaintedAsStackingContext,
+        };
+        let child = CaptureSite {
+            paintable: allocate_paintable(&mut arena),
+            kind: CaptureKind::DescendantSubtreePhase(StackingContextPaintPhase::Foreground),
+        };
+        let point = FfiCssPixelPoint::default();
+        let leaf_address = address(Some(child), 40, 2, 1);
+        let mut source = PendingPaintCacheUpdates::default();
+        source.set_subtree_capture(root, point, capture(address(None, 1000, 10, 1), 1));
+        source.set_subtree_capture(child, point, capture(address(Some(root), 500, 5, 1), 1));
+        source.set_commands(
+            child.paintable,
+            point,
+            PaintPhase::Foreground,
+            CachedBoxPhaseCommands {
+                address: leaf_address,
+                command_byte_count: 32,
+                ..Default::default()
+            },
         );
-        let mut fresh_memo = ResolvedEnclosingCaptureMemo::default();
-        assert_eq!(
-            resolve(5, address(Some(subtree(2)), 8, 1, 4), &anchors, &mut fresh_memo),
-            None
+        source.set_hit_test_items(
+            child.paintable,
+            point,
+            PaintPhase::Foreground,
+            CachedBoxPhaseHitTestItems {
+                address: leaf_address,
+                count: 1,
+                ..Default::default()
+            },
         );
+        source.commit(&arena);
+        arena.note_paint_record_completed_with_cache_writes();
+
+        for order in [[root, child], [child, root]] {
+            let mut pending = PendingPaintCacheUpdates::default();
+            for site in order {
+                let updated = if site == root {
+                    capture(address(None, 1000, 10, 2), 2)
+                } else {
+                    // The child is spliced to a different offset; its interior captures are untouched.
+                    capture(address(Some(root), 900, 9, 2), 1)
+                };
+                pending.set_subtree_capture(site, point, updated);
+            }
+            let cache = arena.paintable_paint_cache(child.paintable);
+            // Each lookup starts with an empty memo, after both replacements have been staged.
+            assert_eq!(
+                resolve_in_arena(&arena, cache.commands(PaintPhase::Foreground).unwrap().address),
+                Some(position(1540, 17))
+            );
+            assert_eq!(
+                resolve_in_arena(&arena, cache.hit_test_items(PaintPhase::Foreground).unwrap().address),
+                Some(position(1540, 17))
+            );
+            drop(cache);
+            assert_eq!(arena.paint_cache_completed_record_gen(), 1);
+            if order[0] == child {
+                pending.commit(&arena);
+                arena.note_paint_record_completed_with_cache_writes();
+            }
+            // Dropping the first pending recording does not change the source.
+        }
+        assert_eq!(resolve_in_arena(&arena, leaf_address), Some(position(1940, 21)));
+
+        // A quiet recording only updates the root. Nested captures must still resolve through it.
+        let mut quiet = PendingPaintCacheUpdates::default();
+        quiet.set_subtree_capture(root, point, capture(address(None, 1000, 10, 3), 2));
+        assert_eq!(quiet.rows.len(), 1);
+        quiet.commit(&arena);
+        arena.note_paint_record_completed_with_cache_writes();
+        let cache = arena.paintable_paint_cache(child.paintable);
+        assert_eq!(cache.commands(PaintPhase::Foreground).unwrap().command_byte_count, 32);
+        assert_eq!(cache.hit_test_items(PaintPhase::Foreground).unwrap().count, 1);
+        assert_eq!(resolve_in_arena(&arena, leaf_address), Some(position(1940, 21)));
+    }
+
+    #[test]
+    fn moved_row_keeps_its_source_position_and_entries_until_commit() {
+        let mut arena = LayoutNodeArena::new();
+        let row = allocate_paintable(&mut arena);
+        let stacking = CaptureSite {
+            paintable: row,
+            kind: CaptureKind::PaintedAsStackingContext,
+        };
+        let descendants = CaptureSite {
+            paintable: row,
+            kind: CaptureKind::DescendantSubtreePhase(StackingContextPaintPhase::Foreground),
+        };
+        let old_position = FfiCssPixelPoint::default();
+        let new_position = FfiCssPixelPoint {
+            x: crate::layout::CssPixels::from_integer(10),
+            ..old_position
+        };
+        let mut source = PendingPaintCacheUpdates::default();
+        source.set_commands(
+            row,
+            old_position,
+            PaintPhase::Foreground,
+            CachedBoxPhaseCommands::default(),
+        );
+        source.set_hit_test_items(
+            row,
+            old_position,
+            PaintPhase::Foreground,
+            CachedBoxPhaseHitTestItems::default(),
+        );
+        source.set_subtree_capture(stacking, old_position, capture(address(None, 100, 2, 1), 1));
+        source.commit(&arena);
+        arena.note_paint_record_completed_with_cache_writes();
+        arena.invalidate_paint_cache(row);
+
+        let mut pending = PendingPaintCacheUpdates::default();
+        // Even an empty new capture must retire every old-position entry at publication.
+        pending.set_subtree_capture(descendants, new_position, capture(address(None, 200, 4, 2), 2));
+        let cache = arena.paintable_paint_cache(row);
+        assert_eq!(cache.captured_absolute_position(), old_position);
+        assert!(cache.commands(PaintPhase::Foreground).is_some());
+        assert!(cache.hit_test_items(PaintPhase::Foreground).is_some());
+        assert!(cache.subtree_capture(stacking.kind).is_some());
+        assert!(cache.subtree_capture(descendants.kind).is_none());
+        drop(cache);
+
+        pending.commit(&arena);
+        let cache = arena.paintable_paint_cache(row);
+        assert_eq!(cache.captured_absolute_position(), new_position);
+        assert!(cache.commands(PaintPhase::Foreground).is_none());
+        assert!(cache.hit_test_items(PaintPhase::Foreground).is_none());
+        assert!(cache.subtree_capture(stacking.kind).is_none());
+        assert_eq!(
+            cache.subtree_capture(descendants.kind).unwrap().address,
+            address(None, 200, 4, 2)
+        );
+        // Capture publication does not itself consume dirty state or advance the recording generation.
+        assert!(cache.is_self_dirty_since(1));
+        assert_eq!(arena.paint_cache_completed_record_gen(), 1);
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -31,7 +31,7 @@ use crate::painting::hit_test::HitTestList;
 use crate::painting::host::{FfiRecordingInputs, FfiRootBackgroundSource, FfiVisualContextTreeInputs};
 use crate::painting::paintable_data::{InlineBoxPieceRecord, PaintableData};
 use crate::painting::paintable_rows::PaintableRowsRef;
-use crate::painting::record::cache::{OpenCapture, RecordGen};
+use crate::painting::record::cache::{OpenCapture, PendingPaintCacheUpdates, RecordGen};
 use crate::painting::record::svg_resources::SvgResourceWalk;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -89,6 +89,12 @@ pub struct RecordingOutput {
     pub(crate) capture_log_for_verification: Option<verify::CaptureLog>,
 }
 
+pub(crate) struct RecordingResult {
+    pub(crate) output: RecordingOutput,
+    pub(crate) resources: resources::RecordingResourceManifest,
+    pub(crate) cache_updates: PendingPaintCacheUpdates,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum PaintPhase {
@@ -125,6 +131,7 @@ pub struct PaintRecorder<'a, O: Observer> {
     command_cache_source: Option<Rc<RecordingOutput>>,
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
     open_capture_stack: Vec<OpenCapture>,
+    cache_updates: PendingPaintCacheUpdates,
     deferred_whole_tape_splice: Option<DeferredWholeTapeSplice>,
     pub(crate) blocking_wheel_event_region_count: u32,
     uncacheable_paint_generation: u64,

--- a/Libraries/LibWeb/Rust/src/painting/record/publish.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/publish.rs
@@ -8,11 +8,12 @@ use crate::layout::LayoutNodeArena;
 use crate::painting::display_list::commands::{DisplayListCommandType, DisplayListResourceId, PaintNestedDisplayList};
 use crate::painting::host::FfiRecordingPublishCallbacks;
 use crate::painting::paint_state::PendingRecording;
-use crate::painting::record::RecordingOutput;
+use crate::painting::record::cache::PendingPaintCacheUpdates;
 use crate::painting::record::resources::RecordingResourceManifest;
 use crate::painting::record::vector_images::{
     VectorImageRenderRequest, is_vector_image_placeholder, vector_image_placeholder_index,
 };
+use crate::painting::record::{RecordingOutput, RecordingResult};
 
 fn resolve_vector_image_placeholders(
     output: &mut RecordingOutput,
@@ -57,8 +58,11 @@ pub(crate) fn publish_recording(
     publish: &FfiRecordingPublishCallbacks,
 ) -> u64 {
     let PendingRecording {
-        mut output,
-        resources,
+        recording: RecordingResult {
+            mut output,
+            resources,
+            cache_updates,
+        },
         recording_from_scratch,
         paint_command_cache_read_write,
     } = pending;
@@ -82,14 +86,28 @@ pub(crate) fn publish_recording(
         publish.add_video_sink(resource_id, sink_handle);
     }
     resolve_vector_image_placeholders(&mut output, &vector_image_render_requests, publish);
-    if let Some((mut recording_from_scratch, resources_from_scratch)) = recording_from_scratch {
+    if let Some(mut recording_from_scratch) = recording_from_scratch {
+        debug_assert!(recording_from_scratch.cache_updates.is_empty());
         resolve_vector_image_placeholders(
-            &mut recording_from_scratch,
-            &resources_from_scratch.vector_image_render_requests,
+            &mut recording_from_scratch.output,
+            &recording_from_scratch.resources.vector_image_render_requests,
             publish,
         );
-        crate::painting::record::verify::verify_spliced_recording_matches_fresh(&output, &recording_from_scratch);
+        crate::painting::record::verify::verify_spliced_recording_matches_fresh(
+            &output,
+            &recording_from_scratch.output,
+        );
     }
+    publish_recording_output(arena, output, cache_updates, paint_command_cache_read_write)
+}
+
+// Resource callbacks and verification must finish before the new captures become the source.
+fn publish_recording_output(
+    arena: &LayoutNodeArena,
+    mut output: RecordingOutput,
+    cache_updates: PendingPaintCacheUpdates,
+    paint_command_cache_read_write: bool,
+) -> u64 {
     let mut paint_state = arena.paint_state().borrow_mut();
     output.is_identical_to_cache_source = paint_state
         .paint_command_cache_source
@@ -124,11 +142,90 @@ pub(crate) fn publish_recording(
     }
     let output = std::rc::Rc::new(output);
     if paint_command_cache_read_write {
+        cache_updates.commit(arena);
         paint_state.paint_command_cache_source = Some(output.clone());
         // Read-only recordings commit nothing and must not age dirty stamps out.
         arena.note_paint_record_completed_with_cache_writes();
         paint_state.visual_context.quarantined_slots_are_releasable = true;
+    } else {
+        debug_assert!(cache_updates.is_empty());
     }
     paint_state.last_recording = Some(output);
     paint_state.hit_test_list.as_ref().map_or(0, |list| list.generation)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::used_values::FfiCssPixelPoint;
+    use crate::painting::hit_test::HitTestList;
+    use crate::painting::record::PaintPhase;
+    use crate::painting::record::cache::{CachedBoxPhaseCommands, CaptureAddress, PendingPaintCacheUpdates};
+    use std::rc::Rc;
+
+    #[test]
+    fn read_only_publication_preserves_capture_source_and_pending_dirtiness() {
+        let mut arena = LayoutNodeArena::new();
+        let row = arena.allocate_for_test().slot;
+        arena.populate_paintable_row(row);
+        let mut original_source = None;
+        // Publish a source, a read-only recording, and then the pending repaint.
+        for (hit_test_generation, read_write) in [(1, true), (2, false), (3, true)] {
+            let mut cache_updates = PendingPaintCacheUpdates::default();
+            let next_record_gen = arena.paint_cache_completed_record_gen() as u32 + 1;
+            if read_write {
+                cache_updates.set_commands(
+                    row,
+                    FfiCssPixelPoint::default(),
+                    PaintPhase::Foreground,
+                    CachedBoxPhaseCommands {
+                        address: CaptureAddress {
+                            written_in_record_gen: next_record_gen,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                );
+            }
+            let output = RecordingOutput {
+                hit_test_list: HitTestList {
+                    generation: hit_test_generation,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            assert_eq!(
+                publish_recording_output(&arena, output, cache_updates, read_write),
+                hit_test_generation
+            );
+            let source = arena.paint_state().borrow().paint_command_cache_source.clone().unwrap();
+            let cache = arena.paintable_paint_cache(row);
+            let capture_gen = cache
+                .commands(PaintPhase::Foreground)
+                .unwrap()
+                .address
+                .written_in_record_gen;
+            match hit_test_generation {
+                1 => {
+                    original_source = Some(source);
+                    arena.invalidate_paint_cache(row);
+                    assert_eq!(capture_gen, 1);
+                    assert!(cache.is_self_dirty_since(1));
+                }
+                2 => {
+                    assert!(Rc::ptr_eq(original_source.as_ref().unwrap(), &source));
+                    assert_eq!(capture_gen, 1);
+                    assert_eq!(arena.paint_cache_completed_record_gen(), 1);
+                    assert!(cache.is_self_dirty_since(1));
+                }
+                3 => {
+                    assert!(!Rc::ptr_eq(original_source.as_ref().unwrap(), &source));
+                    assert_eq!(capture_gen, 2);
+                    assert_eq!(arena.paint_cache_completed_record_gen(), 2);
+                    assert!(!cache.is_self_dirty_since(2));
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/scratch.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/scratch.rs
@@ -33,9 +33,6 @@ pub(crate) struct PerRecordingMemoTables {
     base_paint_facts: Vec<StampedEntry<BasePaintFacts>>,
     hit_test_facts: Vec<StampedEntry<HitTestFacts>>,
     absolute_positions: Vec<StampedEntry<FfiCssPixelPoint>>,
-    // The first phase that re-records a moved row updates the live per-row cell, so later
-    // phases must compare against this snapshot or they would accept their stale captures.
-    captured_positions_snapshotted_at_recording_start: Vec<StampedEntry<FfiCssPixelPoint>>,
     resolved_enclosing_capture_memo: ResolvedEnclosingCaptureMemo,
 }
 
@@ -83,7 +80,6 @@ impl PerRecordingMemoTables {
                 self.base_paint_facts.clear();
                 self.hit_test_facts.clear();
                 self.absolute_positions.clear();
-                self.captured_positions_snapshotted_at_recording_start.clear();
                 1
             }
         };
@@ -91,8 +87,6 @@ impl PerRecordingMemoTables {
             self.base_paint_facts.resize(row_count, StampedEntry::default());
             self.hit_test_facts.resize(row_count, StampedEntry::default());
             self.absolute_positions.resize(row_count, StampedEntry::default());
-            self.captured_positions_snapshotted_at_recording_start
-                .resize(row_count, StampedEntry::default());
         }
         self.resolved_enclosing_capture_memo.clear();
     }
@@ -107,12 +101,6 @@ impl PerRecordingMemoTables {
         absolute_position,
         set_absolute_position,
         absolute_positions,
-        FfiCssPixelPoint
-    );
-    memo_table!(
-        captured_position_at_recording_start,
-        set_captured_position_at_recording_start,
-        captured_positions_snapshotted_at_recording_start,
         FfiCssPixelPoint
     );
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -27,7 +27,7 @@ use crate::painting::record::resources::RecordingResourceManifest;
 use crate::painting::record::svg_resources::MaskLayerSet;
 use crate::painting::record::trace::{Action, Operation};
 use crate::painting::record::verify::LoggedCapture;
-use crate::painting::record::{DeferredWholeTapeSplice, RecordingOutput};
+use crate::painting::record::{DeferredWholeTapeSplice, RecordingOutput, RecordingResult};
 use crate::painting::style_queries;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -73,7 +73,7 @@ pub(crate) fn record_display_list(
     command_cache_source: Option<Rc<RecordingOutput>>,
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
     trace: bool,
-) -> (RecordingOutput, RecordingResourceManifest) {
+) -> RecordingResult {
     macro_rules! record {
         ($observer:ty) => {
             record_display_list_impl::<$observer>(
@@ -103,7 +103,7 @@ fn record_display_list_impl<O: Observer>(
     hit_test_list_generation: u64,
     command_cache_source: Option<Rc<RecordingOutput>>,
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
-) -> (RecordingOutput, RecordingResourceManifest) {
+) -> RecordingResult {
     let structural_epoch = paint_state.visual_context.structural_epoch();
     let command_cache_source = command_cache_source
         .filter(|source| source.recorded_device_pixels_per_css_pixel == inputs.device_pixels_per_css_pixel);
@@ -127,6 +127,7 @@ fn record_display_list_impl<O: Observer>(
         command_cache_source,
         item_cache_source,
         open_capture_stack: Vec::new(),
+        cache_updates: Default::default(),
         deferred_whole_tape_splice: None,
         viewport,
         blocking_wheel_event_region_count: 0,
@@ -196,7 +197,11 @@ fn record_display_list_impl<O: Observer>(
         is_identical_to_cache_source: false,
         capture_log_for_verification: recorder.observer.finish(),
     };
-    (output, recorder.resources)
+    RecordingResult {
+        output,
+        resources: recorder.resources,
+        cache_updates: recorder.cache_updates,
+    }
 }
 
 fn materialize_deferred_whole_tape_splice(
@@ -691,6 +696,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         let Some(cached) = cache.subtree_capture(site.kind) else {
             return false;
         };
+        let captured_position = cache.captured_absolute_position();
         drop(cache);
         if !cached.may_be_spliced_verbatim {
             return false;
@@ -700,7 +706,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         {
             return false;
         }
-        if self.captured_position_at_recording_start(site.paintable) != self.current_absolute_position(site.paintable) {
+        if captured_position != self.current_absolute_position(site.paintable) {
             return false;
         }
         let Some(source_position) = self.resolve_capture_address_in_source_tape(cached.address) else {
@@ -766,23 +772,16 @@ impl<O: Observer> PaintRecorder<'_, O> {
     }
 
     fn store_subtree_capture(
-        &self,
+        &mut self,
         site: CaptureSite,
         command_range: CommandRange,
         hit_test_item_start: usize,
         hit_test_item_count: usize,
         walk_outcome: SubtreeCaptureWalkOutcome,
     ) {
-        let cache = self.layout_arena.paintable_paint_cache(site.paintable);
-        cache.register_capture_position(self.current_absolute_position(site.paintable));
-        debug_assert!(
-            cache
-                .subtree_capture(site.kind)
-                .is_none_or(|entry| entry.address.written_in_record_gen != self.current_record_gen()),
-            "a capture site ran twice in one recording"
-        );
-        cache.set_subtree_capture(
-            site.kind,
+        self.cache_updates.set_subtree_capture(
+            site,
+            self.current_absolute_position(site.paintable),
             CachedSubtreeCapture {
                 address: self
                     .address_relative_to_innermost_open_capture(command_range.offset, hit_test_item_start as u32),
@@ -849,24 +848,6 @@ impl<O: Observer> PaintRecorder<'_, O> {
                 spliced_from_cache,
             });
         });
-    }
-
-    fn captured_position_at_recording_start(&self, paintable: NodeSlotId) -> used_values::FfiCssPixelPoint {
-        if let Some(position) = self
-            .memo_tables
-            .borrow()
-            .captured_position_at_recording_start(paintable)
-        {
-            return position;
-        }
-        let position = self
-            .layout_arena
-            .paintable_paint_cache(paintable)
-            .captured_absolute_position();
-        self.memo_tables
-            .borrow_mut()
-            .set_captured_position_at_recording_start(paintable, position);
-        position
     }
 
     fn current_absolute_position(&self, paintable: NodeSlotId) -> used_values::FfiCssPixelPoint {
@@ -1148,8 +1129,9 @@ impl<O: Observer> PaintRecorder<'_, O> {
             return None;
         }
         let entry = cache.commands(phase)?;
+        let captured_position = cache.captured_absolute_position();
         drop(cache);
-        if self.captured_position_at_recording_start(paintable) != self.current_absolute_position(paintable) {
+        if captured_position != self.current_absolute_position(paintable) {
             return None;
         }
         let offset = self
@@ -1232,8 +1214,9 @@ impl<O: Observer> PaintRecorder<'_, O> {
         if entry.recorded_context != own_context || entry.recorded_context_for_descendants != for_descendants_context {
             return None;
         }
+        let captured_position = cache.captured_absolute_position();
         drop(cache);
-        if self.captured_position_at_recording_start(paintable) != self.current_absolute_position(paintable) {
+        if captured_position != self.current_absolute_position(paintable) {
             return None;
         }
         let start = self
@@ -1243,7 +1226,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
     }
 
     fn set_cached_commands(
-        &self,
+        &mut self,
         paintable: NodeSlotId,
         phase: PaintPhase,
         range: CommandRange,
@@ -1257,15 +1240,9 @@ impl<O: Observer> PaintRecorder<'_, O> {
             self.captured_range_references_only_the_phase_context(paintable, range, recorded_context),
             "a per-phase paint capture records under its phase context or without clips and effects"
         );
-        let cache = self.layout_arena.paintable_paint_cache(paintable);
-        cache.register_capture_position(self.current_absolute_position(paintable));
-        debug_assert!(
-            cache
-                .commands(phase)
-                .is_none_or(|entry| entry.address.written_in_record_gen != self.current_record_gen()),
-            "a per-phase command capture site ran twice in one recording"
-        );
-        cache.set_commands(
+        self.cache_updates.set_commands(
+            paintable,
+            self.current_absolute_position(paintable),
             phase,
             crate::painting::record::cache::CachedBoxPhaseCommands {
                 address: self.address_relative_to_innermost_open_capture(range.offset, self.list.items.len() as u32),
@@ -1321,7 +1298,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
     }
 
     fn set_cached_hit_test_items(
-        &self,
+        &mut self,
         paintable: NodeSlotId,
         phase: PaintPhase,
         start: usize,
@@ -1329,15 +1306,9 @@ impl<O: Observer> PaintRecorder<'_, O> {
         recorded_context: ContextRef,
         recorded_context_for_descendants: ContextRef,
     ) {
-        let cache = self.layout_arena.paintable_paint_cache(paintable);
-        cache.register_capture_position(self.current_absolute_position(paintable));
-        debug_assert!(
-            cache
-                .hit_test_items(phase)
-                .is_none_or(|entry| entry.address.written_in_record_gen != self.current_record_gen()),
-            "a per-phase hit-test capture site ran twice in one recording"
-        );
-        cache.set_hit_test_items(
+        self.cache_updates.set_hit_test_items(
+            paintable,
+            self.current_absolute_position(paintable),
             phase,
             crate::painting::record::cache::CachedBoxPhaseHitTestItems {
                 address: self


### PR DESCRIPTION
Keep source capture addresses and positions unchanged while recording. Collect sparse updates for touched rows and apply them after resource publication and cache verification, alongside the new cache source.

Remove the position snapshot workaround and cover capture resolution in either staging order, moved rows, quiet recordings, and read-only publication.