### PR TITLE
LibWeb: Make display list recording inputs and state explicit

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -6175,19 +6175,6 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
     if (!document)
         return false;
 
-    // Cached captures splice in below the recorder's color resolution, so any effective-state change must drop them.
-    // Caught here, not at the producers: the page can flip the state itself via a color-scheme meta or root restyle.
-    ForceDarkPaintInputs force_dark_paint_inputs {
-        paint_config.force_dark_enabled,
-        paint_config.force_dark_foreground_threshold,
-        paint_config.force_dark_background_threshold,
-    };
-    if (m_force_dark_inputs_of_cached_paint != force_dark_paint_inputs) {
-        if (document->has_committed_viewport_box())
-            document->paint_state().invalidate_all_cached_paint(*document);
-        m_force_dark_inputs_of_cached_paint = force_dark_paint_inputs;
-    }
-
     adopt_pending_async_scroll_offsets();
     document->update_paint_and_hit_testing_properties_if_needed();
     document->update_compositor_animations();

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -563,14 +563,6 @@ private:
     bool m_force_dark_enabled { false };
     i32 m_force_dark_foreground_threshold { default_force_dark_foreground_threshold };
     i32 m_force_dark_background_threshold { default_force_dark_background_threshold };
-    // What the live paint-command cache was recorded under; the recording funnel drops the cache when these move.
-    struct ForceDarkPaintInputs {
-        bool enabled { false };
-        i32 foreground_threshold { 0 };
-        i32 background_threshold { 0 };
-        bool operator==(ForceDarkPaintInputs const&) const = default;
-    };
-    Optional<ForceDarkPaintInputs> m_force_dark_inputs_of_cached_paint;
     bool m_should_show_caret_hit_test_debug_overlay { false };
     Optional<PaintConfig> m_compositor_display_list_paint_config;
     RefPtr<Painting::DisplayList> m_compositor_display_list;

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -516,6 +516,8 @@ pub(crate) struct LayoutNodeArena {
     fc_run_cache_store: super::fc_run_cache::FcRunCacheArenaStore,
     pub(crate) paintable_rows: crate::painting::paintable_rows::PaintableRowStore,
     paint_state: RefCell<crate::painting::paint_state::PaintState>,
+    // Reuse workspace allocations without making recording scratch part of the committed paint state.
+    recording_scratch: RefCell<crate::painting::record::scratch::RecordingScratch>,
     pub(crate) scrollable_overflow: crate::painting::scrollable_overflow::ScrollableOverflowState,
     pub(crate) anchor_positioning_nodes: RefCell<HashSet<NodeSlotId>>,
     pub(crate) partial_relayout_boundary_roots: RefCell<Vec<NodeSlotId>>,
@@ -567,6 +569,7 @@ impl LayoutNodeArena {
             fc_run_cache_store: super::fc_run_cache::FcRunCacheArenaStore::default(),
             paintable_rows: crate::painting::paintable_rows::PaintableRowStore::default(),
             paint_state: RefCell::new(crate::painting::paint_state::PaintState::default()),
+            recording_scratch: RefCell::new(crate::painting::record::scratch::RecordingScratch::default()),
             scrollable_overflow: Default::default(),
             anchor_positioning_nodes: RefCell::new(HashSet::default()),
             partial_relayout_boundary_roots: RefCell::new(Vec::new()),
@@ -2497,6 +2500,10 @@ impl LayoutNodeArena {
 
     pub(crate) fn paint_state(&self) -> &RefCell<crate::painting::paint_state::PaintState> {
         &self.paint_state
+    }
+
+    pub(crate) fn recording_scratch(&self) -> &RefCell<crate::painting::record::scratch::RecordingScratch> {
+        &self.recording_scratch
     }
 
     pub(crate) fn node_flags_if_live(&self, id: NodeSlotId) -> u32 {

--- a/Libraries/LibWeb/Rust/src/painting/chrome_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/chrome_geometry.rs
@@ -214,7 +214,7 @@ pub(crate) struct ChromeGeometry<'a, Arena: PaintableRowsRead> {
 }
 
 impl<'a, Arena: PaintableRowsRead> ChromeGeometry<'a, Arena> {
-    pub(crate) fn for_recording(arena: &'a Arena, inputs: &RecordingInputs) -> Self {
+    pub(crate) fn for_recording(arena: &'a Arena, inputs: &RecordingInputs<'_>) -> Self {
         Self {
             arena,
             metrics: inputs.chrome_metrics,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1492,10 +1492,12 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
                 .last_root_background_source
                 .expect("a recording follows a visual context update"),
         );
+        let mut scratch = arena.recording_scratch().borrow_mut();
         arena.set_paint_recording_in_progress(true);
         let recording = crate::painting::record::traversal::record_display_list(
             arena,
             &paint_state,
+            &mut scratch,
             viewport,
             inputs,
             paint_state.hit_test_list_generation + 1,
@@ -1520,6 +1522,7 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
                 crate::painting::record::traversal::record_display_list(
                     arena,
                     &paint_state,
+                    &mut scratch,
                     viewport,
                     inputs_for_recording_from_scratch,
                     paint_state.hit_test_list_generation + 1,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1465,6 +1465,8 @@ pub unsafe extern "C" fn layout_arena_refresh_scroll_state(
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+/// Input arrays and byte buffers must remain valid and immutable throughout this call;
+/// fonts for enabled overlays must be live `Gfx::Font`s.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_record_display_list(
     arena: *mut c_void,
@@ -1483,15 +1485,18 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
             return false;
         }
         let visual_context = &paint_state.visual_context;
-        let inputs = crate::painting::record::RecordingInputs::from_host_and_last_visual_context_update(
-            inputs,
-            visual_context
-                .last_tree_inputs
-                .expect("a recording follows a visual context update"),
-            visual_context
-                .last_root_background_source
-                .expect("a recording follows a visual context update"),
-        );
+        // SAFETY: The host lends the input arrays and buffers for this call. Only owned
+        // output and retained resources escape into the pending recording below.
+        let inputs = unsafe {
+            inputs.borrow_recording_inputs(
+                visual_context
+                    .last_tree_inputs
+                    .expect("a recording follows a visual context update"),
+                visual_context
+                    .last_root_background_source
+                    .expect("a recording follows a visual context update"),
+            )
+        };
         let mut scratch = arena.recording_scratch().borrow_mut();
         arena.set_paint_recording_in_progress(true);
         let recording = crate::painting::record::traversal::record_display_list(
@@ -1499,7 +1504,7 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
             &paint_state,
             &mut scratch,
             viewport,
-            inputs,
+            &inputs,
             paint_state.hit_test_list_generation + 1,
             paint_state.paint_command_cache_source.clone(),
             paint_state.hit_test_item_cache_source.clone(),
@@ -1517,14 +1522,14 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
                 })
             && !inputs.should_show_line_box_borders)
             .then(|| {
-                let mut inputs_for_recording_from_scratch = inputs;
+                let mut inputs_for_recording_from_scratch = inputs.clone();
                 inputs_for_recording_from_scratch.paint_command_cache_read_write = false;
                 crate::painting::record::traversal::record_display_list(
                     arena,
                     &paint_state,
                     &mut scratch,
                     viewport,
-                    inputs_for_recording_from_scratch,
+                    &inputs_for_recording_from_scratch,
                     paint_state.hit_test_list_generation + 1,
                     None,
                     None,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1476,19 +1476,6 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
         let mut paint_state = arena.paint_state().borrow_mut();
         paint_state.pending_recording_trace = None;
         paint_state.pending_recording = None;
-        let has_blocking_wheel_event_region_covering_viewport =
-            inputs.has_blocking_wheel_event_region_covering_viewport;
-        if paint_state.recorded_has_blocking_wheel_event_region_covering_viewport
-            != Some(has_blocking_wheel_event_region_covering_viewport)
-        {
-            arena.mark_all_descendant_subtree_caches_dirty();
-            paint_state.recorded_has_blocking_wheel_event_region_covering_viewport =
-                Some(has_blocking_wheel_event_region_covering_viewport);
-        }
-        if paint_state.recorded_canvas_color != Some(inputs.canvas_color) {
-            arena.mark_all_paint_caches_dirty();
-            paint_state.recorded_canvas_color = Some(inputs.canvas_color);
-        }
     }
     let (recording, recording_from_scratch) = {
         let paint_state = arena.paint_state().borrow();
@@ -1505,9 +1492,6 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
                 .last_root_background_source
                 .expect("a recording follows a visual context update"),
         );
-        let command_cache_source = (!inputs.should_show_line_box_borders)
-            .then(|| paint_state.paint_command_cache_source.clone())
-            .flatten();
         arena.set_paint_recording_in_progress(true);
         let recording = crate::painting::record::traversal::record_display_list(
             arena,
@@ -1515,7 +1499,7 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
             viewport,
             inputs,
             paint_state.hit_test_list_generation + 1,
-            command_cache_source,
+            paint_state.paint_command_cache_source.clone(),
             paint_state.hit_test_item_cache_source.clone(),
             paint_state.trace_recordings || crate::painting::record::verify::enabled_by_environment(),
         );

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -63,6 +63,134 @@ pub struct FfiRecordingInputs {
     pub grid_label_fonts: FfiOverlayLabelFonts,
 }
 
+impl FfiRecordingInputs {
+    /// # Safety
+    ///
+    /// Nonempty arrays and byte buffers must be aligned, valid and immutable for the
+    /// returned inputs' lifetime. Fonts for enabled overlays must point to live `Gfx::Font`s.
+    pub(crate) unsafe fn borrow_recording_inputs(
+        &self,
+        tree_inputs: super::FfiVisualContextTreeInputs,
+        root_background_source: super::FfiRootBackgroundSource,
+    ) -> crate::painting::record::inputs::RecordingInputs<'_> {
+        use crate::painting::display_list::commands::UniqueNodeId;
+        use crate::painting::ffi::ffi_slice;
+        use crate::painting::force_dark::ForceDarkSettings;
+        use crate::painting::record::inputs::{
+            CaretPaint, CaretTarget, FocusedAreaOutline, FocusedTextControlSelection, GridOverlays, InspectorHighlight,
+            RecordingInputs,
+        };
+
+        // SAFETY: The caller lends these arrays and buffers for the returned inputs' lifetime.
+        let (grid_overlays, flex_overlays, outline_path) = unsafe {
+            (
+                ffi_slice(self.grid_overlays, self.grid_overlay_count),
+                ffi_slice(self.flex_overlays, self.flex_overlay_count),
+                ffi_slice(
+                    self.focused_area_outline.path_bytes,
+                    self.focused_area_outline.path_byte_count,
+                ),
+            )
+        };
+        let caret = self.caret;
+        let caret_target = match caret.kind {
+            FfiCaretPaintKind::None => None,
+            FfiCaretPaintKind::InBlock => Some(CaretTarget::InBlock {
+                block: caret.block,
+                owner: (!caret.owner.is_invalid()).then_some(caret.owner),
+            }),
+            FfiCaretPaintKind::EmptyInline => Some(CaretTarget::EmptyInline(caret.block)),
+        };
+        let control = self.focused_text_control;
+        RecordingInputs {
+            device_pixels_per_css_pixel: tree_inputs.device_pixels_per_css_pixel,
+            viewport_wheel_overflow_x: tree_inputs.viewport_wheel_overflow_x,
+            viewport_wheel_overflow_y: tree_inputs.viewport_wheel_overflow_y,
+            root_background_source,
+            device_viewport_rect: self.device_viewport_rect,
+            css_viewport_rect: self.css_viewport_rect.into(),
+            should_show_line_box_borders: self.should_show_line_box_borders,
+            force_dark_enabled: self.force_dark_enabled,
+            force_dark_settings: ForceDarkSettings {
+                foreground_brightness_threshold: self.force_dark_foreground_threshold,
+                background_brightness_threshold: self.force_dark_background_threshold,
+            },
+            should_paint_overlay: self.should_paint_overlay,
+            is_recording_async_scrolling_metadata: self.is_recording_async_scrolling_metadata,
+            document_id: UniqueNodeId(self.document_id),
+            has_blocking_wheel_event_region_covering_viewport: self.has_blocking_wheel_event_region_covering_viewport,
+            wheel_event_listener_state_generation: self.wheel_event_listener_state_generation,
+            chrome_metrics: self.chrome_metrics,
+            paint_viewport_scrollbars: self.paint_viewport_scrollbars,
+            async_scrolling_enabled: self.async_scrolling_enabled,
+            middle_button_scroll_origin: self
+                .middle_button_scroll_active
+                .then(|| self.middle_button_scroll_origin.into()),
+            canvas_fill_rect: self.canvas_fill_rect.has_value.then_some(self.canvas_fill_rect.value),
+            canvas_color: self.canvas_color,
+            opaque_canvas: self.opaque_canvas,
+            bitmap_rect: self.bitmap_rect,
+            background_color: self.background_color,
+            paint_command_cache_read_write: self.paint_command_cache_read_write,
+            window_is_focused: self.window_is_focused,
+            outline_auto_color: self.outline_auto_color,
+            selection_background_from_palette: self.selection_background_from_palette,
+            selection_background_light: self.selection_background_light,
+            selection_background_dark: self.selection_background_dark,
+            palette_is_dark: self.palette_is_dark,
+            document_has_supported_color_schemes: self.document_has_supported_color_schemes,
+            inspector_highlight: self.has_inspector_highlight.then(|| {
+                // SAFETY: The caller lends the label bytes and supplies live fonts for this overlay.
+                let (text, fonts) = unsafe {
+                    (
+                        ffi_slice(
+                            self.inspector_highlight_label.text,
+                            self.inspector_highlight_label.text_byte_count,
+                        ),
+                        self.inspector_highlight_label.fonts.retain(),
+                    )
+                };
+                InspectorHighlight {
+                    paintable: self.inspector_highlight_paintable,
+                    label: String::from_utf8_lossy(text),
+                    fonts,
+                }
+            }),
+            tooltip_color: self.tooltip_color,
+            tooltip_text_color: self.tooltip_text_color,
+            tooltip_border_color: self.tooltip_border_color,
+            grid_overlays: (!grid_overlays.is_empty()).then(|| GridOverlays {
+                inputs: grid_overlays,
+                // SAFETY: The caller supplies live label fonts when grid overlays are enabled.
+                fonts: unsafe { self.grid_label_fonts.retain() },
+            }),
+            flex_overlays,
+            caret_debug_rect: self
+                .caret_debug_rect
+                .has_value
+                .then(|| self.caret_debug_rect.value.into()),
+            caret: caret_target.map(|target| CaretPaint {
+                target,
+                rect: caret.rect.into(),
+                color: caret.color,
+                blink_cycle_start_time_ns: caret.blink_cycle_start_time_ns,
+                should_blink: caret.should_blink,
+            }),
+            focused_text_control: (control.start != control.end).then_some(FocusedTextControlSelection {
+                text_node: control.text_node,
+                start: control.start,
+                end: control.end,
+            }),
+            focused_area_outline: (!outline_path.is_empty()).then_some(FocusedAreaOutline {
+                image: self.focused_area_outline.image,
+                path_bytes: outline_path,
+                color: self.focused_area_outline.color,
+                width: self.focused_area_outline.width,
+            }),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum FfiCaretPaintKind {
@@ -117,6 +245,21 @@ pub struct FfiFocusedAreaOutline {
 pub struct FfiOverlayLabelFonts {
     pub css_font: *const c_void,
     pub device_font: *const c_void,
+}
+
+impl FfiOverlayLabelFonts {
+    /// # Safety
+    ///
+    /// Both pointers must refer to live `Gfx::Font`s.
+    unsafe fn retain(self) -> crate::painting::record::inputs::OverlayLabelFonts {
+        // SAFETY: The caller supplies live fonts; the handles retain them for recording.
+        unsafe {
+            crate::painting::record::inputs::OverlayLabelFonts {
+                css_font: libgfx_rust::font::FontHandle::intern(self.css_font),
+                device_font: libgfx_rust::font::FontHandle::intern(self.device_font),
+            }
+        }
+    }
 }
 
 /// The inspector's box-model label for the highlighted node: UTF-8 text live for the recording call.

--- a/Libraries/LibWeb/Rust/src/painting/paint_state.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paint_state.rs
@@ -30,8 +30,6 @@ pub struct PaintState {
     pub(crate) last_recording: Option<Rc<crate::painting::record::RecordingOutput>>,
     pub(crate) paint_command_cache_source: Option<Rc<crate::painting::record::RecordingOutput>>,
     pub(crate) hit_test_item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
-    pub(crate) recorded_has_blocking_wheel_event_region_covering_viewport: Option<bool>,
-    pub(crate) recorded_canvas_color: Option<libgfx_rust::Color>,
     pub(crate) selection: Option<crate::painting::selection::SelectionRange>,
     pub(crate) selection_pseudo_styles:
         std::collections::HashMap<NodeSlotId, Rc<crate::painting::record::paint::text::SelectionStyleAnswer>>,

--- a/Libraries/LibWeb/Rust/src/painting/paint_state.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paint_state.rs
@@ -5,7 +5,6 @@
  */
 
 use crate::layout::node_data::NodeSlotId;
-use std::cell::RefCell;
 use std::rc::Rc;
 
 pub(crate) struct PendingRecording {
@@ -33,7 +32,6 @@ pub struct PaintState {
     pub(crate) selection: Option<crate::painting::selection::SelectionRange>,
     pub(crate) selection_pseudo_styles:
         std::collections::HashMap<NodeSlotId, Rc<crate::painting::record::paint::text::SelectionStyleAnswer>>,
-    pub(crate) per_recording_memo_tables: RefCell<crate::painting::record::scratch::PerRecordingMemoTables>,
 }
 
 impl PaintState {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -180,7 +180,6 @@ pub(crate) struct PaintableRowStore {
     chrome_state_callback: Cell<Option<ChromeStateCallback>>,
     completed_record_gen: Cell<u64>,
     all_paint_caches_dirty_gen: Cell<u64>,
-    all_descendant_subtree_caches_dirty_gen: Cell<u64>,
     paint_recording_in_progress: Cell<bool>,
 }
 
@@ -716,7 +715,6 @@ impl LayoutNodeArena {
             cache.reset_entries_position_and_dirty_gens();
         }
         self.paintable_rows.all_paint_caches_dirty_gen.set(0);
-        self.paintable_rows.all_descendant_subtree_caches_dirty_gen.set(0);
         self.paintable_rows.completed_record_gen.set(0);
     }
 
@@ -738,20 +736,8 @@ impl LayoutNodeArena {
             .set(self.paint_cache_next_dirty_gen());
     }
 
-    pub(crate) fn mark_all_descendant_subtree_caches_dirty(&self) {
-        self.debug_assert_not_recording();
-        self.paintable_rows
-            .all_descendant_subtree_caches_dirty_gen
-            .set(self.paint_cache_next_dirty_gen());
-    }
-
     pub(crate) fn all_paint_caches_dirty(&self) -> bool {
         self.paintable_rows.all_paint_caches_dirty_gen.get() > self.paintable_rows.completed_record_gen.get()
-    }
-
-    pub(crate) fn all_descendant_subtree_caches_dirty(&self) -> bool {
-        self.paintable_rows.all_descendant_subtree_caches_dirty_gen.get()
-            > self.paintable_rows.completed_record_gen.get()
     }
 
     pub(crate) fn inline_pieces_root(&self, inline_paintable: NodeSlotId) -> Option<NodeSlotId> {

--- a/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
@@ -144,7 +144,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         }
         let target_scroll_node_index = self.wheel_hit_test_target_scroll_node_index_for(paintable);
         let corner_radii = self.border_radii(paintable).as_corners(&self.converter);
-        let document_id = UniqueNodeId(self.inputs.document_id);
+        let document_id = self.inputs.document_id;
         if corner_radii.has_any_radius() {
             self.recorder.compositor_wheel_hit_test_target_with_corner_radii(
                 CompositorWheelHitTestTargetWithCornerRadii {
@@ -239,7 +239,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         let scale = self.inputs.device_pixels_per_css_pixel;
         let hit_test_facts = self.hit_test_facts(paintable);
         self.recorder.compositor_scroll_node(CompositorScrollNode {
-            document_id: UniqueNodeId(self.inputs.document_id),
+            document_id: self.inputs.document_id,
             scrollable_node_id: UniqueNodeId(node_identity),
             scroll_node_index: self.data(paintable).own_scroll_node_index,
             parent_scroll_node_index,
@@ -261,7 +261,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
     // main thread selects from, recorded with the scroll node so that it is as current as the rest
     // of the display list.
     fn record_snap_geometry(&mut self, paintable: NodeSlotId, geometry: FfiSnapContainerGeometry) {
-        let document_id = UniqueNodeId(self.inputs.document_id);
+        let document_id = self.inputs.document_id;
         let scroll_node_index = self.data(paintable).own_scroll_node_index;
         self.recorder.compositor_snap_container(CompositorSnapContainer {
             document_id,
@@ -309,7 +309,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
             self.inputs.root_background_source,
             self.inputs.canvas_color.blend(self.inputs.background_color),
         );
-        let chrome_geometry = ChromeGeometry::for_recording(self.layout_arena, &self.inputs);
+        let chrome_geometry = ChromeGeometry::for_recording(self.layout_arena, self.inputs);
         for direction in [ScrollDirection::Vertical, ScrollDirection::Horizontal] {
             let Some(scrollbar) = chrome_geometry.compute_scrollbar_data(paintable, direction, false, None) else {
                 continue;
@@ -320,7 +320,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
             let vertical = direction == ScrollDirection::Vertical;
             self.recorder
                 .compositor_viewport_scrollbar(CompositorViewportScrollbar {
-                    document_id: UniqueNodeId(self.inputs.document_id),
+                    document_id: self.inputs.document_id,
                     scroll_node_index,
                     gutter_rect: self.converter.rounded_device_rect(scrollbar.gutter_rect),
                     thumb_rect: self.converter.rounded_device_rect(scrollbar.thumb_rect),

--- a/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
@@ -72,7 +72,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         let mut target = VISUAL_VIEWPORT_NODE_INDEX;
         let mut current = paintable;
         loop {
-            if let Some(cached) = self.wheel_hit_test_target_cache.get(&current) {
+            if let Some(cached) = self.scratch.wheel_hit_test_target_cache.get(&current) {
                 target = *cached;
                 break;
             }
@@ -114,7 +114,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         }
 
         for slot in paintables_to_cache {
-            self.wheel_hit_test_target_cache.insert(slot, target);
+            self.scratch.wheel_hit_test_target_cache.insert(slot, target);
         }
         target
     }

--- a/Libraries/LibWeb/Rust/src/painting/record/cache.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/cache.rs
@@ -74,7 +74,6 @@ pub struct CachedSubtreeCapture {
     pub hit_test_item_count: u32,
     pub(crate) gen_of_last_fresh_walk: RecordGen,
     pub may_be_spliced_verbatim: bool,
-    pub recorded_with_should_paint_overlay: bool,
     pub contains_blocking_wheel_event_region: bool,
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/record/cache_compatibility.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/cache_compatibility.rs
@@ -24,15 +24,12 @@ pub(crate) struct PaintCacheInputs {
 }
 
 impl PaintCacheInputs {
-    pub(crate) fn from_recording_inputs(inputs: &RecordingInputs) -> Self {
+    pub(crate) fn from_recording_inputs(inputs: &RecordingInputs<'_>) -> Self {
         Self {
             device_pixels_per_css_pixel: inputs.device_pixels_per_css_pixel,
             canvas_color: inputs.canvas_color,
             force_dark_enabled: inputs.force_dark_enabled,
-            force_dark_settings: ForceDarkSettings {
-                foreground_brightness_threshold: inputs.force_dark_foreground_threshold,
-                background_brightness_threshold: inputs.force_dark_background_threshold,
-            },
+            force_dark_settings: inputs.force_dark_settings,
             should_show_line_box_borders: inputs.should_show_line_box_borders,
             should_paint_overlay: inputs.should_paint_overlay,
             has_blocking_wheel_event_region_covering_viewport: inputs.has_blocking_wheel_event_region_covering_viewport,

--- a/Libraries/LibWeb/Rust/src/painting/record/cache_compatibility.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/cache_compatibility.rs
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::RecordingInputs;
+use super::cache::CaptureKind;
+use crate::painting::force_dark::ForceDarkSettings;
+use libgfx_rust::Color;
+
+/// Recording inputs whose changes affect cache reuse independently of per-paintable dirtiness.
+/// Keep these with the cache source: a read-only recording must not replace them.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct PaintCacheInputs {
+    // A default-constructed source's 0.0 never matches a real recording scale.
+    pub(crate) device_pixels_per_css_pixel: f64,
+    pub(crate) canvas_color: Color,
+    pub(crate) force_dark_enabled: bool,
+    pub(crate) force_dark_settings: ForceDarkSettings,
+    pub(crate) should_show_line_box_borders: bool,
+    pub(crate) should_paint_overlay: bool,
+    pub(crate) has_blocking_wheel_event_region_covering_viewport: bool,
+}
+
+impl PaintCacheInputs {
+    pub(crate) fn from_recording_inputs(inputs: &RecordingInputs) -> Self {
+        Self {
+            device_pixels_per_css_pixel: inputs.device_pixels_per_css_pixel,
+            canvas_color: inputs.canvas_color,
+            force_dark_enabled: inputs.force_dark_enabled,
+            force_dark_settings: ForceDarkSettings {
+                foreground_brightness_threshold: inputs.force_dark_foreground_threshold,
+                background_brightness_threshold: inputs.force_dark_background_threshold,
+            },
+            should_show_line_box_borders: inputs.should_show_line_box_borders,
+            should_paint_overlay: inputs.should_paint_overlay,
+            has_blocking_wheel_event_region_covering_viewport: inputs.has_blocking_wheel_event_region_covering_viewport,
+        }
+    }
+
+    pub(crate) fn compatibility_with(&self, source: &Self) -> PaintCacheCompatibility {
+        // Preserve the full paint-cache invalidation used for changes to color resolution.
+        let colors_match = self.canvas_color == source.canvas_color
+            && self.force_dark_enabled == source.force_dark_enabled
+            && self.force_dark_settings == source.force_dark_settings;
+        // Commands use device pixels, while hit-test items use CSS pixels. Line-box borders
+        // replace normal text painting but do not change hit-test items.
+        let commands = colors_match
+            && self.device_pixels_per_css_pixel == source.device_pixels_per_css_pixel
+            && !self.should_show_line_box_borders
+            && !source.should_show_line_box_borders;
+        let hit_test_items = colors_match;
+        // Subtree captures also contain scrolling metadata, emitted outside box-phase captures.
+        let descendant_subtrees = commands
+            && hit_test_items
+            && self.has_blocking_wheel_event_region_covering_viewport
+                == source.has_blocking_wheel_event_region_covering_viewport;
+        // Only painting a whole stacking context conditionally includes its overlay phase.
+        let stacking_contexts = descendant_subtrees && self.should_paint_overlay == source.should_paint_overlay;
+        PaintCacheCompatibility {
+            commands,
+            hit_test_items,
+            descendant_subtrees,
+            stacking_contexts,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct PaintCacheCompatibility {
+    pub(crate) commands: bool,
+    pub(crate) hit_test_items: bool,
+    descendant_subtrees: bool,
+    stacking_contexts: bool,
+}
+
+impl PaintCacheCompatibility {
+    pub(crate) fn allows_subtree(self, kind: CaptureKind) -> bool {
+        match kind {
+            CaptureKind::DescendantSubtreePhase(_) => self.descendant_subtrees,
+            CaptureKind::PaintedAsStackingContext => self.stacking_contexts,
+            CaptureKind::BoxPhase(_) => unreachable!("a box phase capture is not a subtree capture"),
+        }
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -34,7 +34,7 @@ pub(crate) struct HitTestFacts {
 pub(crate) fn hit_test_facts(
     arena: &impl crate::painting::paintable_rows::PaintableRowsRead,
     paintable: NodeSlotId,
-    inputs: &crate::painting::record::RecordingInputs,
+    inputs: &crate::painting::record::RecordingInputs<'_>,
 ) -> HitTestFacts {
     let Some(style) = arena.node_style_if_live(paintable) else {
         return HitTestFacts::default();

--- a/Libraries/LibWeb/Rust/src/painting/record/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/inputs.rs
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::css::css_pixels::{CssPixelPoint, CssPixelRect, CssPixels};
+use crate::layout::node_data::NodeSlotId;
+use crate::painting::display_list::commands::UniqueNodeId;
+use crate::painting::ffi::FfiChromeMetrics;
+use crate::painting::force_dark::ForceDarkSettings;
+use crate::painting::host::{FfiFlexOverlayInput, FfiGridOverlayInput, FfiRootBackgroundSource};
+use libgfx_rust::font::FontHandle;
+use libgfx_rust::{Color, IntRect};
+use std::borrow::Cow;
+
+/// Inputs borrowed for one synchronous recording call. Recording results retain their own
+/// resources and never borrow these inputs or the host's arrays and byte buffers.
+#[derive(Clone)]
+pub(crate) struct RecordingInputs<'a> {
+    pub device_pixels_per_css_pixel: f64,
+    pub viewport_wheel_overflow_x: u8,
+    pub viewport_wheel_overflow_y: u8,
+    pub root_background_source: FfiRootBackgroundSource,
+    pub device_viewport_rect: IntRect,
+    pub css_viewport_rect: CssPixelRect,
+    pub should_show_line_box_borders: bool,
+    pub force_dark_enabled: bool,
+    pub force_dark_settings: ForceDarkSettings,
+    pub should_paint_overlay: bool,
+    pub is_recording_async_scrolling_metadata: bool,
+    pub document_id: UniqueNodeId,
+    pub has_blocking_wheel_event_region_covering_viewport: bool,
+    pub wheel_event_listener_state_generation: u64,
+    pub chrome_metrics: FfiChromeMetrics,
+    pub paint_viewport_scrollbars: bool,
+    pub async_scrolling_enabled: bool,
+    pub middle_button_scroll_origin: Option<CssPixelPoint>,
+    pub canvas_fill_rect: Option<IntRect>,
+    pub canvas_color: Color,
+    pub opaque_canvas: bool,
+    pub bitmap_rect: IntRect,
+    pub background_color: Color,
+    pub paint_command_cache_read_write: bool,
+    pub window_is_focused: bool,
+    pub outline_auto_color: Color,
+    pub selection_background_from_palette: Color,
+    pub selection_background_light: Color,
+    pub selection_background_dark: Color,
+    pub palette_is_dark: bool,
+    pub document_has_supported_color_schemes: bool,
+    pub inspector_highlight: Option<InspectorHighlight<'a>>,
+    pub tooltip_color: Color,
+    pub tooltip_text_color: Color,
+    pub tooltip_border_color: Color,
+    pub grid_overlays: Option<GridOverlays<'a>>,
+    // These array elements are already plain values without pointers or optional-value tags.
+    pub flex_overlays: &'a [FfiFlexOverlayInput],
+    pub caret_debug_rect: Option<CssPixelRect>,
+    pub caret: Option<CaretPaint>,
+    pub focused_text_control: Option<FocusedTextControlSelection>,
+    pub focused_area_outline: Option<FocusedAreaOutline<'a>>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CaretTarget {
+    InBlock {
+        block: NodeSlotId,
+        owner: Option<NodeSlotId>,
+    },
+    EmptyInline(NodeSlotId),
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct CaretPaint {
+    pub target: CaretTarget,
+    pub rect: CssPixelRect,
+    pub color: Color,
+    pub blink_cycle_start_time_ns: i64,
+    pub should_blink: bool,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FocusedTextControlSelection {
+    pub text_node: NodeSlotId,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FocusedAreaOutline<'a> {
+    pub image: NodeSlotId,
+    pub path_bytes: &'a [u8],
+    pub color: Color,
+    pub width: CssPixels,
+}
+
+#[derive(Clone)]
+pub(crate) struct OverlayLabelFonts {
+    pub css_font: FontHandle,
+    pub device_font: FontHandle,
+}
+
+#[derive(Clone)]
+pub(crate) struct InspectorHighlight<'a> {
+    pub paintable: NodeSlotId,
+    pub label: Cow<'a, str>,
+    pub fonts: OverlayLabelFonts,
+}
+
+#[derive(Clone)]
+pub(crate) struct GridOverlays<'a> {
+    pub inputs: &'a [FfiGridOverlayInput],
+    pub fonts: OverlayLabelFonts,
+}

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -35,8 +35,6 @@ use crate::painting::paintable_rows::PaintableRowsRef;
 use crate::painting::record::cache::{OpenCapture, PendingPaintCacheUpdates, RecordGen};
 use crate::painting::record::cache_compatibility::{PaintCacheCompatibility, PaintCacheInputs};
 use crate::painting::record::svg_resources::SvgResourceWalk;
-use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 #[derive(Clone, Copy)]
@@ -127,7 +125,6 @@ pub struct PaintRecorder<'a, O: Observer> {
     pub(crate) recorder: DisplayListRecorder,
     pub(crate) converter: DevicePixelConverter,
     pub(crate) svg_resource_walk: Option<SvgResourceWalk>,
-    pattern_tile_records: HashMap<PatternTileKey, Rc<Vec<u8>>>,
     pub(crate) viewport: NodeSlotId,
     command_cache_source: Option<Rc<RecordingOutput>>,
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
@@ -139,12 +136,10 @@ pub struct PaintRecorder<'a, O: Observer> {
     uncacheable_paint_generation: u64,
     pub(crate) observer: O,
     list: HitTestList,
-    pub(crate) memo_tables: &'a RefCell<scratch::PerRecordingMemoTables>,
+    pub(crate) scratch: &'a mut scratch::RecordingScratch,
     pub(crate) completed_record_gen: RecordGen,
     pub(crate) all_paint_caches_dirty: bool,
     pub(crate) resources: resources::RecordingResourceManifest,
-    selection_style_cache: HashMap<u32, Rc<paint::text::SelectionStyleAnswer>>,
-    pub(crate) wheel_hit_test_target_cache: HashMap<NodeSlotId, SpatialNodeIndex>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -174,11 +169,11 @@ impl<O: Observer> PaintRecorder<'_, O> {
     }
 
     fn paintable_facts(&mut self, paintable: NodeSlotId) -> hit_test_items::HitTestFacts {
-        if let Some(facts) = self.memo_tables.borrow().hit_test_facts(paintable) {
+        if let Some(facts) = self.scratch.hit_test_facts(paintable) {
             return facts;
         }
         let facts = hit_test_items::hit_test_facts(self.layout_arena, paintable, &self.inputs);
-        self.memo_tables.borrow_mut().set_hit_test_facts(paintable, facts);
+        self.scratch.set_hit_test_facts(paintable, facts);
         facts
     }
 
@@ -275,7 +270,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         node: crate::layout::node_data::NodeSlotId,
     ) -> Rc<paint::text::SelectionStyleAnswer> {
         let key = node.index;
-        if let Some(answer) = self.selection_style_cache.get(&key) {
+        if let Some(answer) = self.scratch.selection_style_cache.get(&key) {
             return answer.clone();
         }
         let style_source = self.layout_arena.data(node).parent.get();
@@ -283,7 +278,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
             .first_non_anonymous_ancestor_row(node)
             .and_then(|element_row| self.committed_selection_pseudo_style(node, element_row));
         let answer = self.selection_style_answer(committed, node, style_source);
-        self.selection_style_cache.insert(key, answer.clone());
+        self.scratch.selection_style_cache.insert(key, answer.clone());
         answer
     }
 
@@ -292,12 +287,12 @@ impl<O: Observer> PaintRecorder<'_, O> {
         element_row: crate::layout::node_data::NodeSlotId,
     ) -> Rc<paint::text::SelectionStyleAnswer> {
         let key = element_row.index;
-        if let Some(answer) = self.selection_style_cache.get(&key) {
+        if let Some(answer) = self.scratch.selection_style_cache.get(&key) {
             return answer.clone();
         }
         let committed = self.committed_selection_pseudo_style(element_row, element_row);
         let answer = self.selection_style_answer(committed, element_row, element_row);
-        self.selection_style_cache.insert(key, answer.clone());
+        self.scratch.selection_style_cache.insert(key, answer.clone());
         answer
     }
 
@@ -424,12 +419,12 @@ impl<O: Observer> PaintRecorder<'_, O> {
     }
 
     pub(crate) fn base_paint_facts(&mut self, paintable: NodeSlotId) -> BasePaintFacts {
-        if let Some(facts) = self.memo_tables.borrow().base_paint_facts(paintable) {
+        if let Some(facts) = self.scratch.base_paint_facts(paintable) {
             return facts;
         }
         let Some(style) = self.layout_arena.node_style_if_live(paintable) else {
             let facts = BasePaintFacts::default();
-            self.memo_tables.borrow_mut().set_base_paint_facts(paintable, facts);
+            self.scratch.set_base_paint_facts(paintable, facts);
             return facts;
         };
         let effects = style.effects();
@@ -452,7 +447,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
             paint_phase_mask: 0,
         };
         facts.paint_phase_mask = paint::paint_phase_mask(self, paintable, style, &facts);
-        self.memo_tables.borrow_mut().set_base_paint_facts(paintable, facts);
+        self.scratch.set_base_paint_facts(paintable, facts);
         facts
     }
 
@@ -559,7 +554,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
             pattern: pattern.index,
             root_transform_bits: root_transform.values.map(f32::to_bits),
         };
-        if let Some(records) = self.pattern_tile_records.get(&key) {
+        if let Some(records) = self.scratch.pattern_tile_records.get(&key) {
             return records.clone();
         }
         let detached = self.recorder.begin_detached_records();
@@ -570,7 +565,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
             this.walk_svg_resource(pattern, root_transform, false, false);
         });
         let records = Rc::new(self.recorder.finish_detached_records(detached));
-        self.pattern_tile_records.insert(key, records.clone());
+        self.scratch.pattern_tile_records.insert(key, records.clone());
         records
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -10,6 +10,7 @@ pub mod async_scroll_metadata;
 pub mod cache;
 pub(crate) mod cache_compatibility;
 pub mod hit_test_items;
+pub(crate) mod inputs;
 pub mod paint;
 pub(crate) mod publish;
 pub(crate) mod resources;
@@ -29,7 +30,6 @@ use crate::painting::display_list::commands::{ContextRef, SpatialNodeIndex};
 use crate::painting::display_list::device_pixels::DevicePixelConverter;
 use crate::painting::display_list::recorder::DisplayListRecorder;
 use crate::painting::hit_test::HitTestList;
-use crate::painting::host::{FfiRecordingInputs, FfiRootBackgroundSource, FfiVisualContextTreeInputs};
 use crate::painting::paintable_data::{InlineBoxPieceRecord, PaintableData};
 use crate::painting::paintable_rows::PaintableRowsRef;
 use crate::painting::record::cache::{OpenCapture, PendingPaintCacheUpdates, RecordGen};
@@ -37,44 +37,7 @@ use crate::painting::record::cache_compatibility::{PaintCacheCompatibility, Pain
 use crate::painting::record::svg_resources::SvgResourceWalk;
 use std::rc::Rc;
 
-#[derive(Clone, Copy)]
-pub(crate) struct RecordingInputs {
-    pub(crate) host: FfiRecordingInputs,
-    pub(crate) device_pixels_per_css_pixel: f64,
-    pub(crate) viewport_wheel_overflow_x: u8,
-    pub(crate) viewport_wheel_overflow_y: u8,
-    pub(crate) root_background_source: FfiRootBackgroundSource,
-}
-
-impl RecordingInputs {
-    pub(crate) fn from_host_and_last_visual_context_update(
-        host: FfiRecordingInputs,
-        tree_inputs: FfiVisualContextTreeInputs,
-        root_background_source: FfiRootBackgroundSource,
-    ) -> Self {
-        Self {
-            host,
-            device_pixels_per_css_pixel: tree_inputs.device_pixels_per_css_pixel,
-            viewport_wheel_overflow_x: tree_inputs.viewport_wheel_overflow_x,
-            viewport_wheel_overflow_y: tree_inputs.viewport_wheel_overflow_y,
-            root_background_source,
-        }
-    }
-}
-
-impl std::ops::Deref for RecordingInputs {
-    type Target = FfiRecordingInputs;
-
-    fn deref(&self) -> &FfiRecordingInputs {
-        &self.host
-    }
-}
-
-impl std::ops::DerefMut for RecordingInputs {
-    fn deref_mut(&mut self) -> &mut FfiRecordingInputs {
-        &mut self.host
-    }
-}
+pub(crate) use inputs::RecordingInputs;
 
 #[derive(Default)]
 pub struct RecordingOutput {
@@ -121,7 +84,7 @@ pub(crate) struct DeferredWholeTapeSplice {
 pub struct PaintRecorder<'a, O: Observer> {
     pub(crate) layout_arena: &'a PaintableRowsRef<'a>,
     pub(crate) paint_state: &'a crate::painting::paint_state::PaintState,
-    pub(crate) inputs: RecordingInputs,
+    pub(crate) inputs: &'a RecordingInputs<'a>,
     pub(crate) recorder: DisplayListRecorder,
     pub(crate) converter: DevicePixelConverter,
     pub(crate) svg_resource_walk: Option<SvgResourceWalk>,
@@ -172,7 +135,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         if let Some(facts) = self.scratch.hit_test_facts(paintable) {
             return facts;
         }
-        let facts = hit_test_items::hit_test_facts(self.layout_arena, paintable, &self.inputs);
+        let facts = hit_test_items::hit_test_facts(self.layout_arena, paintable, self.inputs);
         self.scratch.set_hit_test_facts(paintable, facts);
         facts
     }
@@ -254,10 +217,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
     /// The focused text control's selection as `(start, end)` when `node` is one of its text
     /// node's committed rows.
     pub(crate) fn text_control_selection(&self, node: NodeSlotId) -> Option<(usize, usize)> {
-        let control = &self.inputs.focused_text_control;
-        if control.start == control.end {
-            return None;
-        }
+        let control = self.inputs.focused_text_control?;
         self.layout_arena
             .text_fragments(control.text_node)
             .as_slice()
@@ -367,7 +327,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         style_source: crate::layout::node_data::NodeSlotId,
     ) -> paint::text::SelectionStyleAnswer {
         use crate::css::color_resolution::{PREFERRED_COLOR_SCHEME_DARK, PREFERRED_COLOR_SCHEME_LIGHT};
-        let inputs = &self.inputs;
+        let inputs = self.inputs;
         let (color_scheme, color_scheme_is_normal) =
             self.layout_arena
                 .node_style_if_live(style_source)

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -8,6 +8,7 @@ use crate::painting::record::trace::{Observer, Operation};
 
 pub mod async_scroll_metadata;
 pub mod cache;
+pub(crate) mod cache_compatibility;
 pub mod hit_test_items;
 pub mod paint;
 pub(crate) mod publish;
@@ -32,6 +33,7 @@ use crate::painting::host::{FfiRecordingInputs, FfiRootBackgroundSource, FfiVisu
 use crate::painting::paintable_data::{InlineBoxPieceRecord, PaintableData};
 use crate::painting::paintable_rows::PaintableRowsRef;
 use crate::painting::record::cache::{OpenCapture, PendingPaintCacheUpdates, RecordGen};
+use crate::painting::record::cache_compatibility::{PaintCacheCompatibility, PaintCacheInputs};
 use crate::painting::record::svg_resources::SvgResourceWalk;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -79,8 +81,7 @@ impl std::ops::DerefMut for RecordingInputs {
 #[derive(Default)]
 pub struct RecordingOutput {
     pub recorded_structural_epoch: u64,
-    // A default-constructed output's 0.0 never matches a real recording scale.
-    pub recorded_device_pixels_per_css_pixel: f64,
+    pub(crate) cache_inputs: PaintCacheInputs,
     pub hit_test_list: HitTestList,
     pub display_list: Rc<RecordedDisplayList>,
     pub has_blocking_wheel_event_listeners: bool,
@@ -130,6 +131,7 @@ pub struct PaintRecorder<'a, O: Observer> {
     pub(crate) viewport: NodeSlotId,
     command_cache_source: Option<Rc<RecordingOutput>>,
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
+    cache_compatibility: PaintCacheCompatibility,
     open_capture_stack: Vec<OpenCapture>,
     cache_updates: PendingPaintCacheUpdates,
     deferred_whole_tape_splice: Option<DeferredWholeTapeSplice>,
@@ -140,7 +142,6 @@ pub struct PaintRecorder<'a, O: Observer> {
     pub(crate) memo_tables: &'a RefCell<scratch::PerRecordingMemoTables>,
     pub(crate) completed_record_gen: RecordGen,
     pub(crate) all_paint_caches_dirty: bool,
-    pub(crate) all_descendant_subtree_caches_dirty: bool,
     pub(crate) resources: resources::RecordingResourceManifest,
     selection_style_cache: HashMap<u32, Rc<paint::text::SelectionStyleAnswer>>,
     pub(crate) wheel_hit_test_target_cache: HashMap<NodeSlotId, SpatialNodeIndex>,

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
@@ -455,7 +455,7 @@ fn resolve_layers<'a, O: Observer>(
         {
             background_positioning_area = CssPixelRect::from_location_and_size(
                 crate::css::css_pixels::CssPixelPoint::default(),
-                CssPixelRect::from(recorder.inputs.css_viewport_rect).size(),
+                recorder.inputs.css_viewport_rect.size(),
             );
         }
 
@@ -763,7 +763,7 @@ pub(crate) fn resolve_background_for_paint<'a, O: Observer>(
         },
     };
     if source.is_root_element {
-        let mut canvas_rect = CssPixelRect::from(recorder.inputs.css_viewport_rect);
+        let mut canvas_rect = recorder.inputs.css_viewport_rect;
         if let Some(overflow_rect) =
             crate::painting::paintable_geometry::scrollable_overflow_rect(recorder.layout_arena, paintable)
         {

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
@@ -133,16 +133,14 @@ pub(crate) fn paint<O: Observer>(recorder: &mut PaintRecorder<'_, O>, paintable:
             text::paint_fragments_foreground(recorder, root, Some(paintable));
             text::paint_cursor(recorder, root, Some(paintable));
         }
-        if facts.is_visible {
-            let caret = recorder.inputs.caret;
-            if caret.kind == crate::painting::host::FfiCaretPaintKind::EmptyInline && caret.block == paintable {
-                let color = caret.color;
-                if color.alpha() != 0 {
-                    let rect = recorder
-                        .converter
-                        .rounded_device_rect(crate::css::css_pixels::CssPixelRect::from(caret.rect));
-                    recorder.recorder.fill_rect(rect, color, ForceDarkRole::Foreground);
-                }
+        if facts.is_visible
+            && let Some(caret) = recorder.inputs.caret
+            && caret.target == crate::painting::record::inputs::CaretTarget::EmptyInline(paintable)
+        {
+            let color = caret.color;
+            if color.alpha() != 0 {
+                let rect = recorder.converter.rounded_device_rect(caret.rect);
+                recorder.recorder.fill_rect(rect, color, ForceDarkRole::Foreground);
             }
         }
     }

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
@@ -14,43 +14,34 @@ use crate::layout::node_data::NodeSlotId;
 use crate::painting::display_list::commands::{ContextRef, DisplayListGlyph, FontResourceId};
 use crate::painting::display_list::recorder::GlyphRunForRecording;
 use crate::painting::force_dark::ForceDarkRole;
-use crate::painting::host::{FfiFlexOverlayInput, FfiGridOverlayInput, FfiOverlayLabelFonts};
+use crate::painting::host::{FfiFlexOverlayInput, FfiGridOverlayInput};
 use crate::painting::paintable_geometry;
 use crate::painting::record::PaintRecorder;
+use crate::painting::record::inputs::{InspectorHighlight, OverlayLabelFonts};
 use libgfx_rust::{Color, FloatPoint, IntPoint, IntRect, LineStyle, Orientation};
 
 pub(crate) fn record_inspector_overlays<O: Observer>(recorder: &mut PaintRecorder<'_, O>) {
     let inputs = recorder.inputs;
     recorder.recorder.set_accumulated_visual_context(ContextRef::default());
-    if inputs.has_inspector_highlight {
-        with_highlight_context(recorder, inputs.inspector_highlight_paintable, |recorder, paintable| {
-            paint_box_model_highlight(recorder, paintable);
+    if let Some(highlight) = &inputs.inspector_highlight {
+        with_highlight_context(recorder, highlight.paintable, |recorder, paintable| {
+            paint_box_model_highlight(recorder, paintable, highlight);
         });
     }
-    // SAFETY: The host borrows the overlay input arrays to the recording, which is synchronous.
-    let flex_overlays: &[FfiFlexOverlayInput] = if inputs.flex_overlay_count == 0 {
-        &[]
-    } else {
-        unsafe { std::slice::from_raw_parts(inputs.flex_overlays, inputs.flex_overlay_count) }
-    };
-    for input in flex_overlays {
+    for input in inputs.flex_overlays {
         with_highlight_context(recorder, input.paintable, |recorder, paintable| {
             paint_flex_overlay(recorder, paintable, input);
         });
     }
-    // SAFETY: See above.
-    let grid_overlays: &[FfiGridOverlayInput] = if inputs.grid_overlay_count == 0 {
-        &[]
-    } else {
-        unsafe { std::slice::from_raw_parts(inputs.grid_overlays, inputs.grid_overlay_count) }
-    };
-    for input in grid_overlays {
-        with_highlight_context(recorder, input.paintable, |recorder, paintable| {
-            paint_grid_overlay(recorder, paintable, input);
-        });
+    if let Some(grid) = &inputs.grid_overlays {
+        for input in grid.inputs {
+            with_highlight_context(recorder, input.paintable, |recorder, paintable| {
+                paint_grid_overlay(recorder, paintable, input, &grid.fonts);
+            });
+        }
     }
-    if inputs.caret_debug_rect.has_value {
-        paint_caret_debug_marker(recorder, CssPixelRect::from(inputs.caret_debug_rect.value));
+    if let Some(rect) = inputs.caret_debug_rect {
+        paint_caret_debug_marker(recorder, rect);
     }
 }
 
@@ -68,7 +59,11 @@ fn with_highlight_context<O: Observer>(
     recorder.with_context(context, |recorder| callback(recorder, paintable));
 }
 
-fn paint_box_model_highlight<O: Observer>(recorder: &mut PaintRecorder<'_, O>, paintable: NodeSlotId) {
+fn paint_box_model_highlight<O: Observer>(
+    recorder: &mut PaintRecorder<'_, O>,
+    paintable: NodeSlotId,
+    highlight: &InspectorHighlight<'_>,
+) {
     let content_rect = paintable_geometry::absolute_rect(recorder.layout_arena, paintable);
     let margin = paintable_geometry::committed_margin(recorder.layout_arena, paintable);
     let border = paintable_geometry::committed_border(recorder.layout_arena, paintable);
@@ -97,11 +92,8 @@ fn paint_box_model_highlight<O: Observer>(recorder: &mut PaintRecorder<'_, O>, p
     paint_inspector_rect(recorder, border_rect, Color::from_rgb(0, 255, 0));
     paint_inspector_rect(recorder, content_rect, Color::from_rgb(255, 0, 255));
 
-    let label_input = recorder.inputs.inspector_highlight_label;
-    // SAFETY: The host keeps the label bytes live for the recording call.
-    let label_bytes = unsafe { crate::painting::ffi::ffi_slice(label_input.text, label_input.text_byte_count) };
-    let text: Vec<u16> = String::from_utf8_lossy(label_bytes).encode_utf16().collect();
-    let label = shape_overlay_label(recorder, &text, label_input.fonts);
+    let text: Vec<u16> = highlight.label.encode_utf16().collect();
+    let label = shape_overlay_label(recorder, &text, &highlight.fonts);
     let mut size_text_rect = border_rect;
     size_text_rect.y = border_rect.y + border_rect.height;
     size_text_rect.width = CssPixels::nearest_value_for_f32(label.css_width) + CssPixels::from_integer(4);
@@ -132,7 +124,7 @@ fn paint_flex_overlay<O: Observer>(
         x: content_rect.x,
         y: content_rect.y,
     };
-    let viewport_rect = CssPixelRect::from(recorder.inputs.css_viewport_rect);
+    let viewport_rect = recorder.inputs.css_viewport_rect;
     let color = input.color;
     let line_color = color.with_alpha(220);
     let container_fill_color = color.with_alpha(28);
@@ -262,6 +254,7 @@ fn paint_grid_overlay<O: Observer>(
     recorder: &mut PaintRecorder<'_, O>,
     paintable: NodeSlotId,
     input: &FfiGridOverlayInput,
+    fonts: &OverlayLabelFonts,
 ) {
     let Some(grid_layout_data) =
         crate::painting::paintable_geometry::committed_grid_layout_data(recorder.layout_arena, paintable)
@@ -273,7 +266,7 @@ fn paint_grid_overlay<O: Observer>(
         x: content_rect.x,
         y: content_rect.y,
     };
-    let viewport_rect = CssPixelRect::from(recorder.inputs.css_viewport_rect);
+    let viewport_rect = recorder.inputs.css_viewport_rect;
     let color = input.color;
     let label_height = CssPixels::nearest_value_for_f32(input.label_css_pixel_size) + CssPixels::from_integer(4);
     let two = CssPixels::from_integer(2);
@@ -285,7 +278,7 @@ fn paint_grid_overlay<O: Observer>(
             .fill_rect(converter.enclosing_device_rect(rect), rect_color, ForceDarkRole::None);
     };
     let paint_label = |recorder: &mut PaintRecorder<'_, O>, top_left: CssPixelPoint, text: &[u16]| {
-        let label = shape_overlay_label(recorder, text, recorder.inputs.grid_label_fonts);
+        let label = shape_overlay_label(recorder, text, fonts);
         let label_width = label_width_for(&label);
         let label_rect = CssPixelRect {
             x: top_left.x,
@@ -304,7 +297,7 @@ fn paint_grid_overlay<O: Observer>(
         draw_label(recorder, &label, label_device_rect, input.label_foreground_color);
     };
     let paint_centered_label = |recorder: &mut PaintRecorder<'_, O>, rect: CssPixelRect, text: &[u16]| {
-        let label = shape_overlay_label(recorder, text, recorder.inputs.grid_label_fonts);
+        let label = shape_overlay_label(recorder, text, fonts);
         let label_width = label_width_for(&label);
         let top_left = CssPixelPoint {
             x: rect.center().x - label_width.div_as_fraction(two),
@@ -482,25 +475,22 @@ struct OverlayLabel {
 fn shape_overlay_label<O: Observer>(
     recorder: &mut PaintRecorder<'_, O>,
     text: &[u16],
-    fonts: FfiOverlayLabelFonts,
+    fonts: &OverlayLabelFonts,
 ) -> OverlayLabel {
-    // SAFETY: The host resolves both fonts from the platform font caches, which keep them live
-    // through the recording call; the handles keep them alive for the rest of it.
-    let css_font = unsafe { libgfx_rust::font::FontHandle::intern(fonts.css_font) };
-    // SAFETY: See above.
-    let device_font = unsafe { libgfx_rust::font::FontHandle::intern(fonts.device_font) };
+    let css_font = &fonts.css_font;
+    let device_font = &fonts.device_font;
     let shaped = libgfx_rust::text_layout::shape_text(
-        &device_font,
+        device_font,
         text,
         libgfx_rust::text_layout::TextType::Ltr,
         0.0,
         0.0,
         0.0,
     );
-    let blob_bounds = libgfx_rust::text_layout::glyph_run_bounding_box(&device_font, shaped.glyphs(), 1.0);
+    let blob_bounds = libgfx_rust::text_layout::glyph_run_bounding_box(device_font, shaped.glyphs(), 1.0);
     let device_ascent = device_font.facts().ascent;
     let device_descent = device_font.facts().descent;
-    let font_id = recorder.register_font(&device_font);
+    let font_id = recorder.register_font(device_font);
     let glyphs = shaped
         .glyphs()
         .iter()

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/outline.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/outline.rs
@@ -126,13 +126,13 @@ fn paint_focused_area_outline<O: Observer>(recorder: &mut PaintRecorder<'_, O>, 
     // inert.
     // NB: Focused area elements have no paintable of their own, so the image whose rendering makes the area's shape a
     // focusable area paints the focus outline along that shape.
-    let outline = recorder.inputs.focused_area_outline;
-    // SAFETY: The host keeps the serialised path bytes live for the recording call.
-    let path_bytes = unsafe { crate::painting::ffi::ffi_slice(outline.path_bytes, outline.path_byte_count) };
-    if path_bytes.is_empty() || outline.image != paintable {
+    let Some(outline) = recorder.inputs.focused_area_outline else {
+        return;
+    };
+    if outline.image != paintable {
         return;
     }
-    let path = libgfx_rust::path::OwnedPath::from_serialized_bytes(path_bytes);
+    let path = libgfx_rust::path::OwnedPath::from_serialized_bytes(outline.path_bytes);
     let converter = recorder.converter;
     let image_rect = paintable_geometry::absolute_rect(recorder.layout_arena, paintable);
     let scale = recorder.inputs.device_pixels_per_css_pixel as f32;

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/overlay.rs
@@ -28,7 +28,7 @@ pub(crate) fn paint_overlay<O: Observer>(recorder: &mut PaintRecorder<'_, O>, pa
         return;
     }
     let converter = recorder.converter;
-    let chrome_geometry = ChromeGeometry::for_recording(recorder.layout_arena, &recorder.inputs);
+    let chrome_geometry = ChromeGeometry::for_recording(recorder.layout_arena, recorder.inputs);
     let style = recorder.layout_arena.node_style_if_live(paintable);
     let paints_scrollbars = style.is_some_and(|style| {
         ((recorder.inputs.paint_viewport_scrollbars && !recorder.inputs.async_scrolling_enabled) || !is_viewport)
@@ -121,14 +121,13 @@ fn paint_middle_button_scroll_indicator<O: Observer>(recorder: &mut PaintRecorde
     const ARROW_SIZE: f32 = 6.0;
     const ARROW_OFFSET: f32 = 8.0;
 
-    if recorder.layout_arena.node_kind_if_live(paintable) != Some(NodeKind::Viewport)
-        || !recorder.inputs.middle_button_scroll_active
-    {
+    if recorder.layout_arena.node_kind_if_live(paintable) != Some(NodeKind::Viewport) {
         return;
     }
-    let device_origin = recorder
-        .converter
-        .rounded_device_point(recorder.inputs.middle_button_scroll_origin.into());
+    let Some(origin) = recorder.inputs.middle_button_scroll_origin else {
+        return;
+    };
+    let device_origin = recorder.converter.rounded_device_point(origin);
     let circle = IntRect::new(
         device_origin.x - RADIUS,
         device_origin.y - RADIUS,

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
@@ -11,9 +11,9 @@ use crate::layout::node_data::{NodeFlag, NodeSlotId};
 use crate::painting::display_list::commands::{DisplayListGlyph, FontResourceId};
 use crate::painting::display_list::recorder::GlyphRunForRecording;
 use crate::painting::force_dark::ForceDarkRole;
-use crate::painting::host::FfiCaretPaintKind;
 use crate::painting::paintable_data::{FragmentRecord, SELECTION_STATE_START_AND_END};
 use crate::painting::record::PaintRecorder;
+use crate::painting::record::inputs::CaretTarget;
 use crate::painting::text_fragment::{self, SelectionOffsets};
 use libgfx_rust::{Color, FloatPoint, IntRect, Orientation};
 
@@ -561,11 +561,10 @@ pub(crate) fn paint_cursor<O: Observer>(
     block: NodeSlotId,
     owner: Option<NodeSlotId>,
 ) {
-    let caret = recorder.inputs.caret;
-    if caret.kind != FfiCaretPaintKind::InBlock
-        || caret.block != block
-        || caret.owner != owner.unwrap_or(NodeSlotId::INVALID)
-    {
+    let Some(caret) = recorder.inputs.caret else {
+        return;
+    };
+    if caret.target != (CaretTarget::InBlock { block, owner }) {
         return;
     }
     let color = caret.color;
@@ -574,7 +573,7 @@ pub(crate) fn paint_cursor<O: Observer>(
     }
     let converter = recorder.converter;
     recorder.recorder.paint_caret(
-        converter.rounded_device_rect(CssPixelRect::from(caret.rect)),
+        converter.rounded_device_rect(caret.rect),
         color,
         caret.blink_cycle_start_time_ns,
         caret.should_blink,

--- a/Libraries/LibWeb/Rust/src/painting/record/scratch.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/scratch.rs
@@ -6,9 +6,13 @@
 
 use crate::layout::node_data::NodeSlotId;
 use crate::layout::used_values::FfiCssPixelPoint;
-use crate::painting::record::BasePaintFacts;
+use crate::painting::display_list::commands::SpatialNodeIndex;
 use crate::painting::record::cache::ResolvedEnclosingCaptureMemo;
 use crate::painting::record::hit_test_items::HitTestFacts;
+use crate::painting::record::paint::text::SelectionStyleAnswer;
+use crate::painting::record::{BasePaintFacts, PatternTileKey};
+use std::collections::HashMap;
+use std::rc::Rc;
 
 #[derive(Clone, Copy)]
 struct StampedEntry<T> {
@@ -27,13 +31,18 @@ impl<T: Default> Default for StampedEntry<T> {
     }
 }
 
+/// Reusable workspace borrowed exclusively by one recording at a time. Its values are
+/// temporary derived facts, never persistent paint-cache entries or recording output.
 #[derive(Default)]
-pub(crate) struct PerRecordingMemoTables {
+pub(crate) struct RecordingScratch {
     recording_stamp: u32,
     base_paint_facts: Vec<StampedEntry<BasePaintFacts>>,
     hit_test_facts: Vec<StampedEntry<HitTestFacts>>,
     absolute_positions: Vec<StampedEntry<FfiCssPixelPoint>>,
     resolved_enclosing_capture_memo: ResolvedEnclosingCaptureMemo,
+    pub(super) pattern_tile_records: HashMap<PatternTileKey, Rc<Vec<u8>>>,
+    pub(super) selection_style_cache: HashMap<u32, Rc<SelectionStyleAnswer>>,
+    pub(super) wheel_hit_test_target_cache: HashMap<NodeSlotId, SpatialNodeIndex>,
 }
 
 fn entry_if_stamped_for_current_recording<T: Copy>(
@@ -72,7 +81,7 @@ macro_rules! memo_table {
     };
 }
 
-impl PerRecordingMemoTables {
+impl RecordingScratch {
     pub(crate) fn begin_recording(&mut self, row_count: usize) {
         self.recording_stamp = match self.recording_stamp.checked_add(1) {
             Some(recording_stamp) => recording_stamp,
@@ -88,7 +97,15 @@ impl PerRecordingMemoTables {
             self.hit_test_facts.resize(row_count, StampedEntry::default());
             self.absolute_positions.resize(row_count, StampedEntry::default());
         }
+        self.clear_temporary_caches();
+    }
+
+    // Retain the allocations, but release temporary records and styles before publication.
+    pub(super) fn clear_temporary_caches(&mut self) {
         self.resolved_enclosing_capture_memo.clear();
+        self.pattern_tile_records.clear();
+        self.selection_style_cache.clear();
+        self.wheel_hit_test_target_cache.clear();
     }
 
     pub(crate) fn resolved_enclosing_capture_memo(&mut self) -> &mut ResolvedEnclosingCaptureMemo {

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -23,6 +23,7 @@ use crate::painting::record::cache::{
     CachedSubtreeCapture, CaptureAddress, CaptureKind, CaptureSite, EnclosingCaptureAnchor, OpenCapture, RecordGen,
     SourceTapePosition, SubtreeCaptureWalkOutcome, narrow_record_gen, resolve_capture_address_in_source_tape,
 };
+use crate::painting::record::cache_compatibility::PaintCacheInputs;
 use crate::painting::record::resources::RecordingResourceManifest;
 use crate::painting::record::svg_resources::MaskLayerSet;
 use crate::painting::record::trace::{Action, Operation};
@@ -105,8 +106,10 @@ fn record_display_list_impl<O: Observer>(
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
 ) -> RecordingResult {
     let structural_epoch = paint_state.visual_context.structural_epoch();
-    let command_cache_source = command_cache_source
-        .filter(|source| source.recorded_device_pixels_per_css_pixel == inputs.device_pixels_per_css_pixel);
+    let cache_inputs = PaintCacheInputs::from_recording_inputs(&inputs);
+    let cache_compatibility = command_cache_source.as_ref().map_or_else(Default::default, |source| {
+        cache_inputs.compatibility_with(&source.cache_inputs)
+    });
     let paintable_rows = layout_arena.paintable_rows();
     paint_state
         .per_recording_memo_tables
@@ -126,6 +129,7 @@ fn record_display_list_impl<O: Observer>(
         pattern_tile_records: HashMap::new(),
         command_cache_source,
         item_cache_source,
+        cache_compatibility,
         open_capture_stack: Vec::new(),
         cache_updates: Default::default(),
         deferred_whole_tape_splice: None,
@@ -143,7 +147,6 @@ fn record_display_list_impl<O: Observer>(
         memo_tables: &paint_state.per_recording_memo_tables,
         completed_record_gen: narrow_record_gen(layout_arena.paint_cache_completed_record_gen()),
         all_paint_caches_dirty: layout_arena.all_paint_caches_dirty(),
-        all_descendant_subtree_caches_dirty: layout_arena.all_descendant_subtree_caches_dirty(),
         resources: RecordingResourceManifest::default(),
         selection_style_cache: HashMap::new(),
         wheel_hit_test_target_cache: HashMap::new(),
@@ -189,7 +192,7 @@ fn record_display_list_impl<O: Observer>(
     };
     let output = RecordingOutput {
         recorded_structural_epoch: structural_epoch,
-        recorded_device_pixels_per_css_pixel: inputs.device_pixels_per_css_pixel,
+        cache_inputs,
         hit_test_list,
         display_list,
         has_blocking_wheel_event_listeners: recorder.blocking_wheel_event_region_count > 0,
@@ -676,7 +679,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
     }
 
     fn try_splice_cached_subtree_capture(&mut self, site: CaptureSite) -> bool {
-        if self.is_recording_svg_resource_content() {
+        if self.is_recording_svg_resource_content() || !self.cache_compatibility.allows_subtree(site.kind) {
             return false;
         }
         let Some(command_source) = self.command_cache_source.as_ref() else {
@@ -687,7 +690,6 @@ impl<O: Observer> PaintRecorder<'_, O> {
         };
         let cache = self.layout_arena.paintable_paint_cache(site.paintable);
         if self.all_paint_caches_dirty
-            || self.all_descendant_subtree_caches_dirty
             || cache.is_self_dirty_since(self.completed_record_gen)
             || cache.has_dirty_descendants_since(self.completed_record_gen)
         {
@@ -699,11 +701,6 @@ impl<O: Observer> PaintRecorder<'_, O> {
         let captured_position = cache.captured_absolute_position();
         drop(cache);
         if !cached.may_be_spliced_verbatim {
-            return false;
-        }
-        if site.kind == CaptureKind::PaintedAsStackingContext
-            && cached.recorded_with_should_paint_overlay != self.inputs.should_paint_overlay
-        {
             return false;
         }
         if captured_position != self.current_absolute_position(site.paintable) {
@@ -789,7 +786,6 @@ impl<O: Observer> PaintRecorder<'_, O> {
                 hit_test_item_count: hit_test_item_count as u32,
                 gen_of_last_fresh_walk: walk_outcome.gen_of_last_fresh_walk,
                 may_be_spliced_verbatim: walk_outcome.may_be_spliced_verbatim,
-                recorded_with_should_paint_overlay: self.inputs.should_paint_overlay,
                 contains_blocking_wheel_event_region: walk_outcome.contains_blocking_wheel_event_region,
             },
         );
@@ -1121,6 +1117,9 @@ impl<O: Observer> PaintRecorder<'_, O> {
         paintable: NodeSlotId,
         phase: PaintPhase,
     ) -> Option<(Rc<RecordingOutput>, CommandRange, ContextRef)> {
+        if !self.cache_compatibility.commands {
+            return None;
+        }
         let source = self.command_cache_source.as_ref()?;
         let cache = self.layout_arena.paintable_paint_cache_if_allocated(paintable)?;
         // Checked before loading the entry so a dirty row's miss stays as cheap as the
@@ -1205,6 +1204,9 @@ impl<O: Observer> PaintRecorder<'_, O> {
         own_context: ContextRef,
         for_descendants_context: ContextRef,
     ) -> Option<(Rc<Vec<HitTestItem>>, usize, usize)> {
+        if !self.cache_compatibility.hit_test_items {
+            return None;
+        }
         let source = self.item_cache_source.as_ref()?;
         let cache = self.layout_arena.paintable_paint_cache_if_allocated(paintable)?;
         if self.all_paint_caches_dirty || cache.is_self_dirty_since(self.completed_record_gen) {

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -15,7 +15,7 @@ use crate::painting::display_list::builder::{CommandRange, DisplayListBuilder, R
 use crate::painting::display_list::commands::{ContextRef, VISUAL_VIEWPORT_NODE_INDEX};
 use crate::painting::display_list::device_pixels::DevicePixelConverter;
 use crate::painting::display_list::recorder::DisplayListRecorder;
-use crate::painting::force_dark::{ForceDarkRole, ForceDarkSettings};
+use crate::painting::force_dark::ForceDarkRole;
 use crate::painting::hit_test::*;
 use crate::painting::node_painting;
 use crate::painting::record::RecordingInputs;
@@ -70,7 +70,7 @@ pub(crate) fn record_display_list(
     paint_state: &crate::painting::paint_state::PaintState,
     scratch: &mut RecordingScratch,
     viewport: NodeSlotId,
-    inputs: RecordingInputs,
+    inputs: &RecordingInputs<'_>,
     hit_test_list_generation: u64,
     command_cache_source: Option<Rc<RecordingOutput>>,
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
@@ -106,21 +106,18 @@ fn record_display_list_impl<O: Observer>(
     paint_state: &crate::painting::paint_state::PaintState,
     scratch: &mut RecordingScratch,
     viewport: NodeSlotId,
-    inputs: RecordingInputs,
+    inputs: &RecordingInputs<'_>,
     hit_test_list_generation: u64,
     command_cache_source: Option<Rc<RecordingOutput>>,
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
 ) -> RecordingResult {
     let structural_epoch = paint_state.visual_context.structural_epoch();
-    let cache_inputs = PaintCacheInputs::from_recording_inputs(&inputs);
+    let cache_inputs = PaintCacheInputs::from_recording_inputs(inputs);
     let cache_compatibility = command_cache_source.as_ref().map_or_else(Default::default, |source| {
         cache_inputs.compatibility_with(&source.cache_inputs)
     });
     let paintable_rows = layout_arena.paintable_rows();
-    let force_dark_settings = inputs.force_dark_enabled.then_some(ForceDarkSettings {
-        foreground_brightness_threshold: inputs.force_dark_foreground_threshold,
-        background_brightness_threshold: inputs.force_dark_background_threshold,
-    });
+    let force_dark_settings = inputs.force_dark_enabled.then_some(inputs.force_dark_settings);
     let mut recorder = PaintRecorder {
         layout_arena: &paintable_rows,
         paint_state,
@@ -151,12 +148,9 @@ fn record_display_list_impl<O: Observer>(
         resources: RecordingResourceManifest::default(),
     };
     recorder.trace_paint(Operation::Producer(None, "canvas"), |this| {
-        if inputs.canvas_fill_rect.has_value {
-            this.recorder.fill_rect(
-                inputs.canvas_fill_rect.value,
-                inputs.canvas_color,
-                ForceDarkRole::Background,
-            );
+        if let Some(rect) = inputs.canvas_fill_rect {
+            this.recorder
+                .fill_rect(rect, inputs.canvas_color, ForceDarkRole::Background);
         }
         // .. in the case of embedded documents typically rendered over a transparent canvas
         // (such as provided via an HTML iframe element), if the used color scheme of the element
@@ -171,10 +165,10 @@ fn record_display_list_impl<O: Observer>(
             .fill_rect(inputs.bitmap_rect, inputs.background_color, ForceDarkRole::Background);
     });
     recorder.paint_and_capture_as_stacking_context(viewport);
-    if inputs.has_inspector_highlight
-        || inputs.grid_overlay_count > 0
-        || inputs.flex_overlay_count > 0
-        || inputs.caret_debug_rect.has_value
+    if inputs.inspector_highlight.is_some()
+        || inputs.grid_overlays.is_some()
+        || !inputs.flex_overlays.is_empty()
+        || inputs.caret_debug_rect.is_some()
     {
         recorder.trace_paint(
             Operation::Producer(None, "inspector-overlays"),

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -25,12 +25,12 @@ use crate::painting::record::cache::{
 };
 use crate::painting::record::cache_compatibility::PaintCacheInputs;
 use crate::painting::record::resources::RecordingResourceManifest;
+use crate::painting::record::scratch::RecordingScratch;
 use crate::painting::record::svg_resources::MaskLayerSet;
 use crate::painting::record::trace::{Action, Operation};
 use crate::painting::record::verify::LoggedCapture;
 use crate::painting::record::{DeferredWholeTapeSplice, RecordingOutput, RecordingResult};
 use crate::painting::style_queries;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -68,6 +68,7 @@ fn to_paint_phase(phase: StackingContextPaintPhase) -> PaintPhase {
 pub(crate) fn record_display_list(
     layout_arena: &LayoutNodeArena,
     paint_state: &crate::painting::paint_state::PaintState,
+    scratch: &mut RecordingScratch,
     viewport: NodeSlotId,
     inputs: RecordingInputs,
     hit_test_list_generation: u64,
@@ -75,11 +76,13 @@ pub(crate) fn record_display_list(
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
     trace: bool,
 ) -> RecordingResult {
+    scratch.begin_recording(layout_arena.paintable_row_count());
     macro_rules! record {
         ($observer:ty) => {
             record_display_list_impl::<$observer>(
                 layout_arena,
                 paint_state,
+                scratch,
                 viewport,
                 inputs,
                 hit_test_list_generation,
@@ -88,17 +91,20 @@ pub(crate) fn record_display_list(
             )
         };
     }
-    if trace {
+    let result = if trace {
         record!(super::trace::Trace)
     } else {
         record!(super::trace::NoTrace)
-    }
+    };
+    scratch.clear_temporary_caches();
+    result
 }
 
 #[allow(clippy::too_many_arguments)]
 fn record_display_list_impl<O: Observer>(
     layout_arena: &LayoutNodeArena,
     paint_state: &crate::painting::paint_state::PaintState,
+    scratch: &mut RecordingScratch,
     viewport: NodeSlotId,
     inputs: RecordingInputs,
     hit_test_list_generation: u64,
@@ -111,10 +117,6 @@ fn record_display_list_impl<O: Observer>(
         cache_inputs.compatibility_with(&source.cache_inputs)
     });
     let paintable_rows = layout_arena.paintable_rows();
-    paint_state
-        .per_recording_memo_tables
-        .borrow_mut()
-        .begin_recording(layout_arena.paintable_row_count());
     let force_dark_settings = inputs.force_dark_enabled.then_some(ForceDarkSettings {
         foreground_brightness_threshold: inputs.force_dark_foreground_threshold,
         background_brightness_threshold: inputs.force_dark_background_threshold,
@@ -126,7 +128,6 @@ fn record_display_list_impl<O: Observer>(
         recorder: DisplayListRecorder::new(force_dark_settings),
         converter: DevicePixelConverter::new(inputs.device_pixels_per_css_pixel),
         svg_resource_walk: None,
-        pattern_tile_records: HashMap::new(),
         command_cache_source,
         item_cache_source,
         cache_compatibility,
@@ -144,12 +145,10 @@ fn record_display_list_impl<O: Observer>(
                 .map_or(0, |list| list.items.len()),
             ..HitTestList::default()
         },
-        memo_tables: &paint_state.per_recording_memo_tables,
+        scratch,
         completed_record_gen: narrow_record_gen(layout_arena.paint_cache_completed_record_gen()),
         all_paint_caches_dirty: layout_arena.all_paint_caches_dirty(),
         resources: RecordingResourceManifest::default(),
-        selection_style_cache: HashMap::new(),
-        wheel_hit_test_target_cache: HashMap::new(),
     };
     recorder.trace_paint(Operation::Producer(None, "canvas"), |this| {
         if inputs.canvas_fill_rect.has_value {
@@ -580,7 +579,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         }
     }
 
-    fn resolve_capture_address_in_source_tape(&self, address: CaptureAddress) -> Option<SourceTapePosition> {
+    fn resolve_capture_address_in_source_tape(&mut self, address: CaptureAddress) -> Option<SourceTapePosition> {
         let layout_arena = self.layout_arena;
         let lookup_enclosing_capture_anchor = |site: CaptureSite| -> Option<EnclosingCaptureAnchor> {
             if !layout_arena.paintable_row_is_populated(site.paintable) {
@@ -594,7 +593,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
             self.completed_record_gen,
             address,
             &lookup_enclosing_capture_anchor,
-            self.memo_tables.borrow_mut().resolved_enclosing_capture_memo(),
+            self.scratch.resolved_enclosing_capture_memo(),
         )
     }
 
@@ -682,9 +681,6 @@ impl<O: Observer> PaintRecorder<'_, O> {
         if self.is_recording_svg_resource_content() || !self.cache_compatibility.allows_subtree(site.kind) {
             return false;
         }
-        let Some(command_source) = self.command_cache_source.as_ref() else {
-            return false;
-        };
         let Some(item_source) = self.item_cache_source.clone() else {
             return false;
         };
@@ -707,6 +703,9 @@ impl<O: Observer> PaintRecorder<'_, O> {
             return false;
         }
         let Some(source_position) = self.resolve_capture_address_in_source_tape(cached.address) else {
+            return false;
+        };
+        let Some(command_source) = self.command_cache_source.as_ref() else {
             return false;
         };
 
@@ -776,9 +775,10 @@ impl<O: Observer> PaintRecorder<'_, O> {
         hit_test_item_count: usize,
         walk_outcome: SubtreeCaptureWalkOutcome,
     ) {
+        let absolute_position = self.current_absolute_position(site.paintable);
         self.cache_updates.set_subtree_capture(
             site,
-            self.current_absolute_position(site.paintable),
+            absolute_position,
             CachedSubtreeCapture {
                 address: self
                     .address_relative_to_innermost_open_capture(command_range.offset, hit_test_item_start as u32),
@@ -846,13 +846,13 @@ impl<O: Observer> PaintRecorder<'_, O> {
         });
     }
 
-    fn current_absolute_position(&self, paintable: NodeSlotId) -> used_values::FfiCssPixelPoint {
-        if let Some(position) = self.memo_tables.borrow().absolute_position(paintable) {
+    fn current_absolute_position(&mut self, paintable: NodeSlotId) -> used_values::FfiCssPixelPoint {
+        if let Some(position) = self.scratch.absolute_position(paintable) {
             return position;
         }
         let position: used_values::FfiCssPixelPoint =
             crate::painting::paintable_geometry::absolute_position(self.layout_arena, paintable).into();
-        self.memo_tables.borrow_mut().set_absolute_position(paintable, position);
+        self.scratch.set_absolute_position(paintable, position);
         position
     }
 
@@ -1113,14 +1113,13 @@ impl<O: Observer> PaintRecorder<'_, O> {
     }
 
     fn valid_cached_commands(
-        &self,
+        &mut self,
         paintable: NodeSlotId,
         phase: PaintPhase,
     ) -> Option<(Rc<RecordingOutput>, CommandRange, ContextRef)> {
         if !self.cache_compatibility.commands {
             return None;
         }
-        let source = self.command_cache_source.as_ref()?;
         let cache = self.layout_arena.paintable_paint_cache_if_allocated(paintable)?;
         // Checked before loading the entry so a dirty row's miss stays as cheap as the
         // absent-entry miss the eager clearing model produced.
@@ -1136,6 +1135,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         let offset = self
             .resolve_capture_address_in_source_tape(entry.address)?
             .command_byte_offset;
+        let source = self.command_cache_source.as_ref()?;
         Some((
             source.clone(),
             CommandRange {
@@ -1198,7 +1198,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
     }
 
     fn valid_cached_hit_test_items(
-        &self,
+        &mut self,
         paintable: NodeSlotId,
         phase: PaintPhase,
         own_context: ContextRef,
@@ -1207,7 +1207,6 @@ impl<O: Observer> PaintRecorder<'_, O> {
         if !self.cache_compatibility.hit_test_items {
             return None;
         }
-        let source = self.item_cache_source.as_ref()?;
         let cache = self.layout_arena.paintable_paint_cache_if_allocated(paintable)?;
         if self.all_paint_caches_dirty || cache.is_self_dirty_since(self.completed_record_gen) {
             return None;
@@ -1224,6 +1223,7 @@ impl<O: Observer> PaintRecorder<'_, O> {
         let start = self
             .resolve_capture_address_in_source_tape(entry.address)?
             .hit_test_item_index;
+        let source = self.item_cache_source.as_ref()?;
         Some((source.items.clone(), start as usize, entry.count as usize))
     }
 
@@ -1242,9 +1242,10 @@ impl<O: Observer> PaintRecorder<'_, O> {
             self.captured_range_references_only_the_phase_context(paintable, range, recorded_context),
             "a per-phase paint capture records under its phase context or without clips and effects"
         );
+        let absolute_position = self.current_absolute_position(paintable);
         self.cache_updates.set_commands(
             paintable,
-            self.current_absolute_position(paintable),
+            absolute_position,
             phase,
             crate::painting::record::cache::CachedBoxPhaseCommands {
                 address: self.address_relative_to_innermost_open_capture(range.offset, self.list.items.len() as u32),
@@ -1308,9 +1309,10 @@ impl<O: Observer> PaintRecorder<'_, O> {
         recorded_context: ContextRef,
         recorded_context_for_descendants: ContextRef,
     ) {
+        let absolute_position = self.current_absolute_position(paintable);
         self.cache_updates.set_hit_test_items(
             paintable,
-            self.current_absolute_position(paintable),
+            absolute_position,
             phase,
             crate::painting::record::cache::CachedBoxPhaseHitTestItems {
                 address: self


### PR DESCRIPTION
Display list recording relies on scattered cache compatibility checks, scratch stored in persistent paint state, and raw FFI inputs. This refactoring separates those responsibilities:
- Centralize compatibility checks against the retained cache source, preserving separate rules for commands, hit-test items, and subtree captures.
- Pass a separate RecordingScratch into traversal, reusing allocations and releasing temporary resources before publication.
- Convert FFI inputs at entry into borrowed Rust slices, typed options, and retained font handles.