### PR TITLE
LibWeb: Preserve unchanged paint caches across relayout

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -44,7 +44,7 @@ fn commit_subtree(
     paintables: &mut crate::painting::paintable_build::PaintableCommit<'_>,
     links_by_slot: &HashMap<u32, &FragmentLink>,
     pass_fragments: &fragment_tree::CompletedPassFragments,
-    enclosing_line_root_content_changed: bool,
+    enclosing_line_root_changes: crate::painting::paintable_build::LineRootChanges,
 ) {
     let slot_index = node.slot_index();
     let entry = links_by_slot.get(&slot_index).copied();
@@ -54,11 +54,11 @@ fn commit_subtree(
         node,
         entry.is_some(),
         reuses_committed_subtree,
-        enclosing_line_root_content_changed,
+        enclosing_line_root_changes,
     );
 
     let mut has_pending_inline_box_geometry = false;
-    let mut line_root_content_changed_for_children = enclosing_line_root_content_changed;
+    let mut line_root_changes_for_children = enclosing_line_root_changes;
     if let Some(link) = entry
         && prepared.has_paintable_row
     {
@@ -75,11 +75,11 @@ fn commit_subtree(
             node,
             link,
             reuses_committed_subtree,
-            enclosing_line_root_content_changed,
+            enclosing_line_root_changes,
             prepared.previous_offset,
         );
         if fragment.line_data.is_some() {
-            line_root_content_changed_for_children = replaced.committed_fragment_identity_changed;
+            line_root_changes_for_children = replaced.line_root_changes;
         }
         if prepared.row_existed_before_this_commit
             && let Some((old_content_size, new_content_size)) = replaced.content_size_change
@@ -110,7 +110,7 @@ fn commit_subtree(
             &mut *paintables,
             links_by_slot,
             pass_fragments,
-            line_root_content_changed_for_children,
+            line_root_changes_for_children,
         );
         child = next;
     }
@@ -157,7 +157,7 @@ pub(crate) fn commit_replacing(
         &mut paintables,
         &links_by_slot,
         pass_fragments,
-        false,
+        Default::default(),
     );
     paintables.discard_absolute_rects_memoized_during_commit();
     CommitNotifications {

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -63,6 +63,19 @@ fn same_allocation<T>(left: Option<&std::rc::Rc<T>>, right: Option<&std::rc::Rc<
 
 impl Fragment {
     fn builds_identically_to(&self, previous: &Fragment) -> bool {
+        self.has_same_box_properties(previous)
+            && same_allocation(self.line_data.as_ref(), previous.line_data.as_ref())
+            && self.children.len() == previous.children.len()
+            && self
+                .children
+                .iter()
+                .zip(&previous.children)
+                .all(|(link, previous_link)| link.places_same_fragment_identically_to(previous_link))
+    }
+
+    /// Box properties excluding inline content and child fragments. Painting compares those
+    /// separately: a new descendant fragment does not necessarily change this box's commands.
+    pub(crate) fn has_same_box_properties(&self, previous: &Fragment) -> bool {
         self.node == previous.node
             && self.content_inline_size == previous.content_inline_size
             && self.content_block_size == previous.content_block_size
@@ -87,7 +100,6 @@ impl Fragment {
                 self.collapsed_table_borders.as_ref(),
                 previous.collapsed_table_borders.as_ref(),
             )
-            && same_allocation(self.line_data.as_ref(), previous.line_data.as_ref())
             && same_allocation(self.grid_layout_data.as_ref(), previous.grid_layout_data.as_ref())
             && same_allocation(self.flex_layout_data.as_ref(), previous.flex_layout_data.as_ref())
             && same_allocation(self.used_grid_tracks.as_ref(), previous.used_grid_tracks.as_ref())
@@ -95,18 +107,25 @@ impl Fragment {
             && same_allocation(self.computed_svg_path.as_ref(), previous.computed_svg_path.as_ref())
             && self.has_line_clamp_point == previous.has_line_clamp_point
             && self.is_invisible_for_line_clamp == previous.is_invisible_for_line_clamp
-            && self.children.len() == previous.children.len()
+    }
+
+    pub(crate) fn has_same_child_placements(&self, previous: &Fragment) -> bool {
+        self.children.len() == previous.children.len()
             && self
                 .children
                 .iter()
                 .zip(&previous.children)
-                .all(|(link, previous_link)| link.places_same_fragment_identically_to(previous_link))
+                .all(|(link, previous_link)| link.has_same_placement(previous_link))
     }
 }
 
 impl FragmentLink {
     fn places_same_fragment_identically_to(&self, previous: &FragmentLink) -> bool {
-        std::rc::Rc::ptr_eq(&self.fragment, &previous.fragment)
+        std::rc::Rc::ptr_eq(&self.fragment, &previous.fragment) && self.has_same_placement(previous)
+    }
+
+    pub(crate) fn has_same_placement(&self, previous: &FragmentLink) -> bool {
+        self.fragment.node == previous.fragment.node
             && self.committed_offset == previous.committed_offset
             && self.inset_left == previous.inset_left
             && self.inset_right == previous.inset_right

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -6,7 +6,7 @@
 
 use crate::css::css_pixels::CssPixelRect;
 use crate::layout::LayoutNodeArena;
-use crate::layout::node_data::{NodeKind, NodeSlotId};
+use crate::layout::node_data::{DomPaintFact, NodeKind, NodeSlotId};
 use crate::layout::{formatting_context, fragment_tree, node_facts, used_values};
 use crate::painting::node_painting;
 use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
@@ -273,8 +273,24 @@ impl<'a> PaintableCommit<'a> {
         // commit. Comparing that final offset with the fragment's temporary one would dirty
         // identical inlines on every relayout; their line content and box properties suffice.
         let paint_offset_unchanged = offset_unchanged || painted_geometry_lives_in_enclosing_line_root;
+        // record_lines_hit_test_items() emits an EmptyEditable target only without paint
+        // children. An out-of-flow child can change that eligibility without changing the
+        // editor's box properties or inline content, so descendant dirtiness alone is insufficient.
+        let empty_editable_children_changed = !child_placements_unchanged
+            && node_painting::has_lines(self.arena(), node)
+            && self
+                .arena()
+                .node_has_dom_paint_fact(node, DomPaintFact::EditableOrEditingHost)
+            && fragment
+                .line_data
+                .as_ref()
+                .is_none_or(|content| content.fragments.is_empty());
         // Equality only avoids adding dirtiness; it never clears a pending style/content repaint.
-        if !own_paint_unchanged || !paint_offset_unchanged || enclosing_inline_paint_changed {
+        if !own_paint_unchanged
+            || !paint_offset_unchanged
+            || enclosing_inline_paint_changed
+            || empty_editable_children_changed
+        {
             self.arena().paintable_rows().mark_paint_cache_self_dirty(node);
         } else if !child_placements_unchanged {
             // Rebuild captures containing inserted, removed or reordered children, while

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -20,7 +20,52 @@ pub(crate) struct PreparedPaintable {
 
 pub(crate) struct ReplacedCommittedFragmentLink {
     pub(crate) content_size_change: Option<(used_values::FfiCssPixelSize, used_values::FfiCssPixelSize)>,
-    pub(crate) committed_fragment_identity_changed: bool,
+    pub(crate) line_root_changes: LineRootChanges,
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct LineRootChanges {
+    pub(crate) fragment_changed: bool,
+    pub(crate) inline_content_changed: bool,
+}
+
+fn same_inline_content(left: &fragment_tree::Fragment, right: &fragment_tree::Fragment) -> bool {
+    match (&left.line_data, &right.line_data) {
+        (None, None) => true,
+        (Some(left), Some(right)) => std::rc::Rc::ptr_eq(left, right) || left == right,
+        _ => false,
+    }
+}
+
+fn has_descendant_dependent_paint(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
+    let kind = arena.data(node).kind.get();
+    if node_painting::is_svg(kind)
+        || matches!(
+            kind,
+            NodeKind::FieldSetBox | NodeKind::SVGBox | NodeKind::SVGSVGBox | NodeKind::SVGForeignObjectBox
+        )
+    {
+        return true;
+    }
+    let Some(style) = arena.node_style_if_live(node) else {
+        return true;
+    };
+    let display = style.display();
+    if display.is_table_inside() || display.is_internal_table() || kind == NodeKind::TableWrapper {
+        return true;
+    }
+    // A text-clipped background can collect glyphs from multiple descendant line roots.
+    fn clips_text(value: &crate::css::style_value::StyleValueData) -> bool {
+        use crate::css::{css_enums, style_value::StyleValueData};
+        match value {
+            StyleValueData::Keyword { keyword } => {
+                css_enums::keyword_to_background_box(*keyword) == Some(css_enums::background_box::TEXT)
+            }
+            StyleValueData::ValueList { values, .. } => values.as_slice().iter().any(|value| clips_text(value.data())),
+            _ => false,
+        }
+    }
+    crate::painting::style_queries::handle_value(&style.background().background_clip).is_some_and(clips_text)
 }
 
 pub(crate) struct PaintableCommit<'a> {
@@ -59,7 +104,7 @@ impl<'a> PaintableCommit<'a> {
         node: formatting_context::Node,
         has_used_values: bool,
         reuses_committed_subtree: bool,
-        enclosing_line_root_content_changed: bool,
+        enclosing_line_root_changes: LineRootChanges,
     ) -> PreparedPaintable {
         let (wants_paintable, node_kind) = {
             let data = self.arena().data(node);
@@ -109,10 +154,13 @@ impl<'a> PaintableCommit<'a> {
         }
         if !has_used_values {
             self.arena().clear_committed_fragment_link(node);
-            // Fragmented inlines commit no fragment link, so the identity diff never sees them;
-            // their painted output changes exactly when the enclosing line root's fragment did.
-            if row_existed_before_this_commit && enclosing_line_root_content_changed {
+            // Fragmented inlines get their painted pieces from the enclosing line root.
+            let inline_paint_changed = enclosing_line_root_changes.inline_content_changed
+                || (enclosing_line_root_changes.fragment_changed && has_descendant_dependent_paint(self.arena(), node));
+            if row_existed_before_this_commit && inline_paint_changed {
                 self.arena().paintable_rows().mark_paint_cache_self_dirty(node);
+            }
+            if row_existed_before_this_commit && enclosing_line_root_changes.fragment_changed {
                 self.arena()
                     .note_visual_context_box_dirty(node, VisualContextBoxDirtyKind::InlineGeometryChanged);
             }
@@ -163,7 +211,7 @@ impl<'a> PaintableCommit<'a> {
         node: formatting_context::Node,
         link: &fragment_tree::FragmentLink,
         reuses_committed_subtree: bool,
-        enclosing_line_root_content_changed: bool,
+        enclosing_line_root_changes: LineRootChanges,
         previous_offset: Option<used_values::FfiCssPixelPoint>,
     ) -> ReplacedCommittedFragmentLink {
         let fragment = &link.fragment;
@@ -172,8 +220,24 @@ impl<'a> PaintableCommit<'a> {
             height: fragment.content_block_size,
         };
         let mut content_size_change = None;
+        let mut own_paint_unchanged = false;
+        let mut child_placements_unchanged = false;
+        let mut inline_content_unchanged = false;
         let (old_identity, old_content_size) = self.arena().with_committed_fragment_link(node, |old_link| {
             old_link.map_or((0, used_values::FfiCssPixelSize::default()), |old_link| {
+                let previous = &old_link.fragment;
+                if reuses_committed_subtree || previous.identity == fragment.identity {
+                    own_paint_unchanged = true;
+                    child_placements_unchanged = true;
+                    inline_content_unchanged = true;
+                } else {
+                    inline_content_unchanged = same_inline_content(fragment, previous);
+                    own_paint_unchanged = inline_content_unchanged
+                        && fragment.has_same_box_properties(previous)
+                        && !has_descendant_dependent_paint(self.arena(), node);
+                    child_placements_unchanged = fragment.has_same_child_placements(previous);
+                }
+                own_paint_unchanged &= old_link.has_same_placement(link);
                 (
                     old_link.fragment.identity,
                     used_values::FfiCssPixelSize {
@@ -191,28 +255,42 @@ impl<'a> PaintableCommit<'a> {
             content_size_change = Some((old_content_size, new_content_size));
         }
         let committed_fragment_identity_changed = old_identity != fragment.identity;
-        let painted_geometry_lives_in_enclosing_line_root = || {
+        let painted_geometry_lives_in_enclosing_line_root = {
             let data = self.arena().data(node);
             node_facts::node_is_fragmented_inline(data, node_facts::node_style_view(data))
         };
-        let painted_content_changed = committed_fragment_identity_changed
-            || (enclosing_line_root_content_changed && painted_geometry_lives_in_enclosing_line_root());
-        // A reused committed subtree's root counts as unchanged even though its run-root
-        // fragment is rebuilt with a fresh identity at placement: the reuse contract guarantees
-        // identical replayed output, enforced by the content-size assertion above.
-        let content_unchanged = reuses_committed_subtree || (old_identity != 0 && !painted_content_changed);
+        let fragment_content_changed = committed_fragment_identity_changed
+            || (enclosing_line_root_changes.fragment_changed && painted_geometry_lives_in_enclosing_line_root);
+        // Keep fragment identity as the conservative signal for overflow and visual contexts.
+        // A reused run root can have a new identity while replaying identical output.
+        let fragment_content_unchanged = reuses_committed_subtree || (old_identity != 0 && !fragment_content_changed);
         let offset_unchanged = previous_offset == Some(link.committed_offset);
-        if !(content_unchanged && offset_unchanged) {
+        let enclosing_inline_paint_changed = painted_geometry_lives_in_enclosing_line_root
+            && (enclosing_line_root_changes.inline_content_changed
+                || (enclosing_line_root_changes.fragment_changed
+                    && has_descendant_dependent_paint(self.arena(), node)));
+        // Fragmented inline offsets are finalized from the line root's pieces after this
+        // commit. Comparing that final offset with the fragment's temporary one would dirty
+        // identical inlines on every relayout; their line content and box properties suffice.
+        let paint_offset_unchanged = offset_unchanged || painted_geometry_lives_in_enclosing_line_root;
+        // Equality only avoids adding dirtiness; it never clears a pending style/content repaint.
+        if !own_paint_unchanged || !paint_offset_unchanged || enclosing_inline_paint_changed {
             self.arena().paintable_rows().mark_paint_cache_self_dirty(node);
+        } else if !child_placements_unchanged {
+            // Rebuild captures containing inserted, removed or reordered children, while
+            // retaining the box's own commands. Changed child output propagates separately.
+            self.arena()
+                .paintable_rows()
+                .mark_descendant_subtree_caches_dirty_along_paint_chain(node);
         }
         if !offset_unchanged {
             self.arena()
                 .note_visual_context_box_dirty(node, VisualContextBoxDirtyKind::MovedWithDescendants);
-        } else if !content_unchanged {
+        } else if !fragment_content_unchanged {
             self.arena()
                 .note_visual_context_box_dirty(node, VisualContextBoxDirtyKind::RecommittedInPlace);
         }
-        if painted_content_changed {
+        if fragment_content_changed {
             self.arena().paintable_rows().clear_cached_overflow_data(node);
         }
         {
@@ -226,7 +304,10 @@ impl<'a> PaintableCommit<'a> {
             .set_committed_fragment_link(self.arena().data(node), link.clone());
         ReplacedCommittedFragmentLink {
             content_size_change,
-            committed_fragment_identity_changed,
+            line_root_changes: LineRootChanges {
+                fragment_changed: committed_fragment_identity_changed,
+                inline_content_changed: !inline_content_unchanged,
+            },
         }
     }
 

--- a/Tests/LibWeb/Text/expected/display_list/paint-cache-abspos-child-insertion.txt
+++ b/Tests/LibWeb/Text/expected/display_list/paint-cache-abspos-child-insertion.txt
@@ -1,0 +1,6 @@
+PASS: quiet before abspos insertion (work)
+PASS: abspos insertion reuses all existing paint (work + checks)
+PASS: quiet after abspos insertion (work)
+PASS: abspos removal reuses all remaining paint (work + checks)
+PASS: quiet after abspos removal (work)
+PASS: abspos reinsertion after quiet frame reuses all existing paint (work + checks)

--- a/Tests/LibWeb/Text/expected/display_list/paint-cache-relayout-descendant-dependencies.txt
+++ b/Tests/LibWeb/Text/expected/display_list/paint-cache-relayout-descendant-dependencies.txt
@@ -1,0 +1,9 @@
+text-clipped background: owner geometry unchanged = true
+text-clipped background: owner paint recorded = true
+text-clipped background: paint changed = true
+fieldset legend gap: owner geometry unchanged = true
+fieldset legend gap: owner paint recorded = true
+fieldset legend gap: paint changed = true
+table row background: owner geometry unchanged = true
+table row background: owner paint recorded = true
+table row background: paint changed = true

--- a/Tests/LibWeb/Text/expected/display_list/paint-cache-relayout-paint-inputs.txt
+++ b/Tests/LibWeb/Text/expected/display_list/paint-cache-relayout-paint-inputs.txt
@@ -1,0 +1,3 @@
+PASS: identical inline output survives full relayout (work + checks)
+PASS: different text at the same size records new paint (work + checks)
+PASS: relayout preserves pending style paint invalidation (work + checks)

--- a/Tests/LibWeb/Text/expected/hit_testing/empty-editable-caret-after-abspos-child-change.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/empty-editable-caret-after-abspos-child-change.txt
@@ -1,0 +1,12 @@
+empty editor, cached: editor @0
+empty editor, quiet: editor @0
+empty editor, fresh: editor @0
+child is non-editable: true
+after insertion, editor hit test updated: true
+after insertion, cached: child @0
+after insertion, quiet: child @0
+after insertion, fresh: child @0
+after removal, editor hit test updated: true
+after removal, cached: editor @0
+after removal, quiet: editor @0
+after removal, fresh: editor @0

--- a/Tests/LibWeb/Text/input/display_list/paint-cache-abspos-child-insertion.html
+++ b/Tests/LibWeb/Text/input/display_list/paint-cache-abspos-child-insertion.html
@@ -1,0 +1,190 @@
+<!doctype html>
+<html id="html">
+<script src="../include.js"></script>
+<script src="recording-test.js"></script>
+<style>
+    body { margin: 0; font: 16px/20px monospace; }
+    #container { position: relative; width: 300px; height: 100px; background: silver; }
+    #existing, #sibling { position: relative; width: 100px; height: 40px; background: blue; }
+    #inserted { position: absolute; left: 160px; top: 20px; width: 100px; height: 20px; background: green; }
+</style>
+<body id="body">
+<div id="container"><div id="existing">Existing</div></div>
+<div id="sibling">Sibling</div>
+<script>
+let previousLayoutCount;
+const insertionStep = {
+    // The new child fits inside its containing block without moving existing boxes
+    // or changing overflow. Only its own paint and hit-test items need recording.
+    name: "abspos insertion reuses all existing paint",
+    mutate: () => {
+        previousLayoutCount = internals.fullLayoutCount() + internals.partialLayoutCount();
+        const inserted = document.createElement("div");
+        inserted.id = "inserted";
+        inserted.textContent = "New child";
+        container.appendChild(inserted);
+    },
+    check: equal => {
+        const layoutCount = internals.fullLayoutCount() + internals.partialLayoutCount();
+        equal(layoutCount > previousLayoutCount, true, "insertion performed layout");
+        equal(container.getBoundingClientRect().height, 100, "container height");
+        equal(existing.getBoundingClientRect().top, 0, "existing child position");
+        equal(sibling.getBoundingClientRect().top, 100, "sibling position");
+        equal(document.elementFromPoint(170, 30).id, "inserted", "inserted child hit target");
+    },
+    expect: `
+        @canvas RECORD (empty)
+        @viewport WALK
+          @viewport/background/hit-test REUSE
+          @viewport/scroll-metadata RECORD (empty)
+          @viewport/background SKIP
+          @viewport/border SKIP
+          BlockContainer<HTML>#html/descendants(background-and-borders) WALK
+          @viewport/foreground/hit-test REUSE
+          @viewport/foreground REUSE
+          BlockContainer<HTML>#html/descendants(foreground) WALK
+          BlockContainer<HTML>#html WALK
+            BlockContainer<HTML>#html/background/hit-test REUSE
+            BlockContainer<HTML>#html/scroll-metadata RECORD (empty)
+            BlockContainer<HTML>#html/background REUSE
+            BlockContainer<HTML>#html/border SKIP
+            BlockContainer<BODY>#body/descendants(background-and-borders) WALK
+              BlockContainer<BODY>#body/background/hit-test REUSE
+              BlockContainer<BODY>#body/scroll-metadata RECORD (empty)
+              BlockContainer<BODY>#body/background SKIP
+              BlockContainer<BODY>#body/border SKIP
+              BlockContainer<DIV>#container/descendants(background-and-borders) WALK
+              BlockContainer<DIV>#sibling/descendants(background-and-borders) REUSE WHOLE CAPTURE
+            BlockContainer<HTML>#html/foreground/hit-test REUSE
+            BlockContainer<HTML>#html/foreground REUSE
+            BlockContainer<BODY>#body/descendants(foreground) WALK
+              BlockContainer<BODY>#body/foreground/hit-test REUSE
+              BlockContainer<BODY>#body/foreground REUSE
+              BlockContainer<DIV>#container/descendants(foreground) WALK
+              BlockContainer<DIV>#sibling/descendants(foreground) REUSE WHOLE CAPTURE
+              BlockContainer<BODY>#body/outline SKIP
+              BlockContainer<BODY>#body/overlay/hit-test REUSE
+              BlockContainer<BODY>#body/overlay SKIP
+            BlockContainer<DIV>#container WALK
+              BlockContainer<DIV>#container/background/hit-test REUSE
+              BlockContainer<DIV>#container/scroll-metadata RECORD (empty)
+              BlockContainer<DIV>#container/background REUSE
+              BlockContainer<DIV>#container/border SKIP
+              BlockContainer<DIV>#existing/descendants(background-and-borders) REUSE WHOLE CAPTURE
+              BlockContainer<DIV>#inserted/descendants(background-and-borders) WALK
+              BlockContainer<DIV>#existing/descendants(floats) REUSE WHOLE CAPTURE
+              BlockContainer<DIV>#inserted/descendants(floats) WALK
+              BlockContainer<DIV>#existing/descendants(inline-background-and-borders) REUSE WHOLE CAPTURE
+              BlockContainer<DIV>#inserted/descendants(inline-background-and-borders) WALK
+              BlockContainer<DIV>#container/foreground/hit-test REUSE
+              BlockContainer<DIV>#container/foreground REUSE
+              BlockContainer<DIV>#existing/descendants(foreground) REUSE WHOLE CAPTURE
+              BlockContainer<DIV>#inserted/descendants(foreground) WALK
+              BlockContainer<DIV>#container/outline SKIP
+              BlockContainer<DIV>#container/overlay/hit-test REUSE
+              BlockContainer<DIV>#container/overlay SKIP
+            BlockContainer<DIV>#existing REUSE WHOLE CAPTURE
+            BlockContainer<DIV>#inserted WALK
+              BlockContainer<DIV>#inserted/background/hit-test RECORD
+              BlockContainer<DIV>#inserted/scroll-metadata RECORD (empty)
+              BlockContainer<DIV>#inserted/background RECORD
+              BlockContainer<DIV>#inserted/border SKIP
+              BlockContainer<DIV>#inserted/foreground/hit-test RECORD
+              BlockContainer<DIV>#inserted/foreground RECORD
+              BlockContainer<DIV>#inserted/outline SKIP
+              BlockContainer<DIV>#inserted/overlay/hit-test RECORD (empty)
+              BlockContainer<DIV>#inserted/overlay SKIP
+            BlockContainer<DIV>#sibling REUSE WHOLE CAPTURE
+            BlockContainer<HTML>#html/outline SKIP
+          @viewport/outline SKIP
+    `,
+};
+displayListTest({
+    setup: removeBodyWhitespace,
+    steps: [
+        {
+            name: "quiet before abspos insertion",
+            expect: `
+                @canvas RECORD (empty)
+                @viewport REUSE WHOLE CAPTURE
+            `,
+        },
+        insertionStep,
+        {
+            name: "quiet after abspos insertion",
+            expect: `
+                @canvas RECORD (empty)
+                @viewport REUSE WHOLE CAPTURE
+            `,
+        },
+        {
+            name: "abspos removal reuses all remaining paint",
+            mutate: () => { inserted.remove(); },
+            check: equal => {
+                equal(sibling.getBoundingClientRect().top, 100, "sibling position");
+                equal(document.elementFromPoint(170, 30).id, "container", "removed child no longer hit");
+            },
+            expect: `
+                @canvas RECORD (empty)
+                @viewport WALK
+                  @viewport/background/hit-test REUSE
+                  @viewport/scroll-metadata RECORD (empty)
+                  @viewport/background SKIP
+                  @viewport/border SKIP
+                  BlockContainer<HTML>#html/descendants(background-and-borders) WALK
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
+                  BlockContainer<HTML>#html/descendants(foreground) WALK
+                  BlockContainer<HTML>#html WALK
+                    BlockContainer<HTML>#html/background/hit-test REUSE
+                    BlockContainer<HTML>#html/scroll-metadata RECORD (empty)
+                    BlockContainer<HTML>#html/background REUSE
+                    BlockContainer<HTML>#html/border SKIP
+                    BlockContainer<BODY>#body/descendants(background-and-borders) WALK
+                      BlockContainer<BODY>#body/background/hit-test REUSE
+                      BlockContainer<BODY>#body/scroll-metadata RECORD (empty)
+                      BlockContainer<BODY>#body/background SKIP
+                      BlockContainer<BODY>#body/border SKIP
+                      BlockContainer<DIV>#container/descendants(background-and-borders) WALK
+                      BlockContainer<DIV>#sibling/descendants(background-and-borders) REUSE WHOLE CAPTURE
+                    BlockContainer<HTML>#html/foreground/hit-test REUSE
+                    BlockContainer<HTML>#html/foreground REUSE
+                    BlockContainer<BODY>#body/descendants(foreground) WALK
+                      BlockContainer<BODY>#body/foreground/hit-test REUSE
+                      BlockContainer<BODY>#body/foreground REUSE
+                      BlockContainer<DIV>#container/descendants(foreground) WALK
+                      BlockContainer<DIV>#sibling/descendants(foreground) REUSE WHOLE CAPTURE
+                      BlockContainer<BODY>#body/outline SKIP
+                      BlockContainer<BODY>#body/overlay/hit-test REUSE
+                      BlockContainer<BODY>#body/overlay SKIP
+                    BlockContainer<DIV>#container WALK
+                      BlockContainer<DIV>#container/background/hit-test REUSE
+                      BlockContainer<DIV>#container/scroll-metadata RECORD (empty)
+                      BlockContainer<DIV>#container/background REUSE
+                      BlockContainer<DIV>#container/border SKIP
+                      BlockContainer<DIV>#existing/descendants(background-and-borders) REUSE WHOLE CAPTURE
+                      BlockContainer<DIV>#existing/descendants(floats) REUSE WHOLE CAPTURE
+                      BlockContainer<DIV>#existing/descendants(inline-background-and-borders) REUSE WHOLE CAPTURE
+                      BlockContainer<DIV>#container/foreground/hit-test REUSE
+                      BlockContainer<DIV>#container/foreground REUSE
+                      BlockContainer<DIV>#existing/descendants(foreground) REUSE WHOLE CAPTURE
+                      BlockContainer<DIV>#container/outline SKIP
+                      BlockContainer<DIV>#container/overlay/hit-test REUSE
+                      BlockContainer<DIV>#container/overlay SKIP
+                    BlockContainer<DIV>#existing REUSE WHOLE CAPTURE
+                    BlockContainer<DIV>#sibling REUSE WHOLE CAPTURE
+                    BlockContainer<HTML>#html/outline SKIP
+                  @viewport/outline SKIP
+            `,
+        },
+        {
+            name: "quiet after abspos removal",
+            expect: `
+                @canvas RECORD (empty)
+                @viewport REUSE WHOLE CAPTURE
+            `,
+        },
+        { ...insertionStep, name: "abspos reinsertion after quiet frame reuses all existing paint" },
+    ],
+});
+</script>

--- a/Tests/LibWeb/Text/input/display_list/paint-cache-first-recording-and-relayout.html
+++ b/Tests/LibWeb/Text/input/display_list/paint-cache-first-recording-and-relayout.html
@@ -97,26 +97,26 @@ displayListTest({
             expect: `
                 @canvas RECORD (empty)
                 @viewport WALK
-                  @viewport/background/hit-test RECORD
+                  @viewport/background/hit-test REUSE
                   @viewport/scroll-metadata RECORD (empty)
                   @viewport/background SKIP
                   @viewport/border SKIP
                   BlockContainer<HTML>#html/descendants(background-and-borders) WALK
-                  @viewport/foreground/hit-test RECORD (empty)
-                  @viewport/foreground RECORD (empty)
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
                   BlockContainer<HTML>#html/descendants(foreground) WALK
                   BlockContainer<HTML>#html WALK
-                    BlockContainer<HTML>#html/background/hit-test RECORD
+                    BlockContainer<HTML>#html/background/hit-test REUSE
                     BlockContainer<HTML>#html/scroll-metadata RECORD (empty)
-                    BlockContainer<HTML>#html/background RECORD (empty)
+                    BlockContainer<HTML>#html/background REUSE
                     BlockContainer<HTML>#html/border SKIP
                     BlockContainer<BODY>#body/descendants(background-and-borders) WALK
-                      BlockContainer<BODY>#body/background/hit-test RECORD
+                      BlockContainer<BODY>#body/background/hit-test REUSE
                       BlockContainer<BODY>#body/scroll-metadata RECORD (empty)
                       BlockContainer<BODY>#body/background SKIP
                       BlockContainer<BODY>#body/border SKIP
                       BlockContainer<DIV>#root/descendants(background-and-borders) WALK
-                        BlockContainer<DIV>#root/background/hit-test RECORD
+                        BlockContainer<DIV>#root/background/hit-test REUSE
                         BlockContainer<DIV>#root/scroll-metadata RECORD (empty)
                         BlockContainer<DIV>#root/background SKIP
                         BlockContainer<DIV>#root/border SKIP
@@ -126,14 +126,14 @@ displayListTest({
                           BlockContainer<DIV>#card1.card/scroll-metadata RECORD (empty)
                           BlockContainer<DIV>#card1.card/background SKIP
                           BlockContainer<DIV>#card1.card/border RECORD
-                    BlockContainer<HTML>#html/foreground/hit-test RECORD (empty)
-                    BlockContainer<HTML>#html/foreground RECORD (empty)
+                    BlockContainer<HTML>#html/foreground/hit-test REUSE
+                    BlockContainer<HTML>#html/foreground REUSE
                     BlockContainer<BODY>#body/descendants(foreground) WALK
-                      BlockContainer<BODY>#body/foreground/hit-test RECORD (empty)
-                      BlockContainer<BODY>#body/foreground RECORD (empty)
+                      BlockContainer<BODY>#body/foreground/hit-test REUSE
+                      BlockContainer<BODY>#body/foreground REUSE
                       BlockContainer<DIV>#root/descendants(foreground) WALK
-                        BlockContainer<DIV>#root/foreground/hit-test RECORD (empty)
-                        BlockContainer<DIV>#root/foreground RECORD (empty)
+                        BlockContainer<DIV>#root/foreground/hit-test REUSE
+                        BlockContainer<DIV>#root/foreground REUSE
                         BlockContainer<DIV>#card0.card/descendants(foreground) REUSE WHOLE CAPTURE
                         BlockContainer<DIV>#card1.card/descendants(foreground) WALK
                           BlockContainer<DIV>#card1.card/foreground/hit-test RECORD
@@ -142,10 +142,10 @@ displayListTest({
                           BlockContainer<DIV>#card1.card/overlay/hit-test RECORD (empty)
                           BlockContainer<DIV>#card1.card/overlay SKIP
                         BlockContainer<DIV>#root/outline SKIP
-                        BlockContainer<DIV>#root/overlay/hit-test RECORD (empty)
+                        BlockContainer<DIV>#root/overlay/hit-test REUSE
                         BlockContainer<DIV>#root/overlay SKIP
                       BlockContainer<BODY>#body/outline SKIP
-                      BlockContainer<BODY>#body/overlay/hit-test RECORD (empty)
+                      BlockContainer<BODY>#body/overlay/hit-test REUSE
                       BlockContainer<BODY>#body/overlay SKIP
                     BlockContainer<HTML>#html/outline SKIP
                   @viewport/outline SKIP

--- a/Tests/LibWeb/Text/input/display_list/paint-cache-relayout-descendant-dependencies.html
+++ b/Tests/LibWeb/Text/input/display_list/paint-cache-relayout-descendant-dependencies.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script src="recording-test.js"></script>
+<style>
+    body { margin: 0; font: 16px/20px monospace; }
+    #clip { width: 200px; height: 40px; background: linear-gradient(red, blue); background-clip: text; color: transparent; }
+    fieldset { width: 200px; height: 60px; margin: 0; border: 4px solid black; }
+    table { width: 200px; table-layout: fixed; border-spacing: 4px; }
+    #row { background: linear-gradient(red, blue); }
+    td { height: 20px; padding: 0; }
+</style>
+<div id="clip"><div id="clipText">AAAA</div></div>
+<fieldset id="fieldset"><legend id="legend">Legend</legend></fieldset>
+<table><tbody><tr id="row"><td id="cell" style="width: 80px"></td><td></td></tr></tbody></table>
+<script>
+promiseTest(async () => {
+    if (document.readyState !== "complete")
+        await new Promise(resolve => window.addEventListener("load", resolve, { once: true }));
+    removeBodyWhitespace();
+    await document.fonts.ready;
+    __outputElement.style.display = "none";
+    const output = [];
+    for (const { name, owner, phase, mutate } of [
+        { name: "text-clipped background", owner: clip, phase: "background", mutate: () => { clipText.firstChild.data = "BBBB"; } },
+        { name: "fieldset legend gap", owner: fieldset, phase: "border", mutate: () => { legend.style.marginLeft = "30px"; } },
+        { name: "table row background", owner: row, phase: "background", mutate: () => { cell.style.width = "100px"; } },
+    ]) {
+        const before = internals.dumpDisplayList();
+        const rectBefore = JSON.stringify(owner.getBoundingClientRect());
+        internals.beginDisplayListTrace();
+        mutate();
+        internals.recordDisplayListForTesting(false, false);
+        const trace = internals.takeDisplayListTrace();
+        const rectAfter = JSON.stringify(owner.getBoundingClientRect());
+        const after = internals.dumpDisplayList();
+        const recordedOwner = trace.split("\n").some(line => line.trim().endsWith(`#${owner.id}/${phase} RECORD`));
+        output.push(`${name}: owner geometry unchanged = ${rectBefore === rectAfter}`);
+        output.push(`${name}: owner paint recorded = ${recordedOwner}`);
+        output.push(`${name}: paint changed = ${before !== after}`);
+    }
+    __outputElement.style.display = "";
+    for (const line of output) println(line);
+});
+</script>

--- a/Tests/LibWeb/Text/input/display_list/paint-cache-relayout-paint-inputs.html
+++ b/Tests/LibWeb/Text/input/display_list/paint-cache-relayout-paint-inputs.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html id="html">
+<script src="../include.js"></script>
+<script src="recording-test.js"></script>
+<style>
+    body { margin: 0; font: 16px/20px monospace; }
+    #target { width: 200px; height: 40px; background: silver; }
+    #inline { position: relative; }
+    canvas { display: block; width: 100px; height: 20px; background: green; }
+</style>
+<body id="body">
+<div id="target"><span id="inline">Original</span></div>
+<canvas id="trigger" width="100" height="20"></canvas>
+<script>
+let previousLayoutCount;
+displayListTest({
+    setup: removeBodyWhitespace,
+    steps: [
+        {
+            name: "identical inline output survives full relayout",
+            mutate: () => {
+                previousLayoutCount = internals.fullLayoutCount();
+                trigger.width = trigger.width;
+            },
+            check: equal => {
+                equal(internals.fullLayoutCount(), previousLayoutCount + 1, "full layout count");
+                equal(document.elementFromPoint(5, 10).id, "inline", "inline hit target");
+            },
+            expect: `
+                @canvas RECORD (empty)
+                @viewport REUSE WHOLE CAPTURE
+            `,
+        },
+        {
+            name: "different text at the same size records new paint",
+            mutate: () => { document.getElementById("inline").firstChild.data = "Changed!"; },
+            check: equal => { equal(target.getBoundingClientRect().height, 40, "unchanged target height"); },
+            expect: `
+                @canvas RECORD (empty)
+                @viewport WALK
+                  @viewport/background/hit-test REUSE
+                  @viewport/scroll-metadata RECORD (empty)
+                  @viewport/background SKIP
+                  @viewport/border SKIP
+                  BlockContainer<HTML>#html/descendants(background-and-borders) WALK
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
+                  BlockContainer<HTML>#html/descendants(foreground) WALK
+                  BlockContainer<HTML>#html WALK
+                    BlockContainer<HTML>#html/background/hit-test REUSE
+                    BlockContainer<HTML>#html/scroll-metadata RECORD (empty)
+                    BlockContainer<HTML>#html/background REUSE
+                    BlockContainer<HTML>#html/border SKIP
+                    BlockContainer<BODY>#body/descendants(background-and-borders) WALK
+                      BlockContainer<BODY>#body/background/hit-test REUSE
+                      BlockContainer<BODY>#body/scroll-metadata RECORD (empty)
+                      BlockContainer<BODY>#body/background SKIP
+                      BlockContainer<BODY>#body/border SKIP
+                      BlockContainer<DIV>#target/descendants(background-and-borders) WALK
+                        BlockContainer<DIV>#target/background/hit-test RECORD
+                        BlockContainer<DIV>#target/scroll-metadata RECORD (empty)
+                        BlockContainer<DIV>#target/background RECORD
+                        BlockContainer<DIV>#target/border SKIP
+                        InlineNode<SPAN>#inline/descendants(background-and-borders) WALK
+                      CanvasBox<CANVAS>#trigger/descendants(background-and-borders) REUSE WHOLE CAPTURE
+                    BlockContainer<BODY>#body/descendants(inline-background-and-borders) WALK
+                      BlockContainer<DIV>#target/descendants(inline-background-and-borders) WALK
+                        InlineNode<SPAN>#inline/descendants(inline-background-and-borders) WALK
+                      CanvasBox<CANVAS>#trigger/descendants(inline-background-and-borders) REUSE WHOLE CAPTURE
+                    BlockContainer<HTML>#html/foreground/hit-test REUSE
+                    BlockContainer<HTML>#html/foreground REUSE
+                    BlockContainer<BODY>#body/descendants(foreground) WALK
+                      BlockContainer<BODY>#body/foreground/hit-test REUSE
+                      BlockContainer<BODY>#body/foreground REUSE
+                      BlockContainer<DIV>#target/descendants(foreground) WALK
+                        BlockContainer<DIV>#target/foreground/hit-test RECORD (empty)
+                        BlockContainer<DIV>#target/foreground RECORD (empty)
+                        InlineNode<SPAN>#inline/descendants(foreground) WALK
+                        BlockContainer<DIV>#target/outline SKIP
+                        BlockContainer<DIV>#target/overlay/hit-test RECORD (empty)
+                        BlockContainer<DIV>#target/overlay SKIP
+                      CanvasBox<CANVAS>#trigger/descendants(foreground) REUSE WHOLE CAPTURE
+                      BlockContainer<BODY>#body/outline SKIP
+                      BlockContainer<BODY>#body/overlay/hit-test REUSE
+                      BlockContainer<BODY>#body/overlay SKIP
+                    InlineNode<SPAN>#inline WALK
+                      InlineNode<SPAN>#inline/background/hit-test RECORD
+                      InlineNode<SPAN>#inline/scroll-metadata RECORD (empty)
+                      InlineNode<SPAN>#inline/background SKIP
+                      InlineNode<SPAN>#inline/border SKIP
+                      InlineNode<SPAN>#inline/foreground/hit-test RECORD
+                      InlineNode<SPAN>#inline/foreground RECORD
+                      InlineNode<SPAN>#inline/outline SKIP
+                      InlineNode<SPAN>#inline/overlay/hit-test RECORD (empty)
+                      InlineNode<SPAN>#inline/overlay SKIP
+                    BlockContainer<HTML>#html/outline SKIP
+                  @viewport/outline SKIP
+            `,
+        },
+        {
+            name: "relayout preserves pending style paint invalidation",
+            mutate: () => {
+                previousLayoutCount = internals.fullLayoutCount();
+                document.getElementById("inline").style.color = "red";
+                trigger.width = trigger.width;
+            },
+            check: equal => {
+                equal(internals.fullLayoutCount(), previousLayoutCount + 1, "full layout count");
+                equal(getComputedStyle(document.getElementById("inline")).color, "rgb(255, 0, 0)", "new text color");
+            },
+            expect: `
+                @canvas RECORD (empty)
+                @viewport WALK
+                  @viewport/background/hit-test REUSE
+                  @viewport/scroll-metadata RECORD (empty)
+                  @viewport/background SKIP
+                  @viewport/border SKIP
+                  BlockContainer<HTML>#html/descendants(background-and-borders) WALK
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
+                  BlockContainer<HTML>#html/descendants(foreground) WALK
+                  BlockContainer<HTML>#html WALK
+                    BlockContainer<HTML>#html/background/hit-test REUSE
+                    BlockContainer<HTML>#html/scroll-metadata RECORD (empty)
+                    BlockContainer<HTML>#html/background REUSE
+                    BlockContainer<HTML>#html/border SKIP
+                    BlockContainer<BODY>#body/descendants(background-and-borders) WALK
+                      BlockContainer<BODY>#body/background/hit-test REUSE
+                      BlockContainer<BODY>#body/scroll-metadata RECORD (empty)
+                      BlockContainer<BODY>#body/background SKIP
+                      BlockContainer<BODY>#body/border SKIP
+                      BlockContainer<DIV>#target/descendants(background-and-borders) WALK
+                        BlockContainer<DIV>#target/background/hit-test RECORD
+                        BlockContainer<DIV>#target/scroll-metadata RECORD (empty)
+                        BlockContainer<DIV>#target/background RECORD
+                        BlockContainer<DIV>#target/border SKIP
+                        InlineNode<SPAN>#inline/descendants(background-and-borders) WALK
+                      CanvasBox<CANVAS>#trigger/descendants(background-and-borders) REUSE WHOLE CAPTURE
+                    BlockContainer<BODY>#body/descendants(inline-background-and-borders) WALK
+                      BlockContainer<DIV>#target/descendants(inline-background-and-borders) WALK
+                        InlineNode<SPAN>#inline/descendants(inline-background-and-borders) WALK
+                      CanvasBox<CANVAS>#trigger/descendants(inline-background-and-borders) REUSE WHOLE CAPTURE
+                    BlockContainer<HTML>#html/foreground/hit-test REUSE
+                    BlockContainer<HTML>#html/foreground REUSE
+                    BlockContainer<BODY>#body/descendants(foreground) WALK
+                      BlockContainer<BODY>#body/foreground/hit-test REUSE
+                      BlockContainer<BODY>#body/foreground REUSE
+                      BlockContainer<DIV>#target/descendants(foreground) WALK
+                        BlockContainer<DIV>#target/foreground/hit-test RECORD (empty)
+                        BlockContainer<DIV>#target/foreground RECORD (empty)
+                        InlineNode<SPAN>#inline/descendants(foreground) WALK
+                        BlockContainer<DIV>#target/outline SKIP
+                        BlockContainer<DIV>#target/overlay/hit-test RECORD (empty)
+                        BlockContainer<DIV>#target/overlay SKIP
+                      CanvasBox<CANVAS>#trigger/descendants(foreground) REUSE WHOLE CAPTURE
+                      BlockContainer<BODY>#body/outline SKIP
+                      BlockContainer<BODY>#body/overlay/hit-test REUSE
+                      BlockContainer<BODY>#body/overlay SKIP
+                    InlineNode<SPAN>#inline WALK
+                      InlineNode<SPAN>#inline/background/hit-test RECORD
+                      InlineNode<SPAN>#inline/scroll-metadata RECORD (empty)
+                      InlineNode<SPAN>#inline/background SKIP
+                      InlineNode<SPAN>#inline/border SKIP
+                      InlineNode<SPAN>#inline/foreground/hit-test RECORD
+                      InlineNode<SPAN>#inline/foreground RECORD
+                      InlineNode<SPAN>#inline/outline SKIP
+                      InlineNode<SPAN>#inline/overlay/hit-test RECORD (empty)
+                      InlineNode<SPAN>#inline/overlay SKIP
+                    BlockContainer<HTML>#html/outline SKIP
+                  @viewport/outline SKIP
+            `,
+        },
+    ],
+});
+</script>

--- a/Tests/LibWeb/Text/input/display_list/paint-cache-scrollability-flip-scope.html
+++ b/Tests/LibWeb/Text/input/display_list/paint-cache-scrollability-flip-scope.html
@@ -121,50 +121,50 @@ displayListTest({
             expect: `
                 @canvas RECORD (empty)
                 @viewport WALK
-                  @viewport/background/hit-test RECORD
+                  @viewport/background/hit-test REUSE
                   @viewport/scroll-metadata RECORD
                   @viewport/background SKIP
                   @viewport/border SKIP
                   BlockContainer<HTML>#html/descendants(background-and-borders) WALK
-                  @viewport/foreground/hit-test RECORD (empty)
-                  @viewport/foreground RECORD (empty)
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
                   BlockContainer<HTML>#html/descendants(foreground) WALK
                   BlockContainer<HTML>#html WALK
-                    BlockContainer<HTML>#html/background/hit-test RECORD
+                    BlockContainer<HTML>#html/background/hit-test REUSE
                     BlockContainer<HTML>#html/scroll-metadata RECORD
-                    BlockContainer<HTML>#html/background RECORD (empty)
+                    BlockContainer<HTML>#html/background REUSE
                     BlockContainer<HTML>#html/border SKIP
                     BlockContainer<BODY>#body/descendants(background-and-borders) WALK
-                      BlockContainer<BODY>#body/background/hit-test RECORD
+                      BlockContainer<BODY>#body/background/hit-test REUSE
                       BlockContainer<BODY>#body/scroll-metadata RECORD
                       BlockContainer<BODY>#body/background SKIP
                       BlockContainer<BODY>#body/border SKIP
                       Box<DIV>#row.row/descendants(background-and-borders) WALK
-                        Box<DIV>#row.row/background/hit-test RECORD
+                        Box<DIV>#row.row/background/hit-test REUSE
                         Box<DIV>#row.row/scroll-metadata RECORD
                         Box<DIV>#row.row/background SKIP
                         Box<DIV>#row.row/border SKIP
                         BlockContainer<DIV>#row-0.box/descendants(background-and-borders) REUSE WHOLE CAPTURE
                         BlockContainer<DIV>#outer.box/descendants(background-and-borders) WALK
-                        BlockContainer<DIV>#row-2.box/descendants(background-and-borders) WALK
+                        BlockContainer<DIV>#row-2.box/descendants(background-and-borders) REUSE WHOLE CAPTURE
                       Box<DIV>#second-row.row/descendants(background-and-borders) REUSE WHOLE CAPTURE
-                    BlockContainer<HTML>#html/foreground/hit-test RECORD (empty)
-                    BlockContainer<HTML>#html/foreground RECORD (empty)
+                    BlockContainer<HTML>#html/foreground/hit-test REUSE
+                    BlockContainer<HTML>#html/foreground REUSE
                     BlockContainer<BODY>#body/descendants(foreground) WALK
-                      BlockContainer<BODY>#body/foreground/hit-test RECORD (empty)
-                      BlockContainer<BODY>#body/foreground RECORD (empty)
+                      BlockContainer<BODY>#body/foreground/hit-test REUSE
+                      BlockContainer<BODY>#body/foreground REUSE
                       Box<DIV>#row.row/descendants(foreground) WALK
-                        Box<DIV>#row.row/foreground/hit-test RECORD (empty)
-                        Box<DIV>#row.row/foreground RECORD (empty)
+                        Box<DIV>#row.row/foreground/hit-test REUSE
+                        Box<DIV>#row.row/foreground REUSE
                         BlockContainer<DIV>#row-0.box/descendants(foreground) REUSE WHOLE CAPTURE
                         BlockContainer<DIV>#outer.box/descendants(foreground) WALK
-                        BlockContainer<DIV>#row-2.box/descendants(foreground) WALK
+                        BlockContainer<DIV>#row-2.box/descendants(foreground) REUSE WHOLE CAPTURE
                         Box<DIV>#row.row/outline SKIP
-                        Box<DIV>#row.row/overlay/hit-test RECORD (empty)
+                        Box<DIV>#row.row/overlay/hit-test REUSE
                         Box<DIV>#row.row/overlay SKIP
                       Box<DIV>#second-row.row/descendants(foreground) REUSE WHOLE CAPTURE
                       BlockContainer<BODY>#body/outline SKIP
-                      BlockContainer<BODY>#body/overlay/hit-test RECORD (empty)
+                      BlockContainer<BODY>#body/overlay/hit-test REUSE
                       BlockContainer<BODY>#body/overlay SKIP
                     BlockContainer<DIV>#row-0.box REUSE WHOLE CAPTURE
                     BlockContainer<DIV>#outer.box WALK
@@ -216,16 +216,7 @@ displayListTest({
                       BlockContainer<DIV>#outer.box/outline SKIP
                       BlockContainer<DIV>#outer.box/overlay/hit-test RECORD
                       BlockContainer<DIV>#outer.box/overlay RECORD
-                    BlockContainer<DIV>#row-2.box WALK
-                      BlockContainer<DIV>#row-2.box/background/hit-test RECORD
-                      BlockContainer<DIV>#row-2.box/scroll-metadata RECORD
-                      BlockContainer<DIV>#row-2.box/background SKIP
-                      BlockContainer<DIV>#row-2.box/border RECORD
-                      BlockContainer<DIV>#row-2.box/foreground/hit-test RECORD
-                      BlockContainer<DIV>#row-2.box/foreground RECORD
-                      BlockContainer<DIV>#row-2.box/outline SKIP
-                      BlockContainer<DIV>#row-2.box/overlay/hit-test RECORD (empty)
-                      BlockContainer<DIV>#row-2.box/overlay SKIP
+                    BlockContainer<DIV>#row-2.box REUSE WHOLE CAPTURE
                     BlockContainer<DIV>#second-row-0.box REUSE WHOLE CAPTURE
                     BlockContainer<DIV>#second-row-1.box REUSE WHOLE CAPTURE
                     BlockContainer<DIV>#second-row-2.box REUSE WHOLE CAPTURE
@@ -239,27 +230,27 @@ displayListTest({
             expect: `
                 @canvas RECORD (empty)
                 @viewport WALK
-                  @viewport/background/hit-test RECORD
+                  @viewport/background/hit-test REUSE
                   @viewport/scroll-metadata RECORD
                   @viewport/background SKIP
                   @viewport/border SKIP
                   BlockContainer<HTML>#html/descendants(background-and-borders) WALK
-                  @viewport/foreground/hit-test RECORD (empty)
-                  @viewport/foreground RECORD (empty)
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
                   BlockContainer<HTML>#html/descendants(foreground) WALK
                   BlockContainer<HTML>#html WALK
-                    BlockContainer<HTML>#html/background/hit-test RECORD
+                    BlockContainer<HTML>#html/background/hit-test REUSE
                     BlockContainer<HTML>#html/scroll-metadata RECORD
-                    BlockContainer<HTML>#html/background RECORD (empty)
+                    BlockContainer<HTML>#html/background REUSE
                     BlockContainer<HTML>#html/border SKIP
                     BlockContainer<BODY>#body/descendants(background-and-borders) WALK
-                      BlockContainer<BODY>#body/background/hit-test RECORD
+                      BlockContainer<BODY>#body/background/hit-test REUSE
                       BlockContainer<BODY>#body/scroll-metadata RECORD
                       BlockContainer<BODY>#body/background SKIP
                       BlockContainer<BODY>#body/border SKIP
                       Box<DIV>#row.row/descendants(background-and-borders) REUSE WHOLE CAPTURE
                       Box<DIV>#second-row.row/descendants(background-and-borders) WALK
-                        Box<DIV>#second-row.row/background/hit-test RECORD
+                        Box<DIV>#second-row.row/background/hit-test REUSE
                         Box<DIV>#second-row.row/scroll-metadata RECORD
                         Box<DIV>#second-row.row/background SKIP
                         Box<DIV>#second-row.row/border SKIP
@@ -267,24 +258,24 @@ displayListTest({
                         BlockContainer<DIV>#second-row-1.box/descendants(background-and-borders) REUSE WHOLE CAPTURE
                         BlockContainer<DIV>#inserted.box/descendants(background-and-borders) WALK
                         BlockContainer<DIV>#second-row-2.box/descendants(background-and-borders) WALK
-                    BlockContainer<HTML>#html/foreground/hit-test RECORD (empty)
-                    BlockContainer<HTML>#html/foreground RECORD (empty)
+                    BlockContainer<HTML>#html/foreground/hit-test REUSE
+                    BlockContainer<HTML>#html/foreground REUSE
                     BlockContainer<BODY>#body/descendants(foreground) WALK
-                      BlockContainer<BODY>#body/foreground/hit-test RECORD (empty)
-                      BlockContainer<BODY>#body/foreground RECORD (empty)
+                      BlockContainer<BODY>#body/foreground/hit-test REUSE
+                      BlockContainer<BODY>#body/foreground REUSE
                       Box<DIV>#row.row/descendants(foreground) REUSE WHOLE CAPTURE
                       Box<DIV>#second-row.row/descendants(foreground) WALK
-                        Box<DIV>#second-row.row/foreground/hit-test RECORD (empty)
-                        Box<DIV>#second-row.row/foreground RECORD (empty)
+                        Box<DIV>#second-row.row/foreground/hit-test REUSE
+                        Box<DIV>#second-row.row/foreground REUSE
                         BlockContainer<DIV>#second-row-0.box/descendants(foreground) REUSE WHOLE CAPTURE
                         BlockContainer<DIV>#second-row-1.box/descendants(foreground) REUSE WHOLE CAPTURE
                         BlockContainer<DIV>#inserted.box/descendants(foreground) WALK
                         BlockContainer<DIV>#second-row-2.box/descendants(foreground) WALK
                         Box<DIV>#second-row.row/outline SKIP
-                        Box<DIV>#second-row.row/overlay/hit-test RECORD (empty)
+                        Box<DIV>#second-row.row/overlay/hit-test REUSE
                         Box<DIV>#second-row.row/overlay SKIP
                       BlockContainer<BODY>#body/outline SKIP
-                      BlockContainer<BODY>#body/overlay/hit-test RECORD (empty)
+                      BlockContainer<BODY>#body/overlay/hit-test REUSE
                       BlockContainer<BODY>#body/overlay SKIP
                     BlockContainer<DIV>#row-0.box REUSE WHOLE CAPTURE
                     BlockContainer<DIV>#outer.box REUSE WHOLE CAPTURE

--- a/Tests/LibWeb/Text/input/display_list/paint-cache-unchanged-relayout.html
+++ b/Tests/LibWeb/Text/input/display_list/paint-cache-unchanged-relayout.html
@@ -77,18 +77,18 @@ displayListTest({
                       BlockContainer<BODY>/overlay/hit-test REUSE
                       BlockContainer<BODY>/overlay SKIP
                     BlockContainer<DIV>#boundary WALK
-                      BlockContainer<DIV>#boundary/background/hit-test RECORD
+                      BlockContainer<DIV>#boundary/background/hit-test REUSE
                       BlockContainer<DIV>#boundary/scroll-metadata RECORD (empty)
                       BlockContainer<DIV>#boundary/background SKIP
                       BlockContainer<DIV>#boundary/border SKIP
                       CanvasBox<CANVAS>#partial/descendants(background-and-borders) REUSE WHOLE CAPTURE
                       CanvasBox<CANVAS>#partial/descendants(floats) REUSE WHOLE CAPTURE
                       CanvasBox<CANVAS>#partial/descendants(inline-background-and-borders) REUSE WHOLE CAPTURE
-                      BlockContainer<DIV>#boundary/foreground/hit-test RECORD (empty)
-                      BlockContainer<DIV>#boundary/foreground RECORD (empty)
+                      BlockContainer<DIV>#boundary/foreground/hit-test REUSE
+                      BlockContainer<DIV>#boundary/foreground REUSE
                       CanvasBox<CANVAS>#partial/descendants(foreground) REUSE WHOLE CAPTURE
                       BlockContainer<DIV>#boundary/outline SKIP
-                      BlockContainer<DIV>#boundary/overlay/hit-test RECORD (empty)
+                      BlockContainer<DIV>#boundary/overlay/hit-test REUSE
                       BlockContainer<DIV>#boundary/overlay SKIP
                     BlockContainer<HTML>/outline SKIP
                   @viewport/outline SKIP

--- a/Tests/LibWeb/Text/input/display_list/painted-as-stacking-context-capture-blocking-wheel-region-top-layer.html
+++ b/Tests/LibWeb/Text/input/display_list/painted-as-stacking-context-capture-blocking-wheel-region-top-layer.html
@@ -33,15 +33,15 @@ displayListTest({
             expect: `
                 @canvas RECORD (empty)
                 @viewport WALK
-                  @viewport/background/hit-test RECORD
+                  @viewport/background/hit-test REUSE
                   @viewport/scroll-metadata RECORD (empty)
                   @viewport/background SKIP
                   @viewport/border SKIP
                   BlockContainer<HTML>#html/descendants(background-and-borders) WALK
                   BlockContainer(anonymous)/descendants(background-and-borders) WALK
                   BlockContainer<DIALOG>#modal/descendants(background-and-borders) WALK
-                  @viewport/foreground/hit-test RECORD (empty)
-                  @viewport/foreground RECORD (empty)
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
                   BlockContainer<HTML>#html/descendants(foreground) WALK
                   BlockContainer(anonymous)/descendants(foreground) WALK
                   BlockContainer<DIALOG>#modal/descendants(foreground) WALK

--- a/Tests/LibWeb/Text/input/display_list/painted-as-stacking-context-capture-moved-box.html
+++ b/Tests/LibWeb/Text/input/display_list/painted-as-stacking-context-capture-moved-box.html
@@ -23,20 +23,20 @@ displayListTest({
             `
         },
         {
-            // Changing top currently relayouts both siblings. The exact trace exposes that scope.
+            // Moving B changes its absolute paint coordinates; A retains its entire capture.
             name: "move B",
             mutate: () => { b.style.top = "20px"; },
             check: equal => { equal(document.elementFromPoint(10, 110).id, "b2", "hit target"); },
             expect: `
                 @canvas RECORD (empty)
                 @viewport WALK
-                  @viewport/background/hit-test RECORD
+                  @viewport/background/hit-test REUSE
                   @viewport/scroll-metadata RECORD (empty)
                   @viewport/background SKIP
                   @viewport/border SKIP
                   BlockContainer<HTML>#html/descendants(background-and-borders) WALK
-                  @viewport/foreground/hit-test RECORD (empty)
-                  @viewport/foreground RECORD (empty)
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
                   BlockContainer<HTML>#html/descendants(foreground) WALK
                   BlockContainer<HTML>#html WALK
                     BlockContainer<HTML>#html/background/hit-test RECORD
@@ -48,54 +48,19 @@ displayListTest({
                       BlockContainer<BODY>#body/scroll-metadata RECORD (empty)
                       BlockContainer<BODY>#body/background SKIP
                       BlockContainer<BODY>#body/border SKIP
-                      BlockContainer<DIV>#a/descendants(background-and-borders) WALK
+                      BlockContainer<DIV>#a/descendants(background-and-borders) REUSE WHOLE CAPTURE
                       BlockContainer<DIV>#b/descendants(background-and-borders) WALK
                     BlockContainer<HTML>#html/foreground/hit-test RECORD (empty)
                     BlockContainer<HTML>#html/foreground RECORD (empty)
                     BlockContainer<BODY>#body/descendants(foreground) WALK
                       BlockContainer<BODY>#body/foreground/hit-test RECORD (empty)
                       BlockContainer<BODY>#body/foreground RECORD (empty)
-                      BlockContainer<DIV>#a/descendants(foreground) WALK
+                      BlockContainer<DIV>#a/descendants(foreground) REUSE WHOLE CAPTURE
                       BlockContainer<DIV>#b/descendants(foreground) WALK
                       BlockContainer<BODY>#body/outline SKIP
                       BlockContainer<BODY>#body/overlay/hit-test RECORD (empty)
                       BlockContainer<BODY>#body/overlay SKIP
-                    BlockContainer<DIV>#a WALK
-                      BlockContainer<DIV>#a/background/hit-test RECORD
-                      BlockContainer<DIV>#a/scroll-metadata RECORD (empty)
-                      BlockContainer<DIV>#a/background SKIP
-                      BlockContainer<DIV>#a/border SKIP
-                      BlockContainer<DIV>#a0.row/descendants(background-and-borders) WALK
-                        BlockContainer<DIV>#a0.row/background/hit-test RECORD
-                        BlockContainer<DIV>#a0.row/scroll-metadata RECORD (empty)
-                        BlockContainer<DIV>#a0.row/background SKIP
-                        BlockContainer<DIV>#a0.row/border SKIP
-                      BlockContainer<DIV>#a1.row/descendants(background-and-borders) WALK
-                        BlockContainer<DIV>#a1.row/background/hit-test RECORD
-                        BlockContainer<DIV>#a1.row/scroll-metadata RECORD (empty)
-                        BlockContainer<DIV>#a1.row/background SKIP
-                        BlockContainer<DIV>#a1.row/border SKIP
-                      BlockContainer<DIV>#a0.row/descendants(floats) WALK
-                      BlockContainer<DIV>#a1.row/descendants(floats) WALK
-                      BlockContainer<DIV>#a0.row/descendants(inline-background-and-borders) WALK
-                      BlockContainer<DIV>#a1.row/descendants(inline-background-and-borders) WALK
-                      BlockContainer<DIV>#a/foreground/hit-test RECORD (empty)
-                      BlockContainer<DIV>#a/foreground RECORD (empty)
-                      BlockContainer<DIV>#a0.row/descendants(foreground) WALK
-                        BlockContainer<DIV>#a0.row/foreground/hit-test RECORD
-                        BlockContainer<DIV>#a0.row/foreground RECORD
-                        BlockContainer<DIV>#a0.row/outline SKIP
-                        BlockContainer<DIV>#a0.row/overlay/hit-test RECORD (empty)
-                        BlockContainer<DIV>#a0.row/overlay SKIP
-                      BlockContainer<DIV>#a1.row/descendants(foreground) WALK
-                        BlockContainer<DIV>#a1.row/foreground/hit-test RECORD
-                        BlockContainer<DIV>#a1.row/foreground RECORD
-                        BlockContainer<DIV>#a1.row/outline SKIP
-                        BlockContainer<DIV>#a1.row/overlay/hit-test RECORD (empty)
-                        BlockContainer<DIV>#a1.row/overlay SKIP
-                      BlockContainer<DIV>#a/outline SKIP
-                      BlockContainer<DIV>#a/overlay/hit-test RECORD (empty)
-                      BlockContainer<DIV>#a/overlay SKIP
+                    BlockContainer<DIV>#a REUSE WHOLE CAPTURE
                     BlockContainer<DIV>#b WALK
                       BlockContainer<DIV>#b/background/hit-test RECORD
                       BlockContainer<DIV>#b/scroll-metadata RECORD (empty)

--- a/Tests/LibWeb/Text/input/display_list/painted-as-stacking-context-capture-new-positioned-descendant.html
+++ b/Tests/LibWeb/Text/input/display_list/painted-as-stacking-context-capture-new-positioned-descendant.html
@@ -22,20 +22,20 @@ displayListTest({
             `
         },
         {
-            // Insertion currently relayouts both siblings, including A. Keep that work visible.
+            // The inserted in-flow child changes B's height; A retains its entire capture.
             name: "insert positioned child into B",
             mutate: () => { const inserted = document.createElement("div"); inserted.id = "inserted"; inserted.className = "row"; inserted.style.position = "relative"; inserted.textContent = "B 1"; b.appendChild(inserted); },
             check: equal => { equal(document.elementFromPoint(10, 70).id, "inserted", "hit target"); },
             expect: `
                 @canvas RECORD (empty)
                 @viewport WALK
-                  @viewport/background/hit-test RECORD
+                  @viewport/background/hit-test REUSE
                   @viewport/scroll-metadata RECORD (empty)
                   @viewport/background SKIP
                   @viewport/border SKIP
                   BlockContainer<HTML>#html/descendants(background-and-borders) WALK
-                  @viewport/foreground/hit-test RECORD (empty)
-                  @viewport/foreground RECORD (empty)
+                  @viewport/foreground/hit-test REUSE
+                  @viewport/foreground REUSE
                   BlockContainer<HTML>#html/descendants(foreground) WALK
                   BlockContainer<HTML>#html WALK
                     BlockContainer<HTML>#html/background/hit-test RECORD
@@ -47,77 +47,33 @@ displayListTest({
                       BlockContainer<BODY>#body/scroll-metadata RECORD (empty)
                       BlockContainer<BODY>#body/background SKIP
                       BlockContainer<BODY>#body/border SKIP
-                      BlockContainer<DIV>#a/descendants(background-and-borders) WALK
+                      BlockContainer<DIV>#a/descendants(background-and-borders) REUSE WHOLE CAPTURE
                       BlockContainer<DIV>#b/descendants(background-and-borders) WALK
                     BlockContainer<HTML>#html/foreground/hit-test RECORD (empty)
                     BlockContainer<HTML>#html/foreground RECORD (empty)
                     BlockContainer<BODY>#body/descendants(foreground) WALK
                       BlockContainer<BODY>#body/foreground/hit-test RECORD (empty)
                       BlockContainer<BODY>#body/foreground RECORD (empty)
-                      BlockContainer<DIV>#a/descendants(foreground) WALK
+                      BlockContainer<DIV>#a/descendants(foreground) REUSE WHOLE CAPTURE
                       BlockContainer<DIV>#b/descendants(foreground) WALK
                       BlockContainer<BODY>#body/outline SKIP
                       BlockContainer<BODY>#body/overlay/hit-test RECORD (empty)
                       BlockContainer<BODY>#body/overlay SKIP
-                    BlockContainer<DIV>#a WALK
-                      BlockContainer<DIV>#a/background/hit-test RECORD
-                      BlockContainer<DIV>#a/scroll-metadata RECORD (empty)
-                      BlockContainer<DIV>#a/background SKIP
-                      BlockContainer<DIV>#a/border SKIP
-                      BlockContainer<DIV>#a0.row/descendants(background-and-borders) WALK
-                        BlockContainer<DIV>#a0.row/background/hit-test RECORD
-                        BlockContainer<DIV>#a0.row/scroll-metadata RECORD (empty)
-                        BlockContainer<DIV>#a0.row/background SKIP
-                        BlockContainer<DIV>#a0.row/border SKIP
-                      BlockContainer<DIV>#a1.row/descendants(background-and-borders) WALK
-                        BlockContainer<DIV>#a1.row/background/hit-test RECORD
-                        BlockContainer<DIV>#a1.row/scroll-metadata RECORD (empty)
-                        BlockContainer<DIV>#a1.row/background SKIP
-                        BlockContainer<DIV>#a1.row/border SKIP
-                      BlockContainer<DIV>#a0.row/descendants(floats) WALK
-                      BlockContainer<DIV>#a1.row/descendants(floats) WALK
-                      BlockContainer<DIV>#a0.row/descendants(inline-background-and-borders) WALK
-                      BlockContainer<DIV>#a1.row/descendants(inline-background-and-borders) WALK
-                      BlockContainer<DIV>#a/foreground/hit-test RECORD (empty)
-                      BlockContainer<DIV>#a/foreground RECORD (empty)
-                      BlockContainer<DIV>#a0.row/descendants(foreground) WALK
-                        BlockContainer<DIV>#a0.row/foreground/hit-test RECORD
-                        BlockContainer<DIV>#a0.row/foreground RECORD
-                        BlockContainer<DIV>#a0.row/outline SKIP
-                        BlockContainer<DIV>#a0.row/overlay/hit-test RECORD (empty)
-                        BlockContainer<DIV>#a0.row/overlay SKIP
-                      BlockContainer<DIV>#a1.row/descendants(foreground) WALK
-                        BlockContainer<DIV>#a1.row/foreground/hit-test RECORD
-                        BlockContainer<DIV>#a1.row/foreground RECORD
-                        BlockContainer<DIV>#a1.row/outline SKIP
-                        BlockContainer<DIV>#a1.row/overlay/hit-test RECORD (empty)
-                        BlockContainer<DIV>#a1.row/overlay SKIP
-                      BlockContainer<DIV>#a/outline SKIP
-                      BlockContainer<DIV>#a/overlay/hit-test RECORD (empty)
-                      BlockContainer<DIV>#a/overlay SKIP
+                    BlockContainer<DIV>#a REUSE WHOLE CAPTURE
                     BlockContainer<DIV>#b WALK
                       BlockContainer<DIV>#b/background/hit-test RECORD
                       BlockContainer<DIV>#b/scroll-metadata RECORD (empty)
                       BlockContainer<DIV>#b/background SKIP
                       BlockContainer<DIV>#b/border SKIP
-                      BlockContainer<DIV>#b0.row/descendants(background-and-borders) WALK
-                        BlockContainer<DIV>#b0.row/background/hit-test RECORD
-                        BlockContainer<DIV>#b0.row/scroll-metadata RECORD (empty)
-                        BlockContainer<DIV>#b0.row/background SKIP
-                        BlockContainer<DIV>#b0.row/border SKIP
+                      BlockContainer<DIV>#b0.row/descendants(background-and-borders) REUSE WHOLE CAPTURE
                       BlockContainer<DIV>#inserted.row/descendants(background-and-borders) WALK
-                      BlockContainer<DIV>#b0.row/descendants(floats) WALK
+                      BlockContainer<DIV>#b0.row/descendants(floats) REUSE WHOLE CAPTURE
                       BlockContainer<DIV>#inserted.row/descendants(floats) WALK
-                      BlockContainer<DIV>#b0.row/descendants(inline-background-and-borders) WALK
+                      BlockContainer<DIV>#b0.row/descendants(inline-background-and-borders) REUSE WHOLE CAPTURE
                       BlockContainer<DIV>#inserted.row/descendants(inline-background-and-borders) WALK
                       BlockContainer<DIV>#b/foreground/hit-test RECORD (empty)
                       BlockContainer<DIV>#b/foreground RECORD (empty)
-                      BlockContainer<DIV>#b0.row/descendants(foreground) WALK
-                        BlockContainer<DIV>#b0.row/foreground/hit-test RECORD
-                        BlockContainer<DIV>#b0.row/foreground RECORD
-                        BlockContainer<DIV>#b0.row/outline SKIP
-                        BlockContainer<DIV>#b0.row/overlay/hit-test RECORD (empty)
-                        BlockContainer<DIV>#b0.row/overlay SKIP
+                      BlockContainer<DIV>#b0.row/descendants(foreground) REUSE WHOLE CAPTURE
                       BlockContainer<DIV>#inserted.row/descendants(foreground) WALK
                       BlockContainer<DIV>#b/outline SKIP
                       BlockContainer<DIV>#b/overlay/hit-test RECORD (empty)

--- a/Tests/LibWeb/Text/input/hit_testing/empty-editable-caret-after-abspos-child-change.html
+++ b/Tests/LibWeb/Text/input/hit_testing/empty-editable-caret-after-abspos-child-change.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #editor { position: relative; width: 200px; height: 100px; background: silver; }
+    #child { position: absolute; left: 120px; top: 10px; width: 30px; height: 30px; }
+</style>
+<div id="editor" contenteditable="true"></div>
+<script>
+promiseTest(async () => {
+    if (document.readyState !== "complete")
+        await new Promise(resolve => window.addEventListener("load", resolve, { once: true }));
+    __outputElement.style.display = "none";
+    internals.recordDisplayListForTesting();
+    const output = [];
+    const caret = () => {
+        const position = document.caretPositionFromPoint(125, 15);
+        return position ? `${position.offsetNode.id} @${position.offset}` : "null";
+    };
+    const check = (name, expectedHitTestWork) => {
+        internals.beginDisplayListTrace();
+        internals.recordDisplayListForTesting();
+        const trace = internals.takeDisplayListTrace();
+        if (expectedHitTestWork)
+            output.push(`${name}, editor hit test updated: ${trace.includes(`#editor/foreground/hit-test ${expectedHitTestWork}\n`)}`);
+        output.push(`${name}, cached: ${caret()}`);
+        // Repeat without a mutation so a whole capture can be replayed as well.
+        internals.recordDisplayListForTesting();
+        output.push(`${name}, quiet: ${caret()}`);
+        internals.recordDisplayListForTesting(false, true);
+        output.push(`${name}, fresh: ${caret()}`);
+    };
+    check("empty editor");
+
+    // The child creates no inline fragments and changes neither the editor's
+    // dimensions nor its overflow, but the editor is no longer an empty caret target.
+    const child = document.createElement("div");
+    child.id = "child";
+    child.contentEditable = "false";
+    editor.appendChild(child);
+    output.push(`child is non-editable: ${!child.isContentEditable}`);
+    check("after insertion", "RECORD (empty)");
+
+    child.remove();
+    check("after removal", "RECORD");
+
+    __outputElement.style.display = "";
+    for (const line of output) println(line);
+});
+</script>


### PR DESCRIPTION
Layout commit treated a changed fragment identity as a change to a box's
own paint. Because fragment identity includes child fragments and inline
allocations, descendant updates and identical text relayouts could
rerecord unchanged ancestors and siblings. The abspos insertion
regression test exposed this over-invalidation.

Compare box properties, inline content and child placements separately
when deciding paint invalidation. Retain ancestor commands when only
descendants change, and compare rebuilt inline content by value. Use the
enclosing line output for fragmented inline paint rather than comparing
finalized offsets with temporary fragment offsets.

Preserve existing style/content dirtiness, subtree dirty propagation,
and conservative overflow and visual-context updates. Keep broader paint
invalidation for fieldsets, table parts, SVG and text-clipped
backgrounds whose commands can depend on descendants.

Add coverage for abspos insertion, removal and reinsertion after quiet
frames, identical inline relayout, pending style changes and painting
that depends on descendants. Update recording traces to require the
newly preserved caches.